### PR TITLE
feat(notifications): add notification preferences and routing (#316)

### DIFF
--- a/packages/db-schema/drizzle/0021_notification_preferences.sql
+++ b/packages/db-schema/drizzle/0021_notification_preferences.sql
@@ -1,0 +1,15 @@
+-- Migration: Create notification_preferences table
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+  notification_type TEXT NOT NULL,
+  channel TEXT NOT NULL DEFAULT 'in_app',
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  quiet_hours_start TEXT,
+  quiet_hours_end TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_prefs_user ON notification_preferences(user_id);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -5,4 +5,5 @@ export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";
 export * from "./notifications.js";
+export * from "./notification-preferences.js";
 export * from "./fhir.js";

--- a/packages/db-schema/src/schema/notification-preferences.ts
+++ b/packages/db-schema/src/schema/notification-preferences.ts
@@ -1,0 +1,23 @@
+/**
+ * User notification preferences schema.
+ *
+ * Controls how and when notifications are delivered to each user.
+ * Supports per-type channel preferences and quiet hours.
+ */
+
+import { pgTable, text, boolean, index } from "drizzle-orm/pg-core";
+import { users } from "./auth.js";
+
+export const notificationPreferences = pgTable("notification_preferences", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => users.id),
+  notification_type: text("notification_type").notNull(), // ai-flag, message, reminder, system
+  channel: text("channel").notNull().default("in_app"), // in_app, email, sms
+  enabled: boolean("enabled").notNull().default(true),
+  quiet_hours_start: text("quiet_hours_start"), // HH:MM — null means no quiet hours
+  quiet_hours_end: text("quiet_hours_end"), // HH:MM
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull(),
+}, (table) => [
+  index("idx_notification_prefs_user").on(table.user_id),
+]);

--- a/services/notifications/src/router.ts
+++ b/services/notifications/src/router.ts
@@ -1,7 +1,7 @@
 import { initTRPC } from "@trpc/server";
 import { z } from "zod";
 import { getDb } from "@carebridge/db-schema";
-import { notifications } from "@carebridge/db-schema";
+import { notifications, notificationPreferences } from "@carebridge/db-schema";
 import { eq, and, desc } from "drizzle-orm";
 import crypto from "node:crypto";
 
@@ -49,6 +49,64 @@ export const notificationsRouter = t.router({
       };
       await db.insert(notifications).values(notification);
       return notification;
+    }),
+  getPreferences: t.procedure
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ input }) => {
+      const db = getDb();
+      return db.select().from(notificationPreferences)
+        .where(eq(notificationPreferences.user_id, input.userId));
+    }),
+
+  updatePreference: t.procedure
+    .input(z.object({
+      userId: z.string(),
+      notificationType: z.string(),
+      channel: z.string(),
+      enabled: z.boolean(),
+      quietHoursStart: z.string().nullable().optional(),
+      quietHoursEnd: z.string().nullable().optional(),
+    }))
+    .mutation(async ({ input }) => {
+      const db = getDb();
+      const now = new Date().toISOString();
+
+      // Check if preference exists
+      const [existing] = await db.select().from(notificationPreferences)
+        .where(
+          and(
+            eq(notificationPreferences.user_id, input.userId),
+            eq(notificationPreferences.notification_type, input.notificationType),
+            eq(notificationPreferences.channel, input.channel),
+          ),
+        );
+
+      if (existing) {
+        await db.update(notificationPreferences)
+          .set({
+            enabled: input.enabled,
+            quiet_hours_start: input.quietHoursStart ?? null,
+            quiet_hours_end: input.quietHoursEnd ?? null,
+            updated_at: now,
+          })
+          .where(eq(notificationPreferences.id, existing.id));
+        return { ...existing, enabled: input.enabled, updated_at: now };
+      }
+
+      const pref = {
+        id: crypto.randomUUID(),
+        user_id: input.userId,
+        notification_type: input.notificationType,
+        channel: input.channel,
+        enabled: input.enabled,
+        quiet_hours_start: input.quietHoursStart ?? null,
+        quiet_hours_end: input.quietHoursEnd ?? null,
+        created_at: now,
+        updated_at: now,
+      };
+
+      await db.insert(notificationPreferences).values(pref);
+      return pref;
     }),
 });
 


### PR DESCRIPTION
## Summary

- `notificationPreferences` table: per-user, per-type, per-channel settings (migration 0021)
- Quiet hours support (start/end times)
- `getPreferences` and `updatePreference` tRPC procedures
- Supports in_app, email, sms channels per notification type (ai-flag, message, reminder, system)

Refs #316

## Test Plan

- [ ] pnpm typecheck passes
- [ ] Migration creates table
- [ ] getPreferences returns user's preferences
- [ ] updatePreference creates new or updates existing
- [ ] Quiet hours stored correctly