### PR TITLE
feat(scheduling): implement appointment scheduling service (#330)

### DIFF
--- a/packages/db-schema/drizzle/0019_scheduling_tables.sql
+++ b/packages/db-schema/drizzle/0019_scheduling_tables.sql
@@ -1,0 +1,51 @@
+-- Migration: Create scheduling tables for appointment management
+
+CREATE TABLE IF NOT EXISTS appointments (
+  id TEXT PRIMARY KEY,
+  patient_id TEXT NOT NULL REFERENCES patients(id),
+  provider_id TEXT NOT NULL REFERENCES users(id),
+  appointment_type TEXT NOT NULL,
+  start_time TEXT NOT NULL,
+  end_time TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'scheduled',
+  location TEXT,
+  reason TEXT,
+  notes TEXT,
+  encounter_id TEXT,
+  cancelled_at TEXT,
+  cancelled_by TEXT,
+  cancel_reason TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_appointments_patient ON appointments(patient_id, start_time);
+CREATE INDEX IF NOT EXISTS idx_appointments_provider ON appointments(provider_id, start_time);
+CREATE INDEX IF NOT EXISTS idx_appointments_status ON appointments(status);
+
+CREATE TABLE IF NOT EXISTS provider_schedules (
+  id TEXT PRIMARY KEY,
+  provider_id TEXT NOT NULL REFERENCES users(id),
+  day_of_week INTEGER NOT NULL,
+  start_time TEXT NOT NULL,
+  end_time TEXT NOT NULL,
+  slot_duration_minutes INTEGER NOT NULL DEFAULT 30,
+  location TEXT,
+  is_active TEXT NOT NULL DEFAULT 'true',
+  effective_from TEXT,
+  effective_until TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_schedules_provider ON provider_schedules(provider_id);
+
+CREATE TABLE IF NOT EXISTS schedule_blocks (
+  id TEXT PRIMARY KEY,
+  provider_id TEXT NOT NULL REFERENCES users(id),
+  start_time TEXT NOT NULL,
+  end_time TEXT NOT NULL,
+  reason TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_blocks_provider ON schedule_blocks(provider_id, start_time);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -5,4 +5,5 @@ export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";
 export * from "./notifications.js";
+export * from "./scheduling.js";
 export * from "./fhir.js";

--- a/packages/db-schema/src/schema/scheduling.ts
+++ b/packages/db-schema/src/schema/scheduling.ts
@@ -1,0 +1,60 @@
+/**
+ * Appointment scheduling schema.
+ *
+ * Supports appointment booking, provider schedule templates, and schedule blocks.
+ */
+
+import { pgTable, text, integer, index } from "drizzle-orm/pg-core";
+import { patients } from "./patients.js";
+import { users } from "./auth.js";
+import { encryptedText } from "../encryption.js";
+
+export const appointments = pgTable("appointments", {
+  id: text("id").primaryKey(),
+  patient_id: text("patient_id").notNull().references(() => patients.id),
+  provider_id: text("provider_id").notNull().references(() => users.id),
+  appointment_type: text("appointment_type").notNull(), // follow_up, new_patient, procedure, telehealth
+  start_time: text("start_time").notNull(),
+  end_time: text("end_time").notNull(),
+  status: text("status").notNull().default("scheduled"), // scheduled, confirmed, checked_in, completed, cancelled, no_show
+  location: text("location"),
+  reason: text("reason"),
+  notes: encryptedText("notes"),
+  encounter_id: text("encounter_id"),
+  cancelled_at: text("cancelled_at"),
+  cancelled_by: text("cancelled_by"),
+  cancel_reason: text("cancel_reason"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull(),
+}, (table) => [
+  index("idx_appointments_patient").on(table.patient_id, table.start_time),
+  index("idx_appointments_provider").on(table.provider_id, table.start_time),
+  index("idx_appointments_status").on(table.status),
+]);
+
+export const providerSchedules = pgTable("provider_schedules", {
+  id: text("id").primaryKey(),
+  provider_id: text("provider_id").notNull().references(() => users.id),
+  day_of_week: integer("day_of_week").notNull(), // 0=Sunday, 6=Saturday
+  start_time: text("start_time").notNull(), // HH:MM format
+  end_time: text("end_time").notNull(), // HH:MM format
+  slot_duration_minutes: integer("slot_duration_minutes").notNull().default(30),
+  location: text("location"),
+  is_active: text("is_active").notNull().default("true"),
+  effective_from: text("effective_from"),
+  effective_until: text("effective_until"),
+  created_at: text("created_at").notNull(),
+}, (table) => [
+  index("idx_provider_schedules_provider").on(table.provider_id),
+]);
+
+export const scheduleBlocks = pgTable("schedule_blocks", {
+  id: text("id").primaryKey(),
+  provider_id: text("provider_id").notNull().references(() => users.id),
+  start_time: text("start_time").notNull(),
+  end_time: text("end_time").notNull(),
+  reason: text("reason"), // vacation, meeting, blocked
+  created_at: text("created_at").notNull(),
+}, (table) => [
+  index("idx_schedule_blocks_provider").on(table.provider_id, table.start_time),
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@carebridge/patient-records':
         specifier: workspace:*
         version: link:../patient-records
+      '@carebridge/scheduling':
+        specifier: workspace:*
+        version: link:../scheduling
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -559,6 +562,31 @@ importers:
       '@carebridge/validators':
         specifier: workspace:*
         version: link:../../packages/validators
+      '@trpc/server':
+        specifier: ^11.0.0
+        version: 11.16.0(typescript@5.9.3)
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  services/scheduling:
+    dependencies:
+      '@carebridge/db-schema':
+        specifier: workspace:*
+        version: link:../../packages/db-schema
+      '@carebridge/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@trpc/server':
         specifier: ^11.0.0
         version: 11.16.0(typescript@5.9.3)

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -21,6 +21,7 @@
     "@carebridge/clinical-notes": "workspace:*",
     "@carebridge/ai-oversight": "workspace:*",
     "@carebridge/notifications": "workspace:*",
+    "@carebridge/scheduling": "workspace:*",
     "@carebridge/fhir-gateway": "workspace:*",
     "fastify": "^5.2.0",
     "@fastify/cookie": "^11.0.0",

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -2,6 +2,7 @@ import { router, publicProcedure } from "./trpc.js";
 import { authRouter } from "@carebridge/auth";
 import { aiOversightRouter } from "@carebridge/ai-oversight";
 import { notificationsRouter } from "@carebridge/notifications";
+import { schedulingRouter } from "@carebridge/scheduling";
 import { patientRecordsRbacRouter } from "./routers/patient-records.js";
 import { clinicalDataRbacRouter } from "./routers/clinical-data.js";
 import { clinicalNotesRbacRouter } from "./routers/clinical-notes.js";
@@ -21,6 +22,7 @@ export const appRouter = router({
   notes: clinicalNotesRbacRouter,
   aiOversight: aiOversightRouter,
   notifications: notificationsRouter,
+  scheduling: schedulingRouter,
   fhir: fhirRbacRouter,
 });
 

--- a/services/scheduling/package.json
+++ b/services/scheduling/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@carebridge/scheduling",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@carebridge/shared-types": "workspace:*",
+    "@carebridge/db-schema": "workspace:*",
+    "@trpc/server": "^11.0.0",
+    "drizzle-orm": "^0.38.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": { "typescript": "^5.7.0", "@types/node": "^22.0.0" }
+}

--- a/services/scheduling/src/index.ts
+++ b/services/scheduling/src/index.ts
@@ -1,0 +1,1 @@
+export { schedulingRouter, type SchedulingRouter } from "./router.js";

--- a/services/scheduling/src/router.ts
+++ b/services/scheduling/src/router.ts
@@ -1,0 +1,305 @@
+/**
+ * Appointment scheduling tRPC router.
+ *
+ * Provides appointment CRUD, provider schedule management, and slot
+ * availability calculation with double-booking prevention.
+ */
+
+import { initTRPC } from "@trpc/server";
+import { z } from "zod";
+import { getDb } from "@carebridge/db-schema";
+import { appointments, providerSchedules, scheduleBlocks } from "@carebridge/db-schema";
+import { eq, and, gte, lte, desc, ne } from "drizzle-orm";
+import crypto from "node:crypto";
+
+const t = initTRPC.create();
+
+export const schedulingRouter = t.router({
+  appointments: t.router({
+    /** List appointments for a patient. */
+    listByPatient: t.procedure
+      .input(z.object({ patientId: z.string() }))
+      .query(async ({ input }) => {
+        const db = getDb();
+        return db.select().from(appointments)
+          .where(eq(appointments.patient_id, input.patientId))
+          .orderBy(desc(appointments.start_time));
+      }),
+
+    /** List appointments for a provider on a date range. */
+    listByProvider: t.procedure
+      .input(z.object({
+        providerId: z.string(),
+        startDate: z.string(),
+        endDate: z.string(),
+      }))
+      .query(async ({ input }) => {
+        const db = getDb();
+        return db.select().from(appointments)
+          .where(
+            and(
+              eq(appointments.provider_id, input.providerId),
+              gte(appointments.start_time, input.startDate),
+              lte(appointments.start_time, input.endDate),
+            ),
+          )
+          .orderBy(appointments.start_time);
+      }),
+
+    /** Create a new appointment with double-booking prevention. */
+    create: t.procedure
+      .input(z.object({
+        patientId: z.string(),
+        providerId: z.string(),
+        appointmentType: z.enum(["follow_up", "new_patient", "procedure", "telehealth"]),
+        startTime: z.string(),
+        endTime: z.string(),
+        location: z.string().optional(),
+        reason: z.string().optional(),
+      }))
+      .mutation(async ({ input }) => {
+        const db = getDb();
+        const now = new Date().toISOString();
+
+        // Check for overlapping appointments (double-booking prevention)
+        const overlapping = await db.select().from(appointments)
+          .where(
+            and(
+              eq(appointments.provider_id, input.providerId),
+              ne(appointments.status, "cancelled"),
+              lte(appointments.start_time, input.endTime),
+              gte(appointments.end_time, input.startTime),
+            ),
+          );
+
+        if (overlapping.length > 0) {
+          throw new Error("Time slot conflicts with an existing appointment");
+        }
+
+        const appointment = {
+          id: crypto.randomUUID(),
+          patient_id: input.patientId,
+          provider_id: input.providerId,
+          appointment_type: input.appointmentType,
+          start_time: input.startTime,
+          end_time: input.endTime,
+          status: "scheduled",
+          location: input.location ?? null,
+          reason: input.reason ?? null,
+          created_at: now,
+          updated_at: now,
+        };
+
+        await db.insert(appointments).values(appointment);
+        return appointment;
+      }),
+
+    /** Cancel an appointment with reason. */
+    cancel: t.procedure
+      .input(z.object({
+        appointmentId: z.string(),
+        cancelledBy: z.string(),
+        reason: z.string(),
+      }))
+      .mutation(async ({ input }) => {
+        const db = getDb();
+        const now = new Date().toISOString();
+
+        await db.update(appointments)
+          .set({
+            status: "cancelled",
+            cancelled_at: now,
+            cancelled_by: input.cancelledBy,
+            cancel_reason: input.reason,
+            updated_at: now,
+          })
+          .where(eq(appointments.id, input.appointmentId));
+
+        return { success: true };
+      }),
+
+    /** Reschedule an appointment (cancel + create new). */
+    reschedule: t.procedure
+      .input(z.object({
+        appointmentId: z.string(),
+        cancelledBy: z.string(),
+        newStartTime: z.string(),
+        newEndTime: z.string(),
+      }))
+      .mutation(async ({ input }) => {
+        const db = getDb();
+        const now = new Date().toISOString();
+
+        // Get original appointment
+        const [original] = await db.select().from(appointments)
+          .where(eq(appointments.id, input.appointmentId));
+
+        if (!original) throw new Error("Appointment not found");
+
+        // Cancel original
+        await db.update(appointments)
+          .set({
+            status: "cancelled",
+            cancelled_at: now,
+            cancelled_by: input.cancelledBy,
+            cancel_reason: "Rescheduled",
+            updated_at: now,
+          })
+          .where(eq(appointments.id, input.appointmentId));
+
+        // Check for conflicts at new time
+        const overlapping = await db.select().from(appointments)
+          .where(
+            and(
+              eq(appointments.provider_id, original.provider_id),
+              ne(appointments.status, "cancelled"),
+              lte(appointments.start_time, input.newEndTime),
+              gte(appointments.end_time, input.newStartTime),
+            ),
+          );
+
+        if (overlapping.length > 0) {
+          throw new Error("New time slot conflicts with an existing appointment");
+        }
+
+        // Create new appointment
+        const newAppt = {
+          id: crypto.randomUUID(),
+          patient_id: original.patient_id,
+          provider_id: original.provider_id,
+          appointment_type: original.appointment_type,
+          start_time: input.newStartTime,
+          end_time: input.newEndTime,
+          status: "scheduled",
+          location: original.location,
+          reason: original.reason,
+          created_at: now,
+          updated_at: now,
+        };
+
+        await db.insert(appointments).values(newAppt);
+        return newAppt;
+      }),
+  }),
+
+  schedule: t.router({
+    /** Get available slots for a provider on a date. */
+    availability: t.procedure
+      .input(z.object({
+        providerId: z.string(),
+        date: z.string(), // ISO date string (YYYY-MM-DD)
+      }))
+      .query(async ({ input }) => {
+        const db = getDb();
+        const dayOfWeek = new Date(input.date).getDay();
+
+        // Get provider's schedule template for this day
+        const [template] = await db.select().from(providerSchedules)
+          .where(
+            and(
+              eq(providerSchedules.provider_id, input.providerId),
+              eq(providerSchedules.day_of_week, dayOfWeek),
+              eq(providerSchedules.is_active, "true"),
+            ),
+          );
+
+        if (!template) return { slots: [], message: "Provider has no schedule for this day" };
+
+        // Get existing appointments for this date
+        const dayStart = `${input.date}T00:00:00.000Z`;
+        const dayEnd = `${input.date}T23:59:59.999Z`;
+
+        const existingAppts = await db.select().from(appointments)
+          .where(
+            and(
+              eq(appointments.provider_id, input.providerId),
+              ne(appointments.status, "cancelled"),
+              gte(appointments.start_time, dayStart),
+              lte(appointments.start_time, dayEnd),
+            ),
+          );
+
+        // Get blocks for this date
+        const blocks = await db.select().from(scheduleBlocks)
+          .where(
+            and(
+              eq(scheduleBlocks.provider_id, input.providerId),
+              lte(scheduleBlocks.start_time, dayEnd),
+              gte(scheduleBlocks.end_time, dayStart),
+            ),
+          );
+
+        // Generate time slots
+        const slots: Array<{ start: string; end: string; available: boolean }> = [];
+        const slotMinutes = template.slot_duration_minutes;
+
+        // Parse template hours
+        const [startHour, startMin] = template.start_time.split(":").map(Number);
+        const [endHour, endMin] = template.end_time.split(":").map(Number);
+
+        const slotStart = new Date(`${input.date}T00:00:00.000Z`);
+        slotStart.setUTCHours(startHour, startMin, 0, 0);
+
+        const scheduleEnd = new Date(`${input.date}T00:00:00.000Z`);
+        scheduleEnd.setUTCHours(endHour, endMin, 0, 0);
+
+        while (slotStart < scheduleEnd) {
+          const slotEnd = new Date(slotStart.getTime() + slotMinutes * 60 * 1000);
+          const startISO = slotStart.toISOString();
+          const endISO = slotEnd.toISOString();
+
+          // Check if slot overlaps with existing appointment
+          const hasConflict = existingAppts.some((appt) =>
+            appt.start_time < endISO && appt.end_time > startISO,
+          );
+
+          // Check if slot overlaps with a block
+          const isBlocked = blocks.some((block) =>
+            block.start_time < endISO && block.end_time > startISO,
+          );
+
+          slots.push({
+            start: startISO,
+            end: endISO,
+            available: !hasConflict && !isBlocked,
+          });
+
+          slotStart.setTime(slotStart.getTime() + slotMinutes * 60 * 1000);
+        }
+
+        return { slots };
+      }),
+
+    /** Set provider schedule template. */
+    setProviderSchedule: t.procedure
+      .input(z.object({
+        providerId: z.string(),
+        dayOfWeek: z.number().min(0).max(6),
+        startTime: z.string(), // HH:MM
+        endTime: z.string(), // HH:MM
+        slotDurationMinutes: z.number().min(10).max(120).optional().default(30),
+        location: z.string().optional(),
+      }))
+      .mutation(async ({ input }) => {
+        const db = getDb();
+        const now = new Date().toISOString();
+
+        const schedule = {
+          id: crypto.randomUUID(),
+          provider_id: input.providerId,
+          day_of_week: input.dayOfWeek,
+          start_time: input.startTime,
+          end_time: input.endTime,
+          slot_duration_minutes: input.slotDurationMinutes,
+          location: input.location ?? null,
+          is_active: "true",
+          created_at: now,
+        };
+
+        await db.insert(providerSchedules).values(schedule);
+        return schedule;
+      }),
+  }),
+});
+
+export type SchedulingRouter = typeof schedulingRouter;

--- a/services/scheduling/src/router.ts
+++ b/services/scheduling/src/router.ts
@@ -61,37 +61,39 @@ export const schedulingRouter = t.router({
         const db = getDb();
         const now = new Date().toISOString();
 
-        // Check for overlapping appointments (double-booking prevention)
-        const overlapping = await db.select().from(appointments)
-          .where(
-            and(
-              eq(appointments.provider_id, input.providerId),
-              ne(appointments.status, "cancelled"),
-              lte(appointments.start_time, input.endTime),
-              gte(appointments.end_time, input.startTime),
-            ),
-          );
+        // Wrap check+insert in a transaction to prevent TOCTOU race on double-booking
+        return db.transaction(async (tx) => {
+          const overlapping = await tx.select().from(appointments)
+            .where(
+              and(
+                eq(appointments.provider_id, input.providerId),
+                ne(appointments.status, "cancelled"),
+                lte(appointments.start_time, input.endTime),
+                gte(appointments.end_time, input.startTime),
+              ),
+            );
 
-        if (overlapping.length > 0) {
-          throw new Error("Time slot conflicts with an existing appointment");
-        }
+          if (overlapping.length > 0) {
+            throw new Error("Time slot conflicts with an existing appointment");
+          }
 
-        const appointment = {
-          id: crypto.randomUUID(),
-          patient_id: input.patientId,
-          provider_id: input.providerId,
-          appointment_type: input.appointmentType,
-          start_time: input.startTime,
-          end_time: input.endTime,
-          status: "scheduled",
-          location: input.location ?? null,
-          reason: input.reason ?? null,
-          created_at: now,
-          updated_at: now,
-        };
+          const appointment = {
+            id: crypto.randomUUID(),
+            patient_id: input.patientId,
+            provider_id: input.providerId,
+            appointment_type: input.appointmentType,
+            start_time: input.startTime,
+            end_time: input.endTime,
+            status: "scheduled",
+            location: input.location ?? null,
+            reason: input.reason ?? null,
+            created_at: now,
+            updated_at: now,
+          };
 
-        await db.insert(appointments).values(appointment);
-        return appointment;
+          await tx.insert(appointments).values(appointment);
+          return appointment;
+        });
       }),
 
     /** Cancel an appointment with reason. */

--- a/services/scheduling/tsconfig.json
+++ b/services/scheduling/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- New `services/scheduling` with full tRPC router
- Schema: `appointments`, `providerSchedules`, `scheduleBlocks` tables (migration 0019)
- Appointment CRUD: create (with double-booking prevention), cancel, reschedule
- Slot availability: generates time slots from provider template, subtracts booked appointments and blocks
- Provider schedule templates: weekly day-of-week patterns with configurable slot duration
- Registered in api-gateway as `scheduling` namespace

Refs #330

## Test Plan

- [ ] pnpm typecheck passes (32/32)
- [ ] Create appointment with time validation
- [ ] Double-booking prevented (error on overlap)
- [ ] Cancel appointment sets status and reason
- [ ] Reschedule cancels original and creates new
- [ ] Availability returns correct open slots