### PR TITLE
feat(portal): flag action confirmation + audit trail

### DIFF
--- a/apps/clinician-portal/app/inbox/page.tsx
+++ b/apps/clinician-portal/app/inbox/page.tsx
@@ -2,133 +2,130 @@
 
 import { useState } from "react";
 import { AuthGuard } from "@/lib/auth-guard";
+import { trpc } from "@/lib/trpc";
+import {
+  FlagActionModal,
+  type FlagAction,
+  type FlagActionModalFlag,
+} from "@/components/flag-action-modal";
 
-interface Flag {
-  id: string;
-  severity: "critical" | "warning" | "info";
-  patient: string;
-  patientId: string;
-  summary: string;
-  suggestion: string;
-  time: string;
-  acknowledged: boolean;
+type Severity = "critical" | "warning" | "info";
+
+const severityOrder: Record<string, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diff = Date.now() - then;
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min} min ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr} hr ago`;
+  const d = Math.floor(hr / 24);
+  return `${d} day${d === 1 ? "" : "s"} ago`;
 }
 
-const initialFlags: Flag[] = [
-  {
-    id: "flag-1",
-    severity: "critical",
-    patient: "Maria Santos",
-    patientId: "pt-001",
-    summary: "Critical lab result: Potassium 6.2 mEq/L",
-    suggestion:
-      "Recommend STAT ECG and urgent potassium correction protocol. Consider sodium polystyrene sulfonate and reassess in 2 hours.",
-    time: "12 min ago",
-    acknowledged: false,
-  },
-  {
-    id: "flag-2",
-    severity: "warning",
-    patient: "James Thompson",
-    patientId: "pt-002",
-    summary: "Medication interaction detected: Warfarin + new Amiodarone order",
-    suggestion:
-      "Consider reducing Warfarin dose by 30-50% and schedule INR check in 3 days. Monitor for signs of bleeding.",
-    time: "34 min ago",
-    acknowledged: false,
-  },
-  {
-    id: "flag-3",
-    severity: "info",
-    patient: "Aisha Johnson",
-    patientId: "pt-003",
-    summary: "HbA1c trending up: 7.1% to 7.8% over 6 months",
-    suggestion:
-      "Consider medication adjustment or endocrinology referral at next visit. Patient may benefit from CGM.",
-    time: "1 hr ago",
-    acknowledged: false,
-  },
-  {
-    id: "flag-4",
-    severity: "warning",
-    patient: "Robert Kim",
-    patientId: "pt-004",
-    summary:
-      "Missed follow-up: Post-discharge cardiology appointment overdue by 7 days",
-    suggestion:
-      "Patient was discharged 14 days ago with instruction to follow up in 7 days. No cardiology appointment has been scheduled.",
-    time: "2 hr ago",
-    acknowledged: false,
-  },
-  {
-    id: "flag-5",
-    severity: "info",
-    patient: "Dorothy Williams",
-    patientId: "pt-005",
-    summary: "Fall risk assessment: MORSE score increased to 55 (high risk)",
-    suggestion:
-      "Consider physical therapy referral and home safety evaluation. Review current medications for fall-risk contributors.",
-    time: "3 hr ago",
-    acknowledged: false,
-  },
-  {
-    id: "flag-6",
-    severity: "warning",
-    patient: "Maria Santos",
-    patientId: "pt-001",
-    summary: "Blood pressure consistently above target: avg 152/94 over 30 days",
-    suggestion:
-      "Current antihypertensive regimen may need adjustment. Consider adding or uptitrating medication.",
-    time: "5 hr ago",
-    acknowledged: false,
-  },
-];
-
-const severityOrder = { critical: 0, warning: 1, info: 2 };
-
 function InboxContent() {
-  const [flags, setFlags] = useState(initialFlags);
-  const [filter, setFilter] = useState<"all" | "critical" | "warning" | "info">(
-    "all"
-  );
+  const utils = trpc.useUtils();
+  const flagsQuery = trpc.aiOversight.flags.getAllOpen.useQuery();
+  const flags = flagsQuery.data ?? [];
 
-  const openFlags = flags.filter((f) => !f.acknowledged);
+  const [filter, setFilter] = useState<"all" | Severity>("all");
+  const [activeFlag, setActiveFlag] = useState<FlagActionModalFlag | null>(
+    null,
+  );
+  const [activeAction, setActiveAction] = useState<FlagAction | null>(null);
+  const [activePatientId, setActivePatientId] = useState<string | null>(null);
+
+  const onSuccess = async () => {
+    await utils.aiOversight.flags.getAllOpen.invalidate();
+    if (activePatientId) {
+      await utils.aiOversight.flags.getByPatient.invalidate({
+        patientId: activePatientId,
+      });
+      await utils.aiOversight.flags.getOpenCount.invalidate({
+        patientId: activePatientId,
+      });
+    }
+    setActiveFlag(null);
+    setActiveAction(null);
+    setActivePatientId(null);
+  };
+
+  const acknowledgeMutation =
+    trpc.aiOversight.flags.acknowledge.useMutation({ onSuccess });
+  const resolveMutation =
+    trpc.aiOversight.flags.resolve.useMutation({ onSuccess });
+  const dismissMutation =
+    trpc.aiOversight.flags.dismiss.useMutation({ onSuccess });
+
+  const isSubmitting =
+    acknowledgeMutation.isPending ||
+    resolveMutation.isPending ||
+    dismissMutation.isPending;
+
   const filteredFlags =
-    filter === "all"
-      ? openFlags
-      : openFlags.filter((f) => f.severity === filter);
+    filter === "all" ? flags : flags.filter((f) => f.severity === filter);
 
   const sorted = [...filteredFlags].sort(
-    (a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+    (a, b) =>
+      (severityOrder[a.severity] ?? 99) - (severityOrder[b.severity] ?? 99),
   );
 
-  function acknowledge(id: string) {
-    setFlags((prev) =>
-      prev.map((f) => (f.id === id ? { ...f, acknowledged: true } : f))
-    );
+  const criticalCount = flags.filter((f) => f.severity === "critical").length;
+  const warningCount = flags.filter((f) => f.severity === "warning").length;
+  const infoCount = flags.filter((f) => f.severity === "info").length;
+
+  function openModal(
+    flag: {
+      id: string;
+      severity: string;
+      summary: string;
+      suggested_action?: string | null;
+      patient_id: string;
+    },
+    action: FlagAction,
+  ) {
+    setActiveFlag({
+      id: flag.id,
+      severity: flag.severity,
+      summary: flag.summary,
+      suggested_action: flag.suggested_action ?? undefined,
+    });
+    setActiveAction(action);
+    setActivePatientId(flag.patient_id);
   }
 
-  function dismiss(id: string) {
-    setFlags((prev) =>
-      prev.map((f) => (f.id === id ? { ...f, acknowledged: true } : f))
-    );
+  function handleConfirm(reason: string) {
+    if (!activeFlag || !activeAction) return;
+    if (activeAction === "acknowledge") {
+      acknowledgeMutation.mutate({ flagId: activeFlag.id });
+    } else if (activeAction === "resolve") {
+      resolveMutation.mutate({
+        flagId: activeFlag.id,
+        resolution_note: reason,
+      });
+    } else if (activeAction === "dismiss") {
+      dismissMutation.mutate({
+        flagId: activeFlag.id,
+        dismiss_reason: reason,
+      });
+    }
   }
-
-  const criticalCount = openFlags.filter(
-    (f) => f.severity === "critical"
-  ).length;
-  const warningCount = openFlags.filter(
-    (f) => f.severity === "warning"
-  ).length;
-  const infoCount = openFlags.filter((f) => f.severity === "info").length;
 
   return (
     <>
       <div className="page-header">
         <h1 className="page-title">AI Flags Inbox</h1>
         <p className="page-subtitle">
-          {openFlags.length} open flag{openFlags.length !== 1 ? "s" : ""}{" "}
-          requiring your attention
+          {flagsQuery.isLoading
+            ? "Loading flags..."
+            : `${flags.length} open flag${flags.length !== 1 ? "s" : ""} requiring your attention`}
         </p>
       </div>
 
@@ -144,14 +141,17 @@ function InboxContent() {
           className={`btn btn-sm ${filter === "all" ? "btn-primary" : "btn-ghost"}`}
           onClick={() => setFilter("all")}
         >
-          All ({openFlags.length})
+          All ({flags.length})
         </button>
         <button
           className={`btn btn-sm ${filter === "critical" ? "btn-primary" : "btn-ghost"}`}
           onClick={() => setFilter("critical")}
           style={
             filter !== "critical"
-              ? { borderColor: "var(--critical-border)", color: "var(--critical)" }
+              ? {
+                  borderColor: "var(--critical-border)",
+                  color: "var(--critical)",
+                }
               : {}
           }
         >
@@ -162,7 +162,10 @@ function InboxContent() {
           onClick={() => setFilter("warning")}
           style={
             filter !== "warning"
-              ? { borderColor: "var(--warning-border)", color: "var(--warning)" }
+              ? {
+                  borderColor: "var(--warning-border)",
+                  color: "var(--warning)",
+                }
               : {}
           }
         >
@@ -182,7 +185,13 @@ function InboxContent() {
       </div>
 
       <div className="table-container">
-        {sorted.length > 0 ? (
+        {flagsQuery.isError ? (
+          <div className="empty-state">
+            <div className="empty-state-text" style={{ color: "var(--critical)" }}>
+              Failed to load flags. Is the API running?
+            </div>
+          </div>
+        ) : sorted.length > 0 ? (
           <div className="flag-list">
             {sorted.map((flag) => (
               <div key={flag.id} className="flag-item">
@@ -194,26 +203,34 @@ function InboxContent() {
                 <div className="flag-content">
                   <div className="flag-patient">
                     <a
-                      href={`/patients/${flag.patientId}`}
+                      href={`/patients/${flag.patient_id}`}
                       className="table-link"
                     >
-                      {flag.patient}
+                      Patient {flag.patient_id.slice(0, 8)}
                     </a>
                   </div>
                   <div className="flag-summary">{flag.summary}</div>
-                  <div className="flag-suggestion">{flag.suggestion}</div>
-                  <div className="flag-time">{flag.time}</div>
+                  <div className="flag-suggestion">{flag.suggested_action}</div>
+                  <div className="flag-time">
+                    {formatRelative(flag.created_at)}
+                  </div>
                 </div>
                 <div className="flag-actions">
                   <button
                     className="btn btn-success btn-sm"
-                    onClick={() => acknowledge(flag.id)}
+                    onClick={() => openModal(flag, "acknowledge")}
                   >
                     Acknowledge
                   </button>
                   <button
+                    className="btn btn-primary btn-sm"
+                    onClick={() => openModal(flag, "resolve")}
+                  >
+                    Resolve
+                  </button>
+                  <button
                     className="btn btn-ghost btn-sm"
-                    onClick={() => dismiss(flag.id)}
+                    onClick={() => openModal(flag, "dismiss")}
                   >
                     Dismiss
                   </button>
@@ -232,6 +249,19 @@ function InboxContent() {
           </div>
         )}
       </div>
+
+      <FlagActionModal
+        flag={activeFlag}
+        action={activeAction}
+        onCancel={() => {
+          if (isSubmitting) return;
+          setActiveFlag(null);
+          setActiveAction(null);
+          setActivePatientId(null);
+        }}
+        onConfirm={handleConfirm}
+        isSubmitting={isSubmitting}
+      />
     </>
   );
 }

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -2,8 +2,14 @@
 
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { AuthGuard } from "@/lib/auth-guard";
+import {
+  FlagActionModal,
+  type FlagAction,
+  type FlagActionModalFlag,
+} from "@/components/flag-action-modal";
 
 const tabs = [
   { key: "overview", label: "Overview" },
@@ -351,10 +357,58 @@ function MedicationsTab({ patientId }: { patientId: string }) {
 }
 
 function FlagsTab({ patientId }: { patientId: string }) {
+  const utils = trpc.useUtils();
   const flagsQuery = trpc.aiOversight.flags.getByPatient.useQuery({
     patientId,
   });
   const flags = flagsQuery.data ?? [];
+
+  const [activeFlag, setActiveFlag] = useState<FlagActionModalFlag | null>(
+    null,
+  );
+  const [activeAction, setActiveAction] = useState<FlagAction | null>(null);
+
+  const onSuccess = async () => {
+    await utils.aiOversight.flags.getByPatient.invalidate({ patientId });
+    await utils.aiOversight.flags.getOpenCount.invalidate({ patientId });
+    await utils.aiOversight.flags.getAllOpen.invalidate();
+    setActiveFlag(null);
+    setActiveAction(null);
+  };
+
+  const acknowledgeMutation =
+    trpc.aiOversight.flags.acknowledge.useMutation({ onSuccess });
+  const resolveMutation =
+    trpc.aiOversight.flags.resolve.useMutation({ onSuccess });
+  const dismissMutation =
+    trpc.aiOversight.flags.dismiss.useMutation({ onSuccess });
+
+  const isSubmitting =
+    acknowledgeMutation.isPending ||
+    resolveMutation.isPending ||
+    dismissMutation.isPending;
+
+  function openModal(flag: FlagActionModalFlag, action: FlagAction) {
+    setActiveFlag(flag);
+    setActiveAction(action);
+  }
+
+  function handleConfirm(reason: string) {
+    if (!activeFlag || !activeAction) return;
+    if (activeAction === "acknowledge") {
+      acknowledgeMutation.mutate({ flagId: activeFlag.id });
+    } else if (activeAction === "resolve") {
+      resolveMutation.mutate({
+        flagId: activeFlag.id,
+        resolution_note: reason,
+      });
+    } else if (activeAction === "dismiss") {
+      dismissMutation.mutate({
+        flagId: activeFlag.id,
+        dismiss_reason: reason,
+      });
+    }
+  }
 
   if (flagsQuery.isLoading) return <LoadingState label="flags" />;
   if (flagsQuery.isError) return <ErrorState label="flags" />;
@@ -391,12 +445,39 @@ function FlagsTab({ patientId }: { patientId: string }) {
               </div>
             </div>
             <div className="flag-actions">
-              <button className="btn btn-success btn-sm">Acknowledge</button>
-              <button className="btn btn-ghost btn-sm">Dismiss</button>
+              <button
+                className="btn btn-success btn-sm"
+                onClick={() => openModal(flag, "acknowledge")}
+              >
+                Acknowledge
+              </button>
+              <button
+                className="btn btn-primary btn-sm"
+                onClick={() => openModal(flag, "resolve")}
+              >
+                Resolve
+              </button>
+              <button
+                className="btn btn-ghost btn-sm"
+                onClick={() => openModal(flag, "dismiss")}
+              >
+                Dismiss
+              </button>
             </div>
           </div>
         ))}
       </div>
+      <FlagActionModal
+        flag={activeFlag}
+        action={activeAction}
+        onCancel={() => {
+          if (isSubmitting) return;
+          setActiveFlag(null);
+          setActiveAction(null);
+        }}
+        onConfirm={handleConfirm}
+        isSubmitting={isSubmitting}
+      />
     </div>
   );
 }

--- a/apps/clinician-portal/src/components/flag-action-modal.tsx
+++ b/apps/clinician-portal/src/components/flag-action-modal.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export type FlagAction = "acknowledge" | "resolve" | "dismiss";
+
+export interface FlagActionModalFlag {
+  id: string;
+  severity: string;
+  summary: string;
+  suggested_action?: string;
+}
+
+interface FlagActionModalProps {
+  flag: FlagActionModalFlag | null;
+  action: FlagAction | null;
+  onCancel: () => void;
+  onConfirm: (reason: string) => void;
+  isSubmitting?: boolean;
+}
+
+/**
+ * Confirmation modal for flag state transitions.
+ *
+ * Requires a reason for dismiss and resolve actions. Dismiss is irreversible
+ * and surfaces a prominent warning. All actions are persisted via the server
+ * so an audit trail (user_id + reason + timestamp) is retained.
+ */
+export function FlagActionModal({
+  flag,
+  action,
+  onCancel,
+  onConfirm,
+  isSubmitting = false,
+}: FlagActionModalProps) {
+  const [reason, setReason] = useState("");
+
+  useEffect(() => {
+    setReason("");
+  }, [flag?.id, action]);
+
+  if (!flag || !action) return null;
+
+  const reasonRequired = action === "dismiss" || action === "resolve";
+  const canSubmit = !reasonRequired || reason.trim().length > 0;
+
+  const titles: Record<FlagAction, string> = {
+    acknowledge: "Acknowledge Flag",
+    resolve: "Resolve Flag",
+    dismiss: "Dismiss Flag",
+  };
+
+  const confirmLabels: Record<FlagAction, string> = {
+    acknowledge: "Acknowledge",
+    resolve: "Resolve",
+    dismiss: "Dismiss Permanently",
+  };
+
+  const confirmClass =
+    action === "dismiss"
+      ? "btn btn-danger"
+      : action === "resolve"
+      ? "btn btn-success"
+      : "btn btn-primary";
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="flag-action-modal-title"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: 16,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isSubmitting) onCancel();
+      }}
+    >
+      <div
+        style={{
+          background: "var(--surface, #1a1a1a)",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 24,
+          maxWidth: 520,
+          width: "100%",
+          boxShadow: "0 20px 40px rgba(0,0,0,0.4)",
+        }}
+      >
+        <h2
+          id="flag-action-modal-title"
+          style={{ marginTop: 0, marginBottom: 12, fontSize: 18 }}
+        >
+          {titles[action]}
+        </h2>
+
+        <div style={{ marginBottom: 16 }}>
+          <span className={`badge badge-${flag.severity}`}>
+            {flag.severity.toUpperCase()}
+          </span>
+          <div style={{ marginTop: 8, fontWeight: 500 }}>{flag.summary}</div>
+          {flag.suggested_action && (
+            <div
+              style={{
+                marginTop: 4,
+                fontSize: 13,
+                color: "var(--text-muted)",
+              }}
+            >
+              {flag.suggested_action}
+            </div>
+          )}
+        </div>
+
+        {action === "dismiss" && (
+          <div
+            style={{
+              padding: 12,
+              marginBottom: 16,
+              background: "rgba(220, 38, 38, 0.1)",
+              border: "1px solid var(--critical-border, #dc2626)",
+              borderRadius: 6,
+              color: "var(--critical, #fca5a5)",
+              fontSize: 13,
+            }}
+          >
+            <strong>Warning:</strong> Dismissing this flag is irreversible. The
+            flag will be permanently marked as not actionable. Your user ID and
+            the reason below will be recorded in the audit trail.
+          </div>
+        )}
+
+        {reasonRequired && (
+          <div style={{ marginBottom: 16 }}>
+            <label
+              htmlFor="flag-reason-input"
+              style={{
+                display: "block",
+                marginBottom: 6,
+                fontSize: 13,
+                fontWeight: 500,
+              }}
+            >
+              Reason <span style={{ color: "var(--critical)" }}>*</span>
+            </label>
+            <textarea
+              id="flag-reason-input"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={4}
+              disabled={isSubmitting}
+              placeholder={
+                action === "dismiss"
+                  ? "Explain why this flag is not clinically actionable..."
+                  : "Describe how the concern was addressed..."
+              }
+              style={{
+                width: "100%",
+                padding: 10,
+                background: "var(--bg, #0a0a0a)",
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                fontFamily: "inherit",
+                fontSize: 13,
+                resize: "vertical",
+              }}
+            />
+          </div>
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+          }}
+        >
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={confirmClass}
+            onClick={() => canSubmit && onConfirm(reason.trim())}
+            disabled={!canSubmit || isSubmitting}
+          >
+            {isSubmitting ? "Saving..." : confirmLabels[action]}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/ai-oversight/src/router.ts
+++ b/services/ai-oversight/src/router.ts
@@ -97,6 +97,11 @@ export const aiOversightRouter = t.router({
         return { success: true };
       }),
 
+    getAllOpen: protectedProcedure
+      .query(async () => {
+        return flagService.getAllOpenFlags();
+      }),
+
     getOpenCount: t.procedure
       .input(z.object({ patientId: z.string().uuid() }))
       .query(async ({ input }) => {

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -174,6 +174,18 @@ export async function getFlagsByPatient(
 }
 
 /**
+ * Get all open flags across all patients (for the clinician inbox).
+ */
+export async function getAllOpenFlags(): Promise<ClinicalFlag[]> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.status, "open"));
+  return rows as unknown as ClinicalFlag[];
+}
+
+/**
  * Get count of open flags for a patient.
  */
 export async function getOpenFlagCount(patientId: string): Promise<number> {


### PR DESCRIPTION
Fixes #140. Adds confirmation modal with required reason input for dismiss/resolve. Persists flag status changes to DB with user_id and reason. Replaces client-only state with real tRPC mutations.