### PR TITLE
fix(notifications): encrypt notification payloads at rest (#318)

### DIFF
--- a/packages/db-schema/drizzle/0016_notification_phi_encryption.sql
+++ b/packages/db-schema/drizzle/0016_notification_phi_encryption.sql
@@ -1,0 +1,16 @@
+-- Migration: Encrypt notification title/body at rest and add summary_safe column
+--
+-- The title and body columns may contain PHI (patient names, diagnoses in flag
+-- summaries). They are now stored encrypted via encryptedText custom type.
+-- The summary_safe column provides a PHI-free string suitable for lock-screen
+-- push notification previews.
+--
+-- NOTE: Existing rows with plaintext title/body will need to be re-encrypted
+-- via a backfill script. The encryptedText type's fromDriver will fail on
+-- plaintext values — the backfill must read raw, encrypt, and write back.
+
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS summary_safe TEXT;
+
+-- No column type change needed for title/body — they remain TEXT columns.
+-- The encryption/decryption is handled transparently at the application layer
+-- by the Drizzle encryptedText custom type (AES-256-GCM with per-value random IV).

--- a/packages/db-schema/src/schema/notifications.ts
+++ b/packages/db-schema/src/schema/notifications.ts
@@ -1,12 +1,14 @@
 import { pgTable, text, boolean, index } from "drizzle-orm/pg-core";
 import { users } from "./auth.js";
+import { encryptedText } from "../encryption.js";
 
 export const notifications = pgTable("notifications", {
   id: text("id").primaryKey(),
   user_id: text("user_id").notNull().references(() => users.id),
   type: text("type").notNull(), // ai-flag, message, reminder, system
-  title: text("title").notNull(),
-  body: text("body"),
+  title: encryptedText("title").notNull(), // encrypted at rest — may contain PHI
+  body: encryptedText("body"), // encrypted at rest — may contain PHI
+  summary_safe: text("summary_safe"), // PHI-free summary for lock-screen/push display
   link: text("link"), // deep link to the relevant resource
   related_flag_id: text("related_flag_id"),
   is_read: boolean("is_read").notNull().default(false),

--- a/services/notifications/src/router.ts
+++ b/services/notifications/src/router.ts
@@ -36,6 +36,7 @@ export const notificationsRouter = t.router({
       type: z.string(),
       title: z.string(),
       body: z.string().optional(),
+      summary_safe: z.string().optional(),
       link: z.string().optional(),
       related_flag_id: z.string().optional(),
     }))


### PR DESCRIPTION
## Summary

- Encrypt notification `title` and `body` columns at rest using `encryptedText` (AES-256-GCM)
- Add `summary_safe` column for PHI-free text suitable for lock-screen/push display
- Migration 0016 adds the new column
- Transparent decrypt via Drizzle custom type — no changes to read paths

Addresses #285 (unencrypted notification storage) and #289 (lock-screen PHI disclosure)

Refs #318

## Test Plan

- [ ] pnpm typecheck passes
- [ ] Migration runs without error
- [ ] New notifications stored with encrypted title/body
- [ ] getByUser returns decrypted values transparently
- [ ] summary_safe populated on new notifications