### PR TITLE
feat(auth): encrypt MFA secret at rest

### DIFF
--- a/packages/db-schema/src/__tests__/mfa-secret-encryption.test.ts
+++ b/packages/db-schema/src/__tests__/mfa-secret-encryption.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import { encrypt, decrypt, getKey, _resetKeyCache } from "../encryption.js";
+
+const TEST_KEY = randomBytes(32).toString("hex");
+
+describe("MFA secret encryption at rest", () => {
+  const originalKey = process.env.PHI_ENCRYPTION_KEY;
+
+  before(() => {
+    _resetKeyCache();
+    process.env.PHI_ENCRYPTION_KEY = TEST_KEY;
+  });
+
+  after(() => {
+    _resetKeyCache();
+    if (originalKey !== undefined) {
+      process.env.PHI_ENCRYPTION_KEY = originalKey;
+    } else {
+      delete process.env.PHI_ENCRYPTION_KEY;
+    }
+  });
+
+  it("stored value is encrypted (not the plaintext TOTP secret)", () => {
+    const secret = "JBSWY3DPEHPK3PXP"; // sample base32 TOTP secret
+    const key = getKey();
+
+    // Simulate what encryptedText.toDriver does on write
+    const stored = encrypt(secret, key);
+
+    // The value persisted to the database must NOT be the plaintext
+    assert.notEqual(stored, secret, "Stored value must not be the plaintext secret");
+
+    // It must not contain the plaintext as a substring either
+    assert.ok(
+      !stored.includes(secret),
+      "Stored value must not contain the plaintext secret",
+    );
+
+    // It should be in the iv:authTag:ciphertext format
+    const parts = stored.split(":");
+    assert.equal(parts.length, 3, "Expected iv:authTag:ciphertext format");
+  });
+
+  it("decrypts back to the original TOTP secret", () => {
+    const secret = "JBSWY3DPEHPK3PXP";
+    const key = getKey();
+
+    const stored = encrypt(secret, key);
+    const recovered = decrypt(stored, key);
+
+    assert.equal(recovered, secret, "Decrypted value must match original secret");
+  });
+
+  it("each write produces a different ciphertext (unique IVs)", () => {
+    const secret = "JBSWY3DPEHPK3PXP";
+    const key = getKey();
+
+    const a = encrypt(secret, key);
+    const b = encrypt(secret, key);
+
+    assert.notEqual(a, b, "Each encryption must produce a unique ciphertext");
+
+    // Both must still decrypt correctly
+    assert.equal(decrypt(a, key), secret);
+    assert.equal(decrypt(b, key), secret);
+  });
+});

--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -1,4 +1,5 @@
 import { pgTable, text, boolean, index } from "drizzle-orm/pg-core";
+import { encryptedText } from "../encryption.js";
 
 export const users = pgTable("users", {
   id: text("id").primaryKey(),
@@ -9,7 +10,7 @@ export const users = pgTable("users", {
   specialty: text("specialty"),
   department: text("department"),
   is_active: boolean("is_active").notNull().default(true),
-  mfa_secret: text("mfa_secret"), // encrypted TOTP secret, null if MFA not set up
+  mfa_secret: encryptedText("mfa_secret"), // encrypted TOTP secret, null if MFA not set up
   mfa_enabled: boolean("mfa_enabled").default(false),
   recovery_codes: text("recovery_codes"), // JSON array of hashed recovery codes
   created_at: text("created_at").notNull(),


### PR DESCRIPTION
## Summary
- Changed the `mfa_secret` column in the users table from `text()` to `encryptedText()`, which uses AES-256-GCM encryption via `PHI_ENCRYPTION_KEY`
- The `encryptedText` custom Drizzle type transparently encrypts on write and decrypts on read, so the auth router's TOTP logic works unchanged
- Added tests confirming the stored value is encrypted (not plaintext), decrypts correctly, and uses unique IVs per write

Closes #33