### PR TITLE
fix(fhir): write audit log entries for each importBundle resource (#274)

### DIFF
--- a/services/api-gateway/src/routers/fhir.ts
+++ b/services/api-gateway/src/routers/fhir.ts
@@ -72,6 +72,7 @@ export const fhirRbacRouter = t.router({
       z.object({
         bundle: fhirBundleSchema,
         source_system: z.string(),
+        bundle_id: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -81,6 +82,12 @@ export const fhirRbacRouter = t.router({
           message: "Access denied: importBundle requires admin role",
         });
       }
-      return fhirCaller.importBundle(input);
+      // Forward the caller's user id so the fhir-gateway can write per-resource
+      // audit_log entries attributed to the admin performing the import
+      // (HIPAA § 164.312(b) audit completeness).
+      return fhirCaller.importBundle({
+        ...input,
+        user_id: ctx.user.id,
+      });
     }),
 });

--- a/services/fhir-gateway/src/__tests__/import-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-audit.test.ts
@@ -12,12 +12,21 @@ const insertMock = vi.fn((table: unknown) => ({
   }),
 }));
 
+// db.transaction(callback) → invokes the callback with a `tx` whose
+// `insert()` mirrors the top-level mock so the existing assertions still
+// see every row that the wrapped block writes.
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
 // Sentinels so the test can distinguish tables without needing real drizzle defs.
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({ insert: insertMock }),
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
   fhirResources: fhirResourcesTable,
   auditLog: auditLogTable,
   // The router also imports these, so they need to exist on the mock even
@@ -37,6 +46,7 @@ const { fhirGatewayRouter } = await import("../router.js");
 beforeEach(() => {
   insertCalls.length = 0;
   insertMock.mockClear();
+  transactionMock.mockClear();
 });
 
 describe("importBundle audit logging", () => {

--- a/services/fhir-gateway/src/__tests__/import-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-audit.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock DB ──────────────────────────────────────────────────────
+// Capture every `db.insert(table).values(row)` call so we can assert the
+// importBundle procedure writes both fhir_resources rows AND audit_log rows.
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+// Sentinels so the test can distinguish tables without needing real drizzle defs.
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  // The router also imports these, so they need to exist on the mock even
+  // though they are only used by the unrelated exportPatient procedure.
+  patients: { __name: "patients" },
+  vitals: { __name: "vitals" },
+  labPanels: { __name: "lab_panels" },
+  labResults: { __name: "lab_results" },
+  medications: { __name: "medications" },
+  diagnoses: { __name: "diagnoses" },
+  allergies: { __name: "allergies" },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────
+const { fhirGatewayRouter } = await import("../router.js");
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+});
+
+describe("importBundle audit logging", () => {
+  it("writes a per-resource audit_log entry for each imported resource", async () => {
+    const caller = fhirGatewayRouter.createCaller({});
+
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-1",
+            status: "final",
+            code: { text: "Heart rate" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-2",
+            status: "final",
+            code: { text: "Blood pressure" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "Condition",
+            id: "cond-1",
+            code: { text: "Hypertension" },
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin-42",
+    });
+
+    expect(result.imported).toBe(3);
+
+    const auditRows = insertCalls
+      .filter((c) => c.table === auditLogTable)
+      .map((c) => c.row);
+
+    expect(auditRows).toHaveLength(3);
+
+    // Every audit row records the acting user and the fhir_import action.
+    for (const row of auditRows) {
+      expect(row.user_id).toBe("user-admin-42");
+      expect(row.action).toBe("fhir_import");
+      expect(row.id).toBeDefined();
+      expect(row.timestamp).toBeDefined();
+    }
+
+    // Resource type / id pairs must match the bundle entries.
+    const pairs = auditRows
+      .map((r) => `${r.resource_type}:${r.resource_id}`)
+      .sort();
+    expect(pairs).toEqual(
+      ["Condition:cond-1", "Observation:obs-1", "Observation:obs-2"].sort(),
+    );
+
+    // Details should capture the FHIR source context.
+    for (const row of auditRows) {
+      expect(typeof row.details).toBe("string");
+      const details = JSON.parse(row.details as string) as Record<string, unknown>;
+      expect(details.source).toBe("fhir_bundle");
+      expect(details.source_system).toBe("epic-sandbox");
+    }
+  });
+
+  it("writes one fhir_resources row and one audit_log row per entry (paired)", async () => {
+    const caller = fhirGatewayRouter.createCaller({});
+
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-a",
+            status: "final",
+          },
+        },
+      ],
+    };
+
+    await caller.importBundle({
+      bundle,
+      source_system: "test-ehr",
+      user_id: "user-1",
+    });
+
+    const fhirRows = insertCalls.filter((c) => c.table === fhirResourcesTable);
+    const auditRows = insertCalls.filter((c) => c.table === auditLogTable);
+
+    expect(fhirRows).toHaveLength(1);
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.row.resource_type).toBe("Observation");
+    expect(auditRows[0]!.row.resource_id).toBe("obs-a");
+  });
+});

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -70,34 +70,42 @@ export const fhirGatewayRouter = t.router({
         const resourceType = (sanitized.resourceType as string) ?? "Unknown";
         const resourceId = (sanitized.id as string) ?? crypto.randomUUID();
 
-        await db.insert(fhirResources).values({
-          id: crypto.randomUUID(),
-          resource_type: resourceType,
-          resource_id: resourceId,
-          patient_id: null,
-          resource: sanitized,
-          source_system: input.source_system,
-          imported_at: now,
-        });
-
-        // HIPAA § 164.312(b): record who imported which PHI. One audit_log
-        // row per resource so the bulk import path leaves the same trail as
-        // a normal per-resource write through the clinical-data router.
-        await db.insert(auditLog).values({
-          id: crypto.randomUUID(),
-          user_id: input.user_id,
-          action: "fhir_import",
-          resource_type: resourceType,
-          resource_id: resourceId,
-          procedure_name: "fhir.importBundle",
-          patient_id: null,
-          details: JSON.stringify({
-            source: "fhir_bundle",
+        // Persist the resource and its audit trail in a single transaction
+        // so the pair commits or rolls back atomically. Without this, a
+        // crash or audit_log outage between the two inserts could leave
+        // imported PHI in fhir_resources with no audit row, defeating the
+        // HIPAA § 164.312(b) audit completeness goal.
+        // Per Copilot review on PR #378.
+        await db.transaction(async (tx) => {
+          await tx.insert(fhirResources).values({
+            id: crypto.randomUUID(),
+            resource_type: resourceType,
+            resource_id: resourceId,
+            patient_id: null,
+            resource: sanitized,
             source_system: input.source_system,
-            bundle_id: input.bundle_id ?? null,
-          }),
-          ip_address: null,
-          timestamp: now,
+            imported_at: now,
+          });
+
+          // HIPAA § 164.312(b): record who imported which PHI. One audit_log
+          // row per resource so the bulk import path leaves the same trail
+          // as a normal per-resource write through the clinical-data router.
+          await tx.insert(auditLog).values({
+            id: crypto.randomUUID(),
+            user_id: input.user_id,
+            action: "fhir_import",
+            resource_type: resourceType,
+            resource_id: resourceId,
+            procedure_name: "fhir.importBundle",
+            patient_id: null,
+            details: JSON.stringify({
+              source: "fhir_bundle",
+              source_system: input.source_system,
+              bundle_id: input.bundle_id ?? null,
+            }),
+            ip_address: null,
+            timestamp: now,
+          });
         });
 
         imported++;

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getDb } from "@carebridge/db-schema";
 import {
   fhirResources,
+  auditLog,
   patients,
   vitals,
   labPanels,
@@ -49,6 +50,14 @@ export const fhirGatewayRouter = t.router({
     .input(z.object({
       bundle: fhirBundleSchema,
       source_system: z.string(),
+      /**
+       * ID of the user performing the import. Required for HIPAA
+       * § 164.312(b) audit completeness — every imported resource is
+       * recorded in audit_log attributed to this user. The api-gateway
+       * RBAC wrapper supplies this from ctx.user.id.
+       */
+      user_id: z.string(),
+      bundle_id: z.string().optional(),
     }))
     .mutation(async ({ input }) => {
       const db = getDb();
@@ -58,15 +67,39 @@ export const fhirGatewayRouter = t.router({
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
+        const resourceType = (sanitized.resourceType as string) ?? "Unknown";
+        const resourceId = (sanitized.id as string) ?? crypto.randomUUID();
+
         await db.insert(fhirResources).values({
           id: crypto.randomUUID(),
-          resource_type: (sanitized.resourceType as string) ?? "Unknown",
-          resource_id: (sanitized.id as string) ?? crypto.randomUUID(),
+          resource_type: resourceType,
+          resource_id: resourceId,
           patient_id: null,
           resource: sanitized,
           source_system: input.source_system,
           imported_at: now,
         });
+
+        // HIPAA § 164.312(b): record who imported which PHI. One audit_log
+        // row per resource so the bulk import path leaves the same trail as
+        // a normal per-resource write through the clinical-data router.
+        await db.insert(auditLog).values({
+          id: crypto.randomUUID(),
+          user_id: input.user_id,
+          action: "fhir_import",
+          resource_type: resourceType,
+          resource_id: resourceId,
+          procedure_name: "fhir.importBundle",
+          patient_id: null,
+          details: JSON.stringify({
+            source: "fhir_bundle",
+            source_system: input.source_system,
+            bundle_id: input.bundle_id ?? null,
+          }),
+          ip_address: null,
+          timestamp: now,
+        });
+
         imported++;
       }
       return { imported };


### PR DESCRIPTION
## Summary
The FHIR gateway `importBundle` path bulk-inserted into `fhir_resources` without creating `audit_log` entries, violating HIPAA § 164.312(b) audit completeness. There was no way to answer "who imported this PHI?"

This change writes one `audit_log` row per imported resource, attributed to the admin performing the import, so the bulk import path leaves the same audit trail as a per-resource write through the clinical-data router.

## Changes
- `services/fhir-gateway/src/router.ts`
  - `importBundle` now requires `user_id` in its input and accepts an optional `bundle_id`.
  - Inside the import loop, after each `fhir_resources` insert, write an `audit_log` row with action `fhir_import`, `procedure_name` `fhir.importBundle`, and `details` capturing `source`, `source_system`, and `bundle_id`.
- `services/api-gateway/src/routers/fhir.ts`
  - RBAC wrapper forwards `ctx.user.id` into the fhir-gateway caller so the audit attribution flows end-to-end from the authenticated tRPC request.
- `services/fhir-gateway/src/__tests__/import-bundle-audit.test.ts`
  - New test file. Mocks `@carebridge/db-schema` with a capturing `insert` so both `fhir_resources` and `audit_log` writes can be asserted.
  - Case 1: bundle with 2 Observations + 1 Condition produces 3 audit rows with matching `user_id`, `action='fhir_import'`, and correct `resource_type` / `resource_id` pairs; `details` parses to JSON with `source: 'fhir_bundle'` and `source_system`.
  - Case 2: single-entry bundle produces exactly one `fhir_resources` row and one paired `audit_log` row.

## Test Plan
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 17/17 pass (new tests included)
- [x] `pnpm typecheck` — pass (34/34)
- [x] `pnpm lint` — pass (pre-existing portal warnings only, unrelated)

Closes #274