### PR TITLE
fix(gateway): add cookie security flags

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@carebridge/validators':
         specifier: workspace:*
         version: link:../../packages/validators
+      '@fastify/cookie':
+        specifier: ^11.0.0
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^11.0.0
         version: 11.2.0
@@ -1039,6 +1042,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -2588,6 +2594,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
 
   '@fastify/cors@11.2.0':
     dependencies:

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -23,6 +23,7 @@
     "@carebridge/notifications": "workspace:*",
     "@carebridge/fhir-gateway": "workspace:*",
     "fastify": "^5.2.0",
+    "@fastify/cookie": "^11.0.0",
     "@fastify/cors": "^11.0.0",
     "@fastify/rate-limit": "^10.3.0",
     "@trpc/server": "^11.0.0",

--- a/services/api-gateway/src/middleware/auth.ts
+++ b/services/api-gateway/src/middleware/auth.ts
@@ -80,11 +80,11 @@ export async function authMiddleware(
   }
 
   if (!sessionId) {
-    // Simple cookie parsing (no @fastify/cookie dependency needed).
-    const cookieHeader = request.headers.cookie ?? "";
-    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]+)/);
-    if (match) {
-      sessionId = match[1];
+    // Parsed by @fastify/cookie plugin registered in server.ts.
+    const cookies = (request as unknown as { cookies?: Record<string, string> })
+      .cookies;
+    if (cookies?.session) {
+      sessionId = cookies.session;
     }
   }
 

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -1,5 +1,6 @@
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import cookie from "@fastify/cookie";
 import rateLimit from "@fastify/rate-limit";
 import { fastifyTRPCPlugin } from "@trpc/server/adapters/fastify";
 import Redis from "ioredis";
@@ -61,6 +62,19 @@ async function main() {
     credentials: true,
   });
 
+  // Register @fastify/cookie so request.cookies is populated and
+  // reply.setCookie is available with proper security flags.
+  const cookieSecret = process.env.SESSION_SECRET;
+  if (process.env.NODE_ENV === "production" && !cookieSecret) {
+    throw new Error(
+      "SESSION_SECRET must be set in production for signed session cookies.",
+    );
+  }
+  await server.register(cookie, {
+    secret: cookieSecret ?? "dev-insecure-cookie-secret-do-not-use-in-prod",
+    parseOptions: {},
+  });
+
   // Global rate limit: 100 requests per minute per IP across all API endpoints.
   // Protects PHI endpoints from enumeration and abuse.
   //
@@ -96,6 +110,37 @@ async function main() {
       router: appRouter,
       createContext,
     },
+  });
+
+  // --- Session cookie endpoints ---
+  //
+  // The tRPC auth.login procedure lives in a shared package and cannot touch
+  // Fastify's reply directly, so the client calls POST /auth/session with the
+  // JWT it received from auth.login and we write it into an HttpOnly cookie
+  // with the proper security flags. This prevents XSS from reading the
+  // session token and blocks CSRF via SameSite=strict.
+  const sessionCookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict" as const,
+    path: "/",
+  };
+
+  server.post<{ Body: { token?: string } }>(
+    "/auth/session",
+    async (request, reply) => {
+      const token = request.body?.token;
+      if (!token || typeof token !== "string") {
+        return reply.code(400).send({ error: "Missing session token" });
+      }
+      reply.setCookie("session", token, sessionCookieOptions);
+      return { ok: true };
+    },
+  );
+
+  server.post("/auth/session/clear", async (_request, reply) => {
+    reply.clearCookie("session", { path: "/" });
+    return { ok: true };
   });
 
   // --- Health check ---


### PR DESCRIPTION
Fixes #134. Registers @fastify/cookie plugin. Sets session cookies with HttpOnly, Secure (prod), SameSite=strict flags. Prevents XSS session theft and CSRF.