### PR TITLE
fix(auth): move MFA state to Redis — survive restarts, work across replicas

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+      ioredis:
+        specifier: ^5.6.0
+        version: 5.10.1
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -25,7 +25,8 @@
     "@trpc/server": "^11.0.0",
     "bullmq": "^5.30.0",
     "drizzle-orm": "^0.38.0",
-    "zod": "^3.24.0"
+    "zod": "^3.24.0",
+    "ioredis": "^5.6.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/services/auth/src/__tests__/mfa-rate-limit.test.ts
+++ b/services/auth/src/__tests__/mfa-rate-limit.test.ts
@@ -1,4 +1,60 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// Mock ioredis with an in-memory store before importing the module
+const store = new Map<string, { value: string; expiresAt: number }>();
+
+vi.mock("ioredis", () => {
+  class MockRedis {
+    async get(key: string): Promise<string | null> {
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (Date.now() >= entry.expiresAt) {
+        store.delete(key);
+        return null;
+      }
+      return entry.value;
+    }
+
+    async set(key: string, value: string, _mode?: string, ttl?: number): Promise<"OK"> {
+      const expiresAt = ttl ? Date.now() + ttl * 1000 : Infinity;
+      store.set(key, { value, expiresAt });
+      return "OK";
+    }
+
+    async del(...keys: string[]): Promise<number> {
+      let deleted = 0;
+      for (const key of keys) {
+        if (store.delete(key)) deleted++;
+      }
+      return deleted;
+    }
+
+    async exists(key: string): Promise<number> {
+      const entry = store.get(key);
+      if (!entry) return 0;
+      if (Date.now() >= entry.expiresAt) {
+        store.delete(key);
+        return 0;
+      }
+      return 1;
+    }
+
+    async keys(pattern: string): Promise<string[]> {
+      const prefix = pattern.replace("*", "");
+      const now = Date.now();
+      const result: string[] = [];
+      for (const [k, v] of store) {
+        if (k.startsWith(prefix) && now < v.expiresAt) {
+          result.push(k);
+        }
+      }
+      return result;
+    }
+  }
+
+  return { default: MockRedis };
+});
+
 import {
   checkMFARateLimit,
   recordMFAAttempt,
@@ -9,8 +65,9 @@ import {
 } from "../mfa-rate-limit.js";
 
 describe("MFA rate limiter", () => {
-  beforeEach(() => {
-    _resetAllAttempts();
+  beforeEach(async () => {
+    store.clear();
+    await _resetAllAttempts();
     vi.useFakeTimers();
   });
 
@@ -18,97 +75,97 @@ describe("MFA rate limiter", () => {
     vi.useRealTimers();
   });
 
-  it("allows the first attempt", () => {
-    const result = checkMFARateLimit("session-1");
+  it("allows the first attempt", async () => {
+    const result = await checkMFARateLimit("session-1");
     expect(result.allowed).toBe(true);
   });
 
-  it("allows up to MAX_ATTEMPTS failed attempts", () => {
+  it("allows up to MAX_ATTEMPTS failed attempts", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      expect(checkMFARateLimit("session-1").allowed).toBe(true);
-      recordMFAAttempt("session-1");
+      expect((await checkMFARateLimit("session-1")).allowed).toBe(true);
+      await recordMFAAttempt("session-1");
     }
   });
 
-  it("blocks after MAX_ATTEMPTS failed attempts", () => {
+  it("blocks after MAX_ATTEMPTS failed attempts", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
-    const result = checkMFARateLimit("session-1");
+    const result = await checkMFARateLimit("session-1");
     expect(result.allowed).toBe(false);
     expect(result.retryAfterMs).toBeGreaterThan(0);
     expect(result.retryAfterMs).toBeLessThanOrEqual(MFA_WINDOW_MS);
   });
 
-  it("returns correct retryAfterMs", () => {
+  it("returns correct retryAfterMs", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
 
     // Advance 5 minutes
     vi.advanceTimersByTime(5 * 60 * 1000);
 
-    const result = checkMFARateLimit("session-1");
+    const result = await checkMFARateLimit("session-1");
     expect(result.allowed).toBe(false);
     // Should be roughly 10 minutes remaining
     expect(result.retryAfterMs).toBeLessThanOrEqual(10 * 60 * 1000);
     expect(result.retryAfterMs).toBeGreaterThan(9 * 60 * 1000);
   });
 
-  it("resets after the window expires", () => {
+  it("resets after the window expires", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
-    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(false);
 
     // Advance past the window
     vi.advanceTimersByTime(MFA_WINDOW_MS + 1);
 
-    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(true);
   });
 
-  it("clearMFAAttempts resets the counter for a key", () => {
+  it("clearMFAAttempts resets the counter for a key", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
-    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(false);
 
-    clearMFAAttempts("session-1");
-    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+    await clearMFAAttempts("session-1");
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(true);
   });
 
-  it("tracks separate keys independently", () => {
+  it("tracks separate keys independently", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-a");
+      await recordMFAAttempt("session-a");
     }
-    expect(checkMFARateLimit("session-a").allowed).toBe(false);
-    expect(checkMFARateLimit("session-b").allowed).toBe(true);
+    expect((await checkMFARateLimit("session-a")).allowed).toBe(false);
+    expect((await checkMFARateLimit("session-b")).allowed).toBe(true);
   });
 
-  it("recordMFAAttempt resets if window has expired", () => {
-    recordMFAAttempt("session-1");
-    recordMFAAttempt("session-1");
+  it("recordMFAAttempt resets if window has expired", async () => {
+    await recordMFAAttempt("session-1");
+    await recordMFAAttempt("session-1");
 
     // Advance past the window
     vi.advanceTimersByTime(MFA_WINDOW_MS + 1);
 
     // This should start a fresh window
-    recordMFAAttempt("session-1");
-    expect(checkMFARateLimit("session-1").allowed).toBe(true);
+    await recordMFAAttempt("session-1");
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(true);
 
     // Should be able to do MAX_ATTEMPTS - 1 more (already recorded 1 above)
     for (let i = 1; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
-    expect(checkMFARateLimit("session-1").allowed).toBe(false);
+    expect((await checkMFARateLimit("session-1")).allowed).toBe(false);
   });
 
-  it("reports retryAfterMs in minutes correctly for error messages", () => {
+  it("reports retryAfterMs in minutes correctly for error messages", async () => {
     for (let i = 0; i < MFA_MAX_ATTEMPTS; i++) {
-      recordMFAAttempt("session-1");
+      await recordMFAAttempt("session-1");
     }
 
-    const result = checkMFARateLimit("session-1");
+    const result = await checkMFARateLimit("session-1");
     expect(result.allowed).toBe(false);
 
     const retryMinutes = Math.ceil((result.retryAfterMs ?? 0) / 60_000);

--- a/services/auth/src/mfa-rate-limit.ts
+++ b/services/auth/src/mfa-rate-limit.ts
@@ -1,41 +1,64 @@
 /**
- * In-memory rate limiter for MFA verification attempts.
+ * Redis-backed rate limiter for MFA verification attempts.
  * Prevents brute-force attacks on TOTP codes and recovery codes.
  *
  * - Max 5 attempts per 15-minute window
  * - After 5 failed attempts, locked out for 15 minutes from the first attempt
  * - Successful verification clears the attempt history
+ *
+ * State is stored in Redis so it survives process restarts and is
+ * consistent across multiple service replicas.
  */
+
+import Redis from "ioredis";
+import { getRedisConnection } from "@carebridge/redis-config";
 
 const MFA_MAX_ATTEMPTS = 5;
 const MFA_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const MFA_WINDOW_SECONDS = Math.ceil(MFA_WINDOW_MS / 1000);
 
-interface AttemptRecord {
-  count: number;
-  firstAttempt: number;
+const KEY_PREFIX = "mfa:rate:";
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis {
+  if (!_redis) {
+    const opts = getRedisConnection();
+    _redis = new Redis({
+      host: opts.host,
+      port: opts.port,
+      password: opts.password,
+      tls: opts.tls,
+      lazyConnect: true,
+      maxRetriesPerRequest: 3,
+    });
+  }
+  return _redis;
 }
-
-const mfaAttempts = new Map<string, AttemptRecord>();
 
 /**
  * Check whether an MFA attempt is allowed for the given key.
  * Returns { allowed: true } if within limits, or
  * { allowed: false, retryAfterMs } if the limit has been exceeded.
  */
-export function checkMFARateLimit(key: string): {
+export async function checkMFARateLimit(key: string): Promise<{
   allowed: boolean;
   retryAfterMs?: number;
-} {
-  const record = mfaAttempts.get(key);
-  if (!record) {
+}> {
+  const redis = getRedis();
+  const redisKey = `${KEY_PREFIX}${key}`;
+
+  const data = await redis.get(redisKey);
+  if (!data) {
     return { allowed: true };
   }
 
+  const record: { count: number; firstAttempt: number } = JSON.parse(data);
   const elapsed = Date.now() - record.firstAttempt;
 
-  // Window has expired -- reset
+  // Window has expired -- Redis TTL should handle cleanup, but be safe
   if (elapsed >= MFA_WINDOW_MS) {
-    mfaAttempts.delete(key);
+    await redis.del(redisKey);
     return { allowed: true };
   }
 
@@ -52,30 +75,57 @@ export function checkMFARateLimit(key: string): {
 /**
  * Record a failed MFA attempt for the given key.
  */
-export function recordMFAAttempt(key: string): void {
+export async function recordMFAAttempt(key: string): Promise<void> {
+  const redis = getRedis();
+  const redisKey = `${KEY_PREFIX}${key}`;
   const now = Date.now();
-  const record = mfaAttempts.get(key);
 
-  if (!record || now - record.firstAttempt >= MFA_WINDOW_MS) {
-    mfaAttempts.set(key, { count: 1, firstAttempt: now });
+  const data = await redis.get(redisKey);
+
+  if (!data) {
+    const record = { count: 1, firstAttempt: now };
+    await redis.set(redisKey, JSON.stringify(record), "EX", MFA_WINDOW_SECONDS);
     return;
   }
 
+  const record: { count: number; firstAttempt: number } = JSON.parse(data);
+  const elapsed = now - record.firstAttempt;
+
+  if (elapsed >= MFA_WINDOW_MS) {
+    // Window expired, start fresh
+    const fresh = { count: 1, firstAttempt: now };
+    await redis.set(redisKey, JSON.stringify(fresh), "EX", MFA_WINDOW_SECONDS);
+    return;
+  }
+
+  // Increment count, preserve original TTL
   record.count += 1;
+  const remainingSeconds = Math.ceil((MFA_WINDOW_MS - elapsed) / 1000);
+  await redis.set(
+    redisKey,
+    JSON.stringify(record),
+    "EX",
+    remainingSeconds,
+  );
 }
 
 /**
  * Clear MFA attempt history on successful verification.
  */
-export function clearMFAAttempts(key: string): void {
-  mfaAttempts.delete(key);
+export async function clearMFAAttempts(key: string): Promise<void> {
+  const redis = getRedis();
+  await redis.del(`${KEY_PREFIX}${key}`);
 }
 
 /**
  * Exposed for testing: reset all rate-limit state.
  */
-export function _resetAllAttempts(): void {
-  mfaAttempts.clear();
+export async function _resetAllAttempts(): Promise<void> {
+  const redis = getRedis();
+  const keys = await redis.keys(`${KEY_PREFIX}*`);
+  if (keys.length > 0) {
+    await redis.del(...keys);
+  }
 }
 
 export { MFA_MAX_ATTEMPTS, MFA_WINDOW_MS };

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -29,6 +29,58 @@ import {
   hashPassword,
   verifyPassword,
 } from "./password.js";
+import Redis from "ioredis";
+import { getRedisConnection } from "@carebridge/redis-config";
+
+// ---------- Redis connection for MFA session state ----------
+
+let _redis: Redis | null = null;
+
+function getRedis(): Redis {
+  if (!_redis) {
+    const opts = getRedisConnection();
+    _redis = new Redis({
+      host: opts.host,
+      port: opts.port,
+      password: opts.password,
+      tls: opts.tls,
+      lazyConnect: true,
+      maxRetriesPerRequest: 3,
+    });
+  }
+  return _redis;
+}
+
+const MFA_SESSION_KEY_PREFIX = "mfa:session:";
+
+async function setPendingMFASession(
+  mfaSessionId: string,
+  userId: string,
+  ttlMs: number,
+): Promise<void> {
+  const redis = getRedis();
+  const ttlSeconds = Math.ceil(ttlMs / 1000);
+  await redis.set(
+    `${MFA_SESSION_KEY_PREFIX}${mfaSessionId}`,
+    JSON.stringify({ userId }),
+    "EX",
+    ttlSeconds,
+  );
+}
+
+async function getPendingMFASession(
+  mfaSessionId: string,
+): Promise<{ userId: string } | null> {
+  const redis = getRedis();
+  const data = await redis.get(`${MFA_SESSION_KEY_PREFIX}${mfaSessionId}`);
+  if (!data) return null;
+  return JSON.parse(data) as { userId: string };
+}
+
+async function deletePendingMFASession(mfaSessionId: string): Promise<void> {
+  const redis = getRedis();
+  await redis.del(`${MFA_SESSION_KEY_PREFIX}${mfaSessionId}`);
+}
 
 // ---------- tRPC setup (mirrors api-gateway's context shape) ----------
 
@@ -59,15 +111,6 @@ const protectedProcedure = t.procedure.use(isAuthenticated);
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MFA_SESSION_TTL_MS = 5 * 60 * 1000; // 5 minutes for MFA completion
 const MAX_CONCURRENT_SESSIONS = 5; // max active sessions per user
-
-/**
- * In-memory store for pending MFA sessions.
- * Maps mfaSessionId -> { userId, expiresAt }
- */
-const pendingMFASessions = new Map<
-  string,
-  { userId: string; expiresAt: number }
->();
 
 /**
  * Verify a password against a stored hash, with a backward-compat fallback
@@ -178,16 +221,7 @@ export const authRouter = t.router({
     // Check if MFA is enabled
     if (row.mfa_enabled === true) {
       const mfaSessionId = crypto.randomUUID();
-      const expiresAt = Date.now() + MFA_SESSION_TTL_MS;
-      pendingMFASessions.set(mfaSessionId, {
-        userId: row.id,
-        expiresAt,
-      });
-
-      // Auto-cleanup if the user abandons the MFA flow
-      setTimeout(() => {
-        pendingMFASessions.delete(mfaSessionId);
-      }, MFA_SESSION_TTL_MS);
+      await setPendingMFASession(mfaSessionId, row.id, MFA_SESSION_TTL_MS);
 
       return {
         requiresMFA: true as const,
@@ -226,7 +260,7 @@ export const authRouter = t.router({
     .input(mfaCompleteLoginSchema)
     .mutation(async ({ input }) => {
       // Rate-limit check keyed on mfaSessionId
-      const rateLimit = checkMFARateLimit(input.mfaSessionId);
+      const rateLimit = await checkMFARateLimit(input.mfaSessionId);
       if (!rateLimit.allowed) {
         const retryMinutes = Math.ceil((rateLimit.retryAfterMs ?? 0) / 60_000);
         throw new TRPCError({
@@ -236,10 +270,9 @@ export const authRouter = t.router({
       }
 
       const db = getDb();
-      const pending = pendingMFASessions.get(input.mfaSessionId);
+      const pending = await getPendingMFASession(input.mfaSessionId);
 
-      if (!pending || pending.expiresAt < Date.now()) {
-        pendingMFASessions.delete(input.mfaSessionId);
+      if (!pending) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "MFA session expired or invalid. Please log in again.",
@@ -254,7 +287,7 @@ export const authRouter = t.router({
         .limit(1);
 
       if (userRows.length === 0) {
-        pendingMFASessions.delete(input.mfaSessionId);
+        await deletePendingMFASession(input.mfaSessionId);
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "User not found.",
@@ -290,7 +323,7 @@ export const authRouter = t.router({
       }
 
       if (!verified) {
-        recordMFAAttempt(input.mfaSessionId);
+        await recordMFAAttempt(input.mfaSessionId);
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Invalid MFA code.",
@@ -298,8 +331,8 @@ export const authRouter = t.router({
       }
 
       // Successful verification -- clear rate-limit history and pending session
-      clearMFAAttempts(input.mfaSessionId);
-      pendingMFASessions.delete(input.mfaSessionId);
+      await clearMFAAttempts(input.mfaSessionId);
+      await deletePendingMFASession(input.mfaSessionId);
 
       // Create real session (evict oldest if at concurrent limit first)
       await enforceSessionLimit(db, row.id);


### PR DESCRIPTION
Fixes #62. Moves pendingMFASessions and MFA rate-limit counters from in-memory Maps to Redis with appropriate TTLs. Ensures MFA state survives restarts and is consistent across horizontal replicas.

## Changes

- **`services/auth/src/router.ts`**: Replaced in-memory `pendingMFASessions` Map with Redis-backed `setPendingMFASession` / `getPendingMFASession` / `deletePendingMFASession` helpers. Removed `setTimeout` cleanup (Redis TTL handles expiry). MFA session TTL: 5 minutes.
- **`services/auth/src/mfa-rate-limit.ts`**: Rewrote all rate-limit functions (`checkMFARateLimit`, `recordMFAAttempt`, `clearMFAAttempts`, `_resetAllAttempts`) to be async and Redis-backed. Rate-limit window TTL: 15 minutes.
- **`services/auth/src/__tests__/mfa-rate-limit.test.ts`**: Updated tests to use `await` and mock `ioredis` with an in-memory store.
- **`services/auth/package.json`**: Added `ioredis` as a direct dependency.

## Key design decisions

- Redis keys use `mfa:session:{id}` and `mfa:rate:{id}` prefixes for clear namespacing.
- TTLs are set on Redis keys so expired state is automatically cleaned up.
- Each module creates its own lazy Redis connection using the shared `@carebridge/redis-config` connection options.
- Multi-instance deployments now share a single rate-limit counter per MFA session (no more N×5 brute-force attempts).