### PR TITLE
feat(auth): emit audit log on deactivated-user session rejection

### DIFF
--- a/services/api-gateway/src/__tests__/auth-middleware.test.ts
+++ b/services/api-gateway/src/__tests__/auth-middleware.test.ts
@@ -40,6 +40,8 @@ let latestSelectChain: ReturnType<typeof makeSelectChain>;
 
 const deletedSessionIds: string[] = [];
 
+const insertedAuditEntries: unknown[] = [];
+
 const mockDb = {
   select: vi.fn(() => {
     latestSelectChain = makeSelectChain();
@@ -52,12 +54,24 @@ const mockDb = {
       return Promise.resolve();
     }),
   })),
+  insert: vi.fn(() => ({
+    values: vi.fn((entry: unknown) => {
+      insertedAuditEntries.push(entry);
+      return Promise.resolve();
+    }),
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve()),
+    })),
+  })),
 };
 
 vi.mock("@carebridge/db-schema", () => ({
   getDb: () => mockDb,
   users: { id: "users.id" },
   sessions: { id: "sessions.id", user_id: "sessions.user_id" },
+  auditLog: { id: "audit_log.id" },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -118,6 +132,7 @@ describe("authMiddleware", () => {
     sessionRows = [];
     userRows = [];
     deletedSessionIds.length = 0;
+    insertedAuditEntries.length = 0;
   });
 
   it("allows an active user with a valid session", async () => {
@@ -193,5 +208,35 @@ describe("authMiddleware", () => {
 
     const user = (request as unknown as Record<string, unknown>).user;
     expect(user).toBeUndefined();
+  });
+
+  it("emits an audit log entry when rejecting a deactivated user session", async () => {
+    sessionRows = [{ id: "sess-inactive", user_id: "user-2", expires_at: FUTURE }];
+    userRows = [inactiveUser];
+
+    const request = makeRequest({
+      headers: { authorization: "Bearer sess-inactive" },
+      ip: "192.168.1.42",
+    });
+    const reply = makeReply();
+
+    await authMiddleware(request, reply);
+
+    // Allow the non-blocking audit insert to settle.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(insertedAuditEntries.length).toBe(1);
+
+    const entry = insertedAuditEntries[0] as Record<string, unknown>;
+    expect(entry.user_id).toBe("user-2");
+    expect(entry.action).toBe("session_rejected_inactive");
+    expect(entry.resource_type).toBe("session");
+    expect(entry.resource_id).toBe("sess-inactive");
+    expect(entry.ip_address).toBe("192.168.1.42");
+
+    const details = JSON.parse(entry.details as string);
+    expect(details.reason).toBe("User account is deactivated");
+    expect(details.ip_address).toBe("192.168.1.42");
   });
 });

--- a/services/api-gateway/src/middleware/auth.ts
+++ b/services/api-gateway/src/middleware/auth.ts
@@ -1,8 +1,9 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 import type { User } from "@carebridge/shared-types";
 import { getDb } from "@carebridge/db-schema";
-import { users, sessions } from "@carebridge/db-schema";
+import { users, sessions, auditLog } from "@carebridge/db-schema";
 import { eq } from "drizzle-orm";
+import crypto from "node:crypto";
 
 /** Hardcoded dev users for local development without a seeded database. */
 const DEV_USERS: Record<string, User> = {
@@ -146,6 +147,26 @@ export async function authMiddleware(
   // Reject deactivated users and clean up their session.
   if (!row.is_active) {
     await db.delete(sessions).where(eq(sessions.id, session.id));
+
+    // Non-blocking audit log for deactivated-user session rejection.
+    db.insert(auditLog)
+      .values({
+        id: crypto.randomUUID(),
+        user_id: row.id,
+        action: "session_rejected_inactive",
+        resource_type: "session",
+        resource_id: session.id,
+        details: JSON.stringify({
+          reason: "User account is deactivated",
+          ip_address: request.ip,
+        }),
+        ip_address: request.ip,
+        timestamp: new Date().toISOString(),
+      })
+      .catch(() => {
+        // Audit logging must never block or crash the rejection flow.
+      });
+
     _reply.code(401).send({ error: "Session expired" });
     return;
   }


### PR DESCRIPTION
## Summary

- When auth middleware rejects a deactivated user's session, an audit log entry is now written with action `session_rejected_inactive`, the session ID, and the client IP address
- The audit write is non-blocking (fire-and-forget with silent error catch) so it never slows down or breaks the 401 rejection flow
- Added test verifying the audit entry is created with correct fields

Closes #28