### PR TITLE
feat(auth): add audit logging for RBAC access denials

### DIFF
--- a/services/api-gateway/src/__tests__/rbac-audit.test.ts
+++ b/services/api-gateway/src/__tests__/rbac-audit.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock @carebridge/db-schema before importing the middleware
+// ---------------------------------------------------------------------------
+
+const insertedRows: Record<string, unknown>[] = [];
+const mockValues = vi.fn((row: Record<string, unknown>) => {
+  insertedRows.push(row);
+  return Promise.resolve();
+});
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+
+// Care-team query: returns empty by default (no assignment)
+let careTeamRows: unknown[] = [];
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => careTeamRows);
+  return chain;
+}
+
+const mockDb = {
+  insert: mockInsert,
+  select: vi.fn(() => makeSelectChain()),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  auditLog: { __table: "audit_log" },
+  careTeamAssignments: {
+    id: "care_team_assignments.id",
+    user_id: "care_team_assignments.user_id",
+    patient_id: "care_team_assignments.patient_id",
+    removed_at: "care_team_assignments.removed_at",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+  and: (...args: unknown[]) => args,
+  isNull: (col: unknown) => ({ isNull: col }),
+}));
+
+import { assertPatientAccess } from "../middleware/rbac.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(user?: Record<string, unknown>) {
+  return {
+    ip: "127.0.0.1",
+    log: { error: vi.fn() },
+    ...(user ? { user } : {}),
+  } as unknown as Parameters<typeof assertPatientAccess>[0];
+}
+
+function makeReply() {
+  const reply: Record<string, unknown> = {};
+  reply.code = vi.fn(() => reply);
+  reply.send = vi.fn(() => reply);
+  return reply as unknown as Parameters<typeof assertPatientAccess>[1];
+}
+
+const patientUser = {
+  id: "patient-1",
+  email: "patient@carebridge.dev",
+  name: "Test Patient",
+  role: "patient",
+  is_active: true,
+};
+
+const physicianUser = {
+  id: "doc-1",
+  email: "dr.smith@carebridge.dev",
+  name: "Dr. Smith",
+  role: "physician",
+  specialty: "Hematology/Oncology",
+  is_active: true,
+};
+
+const adminUser = {
+  id: "admin-1",
+  email: "admin@carebridge.dev",
+  name: "Admin",
+  role: "admin",
+  is_active: true,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RBAC audit logging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedRows.length = 0;
+    careTeamRows = [];
+  });
+
+  it("logs an audit entry when a patient accesses another patient's data", async () => {
+    const request = makeRequest(patientUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "patient-other");
+
+    expect(result).toBe(false);
+    expect((reply as unknown as Record<string, unknown>).code).toHaveBeenCalledWith(403);
+
+    // Verify audit log was inserted
+    expect(mockInsert).toHaveBeenCalled();
+    expect(insertedRows).toHaveLength(1);
+
+    const entry = insertedRows[0]!;
+    expect(entry.user_id).toBe("patient-1");
+    expect(entry.action).toBe("access_denied");
+    expect(entry.resource_type).toBe("rbac");
+    expect(entry.ip_address).toBe("127.0.0.1");
+
+    const details = JSON.parse(entry.details as string);
+    expect(details.reason).toBe("patient_access_denied");
+    expect(details.requested_patient_id).toBe("patient-other");
+    expect(details.role).toBe("patient");
+  });
+
+  it("logs an audit entry when a clinician has no care-team assignment", async () => {
+    careTeamRows = []; // No assignment found
+    const request = makeRequest(physicianUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "patient-99");
+
+    expect(result).toBe(false);
+    expect((reply as unknown as Record<string, unknown>).code).toHaveBeenCalledWith(403);
+
+    // Verify audit log was inserted
+    expect(mockInsert).toHaveBeenCalled();
+    expect(insertedRows).toHaveLength(1);
+
+    const entry = insertedRows[0]!;
+    expect(entry.user_id).toBe("doc-1");
+    expect(entry.action).toBe("access_denied");
+    expect(entry.resource_type).toBe("rbac");
+
+    const details = JSON.parse(entry.details as string);
+    expect(details.reason).toBe("care_team_not_assigned");
+    expect(details.requested_patient_id).toBe("patient-99");
+    expect(details.role).toBe("physician");
+  });
+
+  it("does NOT log an audit entry when a patient accesses their own data", async () => {
+    const request = makeRequest(patientUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "patient-1");
+
+    expect(result).toBe(true);
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(insertedRows).toHaveLength(0);
+  });
+
+  it("does NOT log an audit entry for admin access", async () => {
+    const request = makeRequest(adminUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "any-patient");
+
+    expect(result).toBe(true);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("does NOT log an audit entry when a clinician has a valid care-team assignment", async () => {
+    careTeamRows = [{ id: "assignment-1" }]; // Active assignment exists
+    const request = makeRequest(physicianUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "patient-1");
+
+    expect(result).toBe(true);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("does not crash the request if audit logging fails", async () => {
+    mockInsert.mockImplementationOnce(() => ({
+      values: vi.fn(() => Promise.reject(new Error("DB connection lost"))),
+    }));
+
+    const request = makeRequest(patientUser);
+    const reply = makeReply();
+
+    const result = await assertPatientAccess(request, reply, "patient-other");
+
+    // The access denial still completes normally
+    expect(result).toBe(false);
+    expect((reply as unknown as Record<string, unknown>).code).toHaveBeenCalledWith(403);
+
+    // Error was logged, not thrown
+    expect(
+      (request as unknown as Record<string, { error: ReturnType<typeof vi.fn> }>).log.error,
+    ).toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -1,7 +1,36 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 import type { User } from "@carebridge/shared-types";
-import { getDb, careTeamAssignments } from "@carebridge/db-schema";
+import { getDb, careTeamAssignments, auditLog } from "@carebridge/db-schema";
 import { eq, and, isNull } from "drizzle-orm";
+import crypto from "node:crypto";
+
+/**
+ * Log an RBAC access denial to the audit trail.
+ *
+ * Fires-and-forgets so it never blocks or crashes the request cycle.
+ */
+async function logAccessDenial(
+  request: FastifyRequest,
+  userId: string,
+  reason: string,
+  details: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const db = getDb();
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: userId,
+      action: "access_denied",
+      resource_type: "rbac",
+      resource_id: "",
+      details: JSON.stringify({ reason, ...details }),
+      ip_address: request.ip,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    request.log.error({ err }, "Failed to write RBAC denial audit log");
+  }
+}
 
 /**
  * Type-guard: returns `true` when `request.user` has been populated by
@@ -72,6 +101,10 @@ export async function assertPatientAccess(
     if (user.id === patientId) {
       return true;
     }
+    await logAccessDenial(request, user.id, "patient_access_denied", {
+      requested_patient_id: patientId,
+      role: user.role,
+    });
     reply.code(403).send({ error: "Access denied: patients may only access their own records" });
     return false;
   }
@@ -79,6 +112,10 @@ export async function assertPatientAccess(
   // Clinicians (physician, specialist, nurse) must be on the care team.
   const hasAccess = await assertCareTeamAccess(user.id, patientId);
   if (!hasAccess) {
+    await logAccessDenial(request, user.id, "care_team_not_assigned", {
+      requested_patient_id: patientId,
+      role: user.role,
+    });
     reply.code(403).send({
       error: "Access denied: no active care-team assignment for this patient",
     });


### PR DESCRIPTION
## Summary
- Adds audit trail logging at every RBAC rejection point in `assertPatientAccess`
- Logs `access_denied` entries with reason (`patient_access_denied` or `care_team_not_assigned`), the requested patient ID, user role, and IP address
- Audit writes are wrapped in try/catch so they never block or crash the request cycle
- Adds 6 tests covering both denial paths, all allowed paths, and DB failure resilience

## Test plan
- [x] `vitest run` passes all 6 new tests in `rbac-audit.test.ts`
- [ ] Manual verification: attempt patient cross-access and confirm audit_log row appears
- [ ] Manual verification: attempt clinician access without care-team assignment and confirm audit_log row

Closes #24