### PR TITLE
feat(infra): add Redis TLS support for BullMQ connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ DATABASE_URL=postgresql://carebridge:carebridge_dev@localhost:5432/carebridge
 
 # Redis
 REDIS_URL=redis://localhost:6379
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# REDIS_PASSWORD=
+# REDIS_TLS=true  # Enable TLS for production Redis connections
 
 # API
 API_PORT=4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    # TLS configuration for production:
+    # command: >
+    #   redis-server
+    #   --tls-port 6380
+    #   --port 0
+    #   --tls-cert-file /tls/redis.crt
+    #   --tls-key-file /tls/redis.key
+    #   --tls-ca-cert-file /tls/ca.crt
+    # volumes:
+    #   - ./tls:/tls:ro
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -16,6 +16,8 @@ const QUEUE_NAME = "clinical-events";
 const connection = {
   host: process.env.REDIS_HOST ?? "localhost",
   port: Number(process.env.REDIS_PORT ?? 6379),
+  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
+  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
 };
 
 /**

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -8,8 +8,15 @@ export interface ClinicalEvent {
   payload?: Record<string, unknown>;
 }
 
+const connection = {
+  host: process.env.REDIS_HOST ?? "localhost",
+  port: Number(process.env.REDIS_PORT ?? 6379),
+  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
+  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
+};
+
 const clinicalEventsQueue = new Queue("clinical-events", {
-  connection: { host: "localhost", port: 6379 },
+  connection,
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -9,8 +9,15 @@ export interface ClinicalEvent {
   payload?: Record<string, unknown>;
 }
 
+const connection = {
+  host: process.env.REDIS_HOST ?? "localhost",
+  port: Number(process.env.REDIS_PORT ?? 6379),
+  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
+  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
+};
+
 const clinicalEventsQueue = new Queue("clinical-events", {
-  connection: { host: "localhost", port: 6379 },
+  connection,
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {


### PR DESCRIPTION
## Summary
- All 3 BullMQ connections now support `REDIS_TLS=true` env var
- Consistent env-driven config: host, port, password, TLS
- `.env.example` and `docker-compose.yml` document TLS setup

Closes #2

## Test plan
- [ ] Verify BullMQ connects without TLS (default, backward compatible)
- [ ] Verify BullMQ connects with TLS when `REDIS_TLS=true`
- [ ] Verify clinical events still flow through queue