### PR TITLE
refactor(infra): extract shared Redis connection config

### DIFF
--- a/packages/redis-config/package.json
+++ b/packages/redis-config/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@carebridge/redis-config",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/redis-config/src/index.ts
+++ b/packages/redis-config/src/index.ts
@@ -1,0 +1,2 @@
+export { getRedisConnection } from "./redis.js";
+export type { RedisConnectionOptions } from "./redis.js";

--- a/packages/redis-config/src/redis.test.ts
+++ b/packages/redis-config/src/redis.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getRedisConnection } from "./redis.js";
+
+describe("getRedisConnection", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.REDIS_HOST;
+    delete process.env.REDIS_PORT;
+    delete process.env.REDIS_PASSWORD;
+    delete process.env.REDIS_TLS;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns defaults when no env vars are set", () => {
+    const conn = getRedisConnection();
+    expect(conn).toEqual({ host: "localhost", port: 6379 });
+    expect(conn.password).toBeUndefined();
+    expect(conn.tls).toBeUndefined();
+  });
+
+  it("reads host and port from env vars", () => {
+    process.env.REDIS_HOST = "redis.example.com";
+    process.env.REDIS_PORT = "6380";
+
+    const conn = getRedisConnection();
+    expect(conn.host).toBe("redis.example.com");
+    expect(conn.port).toBe(6380);
+  });
+
+  it("includes password when REDIS_PASSWORD is set", () => {
+    process.env.REDIS_PASSWORD = "s3cret";
+
+    const conn = getRedisConnection();
+    expect(conn.password).toBe("s3cret");
+  });
+
+  it("omits password when REDIS_PASSWORD is empty", () => {
+    process.env.REDIS_PASSWORD = "";
+
+    const conn = getRedisConnection();
+    expect(conn.password).toBeUndefined();
+  });
+
+  it("includes tls when REDIS_TLS is 'true'", () => {
+    process.env.REDIS_TLS = "true";
+
+    const conn = getRedisConnection();
+    expect(conn.tls).toEqual({});
+  });
+
+  it("omits tls when REDIS_TLS is not 'true'", () => {
+    process.env.REDIS_TLS = "false";
+
+    const conn = getRedisConnection();
+    expect(conn.tls).toBeUndefined();
+  });
+
+  it("handles all env vars together", () => {
+    process.env.REDIS_HOST = "prod.redis.io";
+    process.env.REDIS_PORT = "6381";
+    process.env.REDIS_PASSWORD = "p@ss";
+    process.env.REDIS_TLS = "true";
+
+    const conn = getRedisConnection();
+    expect(conn).toEqual({
+      host: "prod.redis.io",
+      port: 6381,
+      password: "p@ss",
+      tls: {},
+    });
+  });
+});

--- a/packages/redis-config/src/redis.ts
+++ b/packages/redis-config/src/redis.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared Redis connection configuration for BullMQ queues and workers.
+ *
+ * Reads from environment variables with sensible defaults for local development.
+ */
+
+export interface RedisConnectionOptions {
+  host: string;
+  port: number;
+  password?: string;
+  tls?: Record<string, never>;
+}
+
+export function getRedisConnection(): RedisConnectionOptions {
+  return {
+    host: process.env.REDIS_HOST ?? "localhost",
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    ...(process.env.REDIS_PASSWORD
+      ? { password: process.env.REDIS_PASSWORD }
+      : {}),
+    ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
+  };
+}

--- a/packages/redis-config/tsconfig.json
+++ b/packages/redis-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,15 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
+  packages/redis-config:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+
   packages/shared-types:
     devDependencies:
       typescript:
@@ -216,6 +225,9 @@ importers:
       '@carebridge/medical-logic':
         specifier: workspace:*
         version: link:../../packages/medical-logic
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -302,6 +314,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -336,6 +351,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -367,6 +385,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types

--- a/services/ai-oversight/package.json
+++ b/services/ai-oversight/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@carebridge/db-schema": "workspace:*",

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -9,16 +9,12 @@
 import { Worker } from "bullmq";
 import type { Job } from "bullmq";
 import type { ClinicalEvent } from "@carebridge/shared-types";
+import { getRedisConnection } from "@carebridge/redis-config";
 import { processReviewJob } from "../services/review-service.js";
 
 const QUEUE_NAME = "clinical-events";
 
-const connection = {
-  host: process.env.REDIS_HOST ?? "localhost",
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
-  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
-};
+const connection = getRedisConnection();
 
 /**
  * Create and start the clinical events review worker.

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@trpc/server": "^11.0.0",

--- a/services/auth/src/cleanup-worker.ts
+++ b/services/auth/src/cleanup-worker.ts
@@ -1,16 +1,8 @@
 import { Queue, Worker } from "bullmq";
+import { getRedisConnection } from "@carebridge/redis-config";
 import { cleanupExpiredSessions } from "./session-cleanup.js";
 
 const QUEUE_NAME = "session-cleanup";
-
-function getRedisConnection() {
-  const host = process.env.REDIS_HOST ?? "localhost";
-  const port = Number(process.env.REDIS_PORT ?? 6379);
-  const password = process.env.REDIS_PASSWORD || undefined;
-  const tls = process.env.REDIS_TLS === "true" ? {} : undefined;
-
-  return { host, port, password, tls };
-}
 
 /**
  * Start the session-cleanup BullMQ worker and enqueue a repeatable hourly job.

--- a/services/clinical-data/package.json
+++ b/services/clinical-data/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@carebridge/db-schema": "workspace:*",

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -1,4 +1,5 @@
 import { Queue } from "bullmq";
+import { getRedisConnection } from "@carebridge/redis-config";
 
 export interface ClinicalEvent {
   type: string;
@@ -8,12 +9,7 @@ export interface ClinicalEvent {
   payload?: Record<string, unknown>;
 }
 
-const connection = {
-  host: process.env.REDIS_HOST ?? "localhost",
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
-  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
-};
+const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,

--- a/services/clinical-notes/package.json
+++ b/services/clinical-notes/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@carebridge/db-schema": "workspace:*",

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -1,4 +1,5 @@
 import { Queue } from "bullmq";
+import { getRedisConnection } from "@carebridge/redis-config";
 
 export interface ClinicalEvent {
   type: string;
@@ -9,12 +10,7 @@ export interface ClinicalEvent {
   payload?: Record<string, unknown>;
 }
 
-const connection = {
-  host: process.env.REDIS_HOST ?? "localhost",
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
-  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
-};
+const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,


### PR DESCRIPTION
Closes #23

## Summary
- Created `@carebridge/redis-config` package with a shared `getRedisConnection()` function that reads `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`, and `REDIS_TLS` from environment variables with sensible defaults
- Replaced duplicated Redis connection config in 4 services: `ai-oversight`, `clinical-data`, `clinical-notes`, and `auth`
- Added 7 unit tests covering default values, individual env vars, empty password handling, and full configuration

## Test plan
- [x] `pnpm --filter @carebridge/redis-config test` passes (7/7 tests)
- [x] `pnpm --filter @carebridge/redis-config typecheck` passes
- [ ] Verify services connect to Redis correctly in dev environment