### PR TITLE
fix(portal): set Referrer-Policy: no-referrer on PHI pages (#284)

### DIFF
--- a/apps/clinician-portal/next.config.ts
+++ b/apps/clinician-portal/next.config.ts
@@ -12,6 +12,24 @@ const nextConfig: NextConfig = {
     "@carebridge/ai-oversight",
     "@carebridge/db-schema",
   ],
+  // Issue #284: PHI pages embed patient UUIDs in the URL path
+  // (e.g. /patients/[id]). Without a strict Referrer-Policy, those
+  // identifiers leak to any third-party origin contacted from the page
+  // via the outbound Referer header. The clinician portal exclusively
+  // serves PHI, so we apply "no-referrer" globally.
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Referrer-Policy",
+            value: "no-referrer",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/clinician-portal/next.config.ts
+++ b/apps/clinician-portal/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/(.*)",
+        source: "/:path*",
         headers: [
           {
             key: "Referrer-Policy",

--- a/apps/clinician-portal/package.json
+++ b/apps/clinician-portal/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
     "clean": "rm -rf .next"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "@types/react-dom": "^19.0.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.1.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/clinician-portal/src/__tests__/next-config-headers.test.ts
+++ b/apps/clinician-portal/src/__tests__/next-config-headers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import nextConfig from "../../next.config";
+
+/**
+ * Issue #284: Patient UUIDs exposed in URLs (Referer leak risk).
+ *
+ * PHI pages such as /patients/[id] embed patient UUIDs in the URL path.
+ * Without a strict Referrer-Policy, those UUIDs leak to any third-party
+ * origin contacted from the page (analytics, embedded images, fonts, etc.)
+ * via the outbound Referer header.
+ *
+ * The clinician portal exclusively serves PHI, so we set
+ * "Referrer-Policy: no-referrer" globally via next.config headers().
+ */
+describe("clinician-portal next.config headers()", () => {
+  it("defines a headers() function", () => {
+    expect(typeof nextConfig.headers).toBe("function");
+  });
+
+  it("sets Referrer-Policy: no-referrer on all routes", async () => {
+    // headers() is defined above; guarded by previous test
+    const headers = await nextConfig.headers!();
+
+    // At least one entry must match every route
+    const globalEntry = headers.find((h) => h.source === "/(.*)");
+    expect(globalEntry).toBeDefined();
+
+    const referrerHeader = globalEntry!.headers.find(
+      (h) => h.key.toLowerCase() === "referrer-policy",
+    );
+    expect(referrerHeader).toBeDefined();
+    expect(referrerHeader!.value).toBe("no-referrer");
+  });
+});

--- a/apps/clinician-portal/src/__tests__/next-config-headers.test.ts
+++ b/apps/clinician-portal/src/__tests__/next-config-headers.test.ts
@@ -21,14 +21,19 @@ describe("clinician-portal next.config headers()", () => {
     // headers() is defined above; guarded by previous test
     const headers = await nextConfig.headers!();
 
-    // At least one entry must match every route
-    const globalEntry = headers.find((h) => h.source === "/(.*)");
-    expect(globalEntry).toBeDefined();
+    // Look for any catch-all entry that sets Referrer-Policy: no-referrer.
+    // Both `/:path*` (path-to-regexp catch-all) and `/(.*)` (raw regex)
+    // are valid Next.js source patterns; assert on the behavior, not the
+    // specific syntax.
+    const globalEntry = headers.find((entry) => {
+      const isGlobalRoute =
+        entry.source === "/:path*" || entry.source === "/(.*)";
+      const referrerHeader = entry.headers.find(
+        (h) => h.key.toLowerCase() === "referrer-policy",
+      );
+      return isGlobalRoute && referrerHeader?.value === "no-referrer";
+    });
 
-    const referrerHeader = globalEntry!.headers.find(
-      (h) => h.key.toLowerCase() === "referrer-policy",
-    );
-    expect(referrerHeader).toBeDefined();
-    expect(referrerHeader!.value).toBe("no-referrer");
+    expect(globalEntry).toBeDefined();
   });
 });

--- a/apps/clinician-portal/vitest.config.ts
+++ b/apps/clinician-portal/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/apps/patient-portal/next.config.ts
+++ b/apps/patient-portal/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/(.*)",
+        source: "/:path*",
         headers: [
           {
             key: "Referrer-Policy",

--- a/apps/patient-portal/next.config.ts
+++ b/apps/patient-portal/next.config.ts
@@ -12,6 +12,24 @@ const nextConfig: NextConfig = {
     "@carebridge/db-schema",
     "@carebridge/validators",
   ],
+  // Issue #284: PHI pages embed patient identifiers in the URL path.
+  // Without a strict Referrer-Policy, those identifiers leak to any
+  // third-party origin contacted from the page via the outbound Referer
+  // header. The patient portal exclusively serves the logged-in patient's
+  // own PHI, so we apply "no-referrer" globally.
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Referrer-Policy",
+            value: "no-referrer",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/patient-portal/package.json
+++ b/apps/patient-portal/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
     "clean": "rm -rf .next"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19.0.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.1.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/patient-portal/src/__tests__/next-config-headers.test.ts
+++ b/apps/patient-portal/src/__tests__/next-config-headers.test.ts
@@ -19,13 +19,19 @@ describe("patient-portal next.config headers()", () => {
   it("sets Referrer-Policy: no-referrer on all routes", async () => {
     const headers = await nextConfig.headers!();
 
-    const globalEntry = headers.find((h) => h.source === "/(.*)");
-    expect(globalEntry).toBeDefined();
+    // Look for any catch-all entry that sets Referrer-Policy: no-referrer.
+    // Both the path-to-regexp catch-all syntax (`/:path*`) and the explicit
+    // wildcard regex (`/(.*)`) are valid Next.js source patterns; assert on
+    // the behavior, not the specific syntax.
+    const globalEntry = headers.find((entry) => {
+      const isGlobalRoute =
+        entry.source === "/:path*" || entry.source === "/(.*)";
+      const referrerHeader = entry.headers.find(
+        (h) => h.key.toLowerCase() === "referrer-policy",
+      );
+      return isGlobalRoute && referrerHeader?.value === "no-referrer";
+    });
 
-    const referrerHeader = globalEntry!.headers.find(
-      (h) => h.key.toLowerCase() === "referrer-policy",
-    );
-    expect(referrerHeader).toBeDefined();
-    expect(referrerHeader!.value).toBe("no-referrer");
+    expect(globalEntry).toBeDefined();
   });
 });

--- a/apps/patient-portal/src/__tests__/next-config-headers.test.ts
+++ b/apps/patient-portal/src/__tests__/next-config-headers.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import nextConfig from "../../next.config";
+
+/**
+ * Issue #284: Patient UUIDs exposed in URLs (Referer leak risk).
+ *
+ * The patient portal displays a logged-in patient's own PHI. Any outbound
+ * request from a PHI page (analytics, embedded images, fonts, etc.) would
+ * otherwise leak the current URL — including patient identifiers — via the
+ * Referer header.
+ *
+ * We set "Referrer-Policy: no-referrer" globally via next.config headers().
+ */
+describe("patient-portal next.config headers()", () => {
+  it("defines a headers() function", () => {
+    expect(typeof nextConfig.headers).toBe("function");
+  });
+
+  it("sets Referrer-Policy: no-referrer on all routes", async () => {
+    const headers = await nextConfig.headers!();
+
+    const globalEntry = headers.find((h) => h.source === "/(.*)");
+    expect(globalEntry).toBeDefined();
+
+    const referrerHeader = globalEntry!.headers.find(
+      (h) => h.key.toLowerCase() === "referrer-policy",
+    );
+    expect(referrerHeader).toBeDefined();
+    expect(referrerHeader!.value).toBe("no-referrer");
+  });
+});

--- a/apps/patient-portal/vitest.config.ts
+++ b/apps/patient-portal/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   apps/patient-portal:
     dependencies:
@@ -136,6 +139,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/ai-prompts:
     dependencies:
@@ -5249,8 +5255,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5269,7 +5275,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5280,22 +5286,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5306,7 +5312,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
Fix #284. PHI pages in both portals embed patient identifiers in URL paths (e.g. `/patients/[id]`). Without a strict `Referrer-Policy`, those UUIDs leak to any third-party origin contacted from the page (analytics, fonts, images, etc.) via the outbound `Referer` header. HIPAA P3 privacy risk.

Apply `Referrer-Policy: no-referrer` globally on both portals via `next.config.ts` `headers()`. Both the clinician-portal and patient-portal serve PHI exclusively, so a blanket `no-referrer` is the safe default (strips on internal navigation too, but that's fine — no code depends on Referer).

## Changes
- `apps/clinician-portal/next.config.ts`: add `async headers()` returning `Referrer-Policy: no-referrer` for `/(.*)`.
- `apps/patient-portal/next.config.ts`: same.
- Add `vitest` devDep, `vitest.config.ts`, and `test` script to both portals (first vitest setup in either portal).
- Add `src/__tests__/next-config-headers.test.ts` in both portals that imports the config and asserts the header is set.

## Test Plan
- [x] `pnpm --filter @carebridge/clinician-portal test` — 2/2 pass
- [x] `pnpm --filter @carebridge/patient-portal test` — 2/2 pass
- [x] `pnpm typecheck --force` at repo root — 34/34 pass
- [x] `pnpm lint` at repo root — 19/19 pass (pre-existing warnings only, no new errors)
- [ ] Manual: `curl -I http://localhost:3000/patients/<id>` in dev shows `Referrer-Policy: no-referrer`

## Notes
- Narrow scope: only `Referrer-Policy` added; no other security headers touched.
- Portals previously had no `headers()` block and no test harness; this PR adds both in a minimal way.
- Unrelated pre-existing typecheck errors exist in `apps/clinician-portal/app/notes/page.tsx`, `apps/clinician-portal/app/symptoms/page.tsx`, and `apps/patient-portal/src/lib/use-my-patient.ts` — the portals have no `typecheck` script and are not part of `pnpm typecheck`, so those are out of scope for #284.

Closes #284