### PR TITLE
feat(fhir): persist MedLens imports to vital/lab repositories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
 
   services/fhir-gateway:
     dependencies:
+      '@carebridge/clinical-data':
+        specifier: workspace:*
+        version: link:../clinical-data
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
@@ -494,6 +497,9 @@ importers:
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@carebridge/validators':
+        specifier: workspace:*
+        version: link:../../packages/validators
       '@trpc/server':
         specifier: ^11.0.0
         version: 11.16.0(typescript@5.9.3)

--- a/services/fhir-gateway/package.json
+++ b/services/fhir-gateway/package.json
@@ -10,6 +10,8 @@
   "dependencies": {
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/clinical-data": "workspace:*",
+    "@carebridge/validators": "workspace:*",
     "@carebridge/phi-sanitizer": "workspace:*",
     "@trpc/server": "^11.0.0",
     "drizzle-orm": "^0.38.0",

--- a/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
+++ b/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
@@ -51,9 +51,9 @@ describe("exportMedications", () => {
 });
 
 describe("importVitals", () => {
-  it("rejects vitals with confidence below 0.6", () => {
+  it("rejects vitals with confidence below 0.6", async () => {
     const token = createMedLensToken("patient-1", ["write:vitals"]);
-    const result = importVitals(token.token, [
+    const result = await importVitals(token.token, [
       {
         type: "heart_rate",
         value: 72,
@@ -71,9 +71,9 @@ describe("importVitals", () => {
     }
   });
 
-  it("accepts vitals with confidence >= 0.6", () => {
+  it("accepts vitals with confidence >= 0.6", async () => {
     const token = createMedLensToken("patient-1", ["write:vitals"]);
-    const result = importVitals(token.token, [
+    const result = await importVitals(token.token, [
       {
         type: "heart_rate",
         value: 72,
@@ -91,9 +91,9 @@ describe("importVitals", () => {
     }
   });
 
-  it("accepts vitals at exactly 0.6 threshold", () => {
+  it("accepts vitals at exactly 0.6 threshold", async () => {
     const token = createMedLensToken("patient-1", ["write:vitals"]);
-    const result = importVitals(token.token, [
+    const result = await importVitals(token.token, [
       {
         type: "o2_sat",
         value: 98,
@@ -112,9 +112,9 @@ describe("importVitals", () => {
 });
 
 describe("importLabs", () => {
-  it("rejects labs with confidence below 0.5", () => {
+  it("rejects labs with confidence below 0.5", async () => {
     const token = createMedLensToken("patient-1", ["write:labs"]);
-    const result = importLabs(token.token, [
+    const result = await importLabs(token.token, [
       {
         testName: "Glucose",
         value: 95,
@@ -132,9 +132,9 @@ describe("importLabs", () => {
     }
   });
 
-  it("accepts labs with confidence >= 0.5", () => {
+  it("accepts labs with confidence >= 0.5", async () => {
     const token = createMedLensToken("patient-1", ["write:labs"]);
-    const result = importLabs(token.token, [
+    const result = await importLabs(token.token, [
       {
         testName: "Glucose",
         value: 95,
@@ -153,7 +153,7 @@ describe("importLabs", () => {
 });
 
 describe("revokeToken", () => {
-  it("revoked token is rejected for all operations", () => {
+  it("revoked token is rejected for all operations", async () => {
     const token = createMedLensToken("patient-1", [
       "read:vitals",
       "read:medications",
@@ -165,7 +165,7 @@ describe("revokeToken", () => {
     const exportResult = exportMedications(token.token);
     expect(exportResult.ok).toBe(false);
 
-    const importResult = importVitals(token.token, []);
+    const importResult = await importVitals(token.token, []);
     expect(importResult.ok).toBe(false);
   });
 });

--- a/services/fhir-gateway/src/medlens-bridge.ts
+++ b/services/fhir-gateway/src/medlens-bridge.ts
@@ -9,6 +9,25 @@
  */
 
 import crypto from "node:crypto";
+import { vitalRepo, labRepo } from "@carebridge/clinical-data";
+import type { CreateVitalInput, CreateLabPanelInput } from "@carebridge/validators";
+
+type VitalType = CreateVitalInput["type"];
+
+const VITAL_TYPES: readonly VitalType[] = [
+  "blood_pressure",
+  "heart_rate",
+  "o2_sat",
+  "temperature",
+  "weight",
+  "respiratory_rate",
+  "pain_level",
+  "blood_glucose",
+] as const;
+
+function isVitalType(t: string): t is VitalType {
+  return (VITAL_TYPES as readonly string[]).includes(t);
+}
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -136,10 +155,10 @@ export function exportMedications(
  * Import vitals from MedLens devices.
  * Rejects entries below the confidence threshold.
  */
-export function importVitals(
+export async function importVitals(
   tokenStr: string,
   vitals: MedLensVital[],
-): { ok: true; result: ImportResult } | { ok: false; error: string } {
+): Promise<{ ok: true; result: ImportResult } | { ok: false; error: string }> {
   const token = validateToken(tokenStr, "write:vitals");
   if (!token) {
     return { ok: false, error: "Invalid or unauthorized token" };
@@ -157,9 +176,32 @@ export function importVitals(
       result.rejectionReasons.push(
         `${vital.type}: confidence ${vital.confidence} below threshold ${VITAL_CONFIDENCE_THRESHOLD}`,
       );
-    } else {
+      continue;
+    }
+
+    if (!isVitalType(vital.type)) {
+      result.rejected++;
+      result.rejectionReasons.push(
+        `${vital.type}: unsupported vital type`,
+      );
+      continue;
+    }
+
+    try {
+      await vitalRepo.createVital({
+        patient_id: token.patientId,
+        recorded_at: vital.recordedAt,
+        type: vital.type,
+        value_primary: vital.value,
+        unit: vital.unit,
+        notes: `MedLens device ${vital.deviceId} (confidence ${vital.confidence.toFixed(2)})`,
+      });
       result.accepted++;
-      // Stub: in production, insert into vitals table
+    } catch (err) {
+      result.rejected++;
+      result.rejectionReasons.push(
+        `${vital.type}: persistence failed (${err instanceof Error ? err.message : "unknown error"})`,
+      );
     }
   }
 
@@ -170,10 +212,10 @@ export function importVitals(
  * Import lab results from MedLens devices.
  * Rejects entries below the confidence threshold.
  */
-export function importLabs(
+export async function importLabs(
   tokenStr: string,
   labs: MedLensLabResult[],
-): { ok: true; result: ImportResult } | { ok: false; error: string } {
+): Promise<{ ok: true; result: ImportResult } | { ok: false; error: string }> {
   const token = validateToken(tokenStr, "write:labs");
   if (!token) {
     return { ok: false, error: "Invalid or unauthorized token" };
@@ -191,9 +233,32 @@ export function importLabs(
       result.rejectionReasons.push(
         `${lab.testName}: confidence ${lab.confidence} below threshold ${LAB_CONFIDENCE_THRESHOLD}`,
       );
-    } else {
+      continue;
+    }
+
+    try {
+      const panelInput: CreateLabPanelInput = {
+        patient_id: token.patientId,
+        panel_name: `MedLens: ${lab.testName}`,
+        collected_at: lab.collectedAt,
+        reported_at: lab.collectedAt,
+        notes: `MedLens device ${lab.deviceId} (confidence ${lab.confidence.toFixed(2)})`,
+        results: [
+          {
+            test_name: lab.testName,
+            test_code: "00000-0",
+            value: lab.value,
+            unit: lab.unit,
+          },
+        ],
+      };
+      await labRepo.createLabPanel(panelInput);
       result.accepted++;
-      // Stub: in production, insert into lab_results table
+    } catch (err) {
+      result.rejected++;
+      result.rejectionReasons.push(
+        `${lab.testName}: persistence failed (${err instanceof Error ? err.message : "unknown error"})`,
+      );
     }
   }
 


### PR DESCRIPTION
Fixes #157. Wires MedLens importVitals and importLabs to call createVital/createLabPanel after confidence checks pass. Previously imported data was silently discarded.