### PR TITLE
fix(ai): redact PHI from Claude client error logs (#282)

### DIFF
--- a/services/ai-oversight/src/__tests__/claude-client-logging.test.ts
+++ b/services/ai-oversight/src/__tests__/claude-client-logging.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Hold a reference to the mocked `create` so individual tests can program it.
+const create = vi.fn();
+
+// Mock the SDK. Error classes are plain stubs so `instanceof` checks in the
+// client route the error into the right branch (non-transient vs transient).
+vi.mock("@anthropic-ai/sdk", () => {
+  class Anthropic {
+    messages = { create };
+    static AuthenticationError = class extends Error {};
+    static PermissionDeniedError = class extends Error {};
+    static BadRequestError = class extends Error {};
+    static NotFoundError = class extends Error {};
+    static RateLimitError = class extends Error {};
+  }
+  return { default: Anthropic };
+});
+
+// Import AFTER vi.mock so the mocked SDK is picked up.
+const { reviewPatientRecord, redactErrorForLog } = await import(
+  "../services/claude-client.js"
+);
+
+// A plausible PHI string that would appear in the original prompt. It must
+// NOT match any of the sanitizer's PHI patterns (MRN/SSN/phone/date) or
+// `assertPromptSanitized` would refuse the prompt before we ever got to the
+// retry path we're trying to exercise. A free-text clinical name fits the
+// bill — it reads like PHI but is not a regex-detectable identifier.
+const PHI_NEEDLE = "Jane Q Doe stage-IV-pancreatic-adenocarcinoma";
+const SAFE_PROMPT = `Review this clinical context: ${PHI_NEEDLE}`;
+
+describe("claude-client error logging — PHI redaction", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    create.mockReset();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Skip real retry backoff so tests don't hang on BASE_DELAY_MS timeouts.
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  function collectLogs(): string {
+    const all = [...logSpy.mock.calls, ...errorSpy.mock.calls];
+    // Flatten every call arg into a single string for a single contains check.
+    return all
+      .flat()
+      .map((arg) =>
+        typeof arg === "string" ? arg : JSON.stringify(arg) ?? String(arg),
+      )
+      .join("\n");
+  }
+
+  it("redactErrorForLog never includes nested request/response or headers", () => {
+    const sdkError: Record<string, unknown> = {
+      name: "APIError",
+      status: 500,
+      message: `Server error echoing prompt: ${PHI_NEEDLE}`,
+      request: {
+        messages: [{ role: "user", content: PHI_NEEDLE }],
+      },
+      response: { body: PHI_NEEDLE },
+      headers: { authorization: "Bearer sk-redact-me" },
+      error: { type: "api_error", message: PHI_NEEDLE },
+    };
+    const redacted = redactErrorForLog(sdkError);
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain(PHI_NEEDLE);
+    expect(serialized).not.toContain("sk-redact-me");
+    // Must retain allow-listed identifying info.
+    expect(redacted.status).toBe(500);
+    expect(redacted.errorType).toBe("api_error");
+    expect(redacted.name).toBe("APIError");
+  });
+
+  it("does NOT log PHI on a transient 5xx retry", async () => {
+    // First two attempts fail with a PHI-laden transient error, third succeeds.
+    const transientErr: Record<string, unknown> = {
+      name: "APIConnectionError",
+      status: 503,
+      message: `upstream rejected body=${PHI_NEEDLE}`,
+      request: {
+        messages: [{ role: "user", content: PHI_NEEDLE }],
+      },
+      error: { type: "overloaded_error", message: PHI_NEEDLE },
+    };
+    create
+      .mockRejectedValueOnce(transientErr)
+      .mockRejectedValueOnce(transientErr)
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+    const pending = reviewPatientRecord("system", SAFE_PROMPT);
+    // Drain the two backoff sleeps.
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    expect(result).toBe("ok");
+
+    const joined = collectLogs();
+    expect(joined).not.toContain(PHI_NEEDLE);
+    // Structured log context we *do* expect to see.
+    expect(joined).toContain("transient_error_retry");
+    expect(joined).toContain("503");
+  });
+
+  it("does NOT log PHI on a rate-limit (429) retry", async () => {
+    const rateErr: Record<string, unknown> = {
+      name: "RateLimitError",
+      status: 429,
+      message: `rate limited while processing ${PHI_NEEDLE}`,
+      headers: { "retry-after": "0" },
+      request: {
+        messages: [{ role: "user", content: PHI_NEEDLE }],
+      },
+      error: { type: "rate_limit_error", message: PHI_NEEDLE },
+    };
+    create
+      .mockRejectedValueOnce(rateErr)
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+    const pending = reviewPatientRecord("system", SAFE_PROMPT);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    expect(result).toBe("ok");
+
+    const joined = collectLogs();
+    expect(joined).not.toContain(PHI_NEEDLE);
+    expect(joined).toContain("rate_limited_retry");
+    expect(joined).toContain("429");
+  });
+
+  it("does NOT leak PHI in the final thrown error message after exhausting retries", async () => {
+    const transientErr: Record<string, unknown> = {
+      name: "APIConnectionError",
+      status: 502,
+      message: `bad gateway echoing ${PHI_NEEDLE}`,
+      request: { messages: [{ role: "user", content: PHI_NEEDLE }] },
+    };
+    create.mockRejectedValue(transientErr);
+
+    const pending = reviewPatientRecord("system", SAFE_PROMPT);
+    const assertion = expect(pending).rejects.toThrow(/Claude API call failed/);
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    // Also assert the thrown error's message directly.
+    create.mockRejectedValue(transientErr);
+    let thrown: unknown;
+    const p = reviewPatientRecord("system", SAFE_PROMPT).catch((e) => {
+      thrown = e;
+    });
+    await vi.runAllTimersAsync();
+    await p;
+    expect(String((thrown as Error).message)).not.toContain(PHI_NEEDLE);
+
+    const joined = collectLogs();
+    expect(joined).not.toContain(PHI_NEEDLE);
+  });
+});

--- a/services/ai-oversight/src/services/claude-client.ts
+++ b/services/ai-oversight/src/services/claude-client.ts
@@ -9,6 +9,89 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { assertPromptSanitized } from "@carebridge/phi-sanitizer";
 
+/**
+ * Allow-listed, non-PHI fields extracted from an error for structured logging.
+ *
+ * SECURITY: API error objects from the Anthropic SDK can carry request/response
+ * fragments that include the original prompt — which in our case contains
+ * patient clinical context. Never log the raw error, its `request`, `response`,
+ * `body`, `messages`, `headers`, or `stack`. Only the fields below are safe.
+ */
+interface RedactedErrorInfo {
+  name: string;
+  status?: number;
+  errorType?: string;
+  code?: string;
+  message: string;
+}
+
+/**
+ * Exact-match allow list of short, generic error messages that by construction
+ * contain no request/response content. Anything not on this list is replaced
+ * with a category label so we never risk logging an SDK error whose `.message`
+ * includes echoed prompt fragments (which for us would be patient context).
+ *
+ * The list is deliberately small and exact — adding loose patterns (e.g.
+ * `/^rate limit.*$/`) would defeat the purpose because upstream services
+ * commonly append request payload excerpts to otherwise-generic messages.
+ */
+const SAFE_MESSAGES: ReadonlySet<string> = new Set([
+  "unauthorized",
+  "forbidden",
+  "not found",
+  "rate limit exceeded",
+  "rate limited",
+  "request timed out",
+  "network error",
+  "bad request",
+  "internal server error",
+  "service unavailable",
+  "bad gateway",
+  "gateway timeout",
+  "connection refused",
+  "connection reset",
+]);
+
+function sanitizeMessage(message: unknown): string {
+  if (typeof message !== "string") return "<non-string message>";
+  const trimmed = message.trim();
+  if (trimmed.length === 0) return "<empty message>";
+  if (SAFE_MESSAGES.has(trimmed.toLowerCase())) return trimmed;
+  return "<redacted: non-allow-listed message>";
+}
+
+/**
+ * Extract an allow-listed, PHI-free view of an error object suitable for
+ * structured logging. No nested objects, no request/response bodies, no
+ * headers, no stack traces.
+ */
+export function redactErrorForLog(error: unknown): RedactedErrorInfo {
+  if (!error || typeof error !== "object") {
+    return { name: "UnknownError", message: "<non-object error>" };
+  }
+  const err = error as {
+    name?: unknown;
+    status?: unknown;
+    code?: unknown;
+    message?: unknown;
+    error?: unknown;
+  };
+  const info: RedactedErrorInfo = {
+    name: typeof err.name === "string" ? err.name : "Error",
+    message: sanitizeMessage(err.message),
+  };
+  if (typeof err.status === "number") info.status = err.status;
+  if (typeof err.code === "string") info.code = err.code;
+  // Anthropic SDK wraps API errors as { error: { type, message } }.
+  // We only read the `type` tag (e.g. "rate_limit_error"), never the message,
+  // because the API may echo fragments of the request in `error.message`.
+  if (err.error && typeof err.error === "object") {
+    const inner = err.error as { type?: unknown };
+    if (typeof inner.type === "string") info.errorType = inner.type;
+  }
+  return info;
+}
+
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TOKENS = 4096;
 const MAX_RETRIES = 3;
@@ -77,24 +160,36 @@ export async function reviewPatientRecord(
       // Don't sleep after the last attempt
       if (attempt < MAX_RETRIES) {
         let delay: number;
+        const redacted = redactErrorForLog(error);
         if (isRateLimitError(error)) {
           delay = getRetryAfterMs(error) ?? DEFAULT_RATE_LIMIT_DELAY_MS;
-          console.log(
-            `[claude-client] Rate-limited (429) on attempt ${attempt}/${MAX_RETRIES}, respecting Retry-After, waiting ${delay}ms: ${lastError.message}`,
-          );
+          console.log("[claude-client] rate_limited_retry", {
+            attempt,
+            maxRetries: MAX_RETRIES,
+            delayMs: delay,
+            error: redacted,
+          });
         } else {
           delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
-          console.log(
-            `[claude-client] Attempt ${attempt}/${MAX_RETRIES} failed, retrying in ${delay}ms: ${lastError.message}`,
-          );
+          console.log("[claude-client] transient_error_retry", {
+            attempt,
+            maxRetries: MAX_RETRIES,
+            delayMs: delay,
+            error: redacted,
+          });
         }
         await sleep(delay);
       }
     }
   }
 
+  const finalRedacted = lastError ? redactErrorForLog(lastError) : null;
   throw new Error(
-    `Claude API call failed after ${MAX_RETRIES} attempts: ${lastError?.message}`,
+    `Claude API call failed after ${MAX_RETRIES} attempts: ${
+      finalRedacted
+        ? `${finalRedacted.name}${finalRedacted.status ? ` status=${finalRedacted.status}` : ""}`
+        : "unknown error"
+    }`,
   );
 }
 

--- a/services/ai-oversight/src/services/claude-client.ts
+++ b/services/ai-oversight/src/services/claude-client.ts
@@ -152,9 +152,19 @@ export async function reviewPatientRecord(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
 
-      // Don't retry on non-transient errors
+      // Don't retry on non-transient errors. Wrap the original error in a
+      // sanitized one — the SDK error's .message can echo back prompt
+      // fragments / response bodies that contain PHI, and downstream
+      // callers (e.g. review-service) log and persist `error.message`.
+      // Per Copilot review on PR #374. Same shape as the exhausted-retries
+      // throw below so all exit paths are PHI-safe.
       if (isNonTransientError(error)) {
-        throw lastError;
+        const redacted = redactErrorForLog(error);
+        throw new Error(
+          `Claude API call failed (non-transient): ${redacted.name}${
+            redacted.status ? ` status=${redacted.status}` : ""
+          }`,
+        );
       }
 
       // Don't sleep after the last attempt


### PR DESCRIPTION
## Summary
Anthropic SDK error objects can carry request/response fragments that include the original prompt — which in our case is patient clinical context. The retry-path `console.log` in `claude-client.ts` was serializing the whole error (including `error.message`, which upstream services often build by appending request payload excerpts) straight into the log stream, where aggregators ingest it unsanitized. This is a HIPAA P2 privacy leak.

Fix: extract only an allow-listed set of non-PHI fields from the error before logging, and stop including the raw `lastError.message` in the final thrown failure message.

## Changes
- `services/ai-oversight/src/services/claude-client.ts`
  - New `redactErrorForLog(error)` helper that returns `{ name, status?, errorType?, code?, message }` — no `request`, no `response`, no `body`, no `headers`, no `stack`.
  - `sanitizeMessage()` uses an exact-match allow list of short generic strings (`"unauthorized"`, `"rate limit exceeded"`, `"bad gateway"`, etc.). Anything else becomes `<redacted: non-allow-listed message>`. Deliberately does NOT use loose regexes like `/^rate limit.*$/` because upstream services commonly append request payload to otherwise-generic messages.
  - Retry-path `console.log` calls now emit a structured payload `{ attempt, maxRetries, delayMs, error: redacted }` instead of template-stringing `lastError.message`.
  - Final throw after exhausted retries no longer inlines `lastError.message`; it uses `name` + `status` only.
- `services/ai-oversight/src/__tests__/claude-client-logging.test.ts` (new)

## Test Plan
- [x] `redactErrorForLog` unit test: given a PHI-laden SDK error with nested `request.messages`, `response.body`, and `headers.authorization`, the serialized output contains neither the PHI needle nor the fake auth token, but still preserves `status`, `name`, and `errorType`.
- [x] Transient 5xx retry: mock the SDK to throw a PHI-laden error twice, then succeed. Spy on `console.log` / `console.error`. Assert the PHI string is absent from captured output and that `"transient_error_retry"` + `"503"` are present.
- [x] Rate-limit 429 retry: same shape, asserts `"rate_limited_retry"` + `"429"` and PHI absence. This test caught a real bug in an earlier iteration where a loose `/^rate limit.*$/` regex leaked the full `rate limited while processing <PHI>` message — the allow list is now exact-match only.
- [x] Exhausted retries: thrown `Error.message` is asserted not to contain the PHI needle.
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass (pre-existing warnings only)

Closes #282