### PR TITLE
Add client-side session expiry handling and auto-logout on 401

### DIFF
--- a/apps/clinician-portal/src/lib/auth.tsx
+++ b/apps/clinician-portal/src/lib/auth.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useState, useCallback, useEffect } from "react";
 import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { SessionExpiryProvider } from "./session-expiry.js";
 
 interface User {
   id: string;
@@ -26,6 +28,8 @@ const SESSION_KEY = "carebridge_session";
 const USER_KEY = "carebridge_user";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
   const [user, setUser] = useState<User | null>(() => {
     if (typeof window === "undefined") return null;
     try {
@@ -55,6 +59,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionId(null);
   }, []);
 
+  const handleSessionExpiry = useCallback(() => {
+    clearSession();
+    router.replace("/login");
+  }, [clearSession, router]);
+
+  const isAuthenticated = !!user && !!sessionId;
+
   return (
     <AuthContext.Provider
       value={{
@@ -62,10 +73,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         sessionId,
         setSession,
         clearSession,
-        isAuthenticated: !!user && !!sessionId,
+        isAuthenticated,
       }}
     >
-      {children}
+      <SessionExpiryProvider
+        isAuthenticated={isAuthenticated}
+        onLogout={handleSessionExpiry}
+      >
+        {children}
+      </SessionExpiryProvider>
     </AuthContext.Provider>
   );
 }

--- a/apps/clinician-portal/src/lib/session-expiry.tsx
+++ b/apps/clinician-portal/src/lib/session-expiry.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import type { ReactNode } from "react";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const IDLE_WARNING_MS = 14 * 60 * 1000; // 14 minutes
+const IDLE_LOGOUT_MS = 15 * 60 * 1000; // 15 minutes
+const LAST_ACTIVITY_KEY = "carebridge_last_activity";
+const SESSION_EXPIRED_KEY = "carebridge_session_expired";
+const ACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
+  "mousedown",
+  "keydown",
+  "scroll",
+  "touchstart",
+];
+
+// ── Session expiry event bus (for 401 interception) ────────────────────────────
+
+type SessionExpiredListener = () => void;
+const listeners = new Set<SessionExpiredListener>();
+
+export function onSessionExpired(listener: SessionExpiredListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function emitSessionExpired(): void {
+  listeners.forEach((fn) => fn());
+}
+
+// ── 401-intercepting fetch wrapper ─────────────────────────────────────────────
+
+/**
+ * Wraps the global fetch to detect 401 responses. When a 401 is received,
+ * clears the session from localStorage and triggers the session-expired flow.
+ */
+export function createAuthFetch(): typeof fetch {
+  return async (input, init) => {
+    const response = await fetch(input, init);
+
+    if (response.status === 401) {
+      localStorage.removeItem("carebridge_session");
+      localStorage.removeItem("carebridge_user");
+      localStorage.setItem(SESSION_EXPIRED_KEY, "true");
+      emitSessionExpired();
+    }
+
+    return response;
+  };
+}
+
+// ── Session Expiry Context ─────────────────────────────────────────────────────
+
+interface SessionExpiryContextValue {
+  showWarning: boolean;
+  showExpiredToast: boolean;
+  dismissExpiredToast: () => void;
+  secondsRemaining: number;
+}
+
+const SessionExpiryContext = createContext<SessionExpiryContextValue>({
+  showWarning: false,
+  showExpiredToast: false,
+  dismissExpiredToast: () => {},
+  secondsRemaining: 60,
+});
+
+export function useSessionExpiry(): SessionExpiryContextValue {
+  return useContext(SessionExpiryContext);
+}
+
+// ── Provider ───────────────────────────────────────────────────────────────────
+
+interface SessionExpiryProviderProps {
+  children: ReactNode;
+  isAuthenticated: boolean;
+  onLogout: () => void;
+}
+
+export function SessionExpiryProvider({
+  children,
+  isAuthenticated,
+  onLogout,
+}: SessionExpiryProviderProps) {
+  const [showWarning, setShowWarning] = useState(false);
+  const [showExpiredToast, setShowExpiredToast] = useState(false);
+  const [secondsRemaining, setSecondsRemaining] = useState(60);
+
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const logoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearAllTimers = useCallback(() => {
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+    if (logoutTimerRef.current) clearTimeout(logoutTimerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    warningTimerRef.current = null;
+    logoutTimerRef.current = null;
+    countdownRef.current = null;
+  }, []);
+
+  const performLogout = useCallback(() => {
+    clearAllTimers();
+    setShowWarning(false);
+    setShowExpiredToast(true);
+    localStorage.setItem(SESSION_EXPIRED_KEY, "true");
+    onLogout();
+  }, [clearAllTimers, onLogout]);
+
+  const resetIdleTimers = useCallback(() => {
+    if (!isAuthenticated) return;
+
+    clearAllTimers();
+    setShowWarning(false);
+    setSecondsRemaining(60);
+    localStorage.setItem(LAST_ACTIVITY_KEY, Date.now().toString());
+
+    warningTimerRef.current = setTimeout(() => {
+      setShowWarning(true);
+      setSecondsRemaining(60);
+
+      countdownRef.current = setInterval(() => {
+        setSecondsRemaining((prev) => {
+          if (prev <= 1) {
+            if (countdownRef.current) clearInterval(countdownRef.current);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }, IDLE_WARNING_MS);
+
+    logoutTimerRef.current = setTimeout(() => {
+      performLogout();
+    }, IDLE_LOGOUT_MS);
+  }, [isAuthenticated, clearAllTimers, performLogout]);
+
+  // Set up activity listeners
+  useEffect(() => {
+    if (!isAuthenticated) {
+      clearAllTimers();
+      return;
+    }
+
+    resetIdleTimers();
+
+    const handleActivity = () => resetIdleTimers();
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, handleActivity, { passive: true });
+    }
+
+    return () => {
+      clearAllTimers();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, handleActivity);
+      }
+    };
+  }, [isAuthenticated, resetIdleTimers, clearAllTimers]);
+
+  // Listen for 401-triggered session expiry
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const unsubscribe = onSessionExpired(() => {
+      clearAllTimers();
+      setShowWarning(false);
+      setShowExpiredToast(true);
+      onLogout();
+    });
+
+    return unsubscribe;
+  }, [isAuthenticated, clearAllTimers, onLogout]);
+
+  // Check if we should show the expired toast on mount (e.g. after redirect)
+  useEffect(() => {
+    if (localStorage.getItem(SESSION_EXPIRED_KEY) === "true") {
+      setShowExpiredToast(true);
+      localStorage.removeItem(SESSION_EXPIRED_KEY);
+    }
+  }, []);
+
+  const dismissExpiredToast = useCallback(() => {
+    setShowExpiredToast(false);
+  }, []);
+
+  return (
+    <SessionExpiryContext.Provider
+      value={{ showWarning, showExpiredToast, dismissExpiredToast, secondsRemaining }}
+    >
+      {children}
+      {showWarning && <IdleWarningBanner secondsRemaining={secondsRemaining} />}
+      {showExpiredToast && (
+        <SessionExpiredToast onDismiss={dismissExpiredToast} />
+      )}
+    </SessionExpiryContext.Provider>
+  );
+}
+
+// ── UI Components ──────────────────────────────────────────────────────────────
+
+function IdleWarningBanner({ secondsRemaining }: { secondsRemaining: number }) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10000,
+        backgroundColor: "#f59e0b",
+        color: "#1a1a1a",
+        padding: "12px 20px",
+        textAlign: "center",
+        fontWeight: 600,
+        fontSize: "14px",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+      }}
+    >
+      Session expiring in {secondsRemaining} second
+      {secondsRemaining !== 1 ? "s" : ""}. Move your mouse or press a key to
+      stay logged in.
+    </div>
+  );
+}
+
+function SessionExpiredToast({ onDismiss }: { onDismiss: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 8000);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 20,
+        right: 20,
+        zIndex: 10001,
+        backgroundColor: "#ef4444",
+        color: "#fff",
+        padding: "14px 24px",
+        borderRadius: "8px",
+        fontSize: "14px",
+        fontWeight: 500,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+        maxWidth: "400px",
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+      }}
+    >
+      <span style={{ flex: 1 }}>
+        Your session has expired. Please log in again.
+      </span>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        style={{
+          background: "none",
+          border: "none",
+          color: "#fff",
+          cursor: "pointer",
+          fontSize: "18px",
+          lineHeight: 1,
+          padding: "0 4px",
+        }}
+      >
+        x
+      </button>
+    </div>
+  );
+}

--- a/apps/clinician-portal/src/lib/trpc.ts
+++ b/apps/clinician-portal/src/lib/trpc.ts
@@ -3,6 +3,7 @@
 import { createTRPCReact, httpBatchLink } from "@trpc/react-query";
 import { createTRPCClient, httpBatchLink as vanillaHttpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@carebridge/api-gateway/src/router.js";
+import { createAuthFetch } from "./session-expiry.js";
 
 /**
  * React Query-integrated tRPC hooks for use inside components.
@@ -18,12 +19,18 @@ function getSessionToken(): string | undefined {
 }
 
 /**
+ * Fetch wrapper that intercepts 401 responses and triggers session expiry.
+ */
+const authFetch = typeof window !== "undefined" ? createAuthFetch() : fetch;
+
+/**
  * Create links array for the tRPC React provider.
  */
 export function getTRPCLinks() {
   return [
     httpBatchLink({
       url: "http://localhost:4000/trpc",
+      fetch: authFetch,
       headers() {
         const token = getSessionToken();
         return token ? { Authorization: `Bearer ${token}` } : {};
@@ -39,6 +46,7 @@ export const trpcVanilla = createTRPCClient<AppRouter>({
   links: [
     vanillaHttpBatchLink({
       url: "http://localhost:4000/trpc",
+      fetch: authFetch,
       headers() {
         const token = getSessionToken();
         return token ? { Authorization: `Bearer ${token}` } : {};

--- a/apps/patient-portal/src/lib/auth.tsx
+++ b/apps/patient-portal/src/lib/auth.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useState, useCallback } from "react";
 import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { SessionExpiryProvider } from "./session-expiry.js";
 
 interface User {
   id: string;
@@ -24,6 +26,8 @@ const SESSION_KEY = "carebridge_session";
 const USER_KEY = "carebridge_user";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+
   const [user, setUser] = useState<User | null>(() => {
     if (typeof window === "undefined") return null;
     try {
@@ -53,6 +57,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionId(null);
   }, []);
 
+  const handleSessionExpiry = useCallback(() => {
+    clearSession();
+    router.replace("/login");
+  }, [clearSession, router]);
+
+  const isAuthenticated = !!user && !!sessionId;
+
   return (
     <AuthContext.Provider
       value={{
@@ -60,10 +71,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         sessionId,
         setSession,
         clearSession,
-        isAuthenticated: !!user && !!sessionId,
+        isAuthenticated,
       }}
     >
-      {children}
+      <SessionExpiryProvider
+        isAuthenticated={isAuthenticated}
+        onLogout={handleSessionExpiry}
+      >
+        {children}
+      </SessionExpiryProvider>
     </AuthContext.Provider>
   );
 }

--- a/apps/patient-portal/src/lib/session-expiry.tsx
+++ b/apps/patient-portal/src/lib/session-expiry.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import type { ReactNode } from "react";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const IDLE_WARNING_MS = 14 * 60 * 1000; // 14 minutes
+const IDLE_LOGOUT_MS = 15 * 60 * 1000; // 15 minutes
+const LAST_ACTIVITY_KEY = "carebridge_last_activity";
+const SESSION_EXPIRED_KEY = "carebridge_session_expired";
+const ACTIVITY_EVENTS: Array<keyof WindowEventMap> = [
+  "mousedown",
+  "keydown",
+  "scroll",
+  "touchstart",
+];
+
+// ── Session expiry event bus (for 401 interception) ────────────────────────────
+
+type SessionExpiredListener = () => void;
+const listeners = new Set<SessionExpiredListener>();
+
+export function onSessionExpired(listener: SessionExpiredListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function emitSessionExpired(): void {
+  listeners.forEach((fn) => fn());
+}
+
+// ── 401-intercepting fetch wrapper ─────────────────────────────────────────────
+
+/**
+ * Wraps the global fetch to detect 401 responses. When a 401 is received,
+ * clears the session from localStorage and triggers the session-expired flow.
+ */
+export function createAuthFetch(): typeof fetch {
+  return async (input, init) => {
+    const response = await fetch(input, init);
+
+    if (response.status === 401) {
+      localStorage.removeItem("carebridge_session");
+      localStorage.removeItem("carebridge_user");
+      localStorage.setItem(SESSION_EXPIRED_KEY, "true");
+      emitSessionExpired();
+    }
+
+    return response;
+  };
+}
+
+// ── Session Expiry Context ─────────────────────────────────────────────────────
+
+interface SessionExpiryContextValue {
+  showWarning: boolean;
+  showExpiredToast: boolean;
+  dismissExpiredToast: () => void;
+  secondsRemaining: number;
+}
+
+const SessionExpiryContext = createContext<SessionExpiryContextValue>({
+  showWarning: false,
+  showExpiredToast: false,
+  dismissExpiredToast: () => {},
+  secondsRemaining: 60,
+});
+
+export function useSessionExpiry(): SessionExpiryContextValue {
+  return useContext(SessionExpiryContext);
+}
+
+// ── Provider ───────────────────────────────────────────────────────────────────
+
+interface SessionExpiryProviderProps {
+  children: ReactNode;
+  isAuthenticated: boolean;
+  onLogout: () => void;
+}
+
+export function SessionExpiryProvider({
+  children,
+  isAuthenticated,
+  onLogout,
+}: SessionExpiryProviderProps) {
+  const [showWarning, setShowWarning] = useState(false);
+  const [showExpiredToast, setShowExpiredToast] = useState(false);
+  const [secondsRemaining, setSecondsRemaining] = useState(60);
+
+  const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const logoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearAllTimers = useCallback(() => {
+    if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
+    if (logoutTimerRef.current) clearTimeout(logoutTimerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    warningTimerRef.current = null;
+    logoutTimerRef.current = null;
+    countdownRef.current = null;
+  }, []);
+
+  const performLogout = useCallback(() => {
+    clearAllTimers();
+    setShowWarning(false);
+    setShowExpiredToast(true);
+    localStorage.setItem(SESSION_EXPIRED_KEY, "true");
+    onLogout();
+  }, [clearAllTimers, onLogout]);
+
+  const resetIdleTimers = useCallback(() => {
+    if (!isAuthenticated) return;
+
+    clearAllTimers();
+    setShowWarning(false);
+    setSecondsRemaining(60);
+    localStorage.setItem(LAST_ACTIVITY_KEY, Date.now().toString());
+
+    warningTimerRef.current = setTimeout(() => {
+      setShowWarning(true);
+      setSecondsRemaining(60);
+
+      countdownRef.current = setInterval(() => {
+        setSecondsRemaining((prev) => {
+          if (prev <= 1) {
+            if (countdownRef.current) clearInterval(countdownRef.current);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }, IDLE_WARNING_MS);
+
+    logoutTimerRef.current = setTimeout(() => {
+      performLogout();
+    }, IDLE_LOGOUT_MS);
+  }, [isAuthenticated, clearAllTimers, performLogout]);
+
+  // Set up activity listeners
+  useEffect(() => {
+    if (!isAuthenticated) {
+      clearAllTimers();
+      return;
+    }
+
+    resetIdleTimers();
+
+    const handleActivity = () => resetIdleTimers();
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, handleActivity, { passive: true });
+    }
+
+    return () => {
+      clearAllTimers();
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, handleActivity);
+      }
+    };
+  }, [isAuthenticated, resetIdleTimers, clearAllTimers]);
+
+  // Listen for 401-triggered session expiry
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const unsubscribe = onSessionExpired(() => {
+      clearAllTimers();
+      setShowWarning(false);
+      setShowExpiredToast(true);
+      onLogout();
+    });
+
+    return unsubscribe;
+  }, [isAuthenticated, clearAllTimers, onLogout]);
+
+  // Check if we should show the expired toast on mount (e.g. after redirect)
+  useEffect(() => {
+    if (localStorage.getItem(SESSION_EXPIRED_KEY) === "true") {
+      setShowExpiredToast(true);
+      localStorage.removeItem(SESSION_EXPIRED_KEY);
+    }
+  }, []);
+
+  const dismissExpiredToast = useCallback(() => {
+    setShowExpiredToast(false);
+  }, []);
+
+  return (
+    <SessionExpiryContext.Provider
+      value={{ showWarning, showExpiredToast, dismissExpiredToast, secondsRemaining }}
+    >
+      {children}
+      {showWarning && <IdleWarningBanner secondsRemaining={secondsRemaining} />}
+      {showExpiredToast && (
+        <SessionExpiredToast onDismiss={dismissExpiredToast} />
+      )}
+    </SessionExpiryContext.Provider>
+  );
+}
+
+// ── UI Components ──────────────────────────────────────────────────────────────
+
+function IdleWarningBanner({ secondsRemaining }: { secondsRemaining: number }) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10000,
+        backgroundColor: "#f59e0b",
+        color: "#1a1a1a",
+        padding: "12px 20px",
+        textAlign: "center",
+        fontWeight: 600,
+        fontSize: "14px",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+      }}
+    >
+      Session expiring in {secondsRemaining} second
+      {secondsRemaining !== 1 ? "s" : ""}. Move your mouse or press a key to
+      stay logged in.
+    </div>
+  );
+}
+
+function SessionExpiredToast({ onDismiss }: { onDismiss: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 8000);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 20,
+        right: 20,
+        zIndex: 10001,
+        backgroundColor: "#ef4444",
+        color: "#fff",
+        padding: "14px 24px",
+        borderRadius: "8px",
+        fontSize: "14px",
+        fontWeight: 500,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+        maxWidth: "400px",
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+      }}
+    >
+      <span style={{ flex: 1 }}>
+        Your session has expired. Please log in again.
+      </span>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        style={{
+          background: "none",
+          border: "none",
+          color: "#fff",
+          cursor: "pointer",
+          fontSize: "18px",
+          lineHeight: 1,
+          padding: "0 4px",
+        }}
+      >
+        x
+      </button>
+    </div>
+  );
+}

--- a/apps/patient-portal/src/lib/trpc.ts
+++ b/apps/patient-portal/src/lib/trpc.ts
@@ -3,6 +3,7 @@
 import { createTRPCReact, httpBatchLink } from "@trpc/react-query";
 import { createTRPCClient, httpBatchLink as vanillaHttpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@carebridge/api-gateway/src/router.js";
+import { createAuthFetch } from "./session-expiry.js";
 
 export const trpc = createTRPCReact<AppRouter>();
 
@@ -11,10 +12,13 @@ function getSessionToken(): string | undefined {
   return localStorage.getItem("carebridge_session") ?? undefined;
 }
 
+const authFetch = typeof window !== "undefined" ? createAuthFetch() : fetch;
+
 export function getTRPCLinks() {
   return [
     httpBatchLink({
       url: "http://localhost:4000/trpc",
+      fetch: authFetch,
       headers() {
         const token = getSessionToken();
         return token ? { Authorization: `Bearer ${token}` } : {};
@@ -27,6 +31,7 @@ export const trpcVanilla = createTRPCClient<AppRouter>({
   links: [
     vanillaHttpBatchLink({
       url: "http://localhost:4000/trpc",
+      fetch: authFetch,
       headers() {
         const token = getSessionToken();
         return token ? { Authorization: `Bearer ${token}` } : {};


### PR DESCRIPTION
## Summary

- Adds a `createAuthFetch` wrapper that intercepts 401 responses from the API, clears the session from localStorage, and triggers a redirect to `/login` with an expired-session toast
- Adds client-side idle timeout tracking: warns at 14 minutes of inactivity ("Session expiring in X seconds"), auto-logs out at 15 minutes
- Wires `SessionExpiryProvider` into `AuthProvider` for both clinician-portal and patient-portal
- Passes the auth-intercepting fetch to both `httpBatchLink` and `vanillaHttpBatchLink` in each portal's tRPC config

Closes #37

## Test plan

- [ ] Log in to clinician portal, wait 14 minutes idle — verify warning banner appears with countdown
- [ ] Continue idle past 15 minutes — verify auto-logout and redirect to `/login` with toast
- [ ] Interact (click/keypress) during warning — verify timers reset and warning dismisses
- [ ] Invalidate session server-side (e.g. delete from DB), then trigger a tRPC call — verify 401 triggers logout and toast
- [ ] Verify same behavior in patient portal
- [ ] Verify toast auto-dismisses after 8 seconds or can be manually dismissed