### PR TITLE
fix(gateway): require explicit CORS allowlist, fail-closed in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,13 @@ PHI_ENCRYPTION_KEY_PREVIOUS=
 # Falls back to PHI_ENCRYPTION_KEY if not set.
 PHI_HMAC_KEY=
 
+# CORS
+# Comma-separated list of allowed origins for cross-origin requests.
+# REQUIRED in production — the server will refuse to start if unset.
+# Example (production):  CORS_ORIGIN=https://app.carebridge.health,https://clinician.carebridge.health
+# Example (development): CORS_ORIGIN=http://localhost:3000,http://localhost:3001
+# In development, if omitted, defaults to http://localhost:3000 and http://localhost:3001.
+CORS_ORIGIN=http://localhost:3000,http://localhost:3001
+
 # Environment
 NODE_ENV=development

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/clinician-portal:
     dependencies:
+      '@carebridge/portal-shared':
+        specifier: workspace:*
+        version: link:../../packages/portal-shared
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -75,6 +78,9 @@ importers:
 
   apps/patient-portal:
     dependencies:
+      '@carebridge/portal-shared':
+        specifier: workspace:*
+        version: link:../../packages/portal-shared
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -182,6 +188,34 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+
+  packages/portal-shared:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.60.0
+        version: 5.96.2(react@19.2.4)
+      '@trpc/client':
+        specifier: ^11.0.0
+        version: 11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/react-query':
+        specifier: ^11.0.0
+        version: 11.16.0(@tanstack/react-query@5.96.2(react@19.2.4))(@trpc/client@11.16.0(@trpc/server@11.16.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.16.0(typescript@5.9.3))(react@19.2.4)(typescript@5.9.3)
+      '@trpc/server':
+        specifier: ^11.0.0
+        version: 11.16.0(typescript@5.9.3)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@carebridge/api-gateway':
+        specifier: workspace:*
+        version: link:../../services/api-gateway
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
   packages/redis-config:
     devDependencies:

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -9,7 +9,30 @@ import { auditMiddleware } from "./middleware/audit.js";
 const API_PORT = Number(process.env.API_PORT) || 4000;
 const API_HOST = process.env.API_HOST ?? "0.0.0.0";
 
+function resolveCorsOrigins(): string[] {
+  const isProduction = process.env.NODE_ENV === "production";
+  const rawOrigin = process.env.CORS_ORIGIN;
+
+  if (isProduction) {
+    if (!rawOrigin) {
+      throw new Error(
+        "CORS_ORIGIN must be explicitly set in production. " +
+          "Refusing to start with a wildcard origin — this would expose all PHI to any requestor.",
+      );
+    }
+    return rawOrigin.split(",").map((o) => o.trim());
+  }
+
+  // Development: use CORS_ORIGIN if set, otherwise fall back to local dev origins
+  if (rawOrigin) {
+    return rawOrigin.split(",").map((o) => o.trim());
+  }
+  return ["http://localhost:3000", "http://localhost:3001"];
+}
+
 async function main() {
+  const corsOrigins = resolveCorsOrigins();
+
   const server = Fastify({
     logger: {
       level: process.env.LOG_LEVEL ?? "info",
@@ -18,7 +41,7 @@ async function main() {
 
   // --- Plugins ---
   await server.register(cors, {
-    origin: process.env.CORS_ORIGIN ?? true,
+    origin: corsOrigins,
     credentials: true,
   });
 


### PR DESCRIPTION
## Summary

Closes #58

- Replaces `origin: process.env.CORS_ORIGIN ?? true` with a `resolveCorsOrigins()` helper that always returns an explicit string array — never a boolean wildcard
- In **production** (`NODE_ENV=production`): if `CORS_ORIGIN` is unset the process throws at startup with a clear error, preventing PHI from being served under a reflected-origin policy
- In **development**: uses `CORS_ORIGIN` (parsed as comma-separated list) if set, otherwise falls back to `['http://localhost:3000', 'http://localhost:3001']`
- Updates `.env.example` to document `CORS_ORIGIN` with production and development examples

## Test plan

- [ ] Set `NODE_ENV=production` with `CORS_ORIGIN` unset — confirm server exits on startup with descriptive error
- [ ] Set `NODE_ENV=production` with `CORS_ORIGIN=https://app.carebridge.health` — confirm server starts and only that origin is allowed
- [ ] Set `NODE_ENV=development` with `CORS_ORIGIN` unset — confirm server starts allowing `localhost:3000` and `localhost:3001`
- [ ] Set `NODE_ENV=development` with `CORS_ORIGIN=http://localhost:3000,http://localhost:3001` — confirm comma-separated parsing works
- [ ] Confirm cross-origin requests from a non-allowlisted origin receive a CORS rejection
- [ ] `pnpm --filter @carebridge/api-gateway typecheck` passes with no errors