### PR TITLE
fix(hipaa): encrypt clinical narrative PHI fields

### DIFF
--- a/packages/db-schema/drizzle/0011_encrypt_clinical_narratives.sql
+++ b/packages/db-schema/drizzle/0011_encrypt_clinical_narratives.sql
@@ -1,0 +1,40 @@
+-- 0011_encrypt_clinical_narratives.sql
+--
+-- HIPAA: encrypt clinical narrative PHI fields at rest using AES-256-GCM
+-- via the `encryptedText` / `encryptedJsonb` Drizzle custom types
+-- (see packages/db-schema/src/encryption.ts).
+--
+-- The custom types map to a `text` column at the SQL level, so no
+-- ALTER COLUMN TYPE statements are required for columns that were
+-- already `text`. The JSONB `sections` columns on clinical_notes /
+-- note_versions are converted to `text` to hold the ciphertext, because
+-- encrypted bytes are not valid JSON and cannot live in a `jsonb` column.
+--
+-- Fields now encrypted:
+--   diagnoses.description
+--   allergies.allergen
+--   allergies.reaction
+--   medications.name
+--   medications.brand_name
+--   medications.notes
+--   vitals.notes
+--   lab_results.notes
+--   procedures.notes
+--   clinical_notes.sections      (jsonb -> text, encrypted JSON blob)
+--   note_versions.sections       (jsonb -> text, encrypted JSON blob)
+--
+-- IMPORTANT — DATA MIGRATION REQUIRED:
+-- Any rows that already exist in these tables are plaintext and will fail
+-- to decrypt through the custom type (which expects the `iv:authTag:ct`
+-- format produced by encrypt()). A one-time re-encryption script must run
+-- against the live database to rewrite every existing row through the
+-- encryption pipeline before application reads will succeed.
+-- See tooling/scripts/ for the re-encryption migration (to be added
+-- separately) — do not deploy this migration to an environment with
+-- existing PHI data without running it.
+
+ALTER TABLE "clinical_notes"
+  ALTER COLUMN "sections" SET DATA TYPE text USING "sections"::text;
+
+ALTER TABLE "note_versions"
+  ALTER COLUMN "sections" SET DATA TYPE text USING "sections"::text;

--- a/packages/db-schema/src/encryption.ts
+++ b/packages/db-schema/src/encryption.ts
@@ -153,3 +153,30 @@ export const encryptedText = customType<{ data: string; driverData: string }>({
     return decrypt(value, getKey());
   },
 });
+
+/**
+ * Encrypted JSONB custom type. Serializes the JS value to JSON, encrypts the
+ * resulting string with AES-256-GCM, and stores it as text. On read, decrypts
+ * and parses back into a JS value.
+ *
+ * Note: this stores the ciphertext in a `text` column (not `jsonb`) because
+ * ciphertext is not valid JSON. Query operators that rely on JSONB (e.g. ->,
+ * @>) will not work against encrypted columns — callers must read the full
+ * value and filter in application code.
+ */
+export const encryptedJsonb = <T = unknown>() =>
+  customType<{ data: T; driverData: string }>({
+    dataType() {
+      return "text";
+    },
+    toDriver(value: T): string {
+      return encrypt(JSON.stringify(value), getKey());
+    },
+    fromDriver(value: string): T {
+      const previousKey = getPreviousKey();
+      const plaintext = previousKey
+        ? decryptWithFallback(value, getKey(), previousKey)
+        : decrypt(value, getKey());
+      return JSON.parse(plaintext) as T;
+    },
+  });

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -1,11 +1,12 @@
 import { pgTable, text, real, index, jsonb } from "drizzle-orm/pg-core";
+import { encryptedText } from "../encryption.js";
 import { patients } from "./patients.js";
 
 export const medications = pgTable("medications", {
   id: text("id").primaryKey(),
   patient_id: text("patient_id").notNull().references(() => patients.id),
-  name: text("name").notNull(),
-  brand_name: text("brand_name"),
+  name: encryptedText("name").notNull(),
+  brand_name: encryptedText("brand_name"),
   dose_amount: real("dose_amount"),
   dose_unit: text("dose_unit"),
   route: text("route"),
@@ -14,7 +15,7 @@ export const medications = pgTable("medications", {
   started_at: text("started_at"),
   ended_at: text("ended_at"),
   prescribed_by: text("prescribed_by"),
-  notes: text("notes"),
+  notes: encryptedText("notes"),
   rxnorm_code: text("rxnorm_code"),
   ordering_provider_id: text("ordering_provider_id"),
   encounter_id: text("encounter_id"),
@@ -47,7 +48,7 @@ export const vitals = pgTable("vitals", {
   value_primary: real("value_primary").notNull(),
   value_secondary: real("value_secondary"),
   unit: text("unit").notNull(),
-  notes: text("notes"),
+  notes: encryptedText("notes"),
   provider_id: text("provider_id"),
   encounter_id: text("encounter_id"),
   source_system: text("source_system").default("internal"),
@@ -82,7 +83,7 @@ export const labResults = pgTable("lab_results", {
   reference_low: real("reference_low"),
   reference_high: real("reference_high"),
   flag: text("flag"),
-  notes: text("notes"),
+  notes: encryptedText("notes"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_lab_results_panel").on(table.panel_id),
@@ -100,7 +101,7 @@ export const procedures = pgTable("procedures", {
   performed_by: text("performed_by"),
   provider_id: text("provider_id"),
   encounter_id: text("encounter_id"),
-  notes: text("notes"),
+  notes: encryptedText("notes"),
   source_system: text("source_system").default("internal"),
   created_at: text("created_at").notNull(),
 }, (table) => [

--- a/packages/db-schema/src/schema/notes.ts
+++ b/packages/db-schema/src/schema/notes.ts
@@ -1,5 +1,11 @@
-import { pgTable, text, integer, real, jsonb, index } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, real, index } from "drizzle-orm/pg-core";
+import { encryptedJsonb } from "../encryption.js";
 import { patients } from "./patients.js";
+
+// NoteSection[] stored encrypted at rest. Ciphertext lives in a text column
+// because encrypted bytes are not valid JSON; JSONB operators are unavailable
+// on this column.
+const encryptedSections = encryptedJsonb<unknown>();
 
 export const clinicalNotes = pgTable("clinical_notes", {
   id: text("id").primaryKey(),
@@ -7,7 +13,7 @@ export const clinicalNotes = pgTable("clinical_notes", {
   provider_id: text("provider_id").notNull(),
   encounter_id: text("encounter_id"),
   template_type: text("template_type").notNull(), // soap, progress, h_and_p, discharge, consult
-  sections: jsonb("sections").notNull(), // NoteSection[]
+  sections: encryptedSections("sections").notNull(), // NoteSection[] — encrypted at rest
   version: integer("version").notNull().default(1),
   status: text("status").notNull().default("draft"), // draft, signed, cosigned, amended
   signed_at: text("signed_at"),
@@ -27,7 +33,7 @@ export const noteVersions = pgTable("note_versions", {
   id: text("id").primaryKey(),
   note_id: text("note_id").notNull().references(() => clinicalNotes.id),
   version: integer("version").notNull(),
-  sections: jsonb("sections").notNull(),
+  sections: encryptedSections("sections").notNull(),
   saved_at: text("saved_at").notNull(),
   saved_by: text("saved_by").notNull(),
 }, (table) => [

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -31,7 +31,7 @@ export const diagnoses = pgTable("diagnoses", {
   patient_id: text("patient_id").notNull().references(() => patients.id),
   icd10_code: text("icd10_code"),
   snomed_code: text("snomed_code"),
-  description: text("description").notNull(),
+  description: encryptedText("description").notNull(),
   status: text("status").notNull().default("active"), // active, resolved, chronic
   onset_date: text("onset_date"),
   resolved_date: text("resolved_date"),
@@ -44,10 +44,10 @@ export const diagnoses = pgTable("diagnoses", {
 export const allergies = pgTable("allergies", {
   id: text("id").primaryKey(),
   patient_id: text("patient_id").notNull().references(() => patients.id),
-  allergen: text("allergen").notNull(),
+  allergen: encryptedText("allergen").notNull(),
   snomed_code: text("snomed_code"),
   rxnorm_code: text("rxnorm_code"),
-  reaction: text("reaction"),
+  reaction: encryptedText("reaction"),
   severity: text("severity"), // mild, moderate, severe
   created_at: text("created_at").notNull(),
 }, (table) => [


### PR DESCRIPTION
Fixes #132. Applies encryptedText (AES-256-GCM) to medication names, diagnosis descriptions, allergy allergen/reaction, and all *.notes fields across clinical schemas. Includes migration. Existing rows require one-time re-encryption.