### PR TITLE
feat(gateway): add SSE endpoint for real-time notifications (#315)

### DIFF
--- a/services/api-gateway/src/routes/notifications-sse.ts
+++ b/services/api-gateway/src/routes/notifications-sse.ts
@@ -1,0 +1,100 @@
+/**
+ * Server-Sent Events endpoint for real-time notification delivery.
+ *
+ * Clients connect to GET /notifications/stream with their JWT in the
+ * Authorization header or session cookie. The connection stays open and
+ * pushes new notifications as they arrive via Redis Pub/Sub.
+ *
+ * Flow:
+ * 1. Client connects → auth validated → Redis subscription created
+ * 2. Notification dispatch worker publishes to Redis channel "notifications:{userId}"
+ * 3. This SSE handler forwards the message to the connected client
+ * 4. Client reconnects automatically on disconnect (EventSource spec)
+ */
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import Redis from "ioredis";
+
+function createSubscriberClient(): Redis {
+  return new Redis({
+    host: process.env.REDIS_HOST ?? "localhost",
+    port: Number(process.env.REDIS_PORT ?? 6379),
+    ...(process.env.REDIS_PASSWORD
+      ? { password: process.env.REDIS_PASSWORD }
+      : {}),
+    ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
+  });
+}
+
+export function registerNotificationSSE(server: FastifyInstance): void {
+  server.get(
+    "/notifications/stream",
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      // Extract user ID from the auth context (set by authMiddleware)
+      const userId = (request as unknown as { userId?: string }).userId;
+
+      if (!userId) {
+        return reply.code(401).send({ error: "Authentication required" });
+      }
+
+      // Set SSE headers
+      reply.raw.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no", // Disable nginx buffering
+      });
+
+      // Send initial connection event
+      reply.raw.write(`event: connected\ndata: ${JSON.stringify({ userId, timestamp: new Date().toISOString() })}\n\n`);
+
+      // Create a dedicated Redis subscriber for this connection
+      const subscriber = createSubscriberClient();
+      const channel = `notifications:${userId}`;
+
+      subscriber.subscribe(channel).catch((err: Error) => {
+        console.error(`[sse] Failed to subscribe to ${channel}: ${err.message}`);
+      });
+
+      subscriber.on("message", (_ch: string, message: string) => {
+        reply.raw.write(`event: notification\ndata: ${message}\n\n`);
+      });
+
+      // Heartbeat every 30s to keep connection alive
+      const heartbeat = setInterval(() => {
+        reply.raw.write(`: heartbeat ${new Date().toISOString()}\n\n`);
+      }, 30_000);
+
+      // Clean up on disconnect
+      request.raw.on("close", () => {
+        clearInterval(heartbeat);
+        subscriber.unsubscribe(channel).catch(() => {});
+        subscriber.quit().catch(() => {});
+      });
+
+      // Don't let Fastify close the reply — we're managing the stream
+      await reply.hijack();
+    },
+  );
+}
+
+/**
+ * Publish a notification to the Redis channel for a specific user.
+ * Call this from the notification dispatch worker after creating records.
+ */
+export async function publishNotificationToUser(
+  redisClient: Redis,
+  userId: string,
+  notification: {
+    id: string;
+    type: string;
+    title: string;
+    body?: string;
+    link?: string;
+    related_flag_id?: string;
+    created_at: string;
+  },
+): Promise<void> {
+  const channel = `notifications:${userId}`;
+  await redisClient.publish(channel, JSON.stringify(notification));
+}

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -9,6 +9,7 @@ import { appRouter } from "./router.js";
 import { createContext } from "./context.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { auditMiddleware } from "./middleware/audit.js";
+import { registerNotificationSSE } from "./routes/notifications-sse.js";
 
 const API_PORT = Number(process.env.API_PORT) || 4000;
 const API_HOST = process.env.API_HOST ?? "0.0.0.0";
@@ -158,6 +159,9 @@ async function main() {
     reply.clearCookie("session", { path: "/" });
     return { ok: true };
   });
+
+  // --- SSE notification stream ---
+  registerNotificationSSE(server);
 
   // --- Health check ---
   server.get("/health", async () => {


### PR DESCRIPTION
## Summary

- GET /notifications/stream SSE endpoint with JWT authentication
- Redis Pub/Sub for real-time delivery (channel per user: `notifications:{userId}`)
- Heartbeat every 30s to keep connections alive through proxies
- Auto-cleanup of Redis subscriber on client disconnect
- `publishNotificationToUser` helper for dispatch worker integration

Refs #315

## Test Plan

- [ ] pnpm typecheck passes
- [ ] SSE endpoint returns 401 without auth
- [ ] Authenticated connection receives `connected` event
- [ ] Published notification appears as `notification` event
- [ ] Heartbeat keeps connection alive
- [ ] Client disconnect cleans up Redis subscription