### PR TITLE
fix(portal): replace patient name-match with user-patient ID mapping (#359)

### DIFF
--- a/apps/patient-portal/app/health-summary/page.tsx
+++ b/apps/patient-portal/app/health-summary/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 function severityColor(severity?: string | null): string {
   switch (severity) {
@@ -26,10 +27,7 @@ export default function HealthSummaryPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const diagnosesQuery = trpc.patients.diagnoses.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },

--- a/apps/patient-portal/app/labs/page.tsx
+++ b/apps/patient-portal/app/labs/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 function flagColor(flag?: string | null): string {
   switch (flag) {
@@ -22,10 +23,7 @@ export default function LabsPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const labsQuery = trpc.clinicalData.labs.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },

--- a/apps/patient-portal/app/messages/page.tsx
+++ b/apps/patient-portal/app/messages/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
@@ -22,10 +23,7 @@ export default function PatientMessagesPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const conversationsQuery = trpc.messaging.listConversations.useQuery(
     undefined,

--- a/apps/patient-portal/app/notes/page.tsx
+++ b/apps/patient-portal/app/notes/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 const NOTE_TYPE_LABELS: Record<string, string> = {
   soap: "SOAP Note",
@@ -18,10 +19,7 @@ export default function NotesPage() {
   const router = useRouter();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const notesQuery = trpc.notes.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },

--- a/apps/patient-portal/app/page.tsx
+++ b/apps/patient-portal/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -26,12 +27,7 @@ function PatientDashboard() {
   const router = useRouter();
 
   const healthQuery = trpc.healthCheck.useQuery();
-  const patientsQuery = trpc.patients.list.useQuery();
-
-  // Find the patient record matching this logged-in user (by name match or first patient)
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const medsQuery = trpc.clinicalData.medications.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -111,7 +107,7 @@ function PatientDashboard() {
                 <span>{myRecord.biological_sex}</span>
               </div>
             </div>
-          ) : patientsQuery.isLoading ? (
+          ) : patientLoading ? (
             <p style={{ margin: 0, color: "#999", fontSize: "0.875rem" }}>Loading...</p>
           ) : (
             <p style={{ margin: 0, color: "#999", fontSize: "0.875rem" }}>

--- a/apps/patient-portal/app/refill/page.tsx
+++ b/apps/patient-portal/app/refill/page.tsx
@@ -4,15 +4,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 export default function RefillPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const medsQuery = trpc.clinicalData.medications.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },

--- a/apps/patient-portal/app/symptoms/page.tsx
+++ b/apps/patient-portal/app/symptoms/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
 
 const OBSERVATION_TYPES = [
   { value: "pain", label: "Pain" },
@@ -29,10 +30,7 @@ export default function SymptomsPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const patientsQuery = trpc.patients.list.useQuery();
-  const myRecord = patientsQuery.data?.find(
-    (p) => p.name === user?.name,
-  ) ?? patientsQuery.data?.[0];
+  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
 
   const observationsQuery = trpc.patients.observations.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },

--- a/apps/patient-portal/src/lib/use-my-patient.ts
+++ b/apps/patient-portal/src/lib/use-my-patient.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared hook to resolve the current patient's record.
+ *
+ * Uses user.patient_id (set on the users table) instead of the fragile
+ * name-match + fallback-to-first pattern that could expose PHI.
+ *
+ * Falls back to patients.getById if patient_id is available on the user,
+ * otherwise falls back to name-match (legacy compat) but WITHOUT the
+ * dangerous data[0] fallback.
+ */
+
+import { useAuth } from "./auth";
+import { trpc } from "./trpc";
+
+export function useMyPatientRecord() {
+  const { user } = useAuth();
+
+  // Preferred path: direct lookup by patient_id
+  const directQuery = trpc.patients.getById.useQuery(
+    { id: user?.patient_id ?? "" },
+    { enabled: !!user?.patient_id },
+  );
+
+  // Legacy fallback: find by name (without dangerous data[0] fallback)
+  const listQuery = trpc.patients.list.useQuery(
+    undefined,
+    { enabled: !!user && !user.patient_id },
+  );
+
+  if (user?.patient_id && directQuery.data) {
+    return {
+      patient: directQuery.data,
+      isLoading: directQuery.isLoading,
+      isError: directQuery.isError,
+    };
+  }
+
+  // Legacy name-match — NO fallback to first record
+  const nameMatch = listQuery.data?.find((p) => p.name === user?.name) ?? null;
+
+  return {
+    patient: nameMatch,
+    isLoading: listQuery.isLoading,
+    isError: listQuery.isError,
+  };
+}

--- a/packages/db-schema/drizzle/0022_user_patient_id.sql
+++ b/packages/db-schema/drizzle/0022_user_patient_id.sql
@@ -1,0 +1,6 @@
+-- Migration: Add patient_id column to users table
+--
+-- Links patient-role users directly to their patient record, replacing
+-- the fragile name-match lookup pattern in the patient portal.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS patient_id TEXT REFERENCES patients(id);

--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -7,6 +7,7 @@ export const users = pgTable("users", {
   password_hash: text("password_hash").notNull(),
   name: text("name").notNull(),
   role: text("role").notNull(), // patient, nurse, physician, specialist, admin
+  patient_id: text("patient_id"), // links patient users to their patient record
   specialty: text("specialty"),
   department: text("department"),
   is_active: boolean("is_active").notNull().default(true),

--- a/packages/shared-types/src/auth.ts
+++ b/packages/shared-types/src/auth.ts
@@ -6,6 +6,7 @@ export interface User extends MutableRecord {
   email: string;
   name: string;
   role: UserRole;
+  patient_id?: string; // links patient-role users to their patient record
   specialty?: string; // for physicians/specialists
   department?: string;
   is_active: boolean;


### PR DESCRIPTION
## Summary

**Critical HIPAA fix** — 6/8 swarm audit agents flagged as P0.

Old pattern matched by display name with fallback to `data[0]`, potentially exposing one patient's data to another.

- Add `patient_id` column to users table (migration 0022)
- Add `patient_id` to `User` interface
- Create `useMyPatientRecord()` shared hook
- Update all 7 patient portal pages
- No more `data[0]` fallback

Closes #359

## Test Plan

- [ ] pnpm typecheck passes (34/34)
- [ ] Patient with patient_id set sees own record
- [ ] Patient without patient_id falls back to name-match (no data[0])
- [ ] No cross-patient data exposure