### PR TITLE
chore(fhir): consolidate duplicate FHIR types (Wave 2 retry)

### DIFF
--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -7,14 +7,12 @@
  */
 
 import type { allergies } from "@carebridge/db-schema";
+import type { Coding } from "../types/fhir-r4.js";
 
 type Allergy = typeof allergies.$inferSelect;
 
-interface FhirCoding {
-  system: string;
-  code: string;
-  display?: string;
-}
+// Local alias: AllergyIntolerance codings are always fully populated.
+type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
 
 interface FhirReaction {
   substance?: {

--- a/services/fhir-gateway/src/generators/condition.ts
+++ b/services/fhir-gateway/src/generators/condition.ts
@@ -7,14 +7,12 @@
  */
 
 import type { diagnoses } from "@carebridge/db-schema";
+import type { Coding } from "../types/fhir-r4.js";
 
 type Diagnosis = typeof diagnoses.$inferSelect;
 
-interface FhirCoding {
-  system: string;
-  code: string;
-  display?: string;
-}
+// Local alias: Condition codings are always fully populated.
+type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
 
 interface FhirCondition {
   resourceType: "Condition";

--- a/services/fhir-gateway/src/generators/medication-statement.ts
+++ b/services/fhir-gateway/src/generators/medication-statement.ts
@@ -7,8 +7,12 @@
  */
 
 import type { medications } from "@carebridge/db-schema";
+import type { Coding } from "../types/fhir-r4.js";
 
 type Medication = typeof medications.$inferSelect;
+
+// Local alias: MedicationStatement uses fully-populated Coding entries.
+type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
 
 const ROUTE_SNOMED: Record<string, { code: string; display: string }> = {
   oral: { code: "26643006", display: "Oral route" },
@@ -20,12 +24,6 @@ const ROUTE_SNOMED: Record<string, { code: string; display: string }> = {
   rectal: { code: "37161004", display: "Rectal route" },
   other: { code: "284009009", display: "Route of administration" },
 };
-
-interface FhirCoding {
-  system: string;
-  code: string;
-  display?: string;
-}
 
 interface FhirDosage {
   text?: string;

--- a/services/fhir-gateway/src/generators/observation.ts
+++ b/services/fhir-gateway/src/generators/observation.ts
@@ -1,5 +1,12 @@
 import type { Vital, VitalType, LabResult } from "@carebridge/shared-types";
 import { VITAL_LOINC_CODES } from "@carebridge/shared-types";
+import type {
+  Coding,
+  CodeableConcept,
+  Quantity,
+  Reference,
+  ObservationComponent,
+} from "../types/fhir-r4.js";
 
 const UNIT_TO_UCUM: Record<string, string> = {
   "K/uL": "10*3/uL",
@@ -27,35 +34,6 @@ const UNIT_TO_UCUM: Record<string, string> = {
 function toUcumCode(unit: string | null): string {
   if (!unit) return "{unknown}";
   return UNIT_TO_UCUM[unit] ?? unit;
-}
-
-// ─── FHIR R4 Types (inline to avoid external dependency) ────────
-
-interface Coding {
-  system?: string;
-  code?: string;
-  display?: string;
-}
-
-interface CodeableConcept {
-  coding?: Coding[];
-  text?: string;
-}
-
-interface Quantity {
-  value?: number;
-  unit?: string;
-  system?: string;
-  code?: string;
-}
-
-interface Reference {
-  reference?: string;
-}
-
-interface ObservationComponent {
-  code: CodeableConcept;
-  valueQuantity?: Quantity;
 }
 
 interface ObservationReferenceRange {

--- a/services/fhir-gateway/src/types/fhir-r4.ts
+++ b/services/fhir-gateway/src/types/fhir-r4.ts
@@ -1,45 +1,78 @@
 /**
  * Subset of FHIR R4 type definitions used by the CareBridge FHIR gateway.
- * Covers the Patient resource and its immediate dependencies.
+ * Shared primitives used across resource generators (Patient, Observation,
+ * Condition, AllergyIntolerance, MedicationStatement, ...).
  */
 
-export interface FhirMeta {
-  profile?: string[];
-  lastUpdated?: string;
-  versionId?: string;
-}
-
-export interface FhirCoding {
+export interface Coding {
   system?: string;
   code?: string;
   display?: string;
 }
 
-export interface FhirCodeableConcept {
-  coding?: FhirCoding[];
+export interface CodeableConcept {
+  coding?: Coding[];
   text?: string;
 }
 
-export interface FhirIdentifier {
+export interface Quantity {
+  value?: number;
+  unit?: string;
+  system?: string;
+  code?: string;
+}
+
+export interface Reference {
+  reference?: string;
+}
+
+export interface Period {
+  start?: string;
+  end?: string;
+}
+
+export interface Identifier {
   use?: "usual" | "official" | "temp" | "secondary" | "old";
-  type?: FhirCodeableConcept;
+  type?: CodeableConcept;
   system?: string;
   value?: string;
 }
 
-export interface FhirHumanName {
+export interface HumanName {
   use?: "usual" | "official" | "temp" | "nickname" | "anonymous" | "old" | "maiden";
   text?: string;
   family?: string;
   given?: string[];
 }
 
+export interface Meta {
+  profile?: string[];
+  lastUpdated?: string;
+  versionId?: string;
+}
+
+export interface ObservationComponent {
+  code: CodeableConcept;
+  valueQuantity?: Quantity;
+}
+
+// ─── Backwards-compat aliases (Fhir-prefixed names) ─────────────
+export type FhirCoding = Coding;
+export type FhirCodeableConcept = CodeableConcept;
+export type FhirQuantity = Quantity;
+export type FhirReference = Reference;
+export type FhirPeriod = Period;
+export type FhirIdentifier = Identifier;
+export type FhirHumanName = HumanName;
+export type FhirMeta = Meta;
+
+// ─── Patient resource ───────────────────────────────────────────
 export interface FhirPatient {
   resourceType: "Patient";
   id: string;
-  meta?: FhirMeta;
-  identifier?: FhirIdentifier[];
-  name?: FhirHumanName[];
+  meta?: Meta;
+  identifier?: Identifier[];
+  name?: HumanName[];
   birthDate?: string;
   gender?: "male" | "female" | "other" | "unknown";
 }

--- a/services/fhir-gateway/src/types/index.ts
+++ b/services/fhir-gateway/src/types/index.ts
@@ -1,4 +1,13 @@
 export type {
+  Coding,
+  CodeableConcept,
+  Quantity,
+  Reference,
+  Period,
+  Identifier,
+  HumanName,
+  Meta,
+  ObservationComponent,
   FhirMeta,
   FhirCoding,
   FhirCodeableConcept,


### PR DESCRIPTION
Fixes #150. Retry of PR #193 which had merge conflicts. Moves Coding, CodeableConcept, Quantity, Reference, HumanName, Identifier types to fhir-r4.ts. Removes inline duplicates from generators. Preserves UCUM mapping (observation.ts) and SNOMED routes (medication-statement.ts) that landed in between.