### PR TITLE
fix(gateway): enforce RBAC on all patient-scoped procedures

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       '@carebridge/medical-logic':
         specifier: workspace:*
         version: link:../../packages/medical-logic
+      '@carebridge/phi-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/phi-sanitizer
       '@carebridge/redis-config':
         specifier: workspace:*
         version: link:../../packages/redis-config
@@ -284,6 +287,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -335,6 +341,9 @@ importers:
       ioredis:
         specifier: ^5.6.0
         version: 5.10.1
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.0.0

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -25,7 +25,8 @@
     "@fastify/rate-limit": "^10.3.0",
     "@trpc/server": "^11.0.0",
     "drizzle-orm": "^0.38.0",
-    "ioredis": "^5.6.0"
+    "ioredis": "^5.6.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -1,9 +1,9 @@
 import { router, publicProcedure } from "./trpc.js";
 import { authRouter } from "@carebridge/auth";
-import { patientRecordsRouter } from "@carebridge/patient-records";
-import { clinicalDataRouter } from "@carebridge/clinical-data";
-import { clinicalNotesRouter } from "@carebridge/clinical-notes";
 import { aiOversightRouter } from "@carebridge/ai-oversight";
+import { patientRecordsRbacRouter } from "./routers/patient-records.js";
+import { clinicalDataRbacRouter } from "./routers/clinical-data.js";
+import { clinicalNotesRbacRouter } from "./routers/clinical-notes.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -14,9 +14,9 @@ export const appRouter = router({
     };
   }),
   auth: authRouter,
-  patients: patientRecordsRouter,
-  clinicalData: clinicalDataRouter,
-  notes: clinicalNotesRouter,
+  patients: patientRecordsRbacRouter,
+  clinicalData: clinicalDataRbacRouter,
+  notes: clinicalNotesRbacRouter,
   aiOversight: aiOversightRouter,
 });
 

--- a/services/api-gateway/src/routers/clinical-data.ts
+++ b/services/api-gateway/src/routers/clinical-data.ts
@@ -1,0 +1,225 @@
+/**
+ * RBAC-enforced clinical-data router.
+ *
+ * Every patient-scoped procedure calls enforcePatientAccess() before
+ * delegating to the underlying repository functions from @carebridge/clinical-data.
+ *
+ * Procedures where the patient must be resolved from another resource id
+ * (medications.update, medications.logAdmin) perform a lightweight DB lookup
+ * to obtain the patient_id before running the access check.
+ */
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import {
+  createVitalSchema,
+  vitalTypeSchema,
+  createLabPanelSchema,
+  createMedicationSchema,
+  updateMedicationSchema,
+  medStatusSchema,
+  createProcedureSchema,
+} from "@carebridge/validators";
+import {
+  vitalRepo,
+  labRepo,
+  medicationRepo,
+  procedureRepo,
+} from "@carebridge/clinical-data";
+import { getDb, medications } from "@carebridge/db-schema";
+import { eq } from "drizzle-orm";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Authentication required" });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+/**
+ * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
+ * Throws TRPCError(FORBIDDEN) on denial.
+ */
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+): Promise<void> {
+  if (user.role === "admin") return;
+
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  // Clinicians (physician, specialist, nurse) must be on the care team.
+  const hasAccess = await assertCareTeamAccess(user.id, patientId);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+// ─── Vitals ──────────────────────────────────────────────────────────────────
+
+const vitalsRouter = t.router({
+  create: protectedProcedure
+    .input(createVitalSchema)
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patient_id);
+      return vitalRepo.createVital(input);
+    }),
+
+  getByPatient: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid(), type: vitalTypeSchema.optional() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return vitalRepo.getVitalsByPatient(input.patientId, input.type);
+    }),
+
+  getLatest: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return vitalRepo.getLatestVitals(input.patientId);
+    }),
+});
+
+// ─── Labs ─────────────────────────────────────────────────────────────────────
+
+const labsRouter = t.router({
+  createPanel: protectedProcedure
+    .input(createLabPanelSchema)
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patient_id);
+      return labRepo.createLabPanel(input);
+    }),
+
+  getByPatient: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return labRepo.getLabPanelsByPatient(input.patientId);
+    }),
+
+  getHistory: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid(), testName: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return labRepo.getLabResultHistory(input.patientId, input.testName);
+    }),
+});
+
+// ─── Medications ──────────────────────────────────────────────────────────────
+
+const medicationsRouter = t.router({
+  create: protectedProcedure
+    .input(createMedicationSchema)
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patient_id);
+      return medicationRepo.createMedication(input);
+    }),
+
+  update: protectedProcedure
+    .input(z.object({ id: z.string().uuid() }).merge(updateMedicationSchema))
+    .mutation(async ({ ctx, input }) => {
+      // Resolve patientId from the medication record before checking access.
+      const db = getDb();
+      const [existing] = await db
+        .select({ patient_id: medications.patient_id })
+        .from(medications)
+        .where(eq(medications.id, input.id))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: `Medication ${input.id} not found` });
+      }
+
+      await enforcePatientAccess(ctx.user, existing.patient_id);
+
+      const { id, ...rest } = input;
+      return medicationRepo.updateMedication(id, rest);
+    }),
+
+  getByPatient: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid(), status: medStatusSchema.optional() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return medicationRepo.getMedicationsByPatient(input.patientId, input.status);
+    }),
+
+  logAdmin: protectedProcedure
+    .input(
+      z.object({
+        medicationId: z.string().uuid(),
+        administeredAt: z.string().datetime(),
+        doseAmount: z.number().positive().optional(),
+        doseUnit: z.string().max(20).optional(),
+        administeredBy: z.string().uuid().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // Resolve patientId from the medication before checking access.
+      const db = getDb();
+      const [existing] = await db
+        .select({ patient_id: medications.patient_id })
+        .from(medications)
+        .where(eq(medications.id, input.medicationId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Medication ${input.medicationId} not found`,
+        });
+      }
+
+      await enforcePatientAccess(ctx.user, existing.patient_id);
+
+      return medicationRepo.logAdministration(
+        input.medicationId,
+        input.administeredAt,
+        input.doseAmount,
+        input.doseUnit,
+        input.administeredBy,
+      );
+    }),
+});
+
+// ─── Procedures ───────────────────────────────────────────────────────────────
+
+const proceduresRouter = t.router({
+  create: protectedProcedure
+    .input(createProcedureSchema)
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patient_id);
+      return procedureRepo.createProcedure(input);
+    }),
+
+  getByPatient: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return procedureRepo.getProceduresByPatient(input.patientId);
+    }),
+});
+
+// ─── Composed router ──────────────────────────────────────────────────────────
+
+export const clinicalDataRbacRouter = t.router({
+  vitals: vitalsRouter,
+  labs: labsRouter,
+  medications: medicationsRouter,
+  procedures: proceduresRouter,
+});

--- a/services/api-gateway/src/routers/clinical-notes.ts
+++ b/services/api-gateway/src/routers/clinical-notes.ts
@@ -1,0 +1,169 @@
+/**
+ * RBAC-enforced clinical-notes router.
+ *
+ * Every patient-scoped procedure calls enforcePatientAccess() before
+ * delegating to the underlying noteService functions from @carebridge/clinical-notes.
+ *
+ * For notes.update, notes.sign, and notes.getById the patient is resolved
+ * from the note record (DB lookup) before the access check runs.
+ */
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import {
+  createNoteSchema,
+  updateNoteSchema,
+  signNoteSchema,
+  noteTemplateTypeSchema,
+} from "@carebridge/validators";
+import type { NoteTemplateType } from "@carebridge/shared-types";
+import {
+  noteService,
+  createSOAPTemplate,
+  createProgressTemplate,
+} from "@carebridge/clinical-notes";
+import { getDb, clinicalNotes } from "@carebridge/db-schema";
+import { eq } from "drizzle-orm";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Authentication required" });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+/**
+ * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
+ * Throws TRPCError(FORBIDDEN) on denial.
+ */
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+): Promise<void> {
+  if (user.role === "admin") return;
+
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  // Clinicians (physician, specialist, nurse) must be on the care team.
+  const hasAccess = await assertCareTeamAccess(user.id, patientId);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+const templateBuilders: Record<
+  NoteTemplateType,
+  (() => ReturnType<typeof createSOAPTemplate>) | null
+> = {
+  soap: createSOAPTemplate,
+  progress: createProgressTemplate,
+  h_and_p: null,
+  discharge: null,
+  consult: null,
+};
+
+export const clinicalNotesRbacRouter = t.router({
+  create: protectedProcedure
+    .input(createNoteSchema)
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patient_id);
+      return noteService.createNote(input);
+    }),
+
+  update: protectedProcedure
+    .input(z.object({ id: z.string().uuid() }).merge(updateNoteSchema))
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const [existing] = await db
+        .select({ patient_id: clinicalNotes.patient_id })
+        .from(clinicalNotes)
+        .where(eq(clinicalNotes.id, input.id))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: `Note ${input.id} not found` });
+      }
+
+      await enforcePatientAccess(ctx.user, existing.patient_id);
+
+      const { id, ...rest } = input;
+      return noteService.updateNote(id, rest);
+    }),
+
+  sign: protectedProcedure
+    .input(z.object({ noteId: z.string().uuid() }).merge(signNoteSchema))
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const [existing] = await db
+        .select({ patient_id: clinicalNotes.patient_id })
+        .from(clinicalNotes)
+        .where(eq(clinicalNotes.id, input.noteId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: `Note ${input.noteId} not found` });
+      }
+
+      await enforcePatientAccess(ctx.user, existing.patient_id);
+
+      return noteService.signNote(input.noteId, input.signed_by);
+    }),
+
+  getByPatient: protectedProcedure
+    .input(z.object({ patientId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.patientId);
+      return noteService.getNotesByPatient(input.patientId);
+    }),
+
+  getById: protectedProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const result = await noteService.getNoteById(input.id);
+
+      if (!result) {
+        return null;
+      }
+
+      await enforcePatientAccess(ctx.user, result.note.patient_id);
+
+      return result;
+    }),
+
+  templates: t.router({
+    list: t.procedure.query(() => {
+      return Object.entries(templateBuilders)
+        .filter(([, builder]) => builder !== null)
+        .map(([type]) => type as NoteTemplateType);
+    }),
+
+    get: t.procedure
+      .input(z.object({ type: noteTemplateTypeSchema }))
+      .query(({ input }) => {
+        const builder = templateBuilders[input.type];
+        if (!builder) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Template "${input.type}" is not yet implemented`,
+          });
+        }
+        return builder();
+      }),
+  }),
+});

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -1,0 +1,172 @@
+/**
+ * RBAC-enforced patient-records router.
+ *
+ * Patient-scoped read/write procedures call enforcePatientAccess() before
+ * querying the database.
+ *
+ * Administrative procedures (create, list) are restricted to non-patient roles.
+ */
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import {
+  getDb,
+  hmacForIndex,
+  patients,
+  diagnoses,
+  allergies,
+  careTeamMembers,
+} from "@carebridge/db-schema";
+import { createPatientSchema, updatePatientSchema } from "@carebridge/validators";
+import { eq } from "drizzle-orm";
+import crypto from "node:crypto";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Authentication required" });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+/**
+ * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
+ * Throws TRPCError(FORBIDDEN) on denial.
+ */
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+): Promise<void> {
+  if (user.role === "admin") return;
+
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  // Clinicians (physician, specialist, nurse) must be on the care team.
+  const hasAccess = await assertCareTeamAccess(user.id, patientId);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+export const patientRecordsRbacRouter = t.router({
+  // Administrative: creating a patient record is restricted to non-patient roles.
+  create: protectedProcedure
+    .input(createPatientSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (ctx.user.role === "patient") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Patients cannot create patient records",
+        });
+      }
+      const db = getDb();
+      const now = new Date().toISOString();
+      const mrn_hmac = input.mrn ? hmacForIndex(input.mrn) : undefined;
+      const patient = {
+        id: crypto.randomUUID(),
+        ...input,
+        mrn_hmac,
+        created_at: now,
+        updated_at: now,
+      };
+      await db.insert(patients).values(patient);
+      return patient;
+    }),
+
+  // Updating a patient record is patient-scoped: input.id is the patientId.
+  update: protectedProcedure
+    .input(z.object({ id: z.string().uuid() }).merge(updatePatientSchema))
+    .mutation(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.id);
+      const { id, ...data } = input;
+      const db = getDb();
+      const mrn_hmac =
+        data.mrn !== undefined ? (data.mrn ? hmacForIndex(data.mrn) : null) : undefined;
+      const updates = {
+        ...data,
+        ...(mrn_hmac !== undefined ? { mrn_hmac } : {}),
+        updated_at: new Date().toISOString(),
+      };
+      await db.update(patients).set(updates).where(eq(patients.id, id));
+      return { id, ...data };
+    }),
+
+  // Reading a specific patient record is patient-scoped: input.id is the patientId.
+  getById: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await enforcePatientAccess(ctx.user, input.id);
+      const db = getDb();
+      const [patient] = await db
+        .select()
+        .from(patients)
+        .where(eq(patients.id, input.id));
+      return patient ?? null;
+    }),
+
+  // Listing all patients is restricted to non-patient roles.
+  list: protectedProcedure.query(async ({ ctx }) => {
+    if (ctx.user.role === "patient") {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Patients cannot list all patient records",
+      });
+    }
+    const db = getDb();
+    return db.select().from(patients);
+  }),
+
+  diagnoses: t.router({
+    getByPatient: protectedProcedure
+      .input(z.object({ patientId: z.string() }))
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        const db = getDb();
+        return db
+          .select()
+          .from(diagnoses)
+          .where(eq(diagnoses.patient_id, input.patientId));
+      }),
+  }),
+
+  allergies: t.router({
+    getByPatient: protectedProcedure
+      .input(z.object({ patientId: z.string() }))
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        const db = getDb();
+        return db
+          .select()
+          .from(allergies)
+          .where(eq(allergies.patient_id, input.patientId));
+      }),
+  }),
+
+  careTeam: t.router({
+    getByPatient: protectedProcedure
+      .input(z.object({ patientId: z.string() }))
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        const db = getDb();
+        return db
+          .select()
+          .from(careTeamMembers)
+          .where(eq(careTeamMembers.patient_id, input.patientId));
+      }),
+  }),
+});

--- a/services/clinical-data/src/index.ts
+++ b/services/clinical-data/src/index.ts
@@ -1,2 +1,6 @@
 export { clinicalDataRouter } from "./router.js";
 export type { ClinicalDataRouter } from "./router.js";
+export * as vitalRepo from "./repositories/vital-repo.js";
+export * as labRepo from "./repositories/lab-repo.js";
+export * as medicationRepo from "./repositories/medication-repo.js";
+export * as procedureRepo from "./repositories/procedure-repo.js";

--- a/services/clinical-notes/src/index.ts
+++ b/services/clinical-notes/src/index.ts
@@ -1,2 +1,5 @@
 export { clinicalNotesRouter } from "./router.js";
 export type { ClinicalNotesRouter } from "./router.js";
+export * as noteService from "./services/note-service.js";
+export { createSOAPTemplate } from "./templates/soap.js";
+export { createProgressTemplate } from "./templates/progress.js";


### PR DESCRIPTION
Fixes #55. Wires assertPatientAccess() into every patient-scoped tRPC procedure in patient-records, clinical-data, and clinical-notes routers. Previously, any authenticated user could read/write any patient's data regardless of care team assignment.