### PR TITLE
feat(ai): add deterministic keyword screening for patient observations (#362)

### DIFF
--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -18,6 +18,7 @@ import {
   patients,
   allergies,
   messages,
+  patientObservations,
   labPanels,
   labResults,
 } from "@carebridge/db-schema";
@@ -129,6 +130,30 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         if (messageFlags.length > 0) {
           rulesFired.push("message-screening");
           allRuleFlags.push(...messageFlags);
+        }
+      }
+    }
+
+    // 2f. Patient observation screening (only for patient.observation events)
+    // Same keyword patterns as message screening, applied to observation descriptions.
+    // Ensures the symptom journal has deterministic safety coverage even when LLM is unavailable.
+    if (event.type === "patient.observation" && event.data.observation_id) {
+      rulesEvaluated.push("observation-screening");
+
+      const [obs] = await db.select({ description: patientObservations.description })
+        .from(patientObservations)
+        .where(eq(patientObservations.id, event.data.observation_id as string))
+        .limit(1);
+
+      if (obs?.description) {
+        const enrichedEvent = {
+          ...event,
+          data: { ...event.data, message_text: obs.description, sender_role: "patient" },
+        };
+        const obsFlags = screenPatientMessage(enrichedEvent);
+        if (obsFlags.length > 0) {
+          rulesFired.push("observation-screening");
+          allRuleFlags.push(...obsFlags);
         }
       }
     }


### PR DESCRIPTION
## Summary

Patient observations from the symptom journal now get deterministic keyword screening (4/8 audit agents flagged this gap). Reuses the same urgent symptom patterns as message screening — works even when LLM API is unavailable.

Reads observation description from DB (encrypted at rest, Drizzle decrypts transparently).

Closes #362

## Test Plan

- [ ] pnpm typecheck passes (34/34)
- [ ] Patient reporting "worst headache" via symptom journal generates flag
- [ ] Works without LLM API availability
- [ ] Normal observations with no keywords generate no flags