### PR TITLE
fix(notes): enforce role check on note signing (#271)

### DIFF
--- a/apps/clinician-portal/app/notes/[id]/page.tsx
+++ b/apps/clinician-portal/app/notes/[id]/page.tsx
@@ -106,7 +106,10 @@ function NoteDetailContent() {
     if (!confirm("Sign this note? Signed notes become part of the permanent record.")) {
       return;
     }
-    signMutation.mutate({ noteId, signed_by: user.id });
+    // The gateway wrapper derives the signer from ctx.user.id on the server
+    // side to prevent signature spoofing, so `signed_by` is no longer part
+    // of the input. See fix(notes) in PR #372.
+    signMutation.mutate({ noteId });
   }
 
   return (

--- a/services/api-gateway/src/__tests__/clinical-notes-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/clinical-notes-rbac.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const ROLE_IDS: Record<string, string> = {
+  nurse: "33333333-3333-4333-8333-333333333333",
+  physician: "44444444-4444-4444-8444-444444444444",
+  specialist: "55555555-5555-4555-8555-555555555555",
+  admin: "66666666-6666-4666-8666-666666666666",
+  patient: PATIENT_ID,
+};
+
+// Mock DB: every select returns the note row so access checks never 404.
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(async () => [{ patient_id: PATIENT_ID }]);
+  return chain;
+}
+
+const mockDb = {
+  select: vi.fn(() => makeSelectChain()),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  clinicalNotes: {
+    id: "clinical_notes.id",
+    patient_id: "clinical_notes.patient_id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+}));
+
+// Always grant care-team access so the only gate under test is the role check.
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: vi.fn(async () => true),
+}));
+
+// Stub the note service so signNote does not touch a real DB.
+vi.mock("@carebridge/clinical-notes", () => ({
+  noteService: {
+    createNote: vi.fn(),
+    updateNote: vi.fn(),
+    signNote: vi.fn(async (noteId: string, signedBy: string) => ({
+      id: noteId,
+      signed_by: signedBy,
+      signed_at: new Date().toISOString(),
+    })),
+    getNotesByPatient: vi.fn(),
+    getNoteById: vi.fn(),
+  },
+  createSOAPTemplate: () => ({}),
+  createProgressTemplate: () => ({}),
+}));
+
+import { noteService } from "@carebridge/clinical-notes";
+import { clinicalNotesRbacRouter } from "../routers/clinical-notes.js";
+import type { Context } from "../context.js";
+
+const signNoteMock = vi.mocked(noteService.signNote);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function makeContext(user: User | null): Context {
+  return {
+    db: mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+}
+
+function callerFor(user: User | null) {
+  return clinicalNotesRbacRouter.createCaller(makeContext(user));
+}
+
+const signInput = {
+  noteId: NOTE_ID,
+  signed_by: ROLE_IDS.physician!,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("clinicalNotesRbacRouter.sign — role enforcement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signNoteMock.mockClear();
+  });
+
+  it("rejects a nurse attempting to sign a note (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("nurse"));
+
+    await expect(caller.sign(signInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(signNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a patient attempting to sign a note (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("patient", PATIENT_ID));
+
+    await expect(caller.sign(signInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(signNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+
+    await expect(caller.sign(signInput)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(signNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a physician to sign a note", async () => {
+    const caller = callerFor(makeUser("physician"));
+
+    await expect(caller.sign(signInput)).resolves.toBeDefined();
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+  });
+
+  it("allows a specialist to sign a note", async () => {
+    const caller = callerFor(makeUser("specialist"));
+
+    await expect(caller.sign(signInput)).resolves.toBeDefined();
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+  });
+
+  it("allows an admin to sign a note", async () => {
+    const caller = callerFor(makeUser("admin"));
+
+    await expect(caller.sign(signInput)).resolves.toBeDefined();
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+  });
+});

--- a/services/api-gateway/src/__tests__/clinical-notes-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/clinical-notes-rbac.test.ts
@@ -99,7 +99,6 @@ function callerFor(user: User | null) {
 
 const signInput = {
   noteId: NOTE_ID,
-  signed_by: ROLE_IDS.physician!,
 };
 
 // ---------------------------------------------------------------------------
@@ -139,24 +138,46 @@ describe("clinicalNotesRbacRouter.sign — role enforcement", () => {
     expect(signNoteMock).not.toHaveBeenCalled();
   });
 
-  it("allows a physician to sign a note", async () => {
-    const caller = callerFor(makeUser("physician"));
+  it("allows a physician to sign a note (signer = ctx.user.id)", async () => {
+    const physician = makeUser("physician");
+    const caller = callerFor(physician);
 
     await expect(caller.sign(signInput)).resolves.toBeDefined();
-    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, physician.id);
   });
 
-  it("allows a specialist to sign a note", async () => {
-    const caller = callerFor(makeUser("specialist"));
+  it("allows a specialist to sign a note (signer = ctx.user.id)", async () => {
+    const specialist = makeUser("specialist");
+    const caller = callerFor(specialist);
 
     await expect(caller.sign(signInput)).resolves.toBeDefined();
-    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, specialist.id);
   });
 
-  it("allows an admin to sign a note", async () => {
-    const caller = callerFor(makeUser("admin"));
+  it("allows an admin to sign a note (signer = ctx.user.id)", async () => {
+    const admin = makeUser("admin");
+    const caller = callerFor(admin);
 
     await expect(caller.sign(signInput)).resolves.toBeDefined();
-    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, signInput.signed_by);
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, admin.id);
+  });
+
+  it("ignores client-supplied signed_by — signature uses ctx.user.id only", async () => {
+    const physicianA = makeUser("physician");
+    const caller = callerFor(physicianA);
+
+    // Even if a client sneaks in an extra `signed_by` field, the wrapper's
+    // input schema strips it and the mutation always passes ctx.user.id to
+    // noteService.signNote. This is the regression guard for the spoofing
+    // bug Copilot flagged on PR #372.
+    await expect(
+      caller.sign({
+        noteId: NOTE_ID,
+        // @ts-expect-error — schema deliberately rejects extra fields at
+        // type level; runtime strips them.
+        signed_by: "00000000-0000-0000-0000-aaaaaaaaaaaa",
+      }),
+    ).resolves.toBeDefined();
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, physicianA.id);
   });
 });

--- a/services/api-gateway/src/routers/clinical-notes.ts
+++ b/services/api-gateway/src/routers/clinical-notes.ts
@@ -12,7 +12,6 @@ import { TRPCError, initTRPC } from "@trpc/server";
 import {
   createNoteSchema,
   updateNoteSchema,
-  signNoteSchema,
   noteTemplateTypeSchema,
 } from "@carebridge/validators";
 import type { NoteTemplateType } from "@carebridge/shared-types";
@@ -107,7 +106,11 @@ export const clinicalNotesRbacRouter = t.router({
     }),
 
   sign: protectedProcedure
-    .input(z.object({ noteId: z.string().uuid() }).merge(signNoteSchema))
+    // Deliberately do NOT merge signNoteSchema here — the signer is always
+    // ctx.user.id (see comment below). Accepting a client-supplied signed_by
+    // would let any permitted role (physician/specialist/admin) forge another
+    // user's signature by sending a different UUID.
+    .input(z.object({ noteId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       // Only physicians, specialists, and admins hold the `sign:notes`
       // permission in ROLE_PERMISSIONS (packages/shared-types/src/auth.ts).
@@ -133,7 +136,11 @@ export const clinicalNotesRbacRouter = t.router({
 
       await enforcePatientAccess(ctx.user, existing.patient_id);
 
-      return noteService.signNote(input.noteId, input.signed_by);
+      // Signer is always the authenticated caller — never a client-supplied
+      // value. The signNoteSchema's `signed_by` field is intentionally
+      // ignored at the gateway boundary so signature spoofing is impossible
+      // even for permitted roles.
+      return noteService.signNote(input.noteId, ctx.user.id);
     }),
 
   getByPatient: protectedProcedure

--- a/services/api-gateway/src/routers/clinical-notes.ts
+++ b/services/api-gateway/src/routers/clinical-notes.ts
@@ -109,6 +109,17 @@ export const clinicalNotesRbacRouter = t.router({
   sign: protectedProcedure
     .input(z.object({ noteId: z.string().uuid() }).merge(signNoteSchema))
     .mutation(async ({ ctx, input }) => {
+      // Only physicians, specialists, and admins hold the `sign:notes`
+      // permission in ROLE_PERMISSIONS (packages/shared-types/src/auth.ts).
+      // Enforce that gate explicitly here so a nurse with care-team access
+      // cannot forge a physician signature. (HIPAA / issue #271)
+      if (!["physician", "specialist", "admin"].includes(ctx.user.role)) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Access denied: role not permitted to sign clinical notes",
+        });
+      }
+
       const db = getDb();
       const [existing] = await db
         .select({ patient_id: clinicalNotes.patient_id })


### PR DESCRIPTION
## Summary
- HIPAA P1: the `notes.sign` tRPC procedure was not checking the `sign:notes` permission declared in `ROLE_PERMISSIONS`, so a nurse with a care-team assignment could forge a physician signature on a clinical note.
- Fix enforces the role check inline in `clinicalNotesRbacRouter.sign`, matching the authoritative list in `packages/shared-types/src/auth.ts` (physician, specialist, admin).

## Changes
- `services/api-gateway/src/routers/clinical-notes.ts`: add role gate to the `sign` procedure; throws `FORBIDDEN` for any role outside {physician, specialist, admin}. Runs before the existing care-team access check and DB lookup.
- `services/api-gateway/src/__tests__/clinical-notes-rbac.test.ts`: new wrapper-level test using `createCaller` that exercises nurse / patient / unauthenticated / physician / specialist / admin against `notes.sign`.

## Test Plan
- [x] New test fails against the old router (nurse and patient both sign successfully) — confirmed as TDD red step.
- [x] New test passes after the fix (all 6 role cases behave correctly).
- [x] `pnpm typecheck` from repo root — pass.
- [x] `pnpm lint` from repo root — pass (only pre-existing warnings in clinician-portal).
- [ ] Manual verification in dev: nurse.rachel cannot sign a note; dr.smith can.

Closes #271