### PR TITLE
docs(db): clarify care_team_members vs care_team_assignments tables

### DIFF
--- a/docs/care-team-tables.md
+++ b/docs/care-team-tables.md
@@ -1,0 +1,42 @@
+# care_team_members vs care_team_assignments
+
+The database has two tables with similar names that serve **different purposes**.
+This document explains why both exist and when to use each one.
+
+## care_team_members — Clinical Roster
+
+| Aspect   | Detail |
+|----------|--------|
+| Purpose  | Tracks which providers are clinically involved in a patient's care. |
+| Consumed by | Patient chart UI (clinician-portal, patient-portal), ai-oversight context builder. |
+| Key columns | `provider_id`, `role` (primary / specialist / nurse / coordinator), `specialty`, `is_active`. |
+| Access control? | **No.** This table is never checked during authorization. |
+
+Use this table when you need to display or reason about the clinical care team
+(e.g., listing a patient's providers, assembling context for AI reviews).
+
+## care_team_assignments — RBAC Access Control
+
+| Aspect   | Detail |
+|----------|--------|
+| Purpose  | Determines which users are authorized to view/modify a patient's records. |
+| Consumed by | api-gateway RBAC middleware (`assertPatientAccess`). |
+| Key columns | `user_id`, `patient_id`, `role` (attending / consulting / nursing), `removed_at`. |
+| Access control? | **Yes.** This is the authorization source of truth. |
+
+Use this table when you need to grant, revoke, or check a user's access to a
+patient's data.
+
+## Why two tables?
+
+A provider can be part of a patient's clinical care team without having system
+access (e.g., an outside specialist listed for coordination purposes). Conversely,
+a user may be granted temporary access to a patient's records for administrative
+or coverage reasons without being a member of the clinical care team.
+
+Keeping the concerns separate avoids coupling clinical documentation with
+authorization logic and makes each table easier to query and audit independently.
+
+## Schema location
+
+Both tables are defined in `packages/db-schema/src/schema/patients.ts`.

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -49,10 +49,18 @@ export const allergies = pgTable("allergies", {
 
 /**
  * Clinical care-team roster displayed on the patient chart.
- * Tracks which providers are clinically responsible for the patient
- * (primary, specialist, nurse, coordinator) and their specialty.
  *
- * NOT used for access control — see `care_team_assignments` for RBAC scoping.
+ * Tracks which providers are clinically involved in a patient's care
+ * (primary, specialist, nurse, coordinator) along with their specialty.
+ * This is the source of truth for the "Care Team" section rendered in the
+ * clinician-portal and patient-portal UIs.
+ *
+ * Referenced by:
+ *  - patient-records service (care team listing on the chart)
+ *  - ai-oversight context builder (assembling clinical context for reviews)
+ *
+ * NOT used for access control — see {@link careTeamAssignments} for RBAC.
+ * A provider can appear here without having system access, and vice-versa.
  */
 export const careTeamMembers = pgTable("care_team_members", {
   id: text("id").primaryKey(),
@@ -69,13 +77,20 @@ export const careTeamMembers = pgTable("care_team_members", {
 ]);
 
 /**
- * RBAC access-control table: determines which users (clinicians) are
- * authorized to view/modify a patient's records in the system.
- * Queried by the api-gateway RBAC middleware (`assertPatientAccess`).
+ * RBAC access-control mapping: determines which users (clinicians) are
+ * authorized to view or modify a patient's records in the system.
  *
- * NOT the same as `care_team_members`, which is the clinical care-team
- * roster shown on the patient chart. A user may be on the access list
- * without appearing on the clinical care team and vice-versa.
+ * Queried by the api-gateway RBAC middleware (`assertPatientAccess`) on
+ * every patient-scoped API request. A row here grants a user access to
+ * the patient; removing the row (setting `removed_at`) revokes it.
+ *
+ * Referenced by:
+ *  - api-gateway rbac middleware (authorization checks)
+ *
+ * NOT the same as {@link careTeamMembers}, which is the clinical care-team
+ * roster shown on the patient chart. A user may have system access without
+ * appearing on the clinical care team, and a care-team member may not yet
+ * have a corresponding access-control row.
  */
 export const careTeamAssignments = pgTable("care_team_assignments", {
   id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),


### PR DESCRIPTION
## Summary
- Enhanced JSDoc comments on `careTeamMembers` and `careTeamAssignments` in `packages/db-schema/src/schema/patients.ts` to clearly document their distinct purposes (clinical roster vs RBAC access control), cross-references, and which services consume each table.
- Added `docs/care-team-tables.md` explaining why both tables exist, when to use each, and how they differ.

Closes #26

## Test plan
- [ ] Verify `pnpm build` still succeeds (comments-only change to schema file)
- [ ] Review JSDoc comments render correctly in editor hover tooltips