### PR TITLE
fix(gateway): mount notifications and fhir-gateway routers

### DIFF
--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -20,6 +20,8 @@
     "@carebridge/clinical-data": "workspace:*",
     "@carebridge/clinical-notes": "workspace:*",
     "@carebridge/ai-oversight": "workspace:*",
+    "@carebridge/notifications": "workspace:*",
+    "@carebridge/fhir-gateway": "workspace:*",
     "fastify": "^5.2.0",
     "@fastify/cors": "^11.0.0",
     "@fastify/rate-limit": "^10.3.0",

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -1,6 +1,8 @@
 import { router, publicProcedure } from "./trpc.js";
 import { authRouter } from "@carebridge/auth";
 import { aiOversightRouter } from "@carebridge/ai-oversight";
+import { notificationsRouter } from "@carebridge/notifications";
+import { fhirGatewayRouter } from "@carebridge/fhir-gateway";
 import { patientRecordsRbacRouter } from "./routers/patient-records.js";
 import { clinicalDataRbacRouter } from "./routers/clinical-data.js";
 import { clinicalNotesRbacRouter } from "./routers/clinical-notes.js";
@@ -18,6 +20,8 @@ export const appRouter = router({
   clinicalData: clinicalDataRbacRouter,
   notes: clinicalNotesRbacRouter,
   aiOversight: aiOversightRouter,
+  notifications: notificationsRouter,
+  fhir: fhirGatewayRouter,
 });
 
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
Fixes #71. Adds @carebridge/notifications and @carebridge/fhir-gateway as api-gateway dependencies and mounts their routers in the merged tRPC router. Previously these services were unreachable.