### PR TITLE
feat(clinical): add LOINC codes to vitals and labs — FHIR R4 compliance

### DIFF
--- a/packages/db-schema/drizzle/0007_add_vitals_loinc_code.sql
+++ b/packages/db-schema/drizzle/0007_add_vitals_loinc_code.sql
@@ -1,0 +1,2 @@
+-- Add LOINC code column to vitals table for FHIR R4 Observation.code compliance
+ALTER TABLE "vitals" ADD COLUMN "loinc_code" text;

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -43,6 +43,7 @@ export const vitals = pgTable("vitals", {
   patient_id: text("patient_id").notNull().references(() => patients.id),
   recorded_at: text("recorded_at").notNull(),
   type: text("type").notNull(),
+  loinc_code: text("loinc_code"),
   value_primary: real("value_primary").notNull(),
   value_secondary: real("value_secondary"),
   unit: text("unit").notNull(),

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -66,10 +66,23 @@ export const VITAL_UNITS: Record<VitalType, string> = {
   blood_glucose: "mg/dL",
 };
 
+/** LOINC codes for standard vital sign types (FHIR R4 Observation.code) */
+export const VITAL_LOINC_CODES: Record<VitalType, string | null> = {
+  blood_pressure: "85354-9",
+  heart_rate: "8867-4",
+  o2_sat: "59408-5",
+  temperature: "8310-5",
+  weight: "29463-7",
+  respiratory_rate: "9279-1",
+  pain_level: "72514-3",
+  blood_glucose: "2339-0",
+};
+
 export interface Vital extends BaseRecord {
   patient_id: string;
   recorded_at: string;
   type: VitalType;
+  loinc_code?: string;
   value_primary: number;
   value_secondary?: number;
   unit: string;

--- a/packages/validators/src/clinical-data.ts
+++ b/packages/validators/src/clinical-data.ts
@@ -66,7 +66,7 @@ export const createLabPanelSchema = z.object({
   results: z.array(
     z.object({
       test_name: z.string().min(1).max(100),
-      test_code: z.string().max(20).optional(),
+      test_code: z.string().regex(/^\d{1,5}-\d$/, "Must be a valid LOINC code (e.g. 6690-2)"),
       value: z.number(),
       unit: z.string().min(1).max(20),
       reference_low: z.number().optional(),

--- a/tooling/seed/index.ts
+++ b/tooling/seed/index.ts
@@ -175,10 +175,10 @@ async function seed() {
 
   // Vitals
   await db.insert(schema.vitals).values([
-    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "blood_pressure", value_primary: 138, value_secondary: 85, unit: "mmHg", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
-    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "heart_rate", value_primary: 88, unit: "bpm", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
-    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "o2_sat", value_primary: 96, unit: "%", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
-    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "temperature", value_primary: 98.4, unit: "°F", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
+    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "blood_pressure", loinc_code: "85354-9", value_primary: 138, value_secondary: 85, unit: "mmHg", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
+    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "heart_rate", loinc_code: "8867-4", value_primary: 88, unit: "bpm", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
+    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "o2_sat", loinc_code: "59408-5", value_primary: 96, unit: "%", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
+    { id: uuid(), patient_id: dvtPatientId, recorded_at: daysAgo(1), type: "temperature", loinc_code: "8310-5", value_primary: 98.4, unit: "°F", provider_id: nurseRachel, source_system: "internal", created_at: daysAgo(1) },
   ]);
 
   // Lab Panel — recent CBC showing some chemo effects
@@ -189,10 +189,10 @@ async function seed() {
     ordering_provider_id: drSmith, source_system: "internal", created_at: daysAgo(3),
   });
   await db.insert(schema.labResults).values([
-    { id: uuid(), panel_id: cbcPanelId, test_name: "WBC", value: 3.8, unit: "K/uL", reference_low: 4.5, reference_high: 11.0, flag: "L", created_at: daysAgo(3) },
-    { id: uuid(), panel_id: cbcPanelId, test_name: "Hemoglobin", value: 10.2, unit: "g/dL", reference_low: 12.0, reference_high: 17.5, flag: "L", created_at: daysAgo(3) },
-    { id: uuid(), panel_id: cbcPanelId, test_name: "Platelets", value: 198, unit: "K/uL", reference_low: 150, reference_high: 400, created_at: daysAgo(3) },
-    { id: uuid(), panel_id: cbcPanelId, test_name: "ANC", value: 1.8, unit: "K/uL", reference_low: 1.5, reference_high: 8.0, created_at: daysAgo(3) },
+    { id: uuid(), panel_id: cbcPanelId, test_name: "WBC", test_code: "6690-2", value: 3.8, unit: "K/uL", reference_low: 4.5, reference_high: 11.0, flag: "L", created_at: daysAgo(3) },
+    { id: uuid(), panel_id: cbcPanelId, test_name: "Hemoglobin", test_code: "718-7", value: 10.2, unit: "g/dL", reference_low: 12.0, reference_high: 17.5, flag: "L", created_at: daysAgo(3) },
+    { id: uuid(), panel_id: cbcPanelId, test_name: "Platelets", test_code: "777-3", value: 198, unit: "K/uL", reference_low: 150, reference_high: 400, created_at: daysAgo(3) },
+    { id: uuid(), panel_id: cbcPanelId, test_name: "ANC", test_code: "751-8", value: 1.8, unit: "K/uL", reference_low: 1.5, reference_high: 8.0, created_at: daysAgo(3) },
   ]);
 
   // Coagulation panel
@@ -203,9 +203,9 @@ async function seed() {
     ordering_provider_id: drSmith, source_system: "internal", created_at: daysAgo(3),
   });
   await db.insert(schema.labResults).values([
-    { id: uuid(), panel_id: coagPanelId, test_name: "D-Dimer", value: 680, unit: "ng/mL", reference_low: 0, reference_high: 500, flag: "H", created_at: daysAgo(3) },
-    { id: uuid(), panel_id: coagPanelId, test_name: "PT", value: 12.1, unit: "sec", reference_low: 11, reference_high: 13.5, created_at: daysAgo(3) },
-    { id: uuid(), panel_id: coagPanelId, test_name: "INR", value: 1.0, unit: "", reference_low: 0.8, reference_high: 1.2, created_at: daysAgo(3) },
+    { id: uuid(), panel_id: coagPanelId, test_name: "D-Dimer", test_code: "48066-5", value: 680, unit: "ng/mL", reference_low: 0, reference_high: 500, flag: "H", created_at: daysAgo(3) },
+    { id: uuid(), panel_id: coagPanelId, test_name: "PT", test_code: "5902-2", value: 12.1, unit: "sec", reference_low: 11, reference_high: 13.5, created_at: daysAgo(3) },
+    { id: uuid(), panel_id: coagPanelId, test_name: "INR", test_code: "6301-6", value: 1.0, unit: "", reference_low: 0.8, reference_high: 1.2, created_at: daysAgo(3) },
   ]);
 
   // ─── Second patient (simpler, for list variety) ─────────────────


### PR DESCRIPTION
Fixes #75. Adds loinc_code column to vitals table with mapping for standard vital signs. Enforces LOINC format regex on lab test_code. Populates seed data with standard LOINC codes.