### PR TITLE
fix(auth): emit audit log entries for session lifecycle events (#276)

### DIFF
--- a/services/auth/src/__tests__/session-audit.test.ts
+++ b/services/auth/src/__tests__/session-audit.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+// In-memory sessions table (list of rows)
+interface SessionRow {
+  id: string;
+  user_id: string;
+  expires_at: string;
+  created_at: string;
+  last_active_at?: string | null;
+  refresh_token?: string | null;
+}
+
+const sessionsStore: SessionRow[] = [];
+const usersStore: Array<{
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  specialty: string | null;
+  department: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  password_hash: string;
+  mfa_enabled: boolean;
+}> = [];
+
+const insertedAuditEntries: Array<Record<string, unknown>> = [];
+
+// Chainable fluent query builder
+function selectBuilder(rows: unknown[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  // Allow awaiting the chain directly (some code paths do)
+  (chain as unknown as { then: unknown }).then = (
+    resolve: (v: unknown) => unknown,
+  ) => Promise.resolve(rows).then(resolve);
+  return chain;
+}
+
+// Predicate matchers for our fake where(): we record the most recent predicate.
+let lastPredicate: unknown = null;
+
+const mockDb = {
+  select: vi.fn((_shape?: unknown) => {
+    // Decide which table is being queried by inspecting the next .from() call.
+    // We'll stash a holder and resolve in .from().
+    const holder: Record<string, unknown> = {};
+    holder.from = vi.fn((table: unknown) => {
+      const rows =
+        table === "SESSIONS_TABLE"
+          ? [...sessionsStore]
+          : table === "USERS_TABLE"
+            ? [...usersStore]
+            : [];
+      // Build a nested chain that supports .where().limit() or .where().orderBy()
+      const nested: Record<string, unknown> = {};
+      let filtered = rows;
+      nested.where = vi.fn((_pred: unknown) => {
+        lastPredicate = _pred;
+        // No filtering — tests seed the store to exactly the expected rows.
+        return nested;
+      });
+      nested.orderBy = vi.fn(() => nested);
+      nested.limit = vi.fn(() => Promise.resolve(filtered));
+      (nested as unknown as { then: unknown }).then = (
+        resolve: (v: unknown) => unknown,
+      ) => Promise.resolve(filtered).then(resolve);
+      return nested;
+    });
+    return holder;
+  }),
+  insert: vi.fn((table: unknown) => ({
+    values: vi.fn((values: Record<string, unknown>) => {
+      if (table === "AUDIT_LOG_TABLE") {
+        insertedAuditEntries.push(values);
+      } else if (table === "SESSIONS_TABLE") {
+        sessionsStore.push(values as unknown as SessionRow);
+      }
+      // Support .catch() — return a promise
+      const p = Promise.resolve();
+      return p;
+    }),
+  })),
+  delete: vi.fn((_table: unknown) => ({
+    where: vi.fn((_pred: unknown) => {
+      // Clear matching sessions: tests use seeds where all rows are "matching"
+      // for the delete call. We remove everything from sessionsStore.
+      const removed = sessionsStore.splice(0, sessionsStore.length);
+      const obj = {
+        returning: vi.fn(() =>
+          Promise.resolve(removed.map((r) => ({ id: r.id }))),
+        ),
+      };
+      // Also callable as a promise directly
+      (obj as unknown as { then: unknown }).then = (
+        resolve: (v: unknown) => unknown,
+      ) => Promise.resolve().then(resolve);
+      return obj;
+    }),
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve()),
+    })),
+  })),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  users: "USERS_TABLE",
+  sessions: "SESSIONS_TABLE",
+  auditLog: "AUDIT_LOG_TABLE",
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  gt: (col: unknown, val: unknown) => ({ op: "gt", col, val }),
+  asc: (col: unknown) => ({ op: "asc", col }),
+  inArray: (col: unknown, values: unknown) => ({ op: "inArray", col, values }),
+}));
+
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({ host: "localhost", port: 6379 }),
+}));
+
+vi.mock("ioredis", () => ({
+  default: class MockRedis {
+    async set() {
+      return "OK";
+    }
+    async get() {
+      return null;
+    }
+    async del() {
+      return 1;
+    }
+  },
+}));
+
+vi.mock("../jwt.js", () => ({
+  signJWT: async () => "signed.jwt.token",
+}));
+
+vi.mock("../password.js", () => ({
+  hashPassword: async (pw: string) => `hashed:${pw}`,
+  verifyPassword: async (pw: string, hash: string) => hash === `hashed:${pw}`,
+}));
+
+// Import router AFTER mocks are set up.
+import { authRouter } from "../router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStores() {
+  sessionsStore.length = 0;
+  usersStore.length = 0;
+  insertedAuditEntries.length = 0;
+  lastPredicate = null;
+}
+
+function makeUser(id: string = "user-1") {
+  return {
+    id,
+    email: `${id}@carebridge.dev`,
+    name: `User ${id}`,
+    role: "physician",
+    specialty: null,
+    department: null,
+    is_active: true,
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-01-01T00:00:00.000Z",
+    password_hash: "hashed:password123",
+    mfa_enabled: false,
+  };
+}
+
+function makeCtx(userId: string | null, sessionId: string | null = null) {
+  return {
+    db: mockDb as unknown as ReturnType<typeof import("@carebridge/db-schema").getDb>,
+    user: userId
+      ? ({
+          id: userId,
+          email: `${userId}@carebridge.dev`,
+          name: `User ${userId}`,
+          role: "physician",
+          is_active: true,
+          created_at: "2025-01-01T00:00:00.000Z",
+          updated_at: "2025-01-01T00:00:00.000Z",
+        } as unknown as import("@carebridge/shared-types").User)
+      : null,
+    sessionId,
+    requestId: "req-1",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("session lifecycle audit events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+  });
+
+  describe("auth.logout", () => {
+    it("writes a session_logout audit entry when a session is deleted", async () => {
+      usersStore.push(makeUser("user-1"));
+      sessionsStore.push({
+        id: "sess-to-logout",
+        user_id: "user-1",
+        expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+        created_at: new Date().toISOString(),
+      });
+
+      const caller = authRouter.createCaller(makeCtx("user-1", "sess-to-logout"));
+      const result = await caller.logout();
+
+      expect(result).toEqual({ success: true });
+
+      const logoutEntries = insertedAuditEntries.filter(
+        (e) => e.action === "session_logout",
+      );
+      expect(logoutEntries).toHaveLength(1);
+      const entry = logoutEntries[0]!;
+      expect(entry.user_id).toBe("user-1");
+      expect(entry.resource_type).toBe("session");
+      expect(entry.resource_id).toBe("sess-to-logout");
+      expect(entry.timestamp).toBeDefined();
+    });
+
+    it("does not write an audit entry when there is no sessionId", async () => {
+      usersStore.push(makeUser("user-1"));
+
+      const caller = authRouter.createCaller(makeCtx("user-1", null));
+      await caller.logout();
+
+      const logoutEntries = insertedAuditEntries.filter(
+        (e) => e.action === "session_logout",
+      );
+      expect(logoutEntries).toHaveLength(0);
+    });
+  });
+
+  describe("auth.refreshSession", () => {
+    it("writes a session_refreshed audit entry when an old session is rotated", async () => {
+      usersStore.push(makeUser("user-1"));
+      sessionsStore.push({
+        id: "old-sess",
+        user_id: "user-1",
+        expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+        created_at: new Date().toISOString(),
+        refresh_token: "will-match",
+      });
+
+      // The refreshSession code hashes the token, then looks up the session
+      // row. Our fake select ignores predicates and returns the whole table,
+      // which is what we want for this unit test.
+      const caller = authRouter.createCaller(makeCtx(null, null));
+      const result = await caller.refreshSession({
+        refresh_token: "any-raw-token",
+      });
+
+      expect(result.user.id).toBe("user-1");
+
+      const refreshEntries = insertedAuditEntries.filter(
+        (e) => e.action === "session_refreshed",
+      );
+      expect(refreshEntries).toHaveLength(1);
+      const entry = refreshEntries[0]!;
+      expect(entry.user_id).toBe("user-1");
+      expect(entry.resource_type).toBe("session");
+      expect(entry.resource_id).toBe("old-sess");
+      const details = JSON.parse(entry.details as string);
+      expect(details.old_session_id).toBe("old-sess");
+      expect(details.new_session_id).toBeDefined();
+    });
+  });
+
+  describe("enforceSessionLimit eviction", () => {
+    it("writes session_evicted audit entries when oldest sessions are removed", async () => {
+      // Seed 5 existing sessions (at the MAX_CONCURRENT_SESSIONS limit of 5).
+      // Logging in a 6th time should evict the oldest one.
+      const now = Date.now();
+      usersStore.push({
+        ...makeUser("user-1"),
+        password_hash: "hashed:password123",
+      });
+      for (let i = 0; i < 5; i++) {
+        sessionsStore.push({
+          id: `sess-${i}`,
+          user_id: "user-1",
+          expires_at: new Date(now + 3_600_000).toISOString(),
+          created_at: new Date(now - (5 - i) * 1000).toISOString(),
+        });
+      }
+
+      const caller = authRouter.createCaller(makeCtx(null, null));
+      await caller.login({
+        email: "user-1@carebridge.dev",
+        password: "password123",
+      });
+
+      const evictionEntries = insertedAuditEntries.filter(
+        (e) => e.action === "session_evicted",
+      );
+      expect(evictionEntries.length).toBeGreaterThanOrEqual(1);
+      const entry = evictionEntries[0]!;
+      expect(entry.user_id).toBe("user-1");
+      expect(entry.resource_type).toBe("session");
+      const details = JSON.parse(entry.details as string);
+      expect(details.reason).toContain("concurrent session limit");
+    });
+  });
+});

--- a/services/auth/src/__tests__/session-cleanup.test.ts
+++ b/services/auth/src/__tests__/session-cleanup.test.ts
@@ -4,19 +4,36 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks — set up before importing the module under test
 // ---------------------------------------------------------------------------
 
-const deletedRows: { id: string }[] = [];
+interface DeletedSessionRow {
+  id: string;
+  user_id: string;
+  expires_at: string | null;
+  last_active_at: string | null;
+  created_at: string;
+}
+
+const deletedRows: DeletedSessionRow[] = [];
 const mockReturning = vi.fn(() => deletedRows);
 const mockWhere = vi.fn(() => ({ returning: mockReturning }));
 const mockDeleteFn = vi.fn(() => ({ where: mockWhere }));
 
+const insertedAuditEntries: Array<Record<string, unknown>> = [];
+const mockInsertValues = vi.fn(async (values: Record<string, unknown>) => {
+  insertedAuditEntries.push(values);
+});
+const mockInsertFn = vi.fn(() => ({ values: mockInsertValues }));
+
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({ delete: mockDeleteFn }),
+  getDb: () => ({ delete: mockDeleteFn, insert: mockInsertFn }),
   sessions: {
     id: "sessions.id",
     user_id: "sessions.user_id",
     expires_at: "sessions.expires_at",
     created_at: "sessions.created_at",
     last_active_at: "sessions.last_active_at",
+  },
+  auditLog: {
+    id: "audit_log.id",
   },
 }));
 
@@ -34,10 +51,23 @@ import { cleanupExpiredSessions } from "../session-cleanup.js";
 // Tests
 // ---------------------------------------------------------------------------
 
+function seedDeletedRow(
+  overrides: Partial<DeletedSessionRow> = {},
+): DeletedSessionRow {
+  return {
+    id: overrides.id ?? "s1",
+    user_id: overrides.user_id ?? "user-1",
+    expires_at: overrides.expires_at ?? new Date(Date.now() + 3_600_000).toISOString(),
+    last_active_at: overrides.last_active_at ?? null,
+    created_at: overrides.created_at ?? new Date().toISOString(),
+  };
+}
+
 describe("cleanupExpiredSessions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     deletedRows.length = 0;
+    insertedAuditEntries.length = 0;
   });
 
   it("calls db.delete on the sessions table", async () => {
@@ -50,7 +80,11 @@ describe("cleanupExpiredSessions", () => {
   });
 
   it("returns the number of deleted rows", async () => {
-    deletedRows.push({ id: "s1" }, { id: "s2" }, { id: "s3" });
+    deletedRows.push(
+      seedDeletedRow({ id: "s1" }),
+      seedDeletedRow({ id: "s2" }),
+      seedDeletedRow({ id: "s3" }),
+    );
 
     const count = await cleanupExpiredSessions();
 
@@ -129,13 +163,66 @@ describe("cleanupExpiredSessions", () => {
 
   it("logs when sessions are deleted", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    deletedRows.push({ id: "s1" });
+    deletedRows.push(seedDeletedRow({ id: "s1" }));
 
     await cleanupExpiredSessions();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("Deleted 1 expired/idle sessions"),
     );
+    consoleSpy.mockRestore();
+  });
+
+  it("writes a session_idle_expired audit entry for each deleted session", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const pastExpiry = new Date(Date.now() - 60_000).toISOString();
+    const idlePast = new Date(Date.now() - 20 * 60 * 1000).toISOString();
+    const oldCreated = new Date(Date.now() - 50 * 60 * 60 * 1000).toISOString();
+
+    deletedRows.push(
+      seedDeletedRow({
+        id: "expired-1",
+        user_id: "user-a",
+        expires_at: pastExpiry,
+      }),
+      seedDeletedRow({
+        id: "idle-1",
+        user_id: "user-b",
+        last_active_at: idlePast,
+      }),
+      seedDeletedRow({
+        id: "hard-cap-1",
+        user_id: "user-c",
+        created_at: oldCreated,
+      }),
+    );
+
+    await cleanupExpiredSessions();
+
+    expect(insertedAuditEntries).toHaveLength(3);
+    for (const entry of insertedAuditEntries) {
+      expect(entry.action).toBe("session_idle_expired");
+      expect(entry.resource_type).toBe("session");
+      expect(typeof entry.resource_id).toBe("string");
+      expect(typeof entry.user_id).toBe("string");
+      const details = JSON.parse(entry.details as string);
+      expect(typeof details.reason).toBe("string");
+      expect(details.reason.length).toBeGreaterThan(0);
+    }
+
+    const byId = Object.fromEntries(
+      insertedAuditEntries.map((e) => [e.resource_id, e]),
+    );
+    expect(JSON.parse(byId["expired-1"].details as string).reason).toContain(
+      "Absolute",
+    );
+    expect(JSON.parse(byId["hard-cap-1"].details as string).reason).toContain(
+      "Hard-cap",
+    );
+    expect(JSON.parse(byId["idle-1"].details as string).reason).toContain(
+      "Idle",
+    );
+
     consoleSpy.mockRestore();
   });
 

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -199,18 +199,30 @@ async function enforceSessionLimit(db: ReturnType<typeof getDb>, userId: string)
 
   const timestamp = new Date().toISOString();
   for (const evictedSessionId of toEvict) {
-    await db.insert(auditLog).values({
-      id: crypto.randomUUID(),
-      user_id: userId,
-      action: "session_evicted",
-      resource_type: "session",
-      resource_id: evictedSessionId,
-      details: JSON.stringify({
-        reason: "Exceeded concurrent session limit",
-        max_concurrent_sessions: MAX_CONCURRENT_SESSIONS,
-      }),
-      timestamp,
-    });
+    // Audit writes are best-effort: an audit_log outage must not block a
+    // login (sessions have already been evicted at this point — failing the
+    // mutation would leave the client locked out without rotated state).
+    // Per Copilot review on PR #375.
+    try {
+      await db.insert(auditLog).values({
+        id: crypto.randomUUID(),
+        user_id: userId,
+        action: "session_evicted",
+        resource_type: "session",
+        resource_id: evictedSessionId,
+        details: JSON.stringify({
+          reason: "Exceeded concurrent session limit",
+          max_concurrent_sessions: MAX_CONCURRENT_SESSIONS,
+        }),
+        timestamp,
+      });
+    } catch (err) {
+      console.error("[auth] audit_log insert failed for session_evicted", {
+        userId,
+        sessionId: evictedSessionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 }
 
@@ -452,15 +464,27 @@ export const authRouter = t.router({
       );
 
       // Audit log for session logout (HIPAA § 164.312(b)).
-      await db.insert(auditLog).values({
-        id: crypto.randomUUID(),
-        user_id: ctx.user.id,
-        action: "session_logout",
-        resource_type: "session",
-        resource_id: ctx.sessionId,
-        details: JSON.stringify({ reason: "User-initiated logout" }),
-        timestamp: new Date().toISOString(),
-      });
+      // Best-effort: don't fail logout if the audit insert throws — the
+      // session has already been deleted, so a thrown error would surface
+      // a confusing "logout failed" to the client even though it succeeded.
+      // Per Copilot review on PR #375.
+      try {
+        await db.insert(auditLog).values({
+          id: crypto.randomUUID(),
+          user_id: ctx.user.id,
+          action: "session_logout",
+          resource_type: "session",
+          resource_id: ctx.sessionId,
+          details: JSON.stringify({ reason: "User-initiated logout" }),
+          timestamp: new Date().toISOString(),
+        });
+      } catch (err) {
+        console.error("[auth] audit_log insert failed for session_logout", {
+          userId: ctx.user.id,
+          sessionId: ctx.sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     return { success: true };
@@ -533,19 +557,31 @@ export const authRouter = t.router({
       });
 
       // Audit log for session refresh / rotation (HIPAA § 164.312(b)).
-      await db.insert(auditLog).values({
-        id: crypto.randomUUID(),
-        user_id: row.id,
-        action: "session_refreshed",
-        resource_type: "session",
-        resource_id: session.id,
-        details: JSON.stringify({
-          old_session_id: session.id,
-          new_session_id: newSessionId,
-          reason: "Refresh-token rotation",
-        }),
-        timestamp: now,
-      });
+      // Best-effort: don't fail the rotation if audit_log is unavailable —
+      // the new session has already been issued and the client needs the
+      // rotated credentials in the response. Per Copilot review on PR #375.
+      try {
+        await db.insert(auditLog).values({
+          id: crypto.randomUUID(),
+          user_id: row.id,
+          action: "session_refreshed",
+          resource_type: "session",
+          resource_id: session.id,
+          details: JSON.stringify({
+            old_session_id: session.id,
+            new_session_id: newSessionId,
+            reason: "Refresh-token rotation",
+          }),
+          timestamp: now,
+        });
+      } catch (err) {
+        console.error("[auth] audit_log insert failed for session_refreshed", {
+          userId: row.id,
+          oldSessionId: session.id,
+          newSessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
 
       return {
         user: buildUserResponse(row),

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -8,7 +8,7 @@ import {
   mfaDisableSchema,
   mfaCompleteLoginSchema,
 } from "@carebridge/validators";
-import { getDb, users, sessions } from "@carebridge/db-schema";
+import { getDb, users, sessions, auditLog } from "@carebridge/db-schema";
 import { eq, and, gt, asc, inArray } from "drizzle-orm";
 import crypto from "node:crypto";
 import {
@@ -173,6 +173,9 @@ async function checkPassword(password: string, storedHash: string): Promise<bool
  * If the count is at or above MAX_CONCURRENT_SESSIONS, the oldest sessions
  * are deleted so that the count drops to MAX_CONCURRENT_SESSIONS - 1,
  * leaving room for the new session about to be inserted by the caller.
+ *
+ * Each evicted session generates a `session_evicted` audit log entry
+ * (HIPAA § 164.312(b) — record of session lifecycle events).
  */
 async function enforceSessionLimit(db: ReturnType<typeof getDb>, userId: string): Promise<void> {
   const now = new Date().toISOString();
@@ -193,6 +196,22 @@ async function enforceSessionLimit(db: ReturnType<typeof getDb>, userId: string)
 
   const toEvict = activeSessions.slice(0, overflow).map((s) => s.id);
   await db.delete(sessions).where(inArray(sessions.id, toEvict));
+
+  const timestamp = new Date().toISOString();
+  for (const evictedSessionId of toEvict) {
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: userId,
+      action: "session_evicted",
+      resource_type: "session",
+      resource_id: evictedSessionId,
+      details: JSON.stringify({
+        reason: "Exceeded concurrent session limit",
+        max_concurrent_sessions: MAX_CONCURRENT_SESSIONS,
+      }),
+      timestamp,
+    });
+  }
 }
 
 function buildUserResponse(row: {
@@ -431,6 +450,17 @@ export const authRouter = t.router({
       await db.delete(sessions).where(
         and(eq(sessions.id, ctx.sessionId), eq(sessions.user_id, ctx.user.id)),
       );
+
+      // Audit log for session logout (HIPAA § 164.312(b)).
+      await db.insert(auditLog).values({
+        id: crypto.randomUUID(),
+        user_id: ctx.user.id,
+        action: "session_logout",
+        resource_type: "session",
+        resource_id: ctx.sessionId,
+        details: JSON.stringify({ reason: "User-initiated logout" }),
+        timestamp: new Date().toISOString(),
+      });
     }
 
     return { success: true };
@@ -500,6 +530,21 @@ export const authRouter = t.router({
         created_at: now,
         last_active_at: now,
         refresh_token: hashToken(newRefreshToken),
+      });
+
+      // Audit log for session refresh / rotation (HIPAA § 164.312(b)).
+      await db.insert(auditLog).values({
+        id: crypto.randomUUID(),
+        user_id: row.id,
+        action: "session_refreshed",
+        resource_type: "session",
+        resource_id: session.id,
+        details: JSON.stringify({
+          old_session_id: session.id,
+          new_session_id: newSessionId,
+          reason: "Refresh-token rotation",
+        }),
+        timestamp: now,
       });
 
       return {

--- a/services/auth/src/session-cleanup.ts
+++ b/services/auth/src/session-cleanup.ts
@@ -1,5 +1,6 @@
-import { getDb, sessions } from "@carebridge/db-schema";
+import { getDb, sessions, auditLog } from "@carebridge/db-schema";
 import { lt, or, and, isNotNull } from "drizzle-orm";
+import crypto from "node:crypto";
 
 const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 const HARD_CAP_MS = 48 * 60 * 60 * 1000; // 48 hours
@@ -11,6 +12,9 @@ const HARD_CAP_MS = 48 * 60 * 60 * 1000; // 48 hours
  *  1. `expires_at` is in the past (absolute expiry)
  *  2. `last_active_at` is non-null AND older than 15 minutes (idle timeout)
  *  3. `created_at` is older than 48 hours (hard cap)
+ *
+ * Each deleted session generates a `session_idle_expired` audit log entry
+ * (HIPAA § 164.312(b) — record of session lifecycle events).
  *
  * Returns the number of deleted sessions.
  */
@@ -37,12 +41,49 @@ export async function cleanupExpiredSessions(): Promise<number> {
         lt(sessions.created_at, hardCapThreshold),
       ),
     )
-    .returning({ id: sessions.id });
+    .returning({
+      id: sessions.id,
+      user_id: sessions.user_id,
+      expires_at: sessions.expires_at,
+      last_active_at: sessions.last_active_at,
+      created_at: sessions.created_at,
+    });
 
   const count = deleted.length;
 
   if (count > 0) {
     console.log(`[session-cleanup] Deleted ${count} expired/idle sessions`);
+
+    // Write one audit entry per deleted session (HIPAA § 164.312(b)).
+    const auditTimestamp = now.toISOString();
+    for (const row of deleted) {
+      let reason = "session_cleanup";
+      if (row.expires_at && row.expires_at < expiredThreshold) {
+        reason = "Absolute session expiry reached";
+      } else if (row.created_at && row.created_at < hardCapThreshold) {
+        reason = "Hard-cap session age exceeded (48h)";
+      } else if (row.last_active_at && row.last_active_at < idleThreshold) {
+        reason = "Idle timeout exceeded (15m)";
+      }
+
+      try {
+        await db.insert(auditLog).values({
+          id: crypto.randomUUID(),
+          user_id: row.user_id,
+          action: "session_idle_expired",
+          resource_type: "session",
+          resource_id: row.id,
+          details: JSON.stringify({ reason }),
+          timestamp: auditTimestamp,
+        });
+      } catch (err) {
+        // Audit logging must never crash the cleanup job.
+        console.error(
+          `[session-cleanup] Failed to write audit entry for ${row.id}:`,
+          err,
+        );
+      }
+    }
   }
 
   return count;


### PR DESCRIPTION
## Summary
Logout, session refresh, eviction, and idle cleanup previously wrote nothing to `audit_log`, leaving a gap in HIPAA § 164.312(b) coverage. Only `session_rejected_inactive` was logged. This PR adds audit entries for every session lifecycle transition.

## Changes
- `services/auth/src/router.ts`
  - `auth.logout` inserts a `session_logout` row for the deleted session.
  - `refreshSession` inserts a `session_refreshed` row after rotation, recording both old and new session IDs in `details`.
  - `enforceSessionLimit` inserts one `session_evicted` row per session removed because of the concurrent-session cap.
- `services/auth/src/session-cleanup.ts`
  - `cleanupExpiredSessions` now returns `user_id`/threshold fields via `.returning()` and writes one `session_idle_expired` row per deleted session, with the reason classified as absolute expiry, idle timeout, or 48-hour hard cap. Audit-write failures are logged and never crash the job.

## Event-type names (all `audit_log.action`)
- `session_logout`
- `session_refreshed`
- `session_evicted`
- `session_idle_expired`

## Test Plan
- [x] `pnpm -F @carebridge/auth test` — 57 passing (including 4 new session-audit tests and 1 new cleanup audit test)
- [x] `pnpm -F @carebridge/api-gateway test` — 40 passing (no regressions)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (no new warnings)
- [x] New tests assert the exact `action` value, `resource_type`, `resource_id`, and `details` shape for each event type.

Closes #276