### PR TITLE
fix(infra): require Redis authentication in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 DATABASE_URL=postgresql://carebridge:carebridge_dev@localhost:5432/carebridge
 
 # Redis
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://:${REDIS_PASSWORD}@localhost:6379
 REDIS_HOST=localhost
 REDIS_PORT=6379
-# REDIS_PASSWORD=
+REDIS_PASSWORD=change-me-in-production
 # REDIS_TLS=true  # Enable TLS for production Redis connections
 
 # API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,13 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
     # TLS configuration for production:
     # command: >
     #   redis-server
+    #   --requirepass ${REDIS_PASSWORD}
     #   --tls-port 6380
     #   --port 0
     #   --tls-cert-file /tls/redis.crt
@@ -30,7 +34,7 @@ services:
     # volumes:
     #   - ./tls:/tls:ro
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes #80. Configures Redis with --requirepass using REDIS_PASSWORD env var. Updates healthcheck to pass auth. Updates .env.example with REDIS_PASSWORD and authenticated REDIS_URL.