### PR TITLE
fix: five open bugs and security issues (#145 #152 #153 #154 #156)

### DIFF
--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -5,16 +5,21 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
 
+type LoginStep = "credentials" | "mfa";
+
 export default function LoginPage() {
   const isDev = process.env.NODE_ENV === "development";
   const [email, setEmail] = useState(isDev ? "patient@carebridge.dev" : "");
   const [password, setPassword] = useState(isDev ? "password123" : "");
+  const [totpCode, setTotpCode] = useState("");
+  const [mfaSessionId, setMfaSessionId] = useState<string | null>(null);
+  const [step, setStep] = useState<LoginStep>("credentials");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
   const { setSession } = useAuth();
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleCredentials(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLoading(true);
@@ -22,7 +27,8 @@ export default function LoginPage() {
     try {
       const result = await trpcVanilla.auth.login.mutate({ email, password });
       if ("requiresMFA" in result && result.requiresMFA) {
-        setError("MFA is required. Please use the clinician portal for MFA login.");
+        setMfaSessionId(result.mfaSessionId);
+        setStep("mfa");
         return;
       }
       const loginResult = result as { user: { id: string; name: string; email: string; role: string }; session: { id: string } };
@@ -35,6 +41,36 @@ export default function LoginPage() {
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleMFA(e: React.FormEvent) {
+    e.preventDefault();
+    if (!mfaSessionId) return;
+    setError(null);
+    setLoading(true);
+
+    try {
+      const result = await trpcVanilla.auth.mfaCompleteLogin.mutate({
+        mfaSessionId,
+        code: totpCode.trim(),
+      });
+      setSession(result.user, result.session.id);
+      router.push("/");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Verification failed. Please try again.";
+      setError(message);
+      setTotpCode("");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleBackToLogin() {
+    setStep("credentials");
+    setMfaSessionId(null);
+    setTotpCode("");
+    setError(null);
   }
 
   const inputStyle = {
@@ -59,74 +95,159 @@ export default function LoginPage() {
           padding: "2rem",
         }}
       >
-        <h2 style={{ margin: "0 0 1.5rem", fontSize: "1.25rem" }}>
-          Sign In to Patient Portal
-        </h2>
+        {step === "credentials" ? (
+          <>
+            <h2 style={{ margin: "0 0 1.5rem", fontSize: "1.25rem" }}>
+              Sign In to Patient Portal
+            </h2>
 
-        <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: "1rem" }}>
-            <label
-              htmlFor="email"
-              style={{ display: "block", fontSize: "0.75rem", color: "#999", marginBottom: 4 }}
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              style={inputStyle}
-            />
-          </div>
+            <form onSubmit={handleCredentials}>
+              <div style={{ marginBottom: "1rem" }}>
+                <label
+                  htmlFor="email"
+                  style={{ display: "block", fontSize: "0.75rem", color: "#999", marginBottom: 4 }}
+                >
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                  style={inputStyle}
+                />
+              </div>
 
-          <div style={{ marginBottom: "1rem" }}>
-            <label
-              htmlFor="password"
-              style={{ display: "block", fontSize: "0.75rem", color: "#999", marginBottom: 4 }}
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              style={inputStyle}
-            />
-          </div>
+              <div style={{ marginBottom: "1rem" }}>
+                <label
+                  htmlFor="password"
+                  style={{ display: "block", fontSize: "0.75rem", color: "#999", marginBottom: 4 }}
+                >
+                  Password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  style={inputStyle}
+                />
+              </div>
 
-          {error && (
-            <div style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
-              {error}
-            </div>
-          )}
+              {error && (
+                <div style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                  {error}
+                </div>
+              )}
 
-          <button
-            type="submit"
-            disabled={loading}
-            style={{
-              width: "100%",
-              padding: "10px",
-              backgroundColor: "#3b82f6",
-              color: "white",
-              border: "none",
-              borderRadius: "6px",
-              cursor: loading ? "not-allowed" : "pointer",
-              opacity: loading ? 0.7 : 1,
-              fontSize: "0.875rem",
-            }}
-          >
-            {loading ? "Signing in..." : "Sign In"}
-          </button>
-        </form>
+              <button
+                type="submit"
+                disabled={loading}
+                style={{
+                  width: "100%",
+                  padding: "10px",
+                  backgroundColor: "#3b82f6",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "6px",
+                  cursor: loading ? "not-allowed" : "pointer",
+                  opacity: loading ? 0.7 : 1,
+                  fontSize: "0.875rem",
+                }}
+              >
+                {loading ? "Signing in..." : "Sign In"}
+              </button>
+            </form>
 
-        {isDev && (
-          <p style={{ marginTop: "1rem", fontSize: "0.75rem", color: "#666", textAlign: "center" }}>
-            Dev account: patient@carebridge.dev / password123
-          </p>
+            {isDev && (
+              <p style={{ marginTop: "1rem", fontSize: "0.75rem", color: "#666", textAlign: "center" }}>
+                Dev account: patient@carebridge.dev / password123
+              </p>
+            )}
+          </>
+        ) : (
+          <>
+            <h2 style={{ margin: "0 0 0.5rem", fontSize: "1.25rem" }}>
+              Two-Factor Authentication
+            </h2>
+            <p style={{ fontSize: "0.8rem", color: "#999", marginBottom: "1.5rem", lineHeight: 1.5 }}>
+              Enter the 6-digit code from your authenticator app, or a recovery code to complete sign-in.
+            </p>
+
+            <form onSubmit={handleMFA}>
+              <div style={{ marginBottom: "1rem" }}>
+                <label
+                  htmlFor="totp-code"
+                  style={{ display: "block", fontSize: "0.75rem", color: "#999", marginBottom: 4 }}
+                >
+                  Verification Code
+                </label>
+                <input
+                  id="totp-code"
+                  type="text"
+                  value={totpCode}
+                  onChange={(e) => setTotpCode(e.target.value)}
+                  placeholder="000000"
+                  autoComplete="one-time-code"
+                  inputMode="numeric"
+                  maxLength={10}
+                  required
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus
+                  style={{
+                    ...inputStyle,
+                    letterSpacing: "0.15em",
+                    fontSize: "1.125rem",
+                    textAlign: "center",
+                  }}
+                />
+              </div>
+
+              {error && (
+                <div style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                  {error}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={loading || totpCode.trim().length === 0}
+                style={{
+                  width: "100%",
+                  padding: "10px",
+                  backgroundColor: "#3b82f6",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "6px",
+                  cursor: (loading || totpCode.trim().length === 0) ? "not-allowed" : "pointer",
+                  opacity: (loading || totpCode.trim().length === 0) ? 0.7 : 1,
+                  fontSize: "0.875rem",
+                  marginBottom: 8,
+                }}
+              >
+                {loading ? "Verifying..." : "Verify"}
+              </button>
+
+              <button
+                type="button"
+                onClick={handleBackToLogin}
+                style={{
+                  width: "100%",
+                  padding: "10px",
+                  backgroundColor: "transparent",
+                  color: "#999",
+                  border: "1px solid #2a2a2a",
+                  borderRadius: "6px",
+                  cursor: "pointer",
+                  fontSize: "0.875rem",
+                }}
+              >
+                Back to Sign In
+              </button>
+            </form>
+          </>
         )}
       </div>
     </div>

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -153,8 +153,8 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     notify_specialties: ["hematology", "oncology"],
   },
   {
-    id: "CHEMO-NEUTRO-FEVER-001",
-    name: "Chemotherapy + neutropenia + fever",
+    id: "CHEMO-FEVER-001",
+    name: "Chemotherapy + fever (evaluate for febrile neutropenia)",
     check: (ctx: PatientContext) => {
       const onChemo = ctx.active_medications.some((m) =>
         /chemo|capecitabine|xeloda|cisplatin|carboplatin|doxorubicin|cyclophosphamide|paclitaxel|docetaxel|methotrexate|5-fu|fluorouracil/i.test(m),

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -36,7 +36,7 @@ async function logAccessDenial(
 /*  In-memory TTL cache for care-team lookups                         */
 /* ------------------------------------------------------------------ */
 
-const CACHE_TTL_MS = 60_000; // 60 seconds
+const CACHE_TTL_MS = 5_000; // 5 seconds
 const CACHE_MAX_ENTRIES = 10_000;
 
 interface CacheEntry {

--- a/services/auth/vitest.config.ts
+++ b/services/auth/vitest.config.ts
@@ -13,12 +13,4 @@ export default defineConfig({
       ),
     },
   },
-  resolve: {
-    alias: {
-      "@carebridge/db-schema": path.resolve(
-        __dirname,
-        "../../packages/db-schema/src/index.ts",
-      ),
-    },
-  },
 });

--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -60,8 +60,9 @@ function mapSeverityToCriticality(
 ): "low" | "high" | "unable-to-assess" {
   switch (severity) {
     case "mild":
-    case "moderate":
       return "low";
+    case "moderate":
+      return "high";
     case "severe":
       return "high";
     default:


### PR DESCRIPTION
## Summary

- **#145 security**: Reduce RBAC cache TTL from 60s to 5s — stale role grants persist for up to a minute after revocation
- **#152 bug**: Remove duplicate `resolve` block in `services/auth/vitest.config.ts` (duplicate key causes last-writer-wins silently)
- **#153 bug**: Rename `CHEMO-NEUTRO-FEVER-001` → `CHEMO-FEVER-001` with accurate name — rule checks chemo+fever but never checks ANC
- **#154 bug**: Fix `AllergyIntolerance` criticality mapping — `moderate` severity now maps to `high` (not `low`) per FHIR R4 semantics
- **#156 bug**: Implement full MFA flow in patient portal — previously blocked any patient with MFA enabled from logging in

## Test plan

- [ ] Patient with MFA enabled can complete 2-step login in patient portal
- [ ] Patient without MFA logs in normally (single-step, unchanged)
- [ ] RBAC denial is reflected within 5s of care-team change
- [ ] FHIR AllergyIntolerance export for moderate-severity allergy returns `criticality: "high"`
- [ ] Auth service tests pass with deduplicated vitest config
- [ ] AI oversight rules engine no longer emits `CHEMO-NEUTRO-FEVER-001` rule ID