### PR TITLE
feat(db): add encounters table for visit context

### DIFF
--- a/packages/db-schema/drizzle/0013_encounters_table.sql
+++ b/packages/db-schema/drizzle/0013_encounters_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "encounters" (
+  "id" text PRIMARY KEY NOT NULL,
+  "patient_id" text NOT NULL REFERENCES "patients"("id"),
+  "encounter_type" text NOT NULL,
+  "status" text NOT NULL,
+  "start_time" text NOT NULL,
+  "end_time" text,
+  "provider_id" text REFERENCES "users"("id"),
+  "location" text,
+  "reason" text,
+  "notes" text,
+  "created_at" text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_encounters_patient" ON "encounters" ("patient_id");
+CREATE INDEX IF NOT EXISTS "idx_encounters_start_time" ON "encounters" ("start_time");

--- a/packages/db-schema/src/schema/encounters.ts
+++ b/packages/db-schema/src/schema/encounters.ts
@@ -1,0 +1,21 @@
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { encryptedText } from "../encryption.js";
+import { patients } from "./patients.js";
+import { users } from "./auth.js";
+
+export const encounters = pgTable("encounters", {
+  id: text("id").primaryKey(),
+  patient_id: text("patient_id").notNull().references(() => patients.id),
+  encounter_type: text("encounter_type").notNull(), // inpatient, outpatient, emergency, telehealth
+  status: text("status").notNull(), // planned, arrived, in-progress, finished, cancelled
+  start_time: text("start_time").notNull(),
+  end_time: text("end_time"),
+  provider_id: text("provider_id").references(() => users.id),
+  location: text("location"),
+  reason: text("reason"),
+  notes: encryptedText("notes"),
+  created_at: text("created_at").notNull(),
+}, (table) => [
+  index("idx_encounters_patient").on(table.patient_id),
+  index("idx_encounters_start_time").on(table.start_time),
+]);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./patients.js";
 export * from "./clinical-data.js";
+export * from "./encounters.js";
 export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";


### PR DESCRIPTION
Fixes #155. Creates encounters table with patient_id, type, status, times, provider, location, reason, encrypted notes. Enables clinical data to be linked to specific visits for episode-of-care reconstruction.