### PR TITLE
perf(auth): cache care-team assignments with 60s TTL

### DIFF
--- a/services/api-gateway/src/middleware/rbac.test.ts
+++ b/services/api-gateway/src/middleware/rbac.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { assertCareTeamAccess, clearCareTeamCache } from "./rbac.js";
+
+// Mock the db-schema module so we never hit a real database.
+const selectMock = vi.fn();
+
+vi.mock("@carebridge/db-schema", () => {
+  const fromMock = vi.fn(() => ({ where: vi.fn(() => ({ limit: selectMock })) }));
+  return {
+    getDb: () => ({ select: () => ({ from: fromMock }) }),
+    careTeamAssignments: {
+      id: "id",
+      user_id: "user_id",
+      patient_id: "patient_id",
+      removed_at: "removed_at",
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  eq: (...args: unknown[]) => args,
+  and: (...args: unknown[]) => args,
+  isNull: (col: unknown) => col,
+}));
+
+describe("care-team cache", () => {
+  beforeEach(() => {
+    clearCareTeamCache();
+    selectMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queries the DB on a cache miss", async () => {
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+
+    const result = await assertCareTeamAccess("user-1", "patient-1");
+
+    expect(result).toBe(true);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cached value without hitting the DB on a cache hit", async () => {
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+
+    await assertCareTeamAccess("user-1", "patient-1");
+    const result = await assertCareTeamAccess("user-1", "patient-1");
+
+    expect(result).toBe(true);
+    expect(selectMock).toHaveBeenCalledTimes(1); // only the first call
+  });
+
+  it("caches false (no access) results as well", async () => {
+    selectMock.mockResolvedValueOnce([]);
+
+    const first = await assertCareTeamAccess("user-2", "patient-2");
+    const second = await assertCareTeamAccess("user-2", "patient-2");
+
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("expires entries after 60 seconds", async () => {
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+    selectMock.mockResolvedValueOnce([]); // second call returns no access
+
+    await assertCareTeamAccess("user-3", "patient-3");
+
+    // Advance time past the 60 s TTL
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(61_000);
+
+    const result = await assertCareTeamAccess("user-3", "patient-3");
+    expect(result).toBe(false);
+    expect(selectMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("clearCareTeamCache() forces a fresh DB query", async () => {
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+
+    await assertCareTeamAccess("user-4", "patient-4");
+    clearCareTeamCache();
+    await assertCareTeamAccess("user-4", "patient-4");
+
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses separate cache entries per user/patient pair", async () => {
+    selectMock.mockResolvedValueOnce([{ id: "row-1" }]);
+    selectMock.mockResolvedValueOnce([]);
+
+    const a = await assertCareTeamAccess("user-a", "patient-x");
+    const b = await assertCareTeamAccess("user-b", "patient-x");
+
+    expect(a).toBe(true);
+    expect(b).toBe(false);
+    expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -3,6 +3,46 @@ import type { User } from "@carebridge/shared-types";
 import { getDb, careTeamAssignments } from "@carebridge/db-schema";
 import { eq, and, isNull } from "drizzle-orm";
 
+/* ------------------------------------------------------------------ */
+/*  In-memory TTL cache for care-team lookups                         */
+/* ------------------------------------------------------------------ */
+
+const CACHE_TTL_MS = 60_000; // 60 seconds
+const CACHE_MAX_ENTRIES = 10_000;
+
+interface CacheEntry {
+  value: boolean;
+  expires: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function getCached(key: string): boolean | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expires) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+function setCache(key: string, value: boolean): void {
+  // Evict oldest entries when at capacity (simple FIFO via insertion order)
+  if (cache.size >= CACHE_MAX_ENTRIES && !cache.has(key)) {
+    const firstKey = cache.keys().next().value as string;
+    cache.delete(firstKey);
+  }
+  cache.set(key, { value, expires: Date.now() + CACHE_TTL_MS });
+}
+
+/** Clear the entire care-team cache. Useful for testing and invalidation. */
+export function clearCareTeamCache(): void {
+  cache.clear();
+}
+
+/* ------------------------------------------------------------------ */
+
 /**
  * Type-guard: returns `true` when `request.user` has been populated by
  * the auth middleware. Avoids an unsafe `as unknown as User` double-cast.
@@ -13,12 +53,19 @@ function getUser(request: FastifyRequest): User | undefined {
 
 /**
  * Verify that the authenticated user has an active care-team assignment
- * for the given patient. Returns true if an active assignment exists.
+ * for the given patient. Uses a short-lived in-memory cache (60 s TTL)
+ * so repeated RBAC checks within the same request window avoid extra
+ * round-trips to the database.
  */
 export async function assertCareTeamAccess(
   userId: string,
   patientId: string,
 ): Promise<boolean> {
+  const cacheKey = `${userId}:${patientId}`;
+
+  const cached = getCached(cacheKey);
+  if (cached !== undefined) return cached;
+
   const db = getDb();
   const rows = await db
     .select({ id: careTeamAssignments.id })
@@ -32,7 +79,9 @@ export async function assertCareTeamAccess(
     )
     .limit(1);
 
-  return rows.length > 0;
+  const hasAccess = rows.length > 0;
+  setCache(cacheKey, hasAccess);
+  return hasAccess;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds an in-memory TTL cache (60s, max 10k entries) to `assertCareTeamAccess()` in the RBAC middleware, keyed by `userId:patientId`
- On cache hit, skips the DB query entirely; on miss, queries and populates the cache
- Exports `clearCareTeamCache()` for testing and manual invalidation
- Adds 6 unit tests covering cache hit/miss, TTL expiry, cache clearing, and per-pair isolation

## Test plan

- [x] All 6 new tests in `rbac.test.ts` pass
- [ ] Verify care-team access checks still work end-to-end with `pnpm dev`
- [ ] Confirm assignment changes propagate within 60s

Closes #25