### PR TITLE
fix(fhir): validate Bundle schema + sanitize resource strings

### DIFF
--- a/services/fhir-gateway/package.json
+++ b/services/fhir-gateway/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/phi-sanitizer": "workspace:*",
     "@trpc/server": "^11.0.0",
     "drizzle-orm": "^0.38.0",
     "zod": "^3.24.0"

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -22,31 +22,48 @@ import {
   toFhirMedicationStatement,
   toFhirAllergyIntolerance,
 } from "./generators/index.js";
+import { fhirBundleSchema } from "./schemas/bundle.js";
+import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
 
 const t = initTRPC.create();
+
+function sanitizeResourceStrings(value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeFreeText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeResourceStrings);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeResourceStrings(v);
+    }
+    return out;
+  }
+  return value;
+}
 
 export const fhirGatewayRouter = t.router({
   importBundle: t.procedure
     .input(z.object({
-      bundle: z.any(), // FHIR Bundle JSON — full parsing in future
+      bundle: fhirBundleSchema,
       source_system: z.string(),
     }))
     .mutation(async ({ input }) => {
       const db = getDb();
       const now = new Date().toISOString();
-      // Stub: store raw bundle entries as fhir_resources
-      const bundle = input.bundle as { entry?: { resource?: Record<string, unknown> }[] };
-      const entries = bundle.entry ?? [];
+      const entries = input.bundle.entry ?? [];
       let imported = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
-        const resource = entry.resource;
+        const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
         await db.insert(fhirResources).values({
           id: crypto.randomUUID(),
-          resource_type: (resource.resourceType as string) ?? "Unknown",
-          resource_id: (resource.id as string) ?? crypto.randomUUID(),
+          resource_type: (sanitized.resourceType as string) ?? "Unknown",
+          resource_id: (sanitized.id as string) ?? crypto.randomUUID(),
           patient_id: null,
-          resource,
+          resource: sanitized,
           source_system: input.source_system,
           imported_at: now,
         });

--- a/services/fhir-gateway/src/schemas/bundle.ts
+++ b/services/fhir-gateway/src/schemas/bundle.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const fhirBundleSchema = z.object({
+  resourceType: z.literal("Bundle"),
+  type: z.enum([
+    "document",
+    "message",
+    "transaction",
+    "batch",
+    "history",
+    "searchset",
+    "collection",
+  ]),
+  entry: z
+    .array(
+      z.object({
+        fullUrl: z.string().optional(),
+        resource: z
+          .object({
+            resourceType: z.string(),
+            id: z.string().optional(),
+          })
+          .passthrough(),
+      }),
+    )
+    .optional(),
+}).passthrough();
+
+export type FhirBundle = z.infer<typeof fhirBundleSchema>;


### PR DESCRIPTION
Fixes #141. Replaces z.any() with a proper Zod FHIR Bundle schema. Walks resource bodies and sanitizes string fields via phi-sanitizer to remove prompt injection delimiters.