### PR TITLE
feat(ai): add rule for anticoagulant discontinuation in VTE patients

### DIFF
--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -7,6 +7,7 @@ export type FlagSeverity = "critical" | "warning" | "info";
 export type FlagCategory =
   | "cross-specialty"
   | "drug-interaction"
+  | "medication-safety"
   | "care-gap"
   | "critical-value"
   | "trend-concern"

--- a/services/ai-oversight/src/__tests__/rules.test.ts
+++ b/services/ai-oversight/src/__tests__/rules.test.ts
@@ -112,6 +112,7 @@ describe("checkCrossSpecialtyPatterns", () => {
         "Pancreatic adenocarcinoma",
         "Deep vein thrombosis, right lower extremity",
       ],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
       active_medications: ["Enoxaparin 40mg SQ daily"],
       new_symptoms: ["New onset severe headache"],
       care_team_specialties: ["hematology", "oncology"],
@@ -130,6 +131,7 @@ describe("checkCrossSpecialtyPatterns", () => {
   it("does not flag when only cancer + VTE but no neuro symptom", () => {
     const ctx: PatientContext = {
       active_diagnoses: ["Lung cancer", "DVT"],
+      active_diagnosis_codes: ["C34.90", "I82.401"],
       active_medications: [],
       new_symptoms: ["nausea"],
       care_team_specialties: ["oncology"],
@@ -143,6 +145,7 @@ describe("checkCrossSpecialtyPatterns", () => {
   it("returns empty for benign patient context", () => {
     const ctx: PatientContext = {
       active_diagnoses: ["Seasonal allergies"],
+      active_diagnosis_codes: ["J30.1"],
       active_medications: ["Cetirizine 10mg"],
       new_symptoms: ["runny nose"],
       care_team_specialties: ["primary_care"],
@@ -155,6 +158,7 @@ describe("checkCrossSpecialtyPatterns", () => {
   it("flags anticoagulant + bleeding symptom (ANTICOAG-BLEED-001)", () => {
     const ctx: PatientContext = {
       active_diagnoses: [],
+      active_diagnosis_codes: [],
       active_medications: ["Warfarin 5mg daily"],
       new_symptoms: ["blood in stool"],
       care_team_specialties: ["primary_care"],
@@ -167,6 +171,99 @@ describe("checkCrossSpecialtyPatterns", () => {
   });
 });
 
+
+  it("flags anticoagulant held in VTE patient (ONCO-ANTICOAG-HELD-001)", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Deep vein thrombosis, left lower extremity"],
+      active_diagnosis_codes: ["I82.402"],
+      active_medications: [],
+      new_symptoms: [],
+      care_team_specialties: ["hematology"],
+      trigger_event: {
+        id: "evt-held-1",
+        type: "medication.updated",
+        patient_id: "p-1",
+        data: { name: "Enoxaparin 40mg", status: "held" },
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const heldFlag = flags.find((f) => f.rule_id === "ONCO-ANTICOAG-HELD-001");
+    expect(heldFlag).toBeDefined();
+    expect(heldFlag!.severity).toBe("critical");
+    expect(heldFlag!.category).toBe("medication-safety");
+  });
+
+  it("does not flag non-anticoagulant held in VTE patient", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Deep vein thrombosis"],
+      active_diagnosis_codes: ["I82.401"],
+      active_medications: [],
+      new_symptoms: [],
+      care_team_specialties: [],
+      trigger_event: {
+        id: "evt-held-2",
+        type: "medication.updated",
+        patient_id: "p-1",
+        data: { name: "Metformin 500mg", status: "held" },
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const heldFlag = flags.find((f) => f.rule_id === "ONCO-ANTICOAG-HELD-001");
+    expect(heldFlag).toBeUndefined();
+  });
+
+  it("does not flag anticoagulant held without VTE diagnosis", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Hypertension"],
+      active_diagnosis_codes: ["I10"],
+      active_medications: [],
+      new_symptoms: [],
+      care_team_specialties: [],
+      trigger_event: {
+        id: "evt-held-3",
+        type: "medication.updated",
+        patient_id: "p-1",
+        data: { name: "Warfarin 5mg", status: "discontinued" },
+        timestamp: new Date().toISOString(),
+      },
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const heldFlag = flags.find((f) => f.rule_id === "ONCO-ANTICOAG-HELD-001");
+    expect(heldFlag).toBeUndefined();
+  });
+
+  it("includes anticoag modifier in ONCO-VTE-NEURO-001 suggested action", () => {
+    const ctxWithAnticoag: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "DVT"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: ["Enoxaparin 40mg SQ daily"],
+      new_symptoms: ["severe headache"],
+      care_team_specialties: [],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctxWithAnticoag);
+    const dvtFlag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(dvtFlag).toBeDefined();
+    expect(dvtFlag!.suggested_action).toContain("hemorrhagic risk");
+
+    const ctxNoAnticoag: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "DVT"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: [],
+      new_symptoms: ["severe headache"],
+      care_team_specialties: [],
+    };
+
+    const flags2 = checkCrossSpecialtyPatterns(ctxNoAnticoag);
+    const dvtFlag2 = flags2.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(dvtFlag2).toBeDefined();
+    expect(dvtFlag2!.suggested_action).toContain("NOT on anticoagulation");
+  });
 describe("checkDrugInteractions", () => {
   it("flags warfarin + NSAID interaction", () => {
     const flags = checkDrugInteractions(["Warfarin 5mg", "Ibuprofen 400mg"]);

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -7,15 +7,26 @@
  * specialists might miss because they only see their piece.
  */
 
-import type { FlagSeverity, FlagCategory } from "@carebridge/shared-types";
+import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
 import type { RuleFlag } from "./critical-values.js";
 
 export interface PatientContext {
   active_diagnoses: string[];
+  /** ICD-10 codes for active diagnoses (parallel to active_diagnoses). */
+  active_diagnosis_codes: string[];
   active_medications: string[];
   new_symptoms: string[];
   care_team_specialties: string[];
+  /** The triggering clinical event, used by medication-status rules. */
+  trigger_event?: ClinicalEvent;
 }
+
+/** Anticoagulant name pattern shared across rules. */
+const ANTICOAGULANT_PATTERN =
+  /warfarin|coumadin|heparin|enoxaparin|lovenox|rivaroxaban|xarelto|apixaban|eliquis|dabigatran|pradaxa|edoxaban|savaysa|fondaparinux|arixtra/i;
+
+/** ICD-10 pattern for active VTE / DVT / PE diagnoses. */
+const VTE_ICD10_PATTERN = /^(I26|I80|I82)\./;
 
 interface CrossSpecialtyRule {
   id: string;
@@ -26,6 +37,8 @@ interface CrossSpecialtyRule {
   summary: string;
   rationale: string;
   suggested_action: string;
+  /** Optional dynamic builder that overrides suggested_action when present. */
+  buildSuggestedAction?: (ctx: PatientContext) => string;
   notify_specialties: string[];
 }
 
@@ -56,6 +69,23 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       "mitigate arterial or cerebral thrombotic risk.",
     suggested_action:
       "Urgent neurological evaluation recommended. Consider CT head / CT angiography to rule out acute cerebral event.",
+    buildSuggestedAction: (ctx: PatientContext) => {
+      const onAnticoag = ctx.active_medications.some((m) =>
+        ANTICOAGULANT_PATTERN.test(m),
+      );
+      const base =
+        "Urgent neurological evaluation recommended. Consider CT head / CT angiography to rule out acute cerebral event.";
+      if (onAnticoag) {
+        return (
+          base +
+          " Note: patient is on anticoagulation — assess hemorrhagic risk before neuroimaging contrast and interventions."
+        );
+      }
+      return (
+        base +
+        " Note: patient is NOT on anticoagulation despite active VTE — assess thrombotic risk and anticoagulation candidacy."
+      );
+    },
     notify_specialties: ["neurology", "hematology"],
   },
   {
@@ -79,6 +109,48 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     suggested_action:
       "Check INR/coagulation studies urgently. Evaluate source of bleeding. Consider holding anticoagulation pending evaluation.",
     notify_specialties: ["hematology"],
+  },
+  {
+    id: "ONCO-ANTICOAG-HELD-001",
+    name: "Anticoagulant held/discontinued in patient with active VTE",
+    check: (ctx: PatientContext) => {
+      const event = ctx.trigger_event;
+      if (!event) return false;
+
+      // Only fires on medication.updated events
+      if (event.type !== "medication.updated") return false;
+
+      // Check if the medication is an anticoagulant
+      const medName = (event.data.name as string) ?? "";
+      if (!ANTICOAGULANT_PATTERN.test(medName)) return false;
+
+      // Check if status transitioned to held or discontinued
+      const newStatus = (event.data.status as string) ?? "";
+      if (!/^(held|discontinued)$/i.test(newStatus)) return false;
+
+      // Check if patient has active VTE/DVT/PE by ICD-10 code or description
+      const hasVTEByCode = ctx.active_diagnosis_codes.some((code) =>
+        VTE_ICD10_PATTERN.test(code),
+      );
+      const hasVTEByDescription = ctx.active_diagnoses.some((d) =>
+        /dvt|deep vein thrombosis|pulmonary embolism|vte|venous thromboembolism|thrombosis/i.test(d),
+      );
+
+      return hasVTEByCode || hasVTEByDescription;
+    },
+    severity: "critical" as const,
+    category: "medication-safety" as const,
+    summary:
+      "Anticoagulant held or discontinued in patient with active VTE — elevated thrombotic risk",
+    rationale:
+      "Holding or discontinuing anticoagulation in a patient with an active venous thromboembolism " +
+      "(DVT/PE) significantly increases the risk of clot propagation, recurrent PE, or new thrombotic events. " +
+      "Cancer patients with VTE are at particularly high risk due to the underlying hypercoagulable state.",
+    suggested_action:
+      "Urgent: anticoagulation held in patient with active VTE. Assess thrombotic risk and document clinical reasoning. " +
+      "If held for a procedure, ensure bridging anticoagulation plan is in place. " +
+      "If discontinued due to bleeding, consider IVC filter placement and hematology consultation.",
+    notify_specialties: ["hematology", "oncology"],
   },
   {
     id: "CHEMO-NEUTRO-FEVER-001",
@@ -188,7 +260,9 @@ export function checkCrossSpecialtyPatterns(
         category: rule.category,
         summary: rule.summary,
         rationale: rule.rationale,
-        suggested_action: rule.suggested_action,
+        suggested_action: rule.buildSuggestedAction
+          ? rule.buildSuggestedAction(patientContext)
+          : rule.suggested_action,
         notify_specialties: rule.notify_specialties,
         rule_id: rule.id,
       });

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -267,15 +267,17 @@ async function buildPatientContextForRules(
   // Extract new symptoms from the event data
   const newSymptoms = extractSymptoms(event);
 
+  const activeDx = activeDiagnoses.filter((d) => d.status === "active");
+
   return {
-    active_diagnoses: activeDiagnoses
-      .filter((d) => d.status === "active")
-      .map((d) => d.description),
+    active_diagnoses: activeDx.map((d) => d.description),
+    active_diagnosis_codes: activeDx.map((d) => d.icd10_code ?? ""),
     active_medications: activeMeds
       .filter((m) => m.status === "active")
       .map((m) => m.name),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future
+    trigger_event: event,
   };
 }
 


### PR DESCRIPTION
Fixes #82. Adds ONCO-ANTICOAG-HELD-001 rule that fires when an anticoagulant is held/discontinued in a patient with active VTE. Severity: critical. Also adds anticoagulant status modifier to ONCO-VTE-NEURO-001 suggested action.