### PR TITLE
fix(auth): gate createUser behind admin-only check

### DIFF
--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -425,10 +425,16 @@ export const authRouter = t.router({
   }),
 
   /**
-   * Create a new user account.
-   * In production this would be admin-only; in dev mode it is open.
+   * Create a new user account. Requires an authenticated admin caller.
    */
-  createUser: publicProcedure.input(createUserSchema).mutation(async ({ input }) => {
+  createUser: protectedProcedure.input(createUserSchema).mutation(async ({ ctx, input }) => {
+    if (ctx.user.role !== "admin") {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Only admins can create user accounts.",
+      });
+    }
+
     const db = getDb();
 
     // Check for duplicate email.


### PR DESCRIPTION
Closes #57

Gates the createUser endpoint behind authentication + admin role enforcement. Previously any unauthenticated caller could create accounts with arbitrary roles including admin.

Changes:
- Wrap createUser in protectedProcedure with an explicit role check (throws FORBIDDEN if caller is not admin)
- In dev/test environments the check still applies — use seeded admin credentials to create users