### PR TITLE
fix(fhir): AllergyIntolerance criticality — moderate severity maps to high

### DIFF
--- a/services/fhir-gateway/src/__tests__/allergy-intolerance.test.ts
+++ b/services/fhir-gateway/src/__tests__/allergy-intolerance.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { toFhirAllergyIntolerance } from "../generators/allergy-intolerance.js";
+
+type Allergy = Parameters<typeof toFhirAllergyIntolerance>[0];
+
+function makeAllergy(severity: string | null): Allergy {
+  return {
+    id: "a1",
+    allergen: "Penicillin",
+    snomed_code: null,
+    rxnorm_code: null,
+    reaction: null,
+    severity,
+    created_at: "2026-01-01T00:00:00.000Z",
+  } as unknown as Allergy;
+}
+
+describe("toFhirAllergyIntolerance severity -> criticality mapping", () => {
+  it("maps mild to low", () => {
+    expect(toFhirAllergyIntolerance(makeAllergy("mild"), "p1").criticality).toBe(
+      "low",
+    );
+  });
+
+  it("maps moderate to high (can escalate to anaphylaxis)", () => {
+    expect(
+      toFhirAllergyIntolerance(makeAllergy("moderate"), "p1").criticality,
+    ).toBe("high");
+  });
+
+  it("maps severe to high", () => {
+    expect(
+      toFhirAllergyIntolerance(makeAllergy("severe"), "p1").criticality,
+    ).toBe("high");
+  });
+
+  it("maps null/unknown to unable-to-assess", () => {
+    expect(toFhirAllergyIntolerance(makeAllergy(null), "p1").criticality).toBe(
+      "unable-to-assess",
+    );
+    expect(
+      toFhirAllergyIntolerance(makeAllergy("bogus"), "p1").criticality,
+    ).toBe("unable-to-assess");
+  });
+});

--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -58,10 +58,14 @@ const VERIFICATION_STATUS_SYSTEM =
 function mapSeverityToCriticality(
   severity: string | null,
 ): "low" | "high" | "unable-to-assess" {
+  // Clinical rationale: FHIR criticality represents the risk of a future
+  // life-threatening reaction, not the observed severity. Moderate reactions
+  // can escalate unpredictably to anaphylaxis, so we conservatively map
+  // moderate -> "high" to prompt clinician caution on subsequent exposures.
   switch (severity) {
     case "mild":
-    case "moderate":
       return "low";
+    case "moderate":
     case "severe":
       return "high";
     default:


### PR DESCRIPTION
Fixes #154. Conservative clinical mapping: moderate severity now maps to 'high' FHIR criticality (was 'low'). Moderate reactions can escalate to anaphylaxis, so the risk of life-threatening reaction should prompt clinician caution.