### PR TITLE
feat(auth): implement break-the-glass emergency access (#338)

### DIFF
--- a/packages/db-schema/drizzle/0020_emergency_access.sql
+++ b/packages/db-schema/drizzle/0020_emergency_access.sql
@@ -1,0 +1,17 @@
+-- Migration: Create emergency_access table for break-the-glass access
+
+CREATE TABLE IF NOT EXISTS emergency_access (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  patient_id TEXT NOT NULL REFERENCES patients(id),
+  justification TEXT NOT NULL,
+  granted_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  revoked_by TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_emergency_access_user ON emergency_access(user_id);
+CREATE INDEX IF NOT EXISTS idx_emergency_access_patient ON emergency_access(patient_id);
+CREATE INDEX IF NOT EXISTS idx_emergency_access_expires ON emergency_access(expires_at);

--- a/packages/db-schema/src/schema/emergency-access.ts
+++ b/packages/db-schema/src/schema/emergency-access.ts
@@ -1,0 +1,28 @@
+/**
+ * Break-the-glass emergency access schema.
+ *
+ * Allows providers to access patient records they're not assigned to in
+ * emergencies, with mandatory justification and time-limited access.
+ * All emergency access is prominently audit-logged and compliance-notified.
+ */
+
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { users } from "./auth.js";
+import { patients } from "./patients.js";
+import { encryptedText } from "../encryption.js";
+
+export const emergencyAccess = pgTable("emergency_access", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => users.id),
+  patient_id: text("patient_id").notNull().references(() => patients.id),
+  justification: encryptedText("justification").notNull(), // encrypted — sensitive reasoning
+  granted_at: text("granted_at").notNull(),
+  expires_at: text("expires_at").notNull(),
+  revoked_at: text("revoked_at"),
+  revoked_by: text("revoked_by"),
+  created_at: text("created_at").notNull(),
+}, (table) => [
+  index("idx_emergency_access_user").on(table.user_id),
+  index("idx_emergency_access_patient").on(table.patient_id),
+  index("idx_emergency_access_expires").on(table.expires_at),
+]);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -5,4 +5,5 @@ export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";
 export * from "./notifications.js";
+export * from "./emergency-access.js";
 export * from "./fhir.js";

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -1,5 +1,5 @@
 import { router, publicProcedure } from "./trpc.js";
-import { authRouter } from "@carebridge/auth";
+import { authRouter, emergencyAccessRouter } from "@carebridge/auth";
 import { aiOversightRouter } from "@carebridge/ai-oversight";
 import { notificationsRouter } from "@carebridge/notifications";
 import { patientRecordsRbacRouter } from "./routers/patient-records.js";
@@ -16,6 +16,7 @@ export const appRouter = router({
     };
   }),
   auth: authRouter,
+  emergencyAccess: emergencyAccessRouter,
   patients: patientRecordsRbacRouter,
   clinicalData: clinicalDataRbacRouter,
   notes: clinicalNotesRbacRouter,

--- a/services/auth/src/emergency-access.ts
+++ b/services/auth/src/emergency-access.ts
@@ -1,0 +1,125 @@
+/**
+ * Break-the-glass emergency access procedures.
+ *
+ * Allows providers to request time-limited access to patient records they
+ * aren't assigned to. Every request is:
+ * 1. Logged with mandatory justification (encrypted at rest)
+ * 2. Time-limited (default: 4 hours)
+ * 3. Immediately flagged to compliance via audit log
+ */
+
+import { initTRPC } from "@trpc/server";
+import { z } from "zod";
+import { getDb, emergencyAccess, auditLog } from "@carebridge/db-schema";
+import { eq, and, gt, isNull } from "drizzle-orm";
+import crypto from "node:crypto";
+
+const t = initTRPC.create();
+
+/** Default emergency access duration: 4 hours. */
+const DEFAULT_ACCESS_HOURS = 4;
+
+export const emergencyAccessRouter = t.router({
+  /** Request emergency access to a patient record. */
+  request: t.procedure
+    .input(z.object({
+      userId: z.string(),
+      patientId: z.string(),
+      justification: z.string().min(10, "Justification must be at least 10 characters"),
+    }))
+    .mutation(async ({ input }) => {
+      const db = getDb();
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + DEFAULT_ACCESS_HOURS * 60 * 60 * 1000);
+
+      const id = crypto.randomUUID();
+
+      await db.insert(emergencyAccess).values({
+        id,
+        user_id: input.userId,
+        patient_id: input.patientId,
+        justification: input.justification,
+        granted_at: now.toISOString(),
+        expires_at: expiresAt.toISOString(),
+        created_at: now.toISOString(),
+      });
+
+      // Create high-priority audit log entry for compliance
+      await db.insert(auditLog).values({
+        id: crypto.randomUUID(),
+        user_id: input.userId,
+        action: "emergency_access",
+        resource_type: "patient",
+        resource_id: input.patientId,
+        patient_id: input.patientId,
+        procedure_name: "emergencyAccess.request",
+        ip_address: "",
+        timestamp: now.toISOString(),
+      });
+
+      return {
+        id,
+        expires_at: expiresAt.toISOString(),
+        duration_hours: DEFAULT_ACCESS_HOURS,
+      };
+    }),
+
+  /** Check if a user has active emergency access to a patient. */
+  check: t.procedure
+    .input(z.object({
+      userId: z.string(),
+      patientId: z.string(),
+    }))
+    .query(async ({ input }) => {
+      const db = getDb();
+      const now = new Date().toISOString();
+
+      const [active] = await db.select().from(emergencyAccess)
+        .where(
+          and(
+            eq(emergencyAccess.user_id, input.userId),
+            eq(emergencyAccess.patient_id, input.patientId),
+            gt(emergencyAccess.expires_at, now),
+            isNull(emergencyAccess.revoked_at),
+          ),
+        )
+        .limit(1);
+
+      return {
+        hasAccess: !!active,
+        expiresAt: active?.expires_at ?? null,
+      };
+    }),
+
+  /** Revoke emergency access (by compliance or admin). */
+  revoke: t.procedure
+    .input(z.object({
+      accessId: z.string(),
+      revokedBy: z.string(),
+    }))
+    .mutation(async ({ input }) => {
+      const db = getDb();
+      const now = new Date().toISOString();
+
+      await db.update(emergencyAccess)
+        .set({
+          revoked_at: now,
+          revoked_by: input.revokedBy,
+        })
+        .where(eq(emergencyAccess.id, input.accessId));
+
+      return { revoked: true };
+    }),
+
+  /** List all emergency access events (for compliance dashboard). */
+  listAll: t.procedure
+    .input(z.object({ limit: z.number().optional().default(50) }))
+    .query(async ({ input }) => {
+      const db = getDb();
+      return db.select().from(emergencyAccess)
+        .orderBy(emergencyAccess.granted_at)
+        .limit(input.limit);
+    }),
+});
+
+export type EmergencyAccessRouter = typeof emergencyAccessRouter;

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,4 +1,5 @@
 export { authRouter, type AuthRouter, type Context as AuthContext } from "./router.js";
+export { emergencyAccessRouter, type EmergencyAccessRouter } from "./emergency-access.js";
 export { cleanupExpiredSessions } from "./session-cleanup.js";
 export { startCleanupWorker } from "./cleanup-worker.js";
 export { signJWT, verifyJWT, JWTError, JWTExpiredError, type JWTPayload } from "./jwt.js";


### PR DESCRIPTION
## Summary

- `emergencyAccess` table with encrypted justification (migration 0020)
- Time-limited access: 4 hours default, auto-expires
- Mandatory justification text required
- Immediate audit log entry for compliance tracking
- tRPC: request, check, revoke, listAll procedures
- Registered in api-gateway as `emergencyAccess` namespace

Refs #338

## Test Plan

- [ ] pnpm typecheck passes
- [ ] Emergency access request creates record with encrypted justification
- [ ] Check returns hasAccess=true within window, false after expiry
- [ ] Revoke sets revoked_at timestamp
- [ ] Audit log entry created with action="emergency_access"