### PR TITLE
fix(ai): add medication-safety to flag category enums

### DIFF
--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -10,6 +10,7 @@ const VALID_SEVERITIES = ["critical", "warning", "info"] as const;
 const VALID_CATEGORIES = [
   "cross-specialty",
   "drug-interaction",
+  "medication-safety",
   "care-gap",
   "critical-value",
   "trend-concern",

--- a/packages/validators/src/ai-flags.ts
+++ b/packages/validators/src/ai-flags.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const flagSeveritySchema = z.enum(["critical", "warning", "info"]);
 export const flagCategorySchema = z.enum([
-  "cross-specialty", "drug-interaction", "care-gap",
+  "cross-specialty", "drug-interaction", "medication-safety", "care-gap",
   "critical-value", "trend-concern", "documentation-discrepancy",
 ]);
 export const flagStatusSchema = z.enum(["open", "acknowledged", "resolved", "dismissed", "escalated"]);


### PR DESCRIPTION
Fixes #138. Synchronizes VALID_CATEGORIES and flagCategorySchema with the FlagCategory type. Required for ONCO-ANTICOAG-HELD-001 rule flags to pass validation.