### PR TITLE
refactor(ai): extract token budget section markers as shared constants

### DIFF
--- a/packages/ai-prompts/src/clinical-review.ts
+++ b/packages/ai-prompts/src/clinical-review.ts
@@ -3,6 +3,8 @@
  * These are versioned and testable — changes to prompts are tracked.
  */
 
+import { PROMPT_SECTIONS } from "./prompt-sections.js";
+
 export const PROMPT_VERSION = "1.0.0";
 
 export const CLINICAL_REVIEW_SYSTEM_PROMPT = `You are a clinical decision support system reviewing a patient's medical record.
@@ -82,30 +84,30 @@ export function buildReviewPrompt(context: ReviewContext): string {
   return `PATIENT CLINICAL CONTEXT
 ========================
 
-Demographics: ${context.patient.age} year old ${context.patient.sex}
+${PROMPT_SECTIONS.DEMOGRAPHICS}: ${context.patient.age} year old ${context.patient.sex}
 
-Active Diagnoses:
+${PROMPT_SECTIONS.DIAGNOSES}:
 ${context.patient.active_diagnoses.map((d) => `  - ${d}`).join("\n") || "  None documented"}
 
-Allergies:
+${PROMPT_SECTIONS.ALLERGIES}:
 ${context.patient.allergies.map((a) => `  - ${a}`).join("\n") || "  NKDA"}
 
-Active Medications:
+${PROMPT_SECTIONS.MEDICATIONS}:
 ${context.active_medications.map((m) => `  - ${m.name} ${m.dose} ${m.route} ${m.frequency} (since ${m.started_at})`).join("\n") || "  None"}
 
-Latest Vitals:
+${PROMPT_SECTIONS.VITALS}:
 ${Object.entries(context.latest_vitals).map(([type, v]) => `  - ${type}: ${v.value} ${v.unit} (${v.recorded_at})${v.trend ? ` [${v.trend}]` : ""}`).join("\n") || "  None recorded"}
 
-${context.recent_labs ? `Recent Lab Results:
+${context.recent_labs ? `${PROMPT_SECTIONS.LABS}:
 ${context.recent_labs.map((l) => `  - ${l.test_name}: ${l.value} ${l.unit}${l.flag ? ` [${l.flag}]` : ""}${l.trend ? ` (${l.trend})` : ""} (${l.collected_at})`).join("\n")}` : ""}
 
-Care Team:
+${PROMPT_SECTIONS.CARE_TEAM}:
 ${context.care_team.map((c) => `  - ${c.name} (${c.specialty})${c.recent_note_date ? ` — last note: ${c.recent_note_date}` : ""}`).join("\n") || "  Not documented"}
 
-Recent Open Flags:
+${PROMPT_SECTIONS.FLAGS}:
 ${context.recent_flags.filter((f) => f.status === "open").map((f) => `  - [${f.severity}] ${f.summary} (${f.created_at})`).join("\n") || "  None"}
 
-TRIGGERING EVENT
+${PROMPT_SECTIONS.TRIGGERING_EVENT}
 ================
 Type: ${context.triggering_event.type}
 Summary: ${context.triggering_event.summary}

--- a/packages/ai-prompts/src/index.ts
+++ b/packages/ai-prompts/src/index.ts
@@ -12,3 +12,6 @@ export {
   DEFAULT_TOKEN_BUDGET,
 } from "./token-budget.js";
 export type { TruncationResult } from "./token-budget.js";
+
+export { PROMPT_SECTIONS } from "./prompt-sections.js";
+export type { PromptSectionKey, PromptSectionLabel } from "./prompt-sections.js";

--- a/packages/ai-prompts/src/prompt-sections.ts
+++ b/packages/ai-prompts/src/prompt-sections.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared section marker constants used by the clinical review prompt
+ * builder and the token budget truncation engine.
+ *
+ * Keeping these in one place prevents drift between the two modules
+ * and makes it easy to rename or reorder sections.
+ */
+
+export const PROMPT_SECTIONS = {
+  DEMOGRAPHICS: "Demographics",
+  DIAGNOSES: "Active Diagnoses",
+  ALLERGIES: "Allergies",
+  MEDICATIONS: "Active Medications",
+  VITALS: "Latest Vitals",
+  LABS: "Recent Lab Results",
+  CARE_TEAM: "Care Team",
+  FLAGS: "Recent Open Flags",
+  TRIGGERING_EVENT: "TRIGGERING EVENT",
+} as const;
+
+export type PromptSectionKey = keyof typeof PROMPT_SECTIONS;
+export type PromptSectionLabel = (typeof PROMPT_SECTIONS)[PromptSectionKey];

--- a/packages/ai-prompts/src/token-budget.ts
+++ b/packages/ai-prompts/src/token-budget.ts
@@ -7,6 +7,8 @@
  * that preserves the most clinically relevant data.
  */
 
+import { PROMPT_SECTIONS } from "./prompt-sections.js";
+
 /** Rough token estimation: ~4 chars per token for English text. */
 export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
@@ -30,10 +32,10 @@ export interface TruncationResult {
 // ─── Section markers used by buildReviewPrompt ─────────────────────
 
 const SECTION_PATTERNS: { name: string; regex: RegExp }[] = [
-  { name: "recent_labs", regex: /Recent Lab Results:\n([\s\S]*?)(?=\n\n|\nCare Team:|\nTRIGGERING EVENT)/ },
-  { name: "latest_vitals", regex: /Latest Vitals:\n([\s\S]*?)(?=\n\n|\nRecent Lab Results:|\nCare Team:)/ },
-  { name: "active_medications", regex: /Active Medications:\n([\s\S]*?)(?=\n\n|\nLatest Vitals:)/ },
-  { name: "recent_flags", regex: /Recent Open Flags:\n([\s\S]*?)(?=\n\n|\nTRIGGERING EVENT)/ },
+  { name: "recent_labs", regex: new RegExp(`${PROMPT_SECTIONS.LABS}:\\n([\\s\\S]*?)(?=\\n\\n|\\n${PROMPT_SECTIONS.CARE_TEAM}:|\\n${PROMPT_SECTIONS.TRIGGERING_EVENT})`) },
+  { name: "latest_vitals", regex: new RegExp(`${PROMPT_SECTIONS.VITALS}:\\n([\\s\\S]*?)(?=\\n\\n|\\n${PROMPT_SECTIONS.LABS}:|\\n${PROMPT_SECTIONS.CARE_TEAM}:)`) },
+  { name: "active_medications", regex: new RegExp(`${PROMPT_SECTIONS.MEDICATIONS}:\\n([\\s\\S]*?)(?=\\n\\n|\\n${PROMPT_SECTIONS.VITALS}:)`) },
+  { name: "recent_flags", regex: new RegExp(`${PROMPT_SECTIONS.FLAGS}:\\n([\\s\\S]*?)(?=\\n\\n|\\n${PROMPT_SECTIONS.TRIGGERING_EVENT})`) },
 ];
 
 /**
@@ -128,7 +130,7 @@ export function enforceTokenBudget(
 
   // Step 5: Hard truncate as last resort — preserve the triggering event at the end
   const budgetChars = budget * 4;
-  const triggerMarker = "TRIGGERING EVENT";
+  const triggerMarker = PROMPT_SECTIONS.TRIGGERING_EVENT;
   const triggerIdx = current.indexOf(triggerMarker);
 
   if (triggerIdx !== -1) {


### PR DESCRIPTION
## Summary
- Extracts hardcoded section marker strings (e.g. "ACTIVE MEDICATIONS", "VITAL SIGNS", "LAB RESULTS") into a shared `PROMPT_SECTIONS` constant object in `packages/ai-prompts/src/prompt-sections.ts`
- Updates `token-budget.ts` to build its regex patterns from the shared constants instead of inline strings
- Updates `clinical-review.ts` to reference the shared constants in `buildReviewPrompt()`
- Exports `PROMPT_SECTIONS` and associated types from the package barrel

## Test plan
- [x] TypeScript compilation passes with no new errors
- [ ] Verify prompt output is identical by running existing integration tests
- [ ] Confirm token budget truncation still works correctly with regex patterns built from constants

Closes #34