### PR TITLE
fix(notifications): filter clinical-flag notifications by recipient specialty (#293)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   services/patient-records:
     dependencies:

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "dev": "tsx watch src/server.ts",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@carebridge/shared-types": "workspace:*",
@@ -23,5 +24,10 @@
     "drizzle-orm": "^0.38.0",
     "zod": "^3.24.0"
   },
-  "devDependencies": { "typescript": "^5.7.0", "@types/node": "^22.0.0", "tsx": "^4.19.0" }
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/services/notifications/src/__tests__/specialty-filter.test.ts
+++ b/services/notifications/src/__tests__/specialty-filter.test.ts
@@ -143,4 +143,27 @@ describe("filterRecipientsBySpecialty", () => {
     );
     expect(result.sort()).toEqual(["user-neuro", "user-onco"].sort());
   });
+
+  it("returns only admins when notify_specialties is non-empty but all entries normalize to empty (regression: PR #377 Copilot review)", () => {
+    // notify_specialties was scoped to *something* but every entry was
+    // blank/whitespace. Treat this as a misconfigured scoped flag — return
+    // admins only, NEVER fall back to fan-out which would re-introduce
+    // the #293 PHI over-disclosure bug.
+    const result = filterRecipientsBySpecialty(
+      [onco, cards, neuro, admin],
+      ["", "  ", "\t"],
+    );
+    expect(result).toEqual(["user-admin"]);
+    expect(result).not.toContain("user-onco");
+    expect(result).not.toContain("user-cards");
+    expect(result).not.toContain("user-neuro");
+  });
+
+  it("returns an empty list when scoped-but-blank specialties target a candidate set with no admins", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, cards, neuro],
+      ["", "   "],
+    );
+    expect(result).toEqual([]);
+  });
 });

--- a/services/notifications/src/__tests__/specialty-filter.test.ts
+++ b/services/notifications/src/__tests__/specialty-filter.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterRecipientsBySpecialty,
+  type CandidateRecipient,
+} from "../workers/specialty-filter.js";
+
+/**
+ * Regression tests for HIPAA § 164.502(b) (minimum-necessary) fix on
+ * clinical-flag notification dispatch. See issue #293.
+ */
+
+const onco: CandidateRecipient = {
+  id: "user-onco",
+  specialty: "Hematology/Oncology",
+  role: "physician",
+};
+
+const cards: CandidateRecipient = {
+  id: "user-cards",
+  specialty: "Cardiology",
+  role: "physician",
+};
+
+const neuro: CandidateRecipient = {
+  id: "user-neuro",
+  specialty: "Neurology",
+  role: "physician",
+};
+
+const infDis: CandidateRecipient = {
+  id: "user-infdis",
+  specialty: "Infectious Disease",
+  role: "physician",
+};
+
+const admin: CandidateRecipient = {
+  id: "user-admin",
+  specialty: null,
+  role: "admin",
+};
+
+const nurseNoSpecialty: CandidateRecipient = {
+  id: "user-nurse",
+  specialty: null,
+  role: "nurse",
+};
+
+describe("filterRecipientsBySpecialty", () => {
+  it("returns only providers whose specialty matches notify_specialties (regression: issue #293)", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, cards, neuro],
+      ["oncology"],
+    );
+    expect(result).toEqual(["user-onco"]);
+    expect(result).not.toContain("user-cards");
+    expect(result).not.toContain("user-neuro");
+  });
+
+  it("matches composite specialty strings like 'Hematology/Oncology' against either token", () => {
+    const hemeOnly = filterRecipientsBySpecialty([onco], ["hematology"]);
+    expect(hemeOnly).toEqual(["user-onco"]);
+
+    const oncoOnly = filterRecipientsBySpecialty([onco], ["oncology"]);
+    expect(oncoOnly).toEqual(["user-onco"]);
+  });
+
+  it("matches specialty tags with underscores against space-separated specialty labels", () => {
+    // Rule lexicon uses snake_case; user specialty uses spaces.
+    const result = filterRecipientsBySpecialty(
+      [infDis, cards],
+      ["infectious_disease"],
+    );
+    expect(result).toEqual(["user-infdis"]);
+  });
+
+  it("comparison is case-insensitive in both directions", () => {
+    const result = filterRecipientsBySpecialty(
+      [{ id: "u1", specialty: "CARDIOLOGY", role: "physician" }],
+      ["cardiology"],
+    );
+    expect(result).toEqual(["u1"]);
+  });
+
+  it("always includes admin users regardless of specialty targeting", () => {
+    const result = filterRecipientsBySpecialty(
+      [cards, admin],
+      ["oncology"],
+    );
+    expect(result).toContain("user-admin");
+    expect(result).not.toContain("user-cards");
+  });
+
+  it("falls back to every candidate when notify_specialties is empty", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, cards, neuro, nurseNoSpecialty],
+      [],
+    );
+    expect(result.sort()).toEqual(
+      ["user-cards", "user-neuro", "user-nurse", "user-onco"].sort(),
+    );
+  });
+
+  it("falls back to every candidate when notify_specialties is null", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, cards],
+      null,
+    );
+    expect(result.sort()).toEqual(["user-cards", "user-onco"].sort());
+  });
+
+  it("does NOT silently fall back to the full care team when a specialty-scoped flag has no matches (PHI over-disclosure bug)", () => {
+    // This is the regression: previously, when the DB filter returned 0
+    // rows the worker would dispatch to every care-team provider, leaking
+    // Oncology PHI to unrelated specialists.
+    const result = filterRecipientsBySpecialty(
+      [cards, neuro],
+      ["oncology"],
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns only admins when a specialty-scoped flag has no provider matches", () => {
+    const result = filterRecipientsBySpecialty(
+      [cards, neuro, admin],
+      ["oncology"],
+    );
+    expect(result).toEqual(["user-admin"]);
+  });
+
+  it("excludes users with a null specialty from specialty-scoped flags", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, nurseNoSpecialty],
+      ["oncology"],
+    );
+    expect(result).toEqual(["user-onco"]);
+    expect(result).not.toContain("user-nurse");
+  });
+
+  it("honours multiple specialties in notify_specialties (OR semantics)", () => {
+    const result = filterRecipientsBySpecialty(
+      [onco, cards, neuro],
+      ["neurology", "hematology"],
+    );
+    expect(result.sort()).toEqual(["user-neuro", "user-onco"].sort());
+  });
+});

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -2,9 +2,13 @@
  * BullMQ worker that dispatches notifications to relevant users.
  *
  * When a clinical flag is created, this worker:
- * 1. Looks up the patient's care team members with matching specialties
- * 2. Creates a notification record for each relevant provider
- * 3. Falls back to all active care team members if no specialty match
+ * 1. Looks up the patient's care team members
+ * 2. Filters the recipient set by specialty when `notify_specialties`
+ *    is non-empty (HIPAA minimum-necessary, § 164.502(b))
+ * 3. Creates notification records only for matched recipients
+ *
+ * When `notify_specialties` is empty/null the notification falls back to
+ * every active care team provider for the patient.
  */
 
 import { Worker, Queue } from "bullmq";
@@ -16,6 +20,8 @@ import { eq, and, inArray } from "drizzle-orm";
 import Redis from "ioredis";
 import crypto from "node:crypto";
 import type { NotificationEvent } from "../queue.js";
+import { filterRecipientsBySpecialty } from "./specialty-filter.js";
+import type { CandidateRecipient } from "./specialty-filter.js";
 
 /** Redis publisher client for SSE real-time delivery. */
 const redisPublisher = new Redis({
@@ -43,9 +49,14 @@ const dlq = new Queue(DLQ_NAME, {
  * Find provider user IDs who should receive a notification for a given flag.
  *
  * Strategy:
- * 1. Look up the patient's care team members
- * 2. Filter by notify_specialties if specified
- * 3. Fall back to all active care team providers for the patient if no specialty match
+ * 1. Look up active care team members for the patient
+ * 2. Load their user rows (id, specialty, role, is_active)
+ * 3. If `notify_specialties` is non-empty, use `filterRecipientsBySpecialty`
+ *    to keep only providers whose specialty matches (plus admins).
+ *    We do NOT silently fall back to the entire care team when the match
+ *    set is empty — that would re-disclose PHI to unrelated providers.
+ * 4. If `notify_specialties` is empty, notify every active care team
+ *    provider (legacy behaviour for flags without a targeted specialty).
  */
 async function findNotificationRecipients(
   patientId: string,
@@ -71,28 +82,13 @@ async function findNotificationRecipients(
 
   const providerIds = teamMembers.map((m) => m.provider_id);
 
-  // If specialties specified, filter providers by specialty
-  if (notifySpecialties.length > 0) {
-    const matchingProviders = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(
-        and(
-          inArray(users.id, providerIds),
-          inArray(users.specialty!, notifySpecialties),
-          eq(users.is_active, true),
-        ),
-      );
-
-    // If we found specialty matches, use those; otherwise fall back to all team members
-    if (matchingProviders.length > 0) {
-      return matchingProviders.map((p) => p.id);
-    }
-  }
-
-  // Fallback: notify all active care team providers (not patients)
+  // Load all active providers on the care team with their specialty + role
   const activeProviders = await db
-    .select({ id: users.id })
+    .select({
+      id: users.id,
+      specialty: users.specialty,
+      role: users.role,
+    })
     .from(users)
     .where(
       and(
@@ -101,8 +97,13 @@ async function findNotificationRecipients(
       ),
     );
 
-  return activeProviders
-    .map((p) => p.id);
+  const candidates: CandidateRecipient[] = activeProviders.map((p) => ({
+    id: p.id,
+    specialty: p.specialty,
+    role: p.role,
+  }));
+
+  return filterRecipientsBySpecialty(candidates, notifySpecialties);
 }
 
 /**

--- a/services/notifications/src/workers/specialty-filter.ts
+++ b/services/notifications/src/workers/specialty-filter.ts
@@ -1,0 +1,127 @@
+/**
+ * Specialty filtering for clinical-flag notification dispatch.
+ *
+ * HIPAA § 164.502(b) (minimum necessary rule) requires that clinical
+ * alerts carrying PHI only reach providers whose role and specialty make
+ * them a legitimate recipient for that flag. Clinical flags published by
+ * the AI oversight engine attach a `notify_specialties` array that
+ * identifies the specialty audiences the flag is relevant to. This module
+ * applies that audience filter to a pre-fetched set of candidate
+ * recipients, so the dispatch worker can stay a thin I/O shell and the
+ * filter logic is independently unit-testable.
+ *
+ * Matching rules:
+ *   * Comparison is case-insensitive.
+ *   * `notify_specialties` entries and user `specialty` strings are split on
+ *     whitespace, `/`, `,`, `&`, `|`, `-`, `(`, `)` so composite specialty
+ *     labels like `"Hematology/Oncology"` correctly match `"oncology"` or
+ *     `"hematology"`. This mirrors how clinicians actually self-identify
+ *     vs. the lowercase tag lexicon used inside `CROSS_SPECIALTY_RULES`.
+ *   * Admin-role users are always included, regardless of specialty. Admins
+ *     are expected to see all clinical flags for oversight and cannot be
+ *     excluded by a specialty scope.
+ *   * When `notifySpecialties` is empty or null the filter returns every
+ *     active candidate — legacy behaviour for flags that don't declare a
+ *     target audience.
+ *   * When `notifySpecialties` is non-empty and no candidate matches, the
+ *     filter returns ONLY admin candidates (possibly empty). It must NOT
+ *     silently fall back to the full care team — doing so re-discloses
+ *     PHI to providers the flag was explicitly scoped away from.
+ */
+
+export interface CandidateRecipient {
+  id: string;
+  specialty: string | null;
+  role: string;
+}
+
+const SPECIALTY_TOKEN_SPLIT = /[\s/,&|()\-]+/;
+
+/**
+ * Normalize a specialty label into a set of lower-case tokens.
+ *
+ * `"Hematology/Oncology"` → `{"hematology", "oncology"}`
+ * `"Infectious Disease"` → `{"infectious", "disease", "infectious_disease"}`
+ * `null`/empty → empty set
+ *
+ * The joined underscore variant exists so rule tags like `"infectious_disease"`
+ * continue to match a user specialty of `"Infectious Disease"`.
+ */
+function tokenizeSpecialty(value: string | null | undefined): Set<string> {
+  if (value == null) return new Set();
+  const lower = value.toLowerCase().trim();
+  if (lower.length === 0) return new Set();
+
+  const tokens = new Set<string>();
+  // Whole-string variants (normalized underscores / spaces)
+  tokens.add(lower);
+  tokens.add(lower.replace(/_/g, " "));
+  tokens.add(lower.replace(/\s+/g, "_"));
+
+  // Individual tokens
+  for (const part of lower.split(SPECIALTY_TOKEN_SPLIT)) {
+    if (part.length > 0) tokens.add(part);
+  }
+  return tokens;
+}
+
+/**
+ * Returns true when any token in `candidateTokens` appears in
+ * `requestedTokens` (set intersection is non-empty).
+ */
+function tokensIntersect(
+  candidateTokens: Set<string>,
+  requestedTokens: Set<string>,
+): boolean {
+  for (const token of candidateTokens) {
+    if (requestedTokens.has(token)) return true;
+  }
+  return false;
+}
+
+/**
+ * Filter a set of candidate recipients down to the user IDs that should
+ * receive a clinical-flag notification, based on the flag's declared
+ * `notify_specialties` audience.
+ *
+ * See module-level docstring for matching rules.
+ */
+export function filterRecipientsBySpecialty(
+  candidates: readonly CandidateRecipient[],
+  notifySpecialties: readonly string[] | null | undefined,
+): string[] {
+  // No specialty targeting → notify everyone in the candidate set.
+  if (notifySpecialties == null || notifySpecialties.length === 0) {
+    return candidates.map((c) => c.id);
+  }
+
+  // Build the union token set for the flag's requested specialties.
+  const requestedTokens = new Set<string>();
+  for (const spec of notifySpecialties) {
+    for (const token of tokenizeSpecialty(spec)) {
+      requestedTokens.add(token);
+    }
+  }
+
+  // If every entry was empty after normalization, degenerate to
+  // "no targeting" rather than silently dropping all recipients.
+  if (requestedTokens.size === 0) {
+    return candidates.map((c) => c.id);
+  }
+
+  const matched: string[] = [];
+  for (const candidate of candidates) {
+    // Admins always receive flags, regardless of specialty scope.
+    if (candidate.role === "admin") {
+      matched.push(candidate.id);
+      continue;
+    }
+    const candidateTokens = tokenizeSpecialty(candidate.specialty);
+    if (candidateTokens.size === 0) continue;
+    if (tokensIntersect(candidateTokens, requestedTokens)) {
+      matched.push(candidate.id);
+    }
+  }
+
+  return matched;
+}

--- a/services/notifications/src/workers/specialty-filter.ts
+++ b/services/notifications/src/workers/specialty-filter.ts
@@ -103,10 +103,13 @@ export function filterRecipientsBySpecialty(
     }
   }
 
-  // If every entry was empty after normalization, degenerate to
-  // "no targeting" rather than silently dropping all recipients.
+  // If every entry was empty after normalization the flag was scoped to
+  // *something* but the requested specialties were all blank/whitespace.
+  // Treat this as a misconfigured-but-scoped flag and return admins only —
+  // NEVER fall back to fan-out, which would re-introduce the #293 PHI
+  // over-disclosure bug. Per Copilot review on PR #377.
   if (requestedTokens.size === 0) {
-    return candidates.map((c) => c.id);
+    return candidates.filter((c) => c.role === "admin").map((c) => c.id);
   }
 
   const matched: string[] = [];

--- a/services/notifications/vitest.config.ts
+++ b/services/notifications/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Clinical flags declare a `notify_specialties` audience (e.g. `["oncology"]`), but the dispatch worker never actually enforced it: the old DB filter was an exact-string match that silently fell back to every active care team member when it produced zero rows. Every Oncology-scoped flag was therefore delivered to the entire care team, leaking PHI to unrelated specialists in violation of HIPAA § 164.502(b) (minimum-necessary rule).
- Extract recipient matching into a pure `filterRecipientsBySpecialty` helper with case-insensitive, token-aware matching so composite labels like `"Hematology/Oncology"` match the lowercase `"oncology"`/`"hematology"` tags emitted by `CROSS_SPECIALTY_RULES`, and drop the silent full-team fallback: when `notify_specialties` is non-empty, only matching providers (plus admins, who always receive flags for oversight) are notified. Empty/null `notify_specialties` still fans out to the whole care team.

## Changes
- `services/notifications/src/workers/specialty-filter.ts` — new pure filter module with tokenization and matching rules documented inline.
- `services/notifications/src/workers/dispatch-worker.ts` — switched `findNotificationRecipients` to fetch candidates once (id, specialty, role) and delegate the filter decision to `filterRecipientsBySpecialty`; removed the permissive fallback.
- `services/notifications/src/__tests__/specialty-filter.test.ts` — 11 vitest cases covering the regression, composite specialty labels, underscore/space normalization, admin pass-through, and the empty/null `notify_specialties` legacy behaviour.
- `services/notifications/package.json`, `services/notifications/vitest.config.ts`, `pnpm-lock.yaml` — wired vitest into the notifications service.

## Test Plan
- [x] `pnpm --filter @carebridge/notifications test` — 11/11 passing.
- [x] `pnpm typecheck` — 34/34 green.
- [x] `pnpm lint` — 19/19 green (only pre-existing portal warnings).
- [x] Regression case: with `notify_specialties=["oncology"]` and no Onco-matching providers, filter returns `[]` (or admins only) instead of the full care team.
- [x] Fallback case: with empty `notify_specialties`, filter still returns every candidate.

Closes #293