### PR TITLE
fix(ai): add RBAC wrapper and enforce patient access on ai-oversight router (#270 #272)

### DIFF
--- a/services/ai-oversight/src/index.ts
+++ b/services/ai-oversight/src/index.ts
@@ -2,3 +2,5 @@ export { aiOversightRouter } from "./router.js";
 export type { AiOversightRouter } from "./router.js";
 export { startReviewWorker } from "./workers/review-worker.js";
 export { processReviewJob } from "./services/review-service.js";
+export * as flagService from "./services/flag-service.js";
+export { getReviewJobsByPatient } from "./services/review-jobs-service.js";

--- a/services/ai-oversight/src/router.ts
+++ b/services/ai-oversight/src/router.ts
@@ -1,9 +1,12 @@
 /**
  * tRPC router for the AI oversight service.
  *
- * Exposes flag management and review job queries to the API gateway.
- * All flag mutation procedures require authentication — the acting user
- * is derived from the session context, never accepted as client input.
+ * The api-gateway mounts flag and review-job queries via the RBAC wrapper in
+ * `services/api-gateway/src/routers/ai-oversight.ts`, not this module. This
+ * router is retained for internal / test use and defence-in-depth: every
+ * procedure requires authentication so a direct mount would still deny
+ * anonymous callers. Patient-scoped authorisation, however, is enforced only
+ * by the RBAC wrapper — do not register this router on an external surface.
  */
 
 import { initTRPC, TRPCError } from "@trpc/server";
@@ -43,7 +46,7 @@ const protectedProcedure = t.procedure.use(isAuthenticated);
 
 export const aiOversightRouter = t.router({
   flags: t.router({
-    getByPatient: t.procedure
+    getByPatient: protectedProcedure
       .input(
         z.object({
           patientId: z.string().uuid(),
@@ -102,7 +105,7 @@ export const aiOversightRouter = t.router({
         return flagService.getAllOpenFlags();
       }),
 
-    getOpenCount: t.procedure
+    getOpenCount: protectedProcedure
       .input(z.object({ patientId: z.string().uuid() }))
       .query(async ({ input }) => {
         const count = await flagService.getOpenFlagCount(input.patientId);
@@ -111,7 +114,7 @@ export const aiOversightRouter = t.router({
   }),
 
   reviews: t.router({
-    getByPatient: t.procedure
+    getByPatient: protectedProcedure
       .input(z.object({ patientId: z.string().uuid() }))
       .query(async ({ input }) => {
         const db = getDb();

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -189,6 +189,25 @@ export async function dismissFlag(
 }
 
 /**
+ * Get a single flag by its id.
+ *
+ * Used by the gateway RBAC wrapper to look up a flag's patient_id before
+ * enforcing patient access on mutations that accept only a flagId
+ * (acknowledge / resolve / dismiss).
+ */
+export async function getFlagById(
+  flagId: string,
+): Promise<ClinicalFlag | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.id, flagId))
+    .limit(1);
+  return (rows[0] ?? null) as ClinicalFlag | null;
+}
+
+/**
  * Get flags for a patient, optionally filtered by status.
  */
 export async function getFlagsByPatient(

--- a/services/ai-oversight/src/services/review-jobs-service.ts
+++ b/services/ai-oversight/src/services/review-jobs-service.ts
@@ -1,0 +1,18 @@
+/**
+ * Read-side helpers for the review_jobs table.
+ *
+ * Kept outside the router module so the RBAC wrapper in api-gateway can call
+ * them directly without going through the raw tRPC router surface.
+ */
+
+import { eq, desc } from "drizzle-orm";
+import { getDb, reviewJobs } from "@carebridge/db-schema";
+
+export async function getReviewJobsByPatient(patientId: string) {
+  const db = getDb();
+  return db
+    .select()
+    .from(reviewJobs)
+    .where(eq(reviewJobs.patient_id, patientId))
+    .orderBy(desc(reviewJobs.created_at));
+}

--- a/services/api-gateway/src/__tests__/ai-oversight-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/ai-oversight-rbac.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression tests for issue #270 — AI oversight IDOR.
+ *
+ * The raw ai-oversight router exposed flags.getByPatient / getOpenCount and
+ * reviews.getByPatient as unauthenticated tRPC procedures, letting any caller
+ * enumerate patient flags by UUID. These tests exercise the RBAC wrapper
+ * directly and prove that:
+ *
+ *  1. An unauthenticated caller is rejected with UNAUTHORIZED.
+ *  2. A patient trying to read another patient's flags is rejected with
+ *     FORBIDDEN and the flag service is never invoked.
+ *  3. A clinician without a care-team assignment is rejected with FORBIDDEN.
+ *  4. A clinician with a care-team assignment is allowed through and sees the
+ *     expected payload from the flag service.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — referenced from vi.mock factories that get hoisted above
+// the rest of the file.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  getFlagsByPatient: vi.fn(),
+  getOpenFlagCount: vi.fn(),
+  getReviewJobsByPatient: vi.fn(),
+  assertCareTeamAccess: vi.fn(),
+}));
+
+vi.mock("@carebridge/ai-oversight", () => ({
+  flagService: {
+    getFlagsByPatient: mocks.getFlagsByPatient,
+    getOpenFlagCount: mocks.getOpenFlagCount,
+    getAllOpenFlags: vi.fn(),
+    acknowledgeFlag: vi.fn(),
+    resolveFlag: vi.fn(),
+    dismissFlag: vi.fn(),
+  },
+  getReviewJobsByPatient: mocks.getReviewJobsByPatient,
+}));
+
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: (...args: unknown[]) =>
+    mocks.assertCareTeamAccess(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are in place.
+// ---------------------------------------------------------------------------
+
+import { aiOversightRbacRouter } from "../routers/ai-oversight.js";
+import type { Context } from "../context.js";
+
+type User = NonNullable<Context["user"]>;
+
+const patientA: User = {
+  id: "11111111-1111-1111-1111-111111111111",
+  email: "alice@carebridge.dev",
+  name: "Alice",
+  role: "patient",
+  is_active: true,
+} as User;
+
+const patientBId = "22222222-2222-2222-2222-222222222222";
+
+const physician: User = {
+  id: "33333333-3333-3333-3333-333333333333",
+  email: "dr.smith@carebridge.dev",
+  name: "Dr. Smith",
+  role: "physician",
+  specialty: "Hematology/Oncology",
+  is_active: true,
+} as User;
+
+function makeContext(user: Context["user"]): Context {
+  return {
+    db: {} as Context["db"],
+    user,
+    sessionId: null,
+    requestId: "test-request",
+  };
+}
+
+const caller = (ctx: Context) =>
+  aiOversightRbacRouter.createCaller(ctx);
+
+describe("aiOversightRbacRouter — issue #270 IDOR regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthenticated flags.getByPatient with UNAUTHORIZED", async () => {
+    await expect(
+      caller(makeContext(null)).flags.getByPatient({ patientId: patientBId }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(mocks.getFlagsByPatient).not.toHaveBeenCalled();
+  });
+
+  it("rejects a patient requesting another patient's flags with FORBIDDEN", async () => {
+    await expect(
+      caller(makeContext(patientA)).flags.getByPatient({
+        patientId: patientBId,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.getFlagsByPatient).not.toHaveBeenCalled();
+  });
+
+  it("rejects a clinician with no care-team assignment with FORBIDDEN", async () => {
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+
+    await expect(
+      caller(makeContext(physician)).flags.getByPatient({
+        patientId: patientBId,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.assertCareTeamAccess).toHaveBeenCalledWith(
+      physician.id,
+      patientBId,
+    );
+    expect(mocks.getFlagsByPatient).not.toHaveBeenCalled();
+  });
+
+  it("allows a clinician with a care-team assignment to read flags", async () => {
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(true);
+    const fakeFlags = [{ id: "flag-1", patient_id: patientBId }];
+    mocks.getFlagsByPatient.mockResolvedValueOnce(fakeFlags);
+
+    const result = await caller(makeContext(physician)).flags.getByPatient({
+      patientId: patientBId,
+    });
+
+    expect(result).toEqual(fakeFlags);
+    expect(mocks.getFlagsByPatient).toHaveBeenCalledWith(patientBId, undefined);
+  });
+
+  it("rejects unauthenticated flags.getOpenCount with UNAUTHORIZED", async () => {
+    await expect(
+      caller(makeContext(null)).flags.getOpenCount({ patientId: patientBId }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(mocks.getOpenFlagCount).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-patient flags.getOpenCount with FORBIDDEN", async () => {
+    await expect(
+      caller(makeContext(patientA)).flags.getOpenCount({
+        patientId: patientBId,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.getOpenFlagCount).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated reviews.getByPatient with UNAUTHORIZED", async () => {
+    await expect(
+      caller(makeContext(null)).reviews.getByPatient({
+        patientId: patientBId,
+      }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    expect(mocks.getReviewJobsByPatient).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-patient reviews.getByPatient with FORBIDDEN", async () => {
+    await expect(
+      caller(makeContext(patientA)).reviews.getByPatient({
+        patientId: patientBId,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.getReviewJobsByPatient).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/__tests__/ai-oversight-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/ai-oversight-rbac.test.ts
@@ -24,6 +24,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mocks = vi.hoisted(() => ({
   getFlagsByPatient: vi.fn(),
   getOpenFlagCount: vi.fn(),
+  getFlagById: vi.fn(),
+  acknowledgeFlag: vi.fn(),
+  resolveFlag: vi.fn(),
+  dismissFlag: vi.fn(),
   getReviewJobsByPatient: vi.fn(),
   assertCareTeamAccess: vi.fn(),
 }));
@@ -33,9 +37,10 @@ vi.mock("@carebridge/ai-oversight", () => ({
     getFlagsByPatient: mocks.getFlagsByPatient,
     getOpenFlagCount: mocks.getOpenFlagCount,
     getAllOpenFlags: vi.fn(),
-    acknowledgeFlag: vi.fn(),
-    resolveFlag: vi.fn(),
-    dismissFlag: vi.fn(),
+    getFlagById: mocks.getFlagById,
+    acknowledgeFlag: mocks.acknowledgeFlag,
+    resolveFlag: mocks.resolveFlag,
+    dismissFlag: mocks.dismissFlag,
   },
   getReviewJobsByPatient: mocks.getReviewJobsByPatient,
 }));
@@ -173,5 +178,79 @@ describe("aiOversightRbacRouter — issue #270 IDOR regression", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(mocks.getReviewJobsByPatient).not.toHaveBeenCalled();
+  });
+});
+
+describe("aiOversightRbacRouter — issue #272 flag-mutation patient-access", () => {
+  const flagOwnedByPatientB = {
+    id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    patient_id: patientBId,
+    rule_id: "TEST-RULE",
+    status: "open",
+    source: "rule",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects flags.acknowledge when caller is a different patient", async () => {
+    mocks.getFlagById.mockResolvedValueOnce(flagOwnedByPatientB);
+
+    await expect(
+      caller(makeContext(patientA)).flags.acknowledge({
+        flagId: flagOwnedByPatientB.id,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.getFlagById).toHaveBeenCalledWith(flagOwnedByPatientB.id);
+    expect(mocks.acknowledgeFlag).not.toHaveBeenCalled();
+  });
+
+  it("rejects flags.resolve when clinician has no care-team relationship", async () => {
+    mocks.getFlagById.mockResolvedValueOnce(flagOwnedByPatientB);
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+
+    await expect(
+      caller(makeContext(physician)).flags.resolve({
+        flagId: flagOwnedByPatientB.id,
+        resolution_note: "test",
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(mocks.assertCareTeamAccess).toHaveBeenCalledWith(
+      physician.id,
+      patientBId,
+    );
+    expect(mocks.resolveFlag).not.toHaveBeenCalled();
+  });
+
+  it("rejects flags.dismiss when the flag does not exist with NOT_FOUND", async () => {
+    mocks.getFlagById.mockResolvedValueOnce(null);
+
+    await expect(
+      caller(makeContext(physician)).flags.dismiss({
+        flagId: flagOwnedByPatientB.id,
+        dismiss_reason: "test",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(mocks.dismissFlag).not.toHaveBeenCalled();
+  });
+
+  it("allows flags.acknowledge for a clinician on the patient's care team", async () => {
+    mocks.getFlagById.mockResolvedValueOnce(flagOwnedByPatientB);
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(true);
+    mocks.acknowledgeFlag.mockResolvedValueOnce(undefined);
+
+    const result = await caller(makeContext(physician)).flags.acknowledge({
+      flagId: flagOwnedByPatientB.id,
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(mocks.acknowledgeFlag).toHaveBeenCalledWith(
+      flagOwnedByPatientB.id,
+      physician.id,
+    );
   });
 });

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -1,10 +1,10 @@
 import { router, publicProcedure } from "./trpc.js";
 import { authRouter } from "@carebridge/auth";
-import { aiOversightRouter } from "@carebridge/ai-oversight";
 import { notificationsRouter } from "@carebridge/notifications";
 import { patientRecordsRbacRouter } from "./routers/patient-records.js";
 import { clinicalDataRbacRouter } from "./routers/clinical-data.js";
 import { clinicalNotesRbacRouter } from "./routers/clinical-notes.js";
+import { aiOversightRbacRouter } from "./routers/ai-oversight.js";
 import { messagingRbacRouter } from "./routers/messaging.js";
 import { schedulingRbacRouter } from "./routers/scheduling.js";
 import { emergencyAccessRbacRouter } from "./routers/emergency-access.js";
@@ -23,7 +23,7 @@ export const appRouter = router({
   patients: patientRecordsRbacRouter,
   clinicalData: clinicalDataRbacRouter,
   notes: clinicalNotesRbacRouter,
-  aiOversight: aiOversightRouter,
+  aiOversight: aiOversightRbacRouter,
   notifications: notificationsRouter,
   messaging: messagingRbacRouter,
   scheduling: schedulingRbacRouter,

--- a/services/api-gateway/src/routers/ai-oversight.ts
+++ b/services/api-gateway/src/routers/ai-oversight.ts
@@ -1,0 +1,149 @@
+/**
+ * RBAC-enforced ai-oversight router.
+ *
+ * Every patient-scoped procedure calls enforcePatientAccess() before
+ * delegating to the flag service functions from @carebridge/ai-oversight.
+ * userId is derived from ctx.user.id — never accepted as client input.
+ *
+ * Closes the IDOR in the raw ai-oversight router (issue #270) where
+ * flags.getByPatient, flags.getOpenCount and reviews.getByPatient were
+ * previously exposed as unauthenticated tRPC procedures.
+ */
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import { flagStatusSchema } from "@carebridge/validators";
+import {
+  flagService,
+  getReviewJobsByPatient,
+} from "@carebridge/ai-oversight";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+/**
+ * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
+ * Throws TRPCError(FORBIDDEN) on denial.
+ */
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+): Promise<void> {
+  if (user.role === "admin") return;
+
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  // Clinicians (physician, specialist, nurse) must be on the care team.
+  const hasAccess = await assertCareTeamAccess(user.id, patientId);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+export const aiOversightRbacRouter = t.router({
+  flags: t.router({
+    getByPatient: protectedProcedure
+      .input(
+        z.object({
+          patientId: z.string().uuid(),
+          status: flagStatusSchema.optional(),
+        }),
+      )
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        return flagService.getFlagsByPatient(input.patientId, input.status);
+      }),
+
+    getOpenCount: protectedProcedure
+      .input(z.object({ patientId: z.string().uuid() }))
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        const count = await flagService.getOpenFlagCount(input.patientId);
+        return { count };
+      }),
+
+    getAllOpen: protectedProcedure.query(async ({ ctx }) => {
+      // Patients are never allowed to enumerate the global open-flag inbox.
+      if (ctx.user.role === "patient") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Access denied: patients cannot list the clinician inbox",
+        });
+      }
+      return flagService.getAllOpenFlags();
+    }),
+
+    acknowledge: protectedProcedure
+      .input(z.object({ flagId: z.string().uuid() }))
+      .mutation(async ({ ctx, input }) => {
+        await flagService.acknowledgeFlag(input.flagId, ctx.user.id);
+        return { success: true };
+      }),
+
+    resolve: protectedProcedure
+      .input(
+        z.object({
+          flagId: z.string().uuid(),
+          resolution_note: z.string().min(1).max(2000),
+        }),
+      )
+      .mutation(async ({ ctx, input }) => {
+        await flagService.resolveFlag(
+          input.flagId,
+          ctx.user.id,
+          input.resolution_note,
+        );
+        return { success: true };
+      }),
+
+    dismiss: protectedProcedure
+      .input(
+        z.object({
+          flagId: z.string().uuid(),
+          dismiss_reason: z.string().min(1).max(2000),
+        }),
+      )
+      .mutation(async ({ ctx, input }) => {
+        await flagService.dismissFlag(
+          input.flagId,
+          ctx.user.id,
+          input.dismiss_reason,
+        );
+        return { success: true };
+      }),
+  }),
+
+  reviews: t.router({
+    getByPatient: protectedProcedure
+      .input(z.object({ patientId: z.string().uuid() }))
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        return getReviewJobsByPatient(input.patientId);
+      }),
+  }),
+});
+
+export type AiOversightRbacRouter = typeof aiOversightRbacRouter;

--- a/services/api-gateway/src/routers/ai-oversight.ts
+++ b/services/api-gateway/src/routers/ai-oversight.ts
@@ -8,6 +8,10 @@
  * Closes the IDOR in the raw ai-oversight router (issue #270) where
  * flags.getByPatient, flags.getOpenCount and reviews.getByPatient were
  * previously exposed as unauthenticated tRPC procedures.
+ *
+ * Also closes issue #272: flags.acknowledge / resolve / dismiss accept
+ * only a flagId, so the wrapper loads the flag first to retrieve its
+ * patient_id and enforces patient access before allowing the mutation.
  */
 import { z } from "zod";
 import { TRPCError, initTRPC } from "@trpc/server";
@@ -99,6 +103,11 @@ export const aiOversightRbacRouter = t.router({
     acknowledge: protectedProcedure
       .input(z.object({ flagId: z.string().uuid() }))
       .mutation(async ({ ctx, input }) => {
+        const flag = await flagService.getFlagById(input.flagId);
+        if (!flag) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found" });
+        }
+        await enforcePatientAccess(ctx.user, flag.patient_id);
         await flagService.acknowledgeFlag(input.flagId, ctx.user.id);
         return { success: true };
       }),
@@ -111,6 +120,11 @@ export const aiOversightRbacRouter = t.router({
         }),
       )
       .mutation(async ({ ctx, input }) => {
+        const flag = await flagService.getFlagById(input.flagId);
+        if (!flag) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found" });
+        }
+        await enforcePatientAccess(ctx.user, flag.patient_id);
         await flagService.resolveFlag(
           input.flagId,
           ctx.user.id,
@@ -127,6 +141,11 @@ export const aiOversightRbacRouter = t.router({
         }),
       )
       .mutation(async ({ ctx, input }) => {
+        const flag = await flagService.getFlagById(input.flagId);
+        if (!flag) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found" });
+        }
+        await enforcePatientAccess(ctx.user, flag.patient_id);
         await flagService.dismissFlag(
           input.flagId,
           ctx.user.id,


### PR DESCRIPTION
## Summary

Closes two related IDOR vulnerabilities in the `ai-oversight` router by introducing an RBAC wrapper at the api-gateway layer and folding the flag-mutation patient-access check into the same wrapper.

- **#270** — `aiOversight.flags.getByPatient`, `flags.getOpenCount`, and `reviews.getByPatient` were registered with unprotected `t.procedure`, so any caller could enumerate patient flags by UUID. No auth, no RBAC, no audit.
- **#272** — `flags.acknowledge / resolve / dismiss` accept only a `flagId` input and never looked up the flag's `patient_id` to verify the caller has access. Any authenticated user could mutate another patient's flag state by guessing UUIDs, silently corrupting the clinical audit trail.

This brings the `ai-oversight` router in line with the CLAUDE.md rule that every service router registered in the gateway must go through an RBAC wrapper that derives `userId` from `ctx.user.id` rather than accepting it as input.

## Changes

**New wrapper** — `services/api-gateway/src/routers/ai-oversight.ts`
- `aiOversightRbacRouter` exposing `flags.{getByPatient, getOpenCount, getAllOpen, acknowledge, resolve, dismiss}` and `reviews.getByPatient`.
- Every patient-scoped query calls `enforcePatientAccess(ctx.user, input.patientId)` before delegating to `flagService`.
- `flags.getAllOpen` refuses `role === "patient"` (patients never see the global clinician inbox).
- For the `flags.acknowledge / resolve / dismiss` mutations, the wrapper first calls `flagService.getFlagById(flagId)`, returns `NOT_FOUND` if the flag is missing, then runs `enforcePatientAccess` against the flag's `patient_id` before calling the underlying mutation. `userId` is always derived from `ctx.user.id` — never from input.

**Raw service router hardening** (defence-in-depth) — `services/ai-oversight/src/router.ts`
- `flags.getByPatient`, `flags.getOpenCount`, and `reviews.getByPatient` switched from `t.procedure` to `protectedProcedure` in case anyone re-mounts the raw router bypassing the wrapper.

**Gateway registration** — `services/api-gateway/src/router.ts`
- Swaps the raw `aiOversightRouter` import for `aiOversightRbacRouter`.

**Supporting code**
- `services/ai-oversight/src/services/flag-service.ts`: adds `getFlagById(flagId)` helper.
- `services/ai-oversight/src/services/review-jobs-service.ts` (new): `getReviewJobsByPatient` helper so the wrapper can query `review_jobs` without going through the raw router.
- `services/ai-oversight/src/index.ts`: re-exports `flagService` and `getReviewJobsByPatient`.

## Test Plan

- [x] New test file `services/api-gateway/src/__tests__/ai-oversight-rbac.test.ts` — **12 tests**, all green.
  - **#270 regression (8 tests)**: UNAUTHORIZED for unauthenticated callers on all three read procedures; FORBIDDEN for cross-patient reads; FORBIDDEN for clinicians without a care-team assignment; happy-path for clinician-with-care-team.
  - **#272 regression (4 tests)**: cross-patient `acknowledge` returns FORBIDDEN; `resolve` for clinician without care-team returns FORBIDDEN; missing flag returns NOT_FOUND; happy-path `acknowledge` for clinician with care-team assignment.
- [x] `pnpm -F @carebridge/api-gateway test` — 48/48 pass (pre-existing tests unaffected).
- [x] `pnpm typecheck` — clean (34/34).
- [x] `pnpm lint` — clean (19/19; only pre-existing unrelated clinician-portal warnings).

Closes #270
Closes #272