### PR TITLE
fix(auth): prevent TOTP replay attacks — Redis used-code store

### DIFF
--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -25,8 +25,8 @@
     "@trpc/server": "^11.0.0",
     "bullmq": "^5.30.0",
     "drizzle-orm": "^0.38.0",
-    "zod": "^3.24.0",
-    "ioredis": "^5.6.0"
+    "ioredis": "^5.6.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -31,6 +31,10 @@ import {
 } from "./password.js";
 import Redis from "ioredis";
 import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  isTOTPCodeUsed,
+  markTOTPCodeUsed,
+} from "./totp-replay-guard.js";
 
 // ---------- Redis connection for MFA session state ----------
 
@@ -310,6 +314,14 @@ export const authRouter = t.router({
 
       // Try TOTP verification first (6-digit code)
       if (/^\d{6}$/.test(code) && row.mfa_secret) {
+        // Reject replayed codes before cryptographic verification
+        if (await isTOTPCodeUsed(row.id, code)) {
+          recordMFAAttempt(input.mfaSessionId);
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Invalid MFA code.",
+          });
+        }
         verified = verifyTOTP(row.mfa_secret, code);
       }
 
@@ -338,6 +350,11 @@ export const authRouter = t.router({
           code: "UNAUTHORIZED",
           message: "Invalid MFA code.",
         });
+      }
+
+      // Mark TOTP code as used to prevent replay attacks
+      if (/^\d{6}$/.test(code)) {
+        await markTOTPCodeUsed(row.id, code);
       }
 
       // Successful verification -- clear rate-limit history and pending session
@@ -602,12 +619,23 @@ export const authRouter = t.router({
         });
       }
 
+      // Reject replayed TOTP codes
+      if (await isTOTPCodeUsed(ctx.user.id, input.code)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid TOTP code. Please try again.",
+        });
+      }
+
       if (!verifyTOTP(row.mfa_secret, input.code)) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Invalid TOTP code. Please try again.",
         });
       }
+
+      // Mark TOTP code as used to prevent replay attacks
+      await markTOTPCodeUsed(ctx.user.id, input.code);
 
       // Enable MFA
       await db
@@ -646,12 +674,23 @@ export const authRouter = t.router({
         });
       }
 
+      // Reject replayed TOTP codes
+      if (await isTOTPCodeUsed(ctx.user.id, input.code)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid TOTP code.",
+        });
+      }
+
       if (!verifyTOTP(row.mfa_secret, input.code)) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Invalid TOTP code.",
         });
       }
+
+      // Mark TOTP code as used to prevent replay attacks
+      await markTOTPCodeUsed(ctx.user.id, input.code);
 
       // Disable MFA and clear secrets
       await db

--- a/services/auth/src/totp-replay-guard.ts
+++ b/services/auth/src/totp-replay-guard.ts
@@ -1,0 +1,53 @@
+/**
+ * TOTP replay-attack prevention via Redis.
+ *
+ * After a TOTP code is successfully verified we store it in Redis with a
+ * short TTL (90 seconds — one full TOTP period plus clock-drift tolerance).
+ * Before accepting any code we check the store; if the code has already been
+ * used within its validity window, verification is rejected.
+ *
+ * Key format: totp:used:{userId}:{code}
+ */
+
+import Redis from "ioredis";
+import { getRedisConnection } from "@carebridge/redis-config";
+
+const USED_CODE_TTL_SECONDS = 90;
+
+let redis: Redis | null = null;
+
+function getRedis(): Redis {
+  if (!redis) {
+    const opts = getRedisConnection();
+    redis = new Redis(opts);
+  }
+  return redis;
+}
+
+function usedCodeKey(userId: string, code: string): string {
+  return `totp:used:${userId}:${code}`;
+}
+
+/**
+ * Returns `true` if the code has already been used (i.e. it is a replay).
+ */
+export async function isTOTPCodeUsed(
+  userId: string,
+  code: string,
+): Promise<boolean> {
+  const key = usedCodeKey(userId, code);
+  const result = await getRedis().exists(key);
+  return result === 1;
+}
+
+/**
+ * Mark a TOTP code as used. Must be called immediately after successful
+ * verification so that any subsequent attempt with the same code is rejected.
+ */
+export async function markTOTPCodeUsed(
+  userId: string,
+  code: string,
+): Promise<void> {
+  const key = usedCodeKey(userId, code);
+  await getRedis().set(key, "1", "EX", USED_CODE_TTL_SECONDS);
+}


### PR DESCRIPTION
Fixes #67. After successful TOTP verification, stores the code in Redis with 90s TTL. Rejects any code that has already been used within its validity window. Prevents replay attacks.