### PR TITLE
feat(auth): add rate limiting to MFA code verification

### DIFF
--- a/services/auth/src/__tests__/mfa-rate-limit.test.ts
+++ b/services/auth/src/__tests__/mfa-rate-limit.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  checkMFARateLimit,
+  recordMFAAttempt,
+  clearMFAAttempts,
+  _resetAllAttempts,
+  MFA_MAX_ATTEMPTS,
+  MFA_WINDOW_MS,
+} from "../mfa-rate-limit.js";
+
+describe("MFA rate limiter", () => {
+  beforeEach(() => {
+    _resetAllAttempts();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("allows the first attempt", () => {
+    const result = checkMFARateLimit("session-1");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows up to MAX_ATTEMPTS failed attempts", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      expect(checkMFARateLimit("session-1").allowed).toBe(true);
+      recordMFAAttempt("session-1");
+    }
+  });
+
+  it("blocks after MAX_ATTEMPTS failed attempts", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+    const result = checkMFARateLimit("session-1");
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(MFA_WINDOW_MS);
+  });
+
+  it("returns correct retryAfterMs", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+
+    // Advance 5 minutes
+    vi.advanceTimersByTime(5 * 60 * 1000);
+
+    const result = checkMFARateLimit("session-1");
+    expect(result.allowed).toBe(false);
+    // Should be roughly 10 minutes remaining
+    expect(result.retryAfterMs).toBeLessThanOrEqual(10 * 60 * 1000);
+    expect(result.retryAfterMs).toBeGreaterThan(9 * 60 * 1000);
+  });
+
+  it("resets after the window expires", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+
+    // Advance past the window
+    vi.advanceTimersByTime(MFA_WINDOW_MS + 1);
+
+    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+  });
+
+  it("clearMFAAttempts resets the counter for a key", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+
+    clearMFAAttempts("session-1");
+    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+  });
+
+  it("tracks separate keys independently", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-a");
+    }
+    expect(checkMFARateLimit("session-a").allowed).toBe(false);
+    expect(checkMFARateLimit("session-b").allowed).toBe(true);
+  });
+
+  it("recordMFAAttempt resets if window has expired", () => {
+    recordMFAAttempt("session-1");
+    recordMFAAttempt("session-1");
+
+    // Advance past the window
+    vi.advanceTimersByTime(MFA_WINDOW_MS + 1);
+
+    // This should start a fresh window
+    recordMFAAttempt("session-1");
+    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+
+    // Should be able to do MAX_ATTEMPTS - 1 more (already recorded 1 above)
+    for (let i = 1; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+  });
+
+  it("reports retryAfterMs in minutes correctly for error messages", () => {
+    for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
+      recordMFAAttempt("session-1");
+    }
+
+    const result = checkMFARateLimit("session-1");
+    expect(result.allowed).toBe(false);
+
+    const retryMinutes = Math.ceil((result.retryAfterMs ?? 0) / 60_000);
+    expect(retryMinutes).toBe(15);
+  });
+});

--- a/services/auth/src/mfa-rate-limit.ts
+++ b/services/auth/src/mfa-rate-limit.ts
@@ -1,0 +1,81 @@
+/**
+ * In-memory rate limiter for MFA verification attempts.
+ * Prevents brute-force attacks on TOTP codes and recovery codes.
+ *
+ * - Max 5 attempts per 15-minute window
+ * - After 5 failed attempts, locked out for 15 minutes from the first attempt
+ * - Successful verification clears the attempt history
+ */
+
+const MFA_MAX_ATTEMPTS = 5;
+const MFA_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+interface AttemptRecord {
+  count: number;
+  firstAttempt: number;
+}
+
+const mfaAttempts = new Map<string, AttemptRecord>();
+
+/**
+ * Check whether an MFA attempt is allowed for the given key.
+ * Returns { allowed: true } if within limits, or
+ * { allowed: false, retryAfterMs } if the limit has been exceeded.
+ */
+export function checkMFARateLimit(key: string): {
+  allowed: boolean;
+  retryAfterMs?: number;
+} {
+  const record = mfaAttempts.get(key);
+  if (!record) {
+    return { allowed: true };
+  }
+
+  const elapsed = Date.now() - record.firstAttempt;
+
+  // Window has expired -- reset
+  if (elapsed >= MFA_WINDOW_MS) {
+    mfaAttempts.delete(key);
+    return { allowed: true };
+  }
+
+  // Under the limit
+  if (record.count < MFA_MAX_ATTEMPTS) {
+    return { allowed: true };
+  }
+
+  // Locked out
+  const retryAfterMs = MFA_WINDOW_MS - elapsed;
+  return { allowed: false, retryAfterMs };
+}
+
+/**
+ * Record a failed MFA attempt for the given key.
+ */
+export function recordMFAAttempt(key: string): void {
+  const now = Date.now();
+  const record = mfaAttempts.get(key);
+
+  if (!record || now - record.firstAttempt >= MFA_WINDOW_MS) {
+    mfaAttempts.set(key, { count: 1, firstAttempt: now });
+    return;
+  }
+
+  record.count += 1;
+}
+
+/**
+ * Clear MFA attempt history on successful verification.
+ */
+export function clearMFAAttempts(key: string): void {
+  mfaAttempts.delete(key);
+}
+
+/**
+ * Exposed for testing: reset all rate-limit state.
+ */
+export function _resetAllAttempts(): void {
+  mfaAttempts.clear();
+}
+
+export { MFA_MAX_ATTEMPTS, MFA_WINDOW_MS };

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -19,6 +19,11 @@ import {
   verifyRecoveryCode,
   buildOTPAuthURI,
 } from "./totp.js";
+import {
+  checkMFARateLimit,
+  recordMFAAttempt,
+  clearMFAAttempts,
+} from "./mfa-rate-limit.js";
 
 // ---------- tRPC setup (mirrors api-gateway's context shape) ----------
 
@@ -180,6 +185,16 @@ export const authRouter = t.router({
   mfaCompleteLogin: publicProcedure
     .input(mfaCompleteLoginSchema)
     .mutation(async ({ input }) => {
+      // Rate-limit check keyed on mfaSessionId
+      const rateLimit = checkMFARateLimit(input.mfaSessionId);
+      if (!rateLimit.allowed) {
+        const retryMinutes = Math.ceil((rateLimit.retryAfterMs ?? 0) / 60_000);
+        throw new TRPCError({
+          code: "TOO_MANY_REQUESTS",
+          message: `Too many MFA attempts. Try again in ${retryMinutes} minute${retryMinutes === 1 ? "" : "s"}.`,
+        });
+      }
+
       const db = getDb();
       const pending = pendingMFASessions.get(input.mfaSessionId);
 
@@ -235,13 +250,15 @@ export const authRouter = t.router({
       }
 
       if (!verified) {
+        recordMFAAttempt(input.mfaSessionId);
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Invalid MFA code.",
         });
       }
 
-      // Clean up the pending session
+      // Successful verification -- clear rate-limit history and pending session
+      clearMFAAttempts(input.mfaSessionId);
       pendingMFASessions.delete(input.mfaSessionId);
 
       // Create real session


### PR DESCRIPTION
## Summary
- Adds in-memory rate limiting to the `mfaCompleteLogin` procedure to prevent brute-force attacks on TOTP and recovery codes
- Limits MFA verification to 5 attempts per 15-minute window, returning a clear retry-after message when exceeded
- Successful verification clears the attempt counter; window auto-expires after 15 minutes

## Implementation
- New `mfa-rate-limit.ts` module with `checkMFARateLimit`, `recordMFAAttempt`, and `clearMFAAttempts` using a simple `Map<string, { count, firstAttempt }>`
- Rate limit keyed on `mfaSessionId` and integrated into the `mfaCompleteLogin` mutation
- No new dependencies required

## Test plan
- [x] 9 unit tests covering: allow/block thresholds, window expiry, clear on success, independent key tracking, retry-after calculation
- [x] All 42 existing auth tests continue to pass

Closes #32