### PR TITLE
feat(db): add HMAC index column for encrypted MRN uniqueness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,5 +31,10 @@ PHI_ENCRYPTION_KEY=
 # After all rows are re-encrypted, remove this variable.
 PHI_ENCRYPTION_KEY_PREVIOUS=
 
+# PHI HMAC key for deterministic index columns (MRN uniqueness).
+# Should be a separate key from PHI_ENCRYPTION_KEY in production.
+# Falls back to PHI_ENCRYPTION_KEY if not set.
+PHI_HMAC_KEY=
+
 # Environment
 NODE_ENV=development

--- a/packages/db-schema/drizzle/0003_mrn_hmac_index.sql
+++ b/packages/db-schema/drizzle/0003_mrn_hmac_index.sql
@@ -1,0 +1,10 @@
+-- Add mrn_hmac column: deterministic HMAC-SHA256 of the MRN for uniqueness enforcement.
+-- Non-deterministic encryption prevents unique constraints on the ciphertext column,
+-- so this companion column stores a stable digest that the DB can index.
+
+ALTER TABLE "patients"
+  ADD COLUMN "mrn_hmac" text;
+
+-- Unique constraint for MRN uniqueness via HMAC digest.
+ALTER TABLE "patients"
+  ADD CONSTRAINT "patients_mrn_hmac_unique" UNIQUE ("mrn_hmac");

--- a/packages/db-schema/src/__tests__/hmac.test.ts
+++ b/packages/db-schema/src/__tests__/hmac.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { hmacForIndex, _resetKeyCache } from "../encryption.js";
+
+const TEST_KEY = randomBytes(32).toString("hex");
+
+describe("hmacForIndex", () => {
+  const originalEncKey = process.env.PHI_ENCRYPTION_KEY;
+  const originalHmacKey = process.env.PHI_HMAC_KEY;
+
+  before(() => {
+    _resetKeyCache();
+    process.env.PHI_ENCRYPTION_KEY = TEST_KEY;
+    delete process.env.PHI_HMAC_KEY;
+  });
+
+  after(() => {
+    _resetKeyCache();
+    if (originalEncKey !== undefined) {
+      process.env.PHI_ENCRYPTION_KEY = originalEncKey;
+    } else {
+      delete process.env.PHI_ENCRYPTION_KEY;
+    }
+    if (originalHmacKey !== undefined) {
+      process.env.PHI_HMAC_KEY = originalHmacKey;
+    } else {
+      delete process.env.PHI_HMAC_KEY;
+    }
+  });
+
+  it("is deterministic — same input always produces the same output", () => {
+    const mrn = "MCH-2026-0042";
+    const a = hmacForIndex(mrn);
+    const b = hmacForIndex(mrn);
+    assert.equal(a, b, "HMAC of the same MRN must be identical across calls");
+  });
+
+  it("returns a 64-character hex string (SHA-256 digest)", () => {
+    const result = hmacForIndex("MRN-12345");
+    assert.match(result, /^[0-9a-f]{64}$/, "Should be 64 hex characters");
+  });
+
+  it("produces different outputs for different inputs (uniqueness detection)", () => {
+    const hmac1 = hmacForIndex("MCH-2026-0042");
+    const hmac2 = hmacForIndex("MCH-2026-0043");
+    assert.notEqual(hmac1, hmac2, "Different MRNs must produce different HMACs");
+  });
+
+  it("uses PHI_HMAC_KEY when available instead of PHI_ENCRYPTION_KEY", () => {
+    const separateKey = randomBytes(32).toString("hex");
+    const hmacWithEncKey = hmacForIndex("TEST-MRN");
+
+    process.env.PHI_HMAC_KEY = separateKey;
+    const hmacWithHmacKey = hmacForIndex("TEST-MRN");
+    delete process.env.PHI_HMAC_KEY;
+
+    assert.notEqual(
+      hmacWithEncKey,
+      hmacWithHmacKey,
+      "HMAC should differ when using PHI_HMAC_KEY vs PHI_ENCRYPTION_KEY"
+    );
+  });
+
+  it("throws when neither PHI_HMAC_KEY nor PHI_ENCRYPTION_KEY is set", () => {
+    const savedEnc = process.env.PHI_ENCRYPTION_KEY;
+    delete process.env.PHI_ENCRYPTION_KEY;
+    delete process.env.PHI_HMAC_KEY;
+
+    assert.throws(
+      () => hmacForIndex("anything"),
+      /Neither PHI_HMAC_KEY nor PHI_ENCRYPTION_KEY/
+    );
+
+    process.env.PHI_ENCRYPTION_KEY = savedEnc;
+  });
+});

--- a/packages/db-schema/src/encrypt-existing.ts
+++ b/packages/db-schema/src/encrypt-existing.ts
@@ -11,7 +11,7 @@
  * Safe to run multiple times — already-encrypted values are skipped.
  */
 import postgres from "postgres";
-import { encrypt } from "./encryption.js";
+import { encrypt, decrypt, hmacForIndex } from "./encryption.js";
 
 const ENCRYPTED_PATTERN = /^[0-9a-f]{32}:[0-9a-f]{32}:[0-9a-f]+$/;
 
@@ -41,7 +41,7 @@ async function main() {
   const sql = postgres(databaseUrl);
 
   try {
-    const rows = await sql`SELECT id, ${sql(PHI_COLUMNS as unknown as string[])} FROM patients`;
+    const rows = await sql`SELECT id, mrn_hmac, ${sql(PHI_COLUMNS as unknown as string[])} FROM patients`;
 
     console.log(`Found ${rows.length} patient rows to process.`);
 
@@ -55,6 +55,14 @@ async function main() {
         if (value != null && typeof value === "string" && !isAlreadyEncrypted(value)) {
           updates[col] = encrypt(value, key);
         }
+      }
+
+      // Backfill mrn_hmac for rows that have an MRN but no HMAC yet
+      if (row.mrn != null && row.mrn_hmac == null) {
+        const plainMrn = isAlreadyEncrypted(row.mrn as string)
+          ? decrypt(row.mrn as string, key)
+          : row.mrn as string;
+        updates.mrn_hmac = hmacForIndex(plainMrn);
       }
 
       if (Object.keys(updates).length > 0) {

--- a/packages/db-schema/src/encryption.ts
+++ b/packages/db-schema/src/encryption.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, createHmac, randomBytes } from "node:crypto";
 import { customType } from "drizzle-orm/pg-core";
 
 const ALGORITHM = "aes-256-gcm";
@@ -102,6 +102,26 @@ export function decryptWithFallback(encrypted: string, currentKey: string | Buff
     }
     throw err;
   }
+}
+
+/**
+ * Compute a deterministic HMAC-SHA256 of a value for use as a unique index.
+ * Non-deterministic encryption (random IV) prevents the DB from enforcing
+ * uniqueness on ciphertext, so we store a separate HMAC digest that is
+ * stable for the same input, enabling a unique constraint in the schema.
+ *
+ * Uses PHI_HMAC_KEY when available; falls back to PHI_ENCRYPTION_KEY.
+ * In production these should be separate keys.
+ */
+export function hmacForIndex(value: string): string {
+  const key = process.env.PHI_HMAC_KEY ?? process.env.PHI_ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error(
+      "Neither PHI_HMAC_KEY nor PHI_ENCRYPTION_KEY environment variable is set. " +
+        "At least one is required to compute HMAC indexes."
+    );
+  }
+  return createHmac("sha256", key).update(value).digest("hex");
 }
 
 export const encryptedText = customType<{ data: string; driverData: string }>({

--- a/packages/db-schema/src/index.ts
+++ b/packages/db-schema/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./schema/index.js";
 export { getDb } from "./connection.js";
-export { encrypt, decrypt, decryptWithFallback, getKey, getPreviousKey, encryptedText } from "./encryption.js";
+export { encrypt, decrypt, decryptWithFallback, getKey, getPreviousKey, encryptedText, hmacForIndex } from "./encryption.js";

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -9,11 +9,11 @@ export const patients = pgTable("patients", {
   biological_sex: text("biological_sex").default("unknown"),
   diagnosis: text("diagnosis"),
   notes: text("notes"),
-  // NOTE: Non-deterministic encryption (random IV per write) means identical MRNs produce
-  // different ciphertexts. The DB unique constraint cannot enforce MRN uniqueness on the
-  // ciphertext. This is an intentional security trade-off — application-level dedup is
-  // required before insert to prevent duplicate MRNs.
+  // Non-deterministic encryption (random IV per write) means identical MRNs produce
+  // different ciphertexts. The `mrn_hmac` column stores a deterministic HMAC-SHA256
+  // digest so the DB unique constraint can enforce MRN uniqueness.
   mrn: encryptedText("mrn"),
+  mrn_hmac: text("mrn_hmac").unique(),
   insurance_id: encryptedText("insurance_id"),
   emergency_contact_name: encryptedText("emergency_contact_name"),
   emergency_contact_phone: encryptedText("emergency_contact_phone"),

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -1,6 +1,6 @@
 import { initTRPC } from "@trpc/server";
 import { z } from "zod";
-import { getDb } from "@carebridge/db-schema";
+import { getDb, hmacForIndex } from "@carebridge/db-schema";
 import { patients, diagnoses, allergies, careTeamMembers } from "@carebridge/db-schema";
 import { createPatientSchema, updatePatientSchema } from "@carebridge/validators";
 import { eq } from "drizzle-orm";
@@ -12,7 +12,8 @@ export const patientRecordsRouter = t.router({
   create: t.procedure.input(createPatientSchema).mutation(async ({ input }) => {
     const db = getDb();
     const now = new Date().toISOString();
-    const patient = { id: crypto.randomUUID(), ...input, created_at: now, updated_at: now };
+    const mrn_hmac = input.mrn ? hmacForIndex(input.mrn) : undefined;
+    const patient = { id: crypto.randomUUID(), ...input, mrn_hmac, created_at: now, updated_at: now };
     await db.insert(patients).values(patient);
     return patient;
   }),
@@ -22,7 +23,9 @@ export const patientRecordsRouter = t.router({
     .mutation(async ({ input }) => {
       const { id, ...data } = input;
       const db = getDb();
-      await db.update(patients).set({ ...data, updated_at: new Date().toISOString() }).where(eq(patients.id, id));
+      const mrn_hmac = data.mrn !== undefined ? (data.mrn ? hmacForIndex(data.mrn) : null) : undefined;
+      const updates = { ...data, ...(mrn_hmac !== undefined ? { mrn_hmac } : {}), updated_at: new Date().toISOString() };
+      await db.update(patients).set(updates).where(eq(patients.id, id));
       return { id, ...data };
     }),
 

--- a/tooling/seed/index.ts
+++ b/tooling/seed/index.ts
@@ -8,6 +8,7 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "@carebridge/db-schema";
+import { hmacForIndex } from "@carebridge/db-schema";
 import crypto from "node:crypto";
 
 const connectionString = process.env.DATABASE_URL
@@ -88,6 +89,7 @@ async function seed() {
     diagnosis: "Stage III Breast Cancer, DVT right lower extremity",
     notes: "Cancer-associated hypercoagulable state. IVC filter placed Feb 2026.",
     mrn: "MCH-2026-0042",
+    mrn_hmac: hmacForIndex("MCH-2026-0042"),
     primary_provider_id: drSmith,
     created_at: daysAgo(90),
     updated_at: now(),
@@ -200,6 +202,7 @@ async function seed() {
     biological_sex: "male",
     diagnosis: "Type 2 Diabetes, Hypertension",
     mrn: "RWL-2026-0108",
+    mrn_hmac: hmacForIndex("RWL-2026-0108"),
     primary_provider_id: drSmith,
     created_at: daysAgo(60),
     updated_at: now(),


### PR DESCRIPTION
## Summary
- Adds `mrn_hmac` column (unique, text) to the patients table storing HMAC-SHA256 of the MRN, solving uniqueness enforcement broken by non-deterministic AES-256-GCM encryption
- Adds `hmacForIndex()` utility in `packages/db-schema/src/encryption.ts` using `PHI_HMAC_KEY` (falls back to `PHI_ENCRYPTION_KEY`)
- Updates patient-records service to compute and store `mrn_hmac` on create/update
- Includes Drizzle migration (`0003_mrn_hmac_index.sql`), seed data updates, and backfill logic in `encrypt-existing.ts`
- Adds `PHI_HMAC_KEY` to `.env.example`

## Test plan
- [x] 5 unit tests for HMAC determinism, hex format, uniqueness detection, key selection, and missing-key error
- [x] All existing encryption tests still pass
- [x] TypeScript compiles cleanly

Closes #27