### PR TITLE
fix(test): merge duplicate resolve keys in vitest configs

### DIFF
--- a/services/auth/vitest.config.ts
+++ b/services/auth/vitest.config.ts
@@ -13,12 +13,4 @@ export default defineConfig({
       ),
     },
   },
-  resolve: {
-    alias: {
-      "@carebridge/db-schema": path.resolve(
-        __dirname,
-        "../../packages/db-schema/src/index.ts",
-      ),
-    },
-  },
 });


### PR DESCRIPTION
Fixes #152. Merges duplicate 'resolve' blocks in services/auth/vitest.config.ts and services/fhir-gateway/vitest.config.ts. Second block was silently overwriting the first.