### PR TITLE
fix(auth): start session cleanup worker on service boot (#268)

### DIFF
--- a/services/api-gateway/src/__tests__/workers.test.ts
+++ b/services/api-gateway/src/__tests__/workers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+const { startCleanupWorkerMock } = vi.hoisted(() => ({
+  startCleanupWorkerMock: vi.fn(async () => ({
+    queue: { close: vi.fn() },
+    worker: { close: vi.fn() },
+  })),
+}));
+
+vi.mock("@carebridge/auth", () => ({
+  startCleanupWorker: startCleanupWorkerMock,
+}));
+
+import { startBackgroundWorkers } from "../workers.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startBackgroundWorkers", () => {
+  beforeEach(() => {
+    startCleanupWorkerMock.mockClear();
+  });
+
+  it("starts the session cleanup worker", async () => {
+    await startBackgroundWorkers();
+
+    expect(startCleanupWorkerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the worker handles so callers can manage shutdown", async () => {
+    const handles = await startBackgroundWorkers();
+
+    expect(handles).toHaveProperty("sessionCleanup");
+    expect(handles.sessionCleanup).toHaveProperty("queue");
+    expect(handles.sessionCleanup).toHaveProperty("worker");
+  });
+});

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -10,6 +10,7 @@ import { createContext } from "./context.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { auditMiddleware } from "./middleware/audit.js";
 import { registerNotificationSSE } from "./routes/notifications-sse.js";
+import { startBackgroundWorkers } from "./workers.js";
 
 const API_PORT = Number(process.env.API_PORT) || 4000;
 const API_HOST = process.env.API_HOST ?? "0.0.0.0";
@@ -171,6 +172,11 @@ async function main() {
       service: "api-gateway",
     };
   });
+
+  // --- Background workers ---
+  // Must run before listen() so the session cleanup worker is enforcing the
+  // 15-minute idle timeout the moment the gateway starts accepting traffic.
+  await startBackgroundWorkers();
 
   // --- Start ---
   await server.listen({ port: API_PORT, host: API_HOST });

--- a/services/api-gateway/src/workers.ts
+++ b/services/api-gateway/src/workers.ts
@@ -1,0 +1,27 @@
+import { startCleanupWorker } from "@carebridge/auth";
+
+/**
+ * Handles for background workers started at gateway boot.
+ *
+ * Holding references prevents the BullMQ workers from being garbage-collected
+ * and gives the caller a way to gracefully shut them down.
+ */
+export interface BackgroundWorkerHandles {
+  sessionCleanup: Awaited<ReturnType<typeof startCleanupWorker>>;
+}
+
+/**
+ * Start all background workers that the API gateway is responsible for.
+ *
+ * Currently:
+ *  - Session cleanup worker (HIPAA § 164.312(a)(2)(i) — enforces the
+ *    15-minute idle timeout and 48-hour hard cap defined in
+ *    services/auth/src/session-cleanup.ts).
+ *
+ * Call once at server startup, after Redis configuration is available.
+ */
+export async function startBackgroundWorkers(): Promise<BackgroundWorkerHandles> {
+  const sessionCleanup = await startCleanupWorker();
+
+  return { sessionCleanup };
+}


### PR DESCRIPTION
## Summary
The session cleanup worker enforces the 15-minute idle timeout and 48-hour hard cap required by HIPAA § 164.312(a)(2)(i), but `startCleanupWorker()` was defined and exported but never invoked at startup. Sessions effectively never expired.

This PR wires `startCleanupWorker()` into the API gateway's bootstrap so the cleanup schedule is running the moment the gateway accepts traffic.

## Changes
- New `services/api-gateway/src/workers.ts` exposing `startBackgroundWorkers()`, which calls `startCleanupWorker()` and returns the worker handles for shutdown management.
- `services/api-gateway/src/server.ts` calls `startBackgroundWorkers()` inside `main()` before `server.listen()`, so the worker is enforcing the timeout before any request can arrive.
- New unit test `services/api-gateway/src/__tests__/workers.test.ts` mocks `@carebridge/auth` and verifies that `startBackgroundWorkers()` invokes `startCleanupWorker` exactly once and returns the expected handles.

Scope is intentionally narrow — server-side enforcement only. Client-side idle warnings/auto-logout are out of scope and can be tracked separately.

## Test Plan
- [x] `pnpm -F @carebridge/api-gateway test` — 42/42 passing (including the 2 new tests)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only pre-existing warnings unrelated to this change)
- [ ] Manual: start the gateway, observe `[session-cleanup] Worker started (hourly schedule)` log line, confirm BullMQ `session-cleanup` queue receives the repeatable job

Closes #268