### PR TITLE
fix(notifications): add RBAC wrapper enforcing user-owned notification access (#292)

### DIFF
--- a/services/api-gateway/src/__tests__/notifications-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/notifications-rbac.test.ts
@@ -1,0 +1,336 @@
+/**
+ * RBAC tests for the notifications gateway wrapper.
+ *
+ * Verifies:
+ *   - Unauthenticated callers receive UNAUTHORIZED
+ *   - Authenticated callers can only read/modify their own notifications
+ *     (userId is derived from ctx.user.id, never from client input)
+ *   - Admin users may read any user's notifications
+ *   - Mutations (markRead, updatePreference) enforce ownership
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+// ---------------------------------------------------------------------------
+// Mock @carebridge/db-schema before importing the router
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+let notificationRows: Row[] = [];
+let preferenceRows: Row[] = [];
+const insertedNotifications: Row[] = [];
+const insertedPreferences: Row[] = [];
+const updatedNotifications: Row[] = [];
+const updatedPreferences: Row[] = [];
+
+function makeSelectChain(rows: Row[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  // Allow awaiting the chain directly (for preferences query without .limit)
+  (chain as { then?: unknown }).then = (onFulfilled: (r: Row[]) => unknown) =>
+    Promise.resolve(rows).then(onFulfilled);
+  return chain;
+}
+
+let nextSelectTarget: "notifications" | "preferences" = "notifications";
+
+const mockDb = {
+  select: vi.fn(() => {
+    const target = nextSelectTarget;
+    nextSelectTarget = "notifications"; // reset to default
+    return makeSelectChain(target === "notifications" ? notificationRows : preferenceRows);
+  }),
+  insert: vi.fn((table: { __table?: string }) => ({
+    values: vi.fn((row: Row) => {
+      if (table.__table === "notification_preferences") {
+        insertedPreferences.push(row);
+      } else {
+        insertedNotifications.push(row);
+      }
+      return Promise.resolve();
+    }),
+  })),
+  update: vi.fn((table: { __table?: string }) => ({
+    set: vi.fn((row: Row) => ({
+      where: vi.fn(() => {
+        if (table.__table === "notification_preferences") {
+          updatedPreferences.push(row);
+        } else {
+          updatedNotifications.push(row);
+        }
+        return Promise.resolve();
+      }),
+    })),
+  })),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  notifications: {
+    __table: "notifications",
+    id: "notifications.id",
+    user_id: "notifications.user_id",
+    is_read: "notifications.is_read",
+    created_at: "notifications.created_at",
+  },
+  notificationPreferences: {
+    __table: "notification_preferences",
+    id: "notification_preferences.id",
+    user_id: "notification_preferences.user_id",
+    notification_type: "notification_preferences.notification_type",
+    channel: "notification_preferences.channel",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  desc: (col: unknown) => ({ op: "desc", col }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import router under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { notificationsRbacRouter } from "../routers/notifications.js";
+import type { Context } from "../context.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(user: Context["user"]): Context {
+  return {
+    db: mockDb as unknown as Context["db"],
+    user,
+    sessionId: user ? "session-1" : null,
+    requestId: "req-1",
+  };
+}
+
+const NOW = "2026-04-10T00:00:00.000Z";
+
+const alice: NonNullable<Context["user"]> = {
+  id: "user-alice",
+  email: "alice@carebridge.dev",
+  name: "Alice",
+  role: "patient",
+  is_active: true,
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+const bob: NonNullable<Context["user"]> = {
+  id: "user-bob",
+  email: "bob@carebridge.dev",
+  name: "Bob",
+  role: "patient",
+  is_active: true,
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+const admin: NonNullable<Context["user"]> = {
+  id: "admin-1",
+  email: "admin@carebridge.dev",
+  name: "Admin",
+  role: "admin",
+  is_active: true,
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("notifications RBAC wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationRows = [];
+    preferenceRows = [];
+    insertedNotifications.length = 0;
+    insertedPreferences.length = 0;
+    updatedNotifications.length = 0;
+    updatedPreferences.length = 0;
+    nextSelectTarget = "notifications";
+  });
+
+  describe("getMine (formerly getByUser)", () => {
+    it("rejects unauthenticated callers with UNAUTHORIZED", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(null));
+
+      await expect(caller.getMine({})).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+
+    it("returns notifications for the authenticated user's own id", async () => {
+      notificationRows = [
+        { id: "n1", user_id: "user-alice", is_read: false, title: "t" },
+      ];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      const result = await caller.getMine({});
+      expect(result).toHaveLength(1);
+      expect(result[0]?.user_id).toBe("user-alice");
+    });
+
+    it("does NOT accept a userId input parameter (derived from ctx)", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      // The wrapper procedure must not accept userId at all — passing it
+      // should either be stripped by Zod or rejected. The critical behaviour
+      // is that the wrapper cannot be tricked into reading another user's
+      // notifications by passing a userId field.
+      notificationRows = [
+        { id: "n-other", user_id: "user-bob", is_read: false },
+      ];
+
+      // Even if a caller tries to pass userId, the query must use ctx.user.id.
+      // We can't easily assert the where clause content through the mock, but
+      // we can assert that the procedure rejects unknown keys (Zod strict) OR
+      // successfully ignores them. Either way the exploit is impossible.
+      const unsafeCaller = caller as unknown as {
+        getMine: (input: Record<string, unknown>) => Promise<unknown[]>;
+      };
+
+      // If Zod strips unknown keys, this resolves; if strict, it throws.
+      // Either is acceptable — what matters is the DB query is built from
+      // ctx.user.id, which we verify in the next test by checking the
+      // mock was called.
+      await unsafeCaller.getMine({ userId: "user-bob" }).catch(() => undefined);
+      // mockDb.select is called at least once with the alice user context
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+  });
+
+  describe("getByUser (admin/back-compat)", () => {
+    it("rejects a cross-user read with FORBIDDEN", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      await expect(
+        caller.getByUser({ userId: bob.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects unauthenticated callers with UNAUTHORIZED", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(null));
+
+      await expect(
+        caller.getByUser({ userId: alice.id }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("allows a user to read their own notifications via getByUser", async () => {
+      notificationRows = [{ id: "n1", user_id: alice.id, is_read: false }];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      const result = await caller.getByUser({ userId: alice.id });
+      expect(result).toHaveLength(1);
+    });
+
+    it("allows admin users to read any user's notifications", async () => {
+      notificationRows = [{ id: "n1", user_id: bob.id, is_read: false }];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(admin));
+
+      const result = await caller.getByUser({ userId: bob.id });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("markRead", () => {
+    it("rejects unauthenticated callers", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(null));
+      await expect(caller.markRead({ id: "n1" })).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+
+    it("rejects marking a notification that belongs to another user", async () => {
+      notificationRows = [{ id: "n1", user_id: bob.id, is_read: false }];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      await expect(caller.markRead({ id: "n1" })).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+      expect(updatedNotifications).toHaveLength(0);
+    });
+
+    it("allows marking a notification owned by the authenticated user", async () => {
+      notificationRows = [{ id: "n1", user_id: alice.id, is_read: false }];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      const result = await caller.markRead({ id: "n1" });
+      expect(result).toEqual({ success: true });
+      expect(updatedNotifications).toHaveLength(1);
+    });
+
+    it("throws NOT_FOUND for a non-existent notification", async () => {
+      notificationRows = [];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      await expect(caller.markRead({ id: "missing" })).rejects.toBeInstanceOf(
+        TRPCError,
+      );
+    });
+  });
+
+  describe("getPreferences", () => {
+    it("rejects unauthenticated callers", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(null));
+      await expect(caller.getPreferences()).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+
+    it("returns preferences scoped to ctx.user.id", async () => {
+      nextSelectTarget = "preferences";
+      preferenceRows = [
+        {
+          id: "p1",
+          user_id: alice.id,
+          notification_type: "flag",
+          channel: "email",
+          enabled: true,
+        },
+      ];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      const result = await caller.getPreferences();
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("updatePreference", () => {
+    it("rejects unauthenticated callers", async () => {
+      const caller = notificationsRbacRouter.createCaller(makeCtx(null));
+      await expect(
+        caller.updatePreference({
+          notificationType: "flag",
+          channel: "email",
+          enabled: true,
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("creates a new preference scoped to ctx.user.id", async () => {
+      nextSelectTarget = "preferences";
+      preferenceRows = [];
+      const caller = notificationsRbacRouter.createCaller(makeCtx(alice));
+
+      await caller.updatePreference({
+        notificationType: "flag",
+        channel: "email",
+        enabled: true,
+      });
+      expect(insertedPreferences).toHaveLength(1);
+      expect(insertedPreferences[0]?.user_id).toBe(alice.id);
+    });
+  });
+});

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -1,7 +1,6 @@
 import { router, publicProcedure } from "./trpc.js";
 import { authRouter } from "@carebridge/auth";
 import { aiOversightRouter } from "@carebridge/ai-oversight";
-import { notificationsRouter } from "@carebridge/notifications";
 import { patientRecordsRbacRouter } from "./routers/patient-records.js";
 import { clinicalDataRbacRouter } from "./routers/clinical-data.js";
 import { clinicalNotesRbacRouter } from "./routers/clinical-notes.js";
@@ -9,6 +8,7 @@ import { messagingRbacRouter } from "./routers/messaging.js";
 import { schedulingRbacRouter } from "./routers/scheduling.js";
 import { emergencyAccessRbacRouter } from "./routers/emergency-access.js";
 import { fhirRbacRouter } from "./routers/fhir.js";
+import { notificationsRbacRouter } from "./routers/notifications.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -24,7 +24,7 @@ export const appRouter = router({
   clinicalData: clinicalDataRbacRouter,
   notes: clinicalNotesRbacRouter,
   aiOversight: aiOversightRouter,
-  notifications: notificationsRouter,
+  notifications: notificationsRbacRouter,
   messaging: messagingRbacRouter,
   scheduling: schedulingRbacRouter,
   fhir: fhirRbacRouter,

--- a/services/api-gateway/src/routers/notifications.ts
+++ b/services/api-gateway/src/routers/notifications.ts
@@ -1,0 +1,203 @@
+/**
+ * RBAC-enforced notifications router.
+ *
+ * Wraps the notifications service procedures with authentication and
+ * ownership checks. userId is derived from ctx.user.id, never from client
+ * input, so cross-user PHI reads are impossible.
+ *
+ * Procedures:
+ *   - getMine:          read the caller's own notifications
+ *   - getByUser:        back-compat alias; allowed only when caller owns the
+ *                       userId (or is admin)
+ *   - markRead:         ownership check against the notification row
+ *   - getPreferences:   scoped to ctx.user.id
+ *   - updatePreference: scoped to ctx.user.id
+ *
+ * The `create` mutation from the raw service router is intentionally NOT
+ * exposed here — notifications are produced internally by workers, not by
+ * external API callers.
+ */
+
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import { getDb } from "@carebridge/db-schema";
+import { notifications, notificationPreferences } from "@carebridge/db-schema";
+import { eq, and, desc } from "drizzle-orm";
+import crypto from "node:crypto";
+import type { Context } from "../context.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+export const notificationsRbacRouter = t.router({
+  /**
+   * Read the authenticated user's notifications. userId is derived from
+   * the session context, so there is no way for a caller to read another
+   * user's notifications.
+   */
+  getMine: protectedProcedure
+    .input(z.object({ unreadOnly: z.boolean().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      const db = getDb();
+      const conditions = [eq(notifications.user_id, ctx.user.id)];
+      if (input?.unreadOnly) {
+        conditions.push(eq(notifications.is_read, false));
+      }
+      return db
+        .select()
+        .from(notifications)
+        .where(and(...conditions))
+        .orderBy(desc(notifications.created_at))
+        .limit(50);
+    }),
+
+  /**
+   * Back-compat alias for clients that still pass userId explicitly.
+   * Enforces that the requested userId matches ctx.user.id, or that the
+   * caller is an admin.
+   */
+  getByUser: protectedProcedure
+    .input(z.object({ userId: z.string(), unreadOnly: z.boolean().optional() }))
+    .query(async ({ ctx, input }) => {
+      if (ctx.user.role !== "admin" && ctx.user.id !== input.userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Access denied: you may only read your own notifications",
+        });
+      }
+
+      const db = getDb();
+      const conditions = [eq(notifications.user_id, input.userId)];
+      if (input.unreadOnly) {
+        conditions.push(eq(notifications.is_read, false));
+      }
+      return db
+        .select()
+        .from(notifications)
+        .where(and(...conditions))
+        .orderBy(desc(notifications.created_at))
+        .limit(50);
+    }),
+
+  /**
+   * Mark a single notification as read. The notification must belong to
+   * the authenticated user (or the caller must be an admin).
+   */
+  markRead: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const [existing] = await db
+        .select()
+        .from(notifications)
+        .where(eq(notifications.id, input.id))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Notification not found",
+        });
+      }
+
+      if (ctx.user.role !== "admin" && existing.user_id !== ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Access denied: notification belongs to another user",
+        });
+      }
+
+      await db
+        .update(notifications)
+        .set({ is_read: true, read_at: new Date().toISOString() })
+        .where(eq(notifications.id, input.id));
+      return { success: true };
+    }),
+
+  /**
+   * Read the authenticated user's notification preferences. userId is
+   * derived from ctx and cannot be overridden by the caller.
+   */
+  getPreferences: protectedProcedure.query(async ({ ctx }) => {
+    const db = getDb();
+    return db
+      .select()
+      .from(notificationPreferences)
+      .where(eq(notificationPreferences.user_id, ctx.user.id));
+  }),
+
+  /**
+   * Upsert a notification preference for the authenticated user. userId
+   * is derived from ctx — the client cannot modify another user's
+   * preferences.
+   */
+  updatePreference: protectedProcedure
+    .input(
+      z.object({
+        notificationType: z.string(),
+        channel: z.string(),
+        enabled: z.boolean(),
+        quietHoursStart: z.string().nullable().optional(),
+        quietHoursEnd: z.string().nullable().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = getDb();
+      const now = new Date().toISOString();
+
+      const [existing] = await db
+        .select()
+        .from(notificationPreferences)
+        .where(
+          and(
+            eq(notificationPreferences.user_id, ctx.user.id),
+            eq(notificationPreferences.notification_type, input.notificationType),
+            eq(notificationPreferences.channel, input.channel),
+          ),
+        );
+
+      if (existing) {
+        await db
+          .update(notificationPreferences)
+          .set({
+            enabled: input.enabled,
+            quiet_hours_start: input.quietHoursStart ?? null,
+            quiet_hours_end: input.quietHoursEnd ?? null,
+            updated_at: now,
+          })
+          .where(eq(notificationPreferences.id, existing.id));
+        return {
+          ...existing,
+          enabled: input.enabled,
+          updated_at: now,
+        };
+      }
+
+      const pref = {
+        id: crypto.randomUUID(),
+        user_id: ctx.user.id,
+        notification_type: input.notificationType,
+        channel: input.channel,
+        enabled: input.enabled,
+        quiet_hours_start: input.quietHoursStart ?? null,
+        quiet_hours_end: input.quietHoursEnd ?? null,
+        created_at: now,
+        updated_at: now,
+      };
+
+      await db.insert(notificationPreferences).values(pref);
+      return pref;
+    }),
+});

--- a/services/api-gateway/src/routers/notifications.ts
+++ b/services/api-gateway/src/routers/notifications.ts
@@ -99,8 +99,11 @@ export const notificationsRbacRouter = t.router({
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const db = getDb();
+      // Select only the ownership column. notifications.title and .body are
+      // encryptedText, so a SELECT * would unnecessarily decrypt PHI just to
+      // perform an ownership check. Per Copilot review on PR #373.
       const [existing] = await db
-        .select()
+        .select({ user_id: notifications.user_id })
         .from(notifications)
         .where(eq(notifications.id, input.id))
         .limit(1);
@@ -178,9 +181,14 @@ export const notificationsRbacRouter = t.router({
             updated_at: now,
           })
           .where(eq(notificationPreferences.id, existing.id));
+        // Reflect ALL updated fields in the response, not just enabled.
+        // Per Copilot review on PR #373 — the previous response leaked the
+        // pre-update quiet_hours_start/end from `existing`.
         return {
           ...existing,
           enabled: input.enabled,
+          quiet_hours_start: input.quietHoursStart ?? null,
+          quiet_hours_end: input.quietHoursEnd ?? null,
           updated_at: now,
         };
       }


### PR DESCRIPTION
## Summary
Fixes #292 — `notifications.getByUser` accepted a `userId` input with no auth check, so any caller could read any user's notifications (which contain PHI).

The api-gateway was registering the raw `notificationsRouter` from `@carebridge/notifications` directly, bypassing the RBAC wrapper pattern that every other patient-scoped router follows (`messagingRbacRouter`, `clinicalDataRbacRouter`, `schedulingRbacRouter`, etc.).

## Changes
- **New**: `services/api-gateway/src/routers/notifications.ts` — RBAC wrapper that derives `userId` from `ctx.user.id` on all read/write procedures.
  - `getMine` — new canonical procedure; reads only the caller's own notifications. No `userId` input.
  - `getByUser` — back-compat alias; enforces `ctx.user.id === input.userId` or admin override. Returns `FORBIDDEN` on cross-user reads.
  - `markRead` — verifies the notification row belongs to `ctx.user` (or admin) before updating. Returns `NOT_FOUND` for missing ids, `FORBIDDEN` for cross-user mutation.
  - `getPreferences` — scoped to `ctx.user.id`; no client-supplied userId.
  - `updatePreference` — scoped to `ctx.user.id`; no client-supplied userId.
  - The raw-router `create` mutation is intentionally **not** exposed — notifications are produced by internal workers, not external API callers.
- **Modified**: `services/api-gateway/src/router.ts` — register `notificationsRbacRouter` instead of importing the raw service router.
- **New**: `services/api-gateway/src/__tests__/notifications-rbac.test.ts` — 15 tests covering unauthenticated rejection, cross-user rejection, self-access success, admin override, ownership enforcement on `markRead`, and `ctx`-scoped preference reads/writes.

The raw `notificationsRouter` in `services/notifications/src/router.ts` is left unchanged — its only production consumer is the api-gateway, and the canonical fix is at the gateway layer per `CLAUDE.md`. Other issues in the notifications backlog (#285, #293, #318, #289) are out of scope.

## Test Plan
- [x] `pnpm typecheck` passes from repo root
- [x] `pnpm lint` passes from repo root (only pre-existing warnings in unrelated portal files)
- [x] `pnpm test` in `services/api-gateway` — 55 tests pass including the 15 new RBAC tests
- [x] New tests cover: unauthenticated → `UNAUTHORIZED`, cross-user → `FORBIDDEN`, self → success, admin → success, markRead ownership, preferences scoped to ctx

Closes #292