### PR TITLE
fix(fhir): enforce auth context in raw FHIR router (#273)

### DIFF
--- a/services/api-gateway/src/routers/fhir.ts
+++ b/services/api-gateway/src/routers/fhir.ts
@@ -49,22 +49,25 @@ async function enforcePatientAccess(
   }
 }
 
-// Delegate to the underlying fhir-gateway router via a context-less caller.
-const fhirCaller = fhirGatewayRouter.createCaller({});
-
+// Delegate to the underlying fhir-gateway router. The raw router now
+// requires an authenticated user in its own context as defense-in-depth
+// (see services/fhir-gateway/src/router.ts), so we thread ctx.user through
+// on every call rather than using a single module-level caller.
 export const fhirRbacRouter = t.router({
   exportPatient: protectedProcedure
     .input(z.object({ patientId: z.string() }))
     .query(async ({ ctx, input }) => {
       await enforcePatientAccess(ctx.user, input.patientId);
-      return fhirCaller.exportPatient(input);
+      const caller = fhirGatewayRouter.createCaller({ user: ctx.user });
+      return caller.exportPatient(input);
     }),
 
   getByPatient: protectedProcedure
     .input(z.object({ patientId: z.string(), resourceType: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       await enforcePatientAccess(ctx.user, input.patientId);
-      return fhirCaller.getByPatient(input);
+      const caller = fhirGatewayRouter.createCaller({ user: ctx.user });
+      return caller.getByPatient(input);
     }),
 
   importBundle: protectedProcedure
@@ -81,6 +84,7 @@ export const fhirRbacRouter = t.router({
           message: "Access denied: importBundle requires admin role",
         });
       }
-      return fhirCaller.importBundle(input);
+      const caller = fhirGatewayRouter.createCaller({ user: ctx.user });
+      return caller.importBundle(input);
     }),
 });

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -122,4 +122,48 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
       ).rejects.toBeInstanceOf(TRPCError);
     });
   });
+
+  describe("getByPatient / exportPatient defense-in-depth (PR #379 Copilot review)", () => {
+    it("rejects a patient requesting another patient's resources via getByPatient", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: patientUser });
+      await expect(
+        caller.getByPatient({ patientId: "some-other-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects a patient requesting another patient's bundle via exportPatient", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: patientUser });
+      await expect(
+        caller.exportPatient({ patientId: "some-other-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects a clinician through the raw router (must use the gateway wrapper)", async () => {
+      const physicianUser = {
+        ...patientUser,
+        id: "user-physician-1",
+        role: "physician" as const,
+        specialty: "Hematology/Oncology",
+      };
+      const caller = fhirGatewayRouter.createCaller({ user: physicianUser });
+      await expect(
+        caller.getByPatient({ patientId: "user-patient-1" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("allows a patient to read their own resources via getByPatient (self-access)", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: patientUser });
+      // No throw — DB select mock returns []
+      await expect(
+        caller.getByPatient({ patientId: patientUser.id }),
+      ).resolves.toEqual([]);
+    });
+
+    it("allows an admin to read any patient via getByPatient", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: adminUser });
+      await expect(
+        caller.getByPatient({ patientId: "any-patient" }),
+      ).resolves.toEqual([]);
+    });
+  });
 });

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+// Stub the DB layer so the router's createCaller doesn't try to connect.
+// The auth middleware rejects unauthenticated/unauthorised callers before
+// any DB access is attempted, so these mocks only need to exist for the
+// admin happy-path test and return empty-ish values.
+const insertMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@carebridge/db-schema", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    "@carebridge/db-schema",
+  );
+  return {
+    ...actual,
+    getDb: () => ({
+      insert: () => ({ values: insertMock }),
+      select: () => ({
+        from: () => ({
+          where: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+  };
+});
+
+import { fhirGatewayRouter } from "../router.js";
+
+const patientUser = {
+  id: "user-patient-1",
+  email: "p@example.com",
+  name: "Patient One",
+  role: "patient" as const,
+  is_active: true,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+const adminUser = {
+  id: "user-admin-1",
+  email: "a@example.com",
+  name: "Admin",
+  role: "admin" as const,
+  is_active: true,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+const validBundle = {
+  resourceType: "Bundle" as const,
+  type: "collection" as const,
+  entry: [],
+};
+
+beforeEach(() => {
+  insertMock.mockClear();
+});
+
+describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
+  describe("unauthenticated access", () => {
+    it("rejects getByPatient with UNAUTHORIZED when ctx.user is null", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: null });
+      await expect(
+        caller.getByPatient({ patientId: "p1" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("rejects exportPatient with UNAUTHORIZED when ctx.user is null", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: null });
+      await expect(
+        caller.exportPatient({ patientId: "p1" }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+
+    it("rejects importBundle with UNAUTHORIZED when ctx.user is null", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: null });
+      await expect(
+        caller.importBundle({
+          bundle: validBundle,
+          source_system: "test",
+        }),
+      ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    });
+  });
+
+  describe("importBundle admin-only", () => {
+    it("rejects a patient user with FORBIDDEN", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: patientUser });
+      await expect(
+        caller.importBundle({
+          bundle: validBundle,
+          source_system: "test",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it("allows an admin user through to the import logic", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: adminUser });
+      const result = await caller.importBundle({
+        bundle: {
+          resourceType: "Bundle",
+          type: "collection",
+          entry: [
+            {
+              resource: {
+                resourceType: "Observation",
+                id: "obs-1",
+              },
+            },
+          ],
+        },
+        source_system: "unit-test",
+      });
+      expect(result).toEqual({ imported: 1 });
+      expect(insertMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws TRPCError instances (not plain Errors) for auth failures", async () => {
+      const caller = fhirGatewayRouter.createCaller({ user: null });
+      await expect(
+        caller.exportPatient({ patientId: "p1" }),
+      ).rejects.toBeInstanceOf(TRPCError);
+    });
+  });
+});

--- a/services/fhir-gateway/src/index.ts
+++ b/services/fhir-gateway/src/index.ts
@@ -1,2 +1,6 @@
-export { fhirGatewayRouter, type FhirGatewayRouter } from "./router.js";
+export {
+  fhirGatewayRouter,
+  type FhirGatewayRouter,
+  type Context as FhirGatewayContext,
+} from "./router.js";
 export { fhirBundleSchema, type FhirBundle } from "./schemas/bundle.js";

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -81,6 +81,38 @@ const isAdmin = t.middleware(({ ctx, next }) => {
 const protectedProcedure = t.procedure.use(isAuthenticated);
 const adminProcedure = t.procedure.use(isAdmin);
 
+/**
+ * Defense-in-depth patient-access guard for the raw router.
+ *
+ * The api-gateway wrapper at services/api-gateway/src/routers/fhir.ts is
+ * the canonical RBAC enforcement point and runs the full care-team check.
+ * This helper exists so that if the raw router is consumed directly
+ * (internal callers, tests, dev-mode), it still rejects cross-patient
+ * access. Per Copilot review on PR #379.
+ *
+ * Allowed:
+ *   - admin role: full access
+ *   - patient role: self-access only (user.id === patientId)
+ *
+ * Clinicians (physician/specialist/nurse) are deliberately NOT allowed
+ * through the raw router — they MUST go through the gateway wrapper which
+ * runs the care-team membership check. The raw router cannot do that
+ * check without coupling to gateway concerns, so we fail closed here.
+ */
+function assertRawPatientAccess(
+  user: User,
+  patientId: string,
+): void {
+  if (user.role === "admin") return;
+  if (user.role === "patient" && user.id === patientId) return;
+  throw new TRPCError({
+    code: "FORBIDDEN",
+    message:
+      "Access denied: raw FHIR router only permits admin or patient self-access. " +
+      "Route through the api-gateway wrapper for care-team-based access.",
+  });
+}
+
 function sanitizeResourceStrings(value: unknown): unknown {
   if (typeof value === "string") {
     return sanitizeFreeText(value);
@@ -128,7 +160,8 @@ export const fhirGatewayRouter = t.router({
 
   getByPatient: protectedProcedure
     .input(z.object({ patientId: z.string(), resourceType: z.string().optional() }))
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
+      assertRawPatientAccess(ctx.user, input.patientId);
       const db = getDb();
       return db.select().from(fhirResources)
         .where(eq(fhirResources.patient_id, input.patientId));
@@ -136,7 +169,8 @@ export const fhirGatewayRouter = t.router({
 
   exportPatient: protectedProcedure
     .input(z.object({ patientId: z.string() }))
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
+      assertRawPatientAccess(ctx.user, input.patientId);
       const db = getDb();
       const { patientId } = input;
 

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -13,7 +13,7 @@ import {
 } from "@carebridge/db-schema";
 import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
-import type { Vital, LabResult } from "@carebridge/shared-types";
+import type { Vital, LabResult, User } from "@carebridge/shared-types";
 import {
   toFhirPatient,
   toFhirVitalObservation,
@@ -25,7 +25,61 @@ import {
 import { fhirBundleSchema } from "./schemas/bundle.js";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
 
-const t = initTRPC.create();
+/**
+ * Context for the raw FHIR gateway router.
+ *
+ * Defense-in-depth: even when this router is consumed directly (e.g. unit
+ * tests, dev mode, other internal callers) rather than through the
+ * api-gateway RBAC wrapper, all procedures require an authenticated user.
+ * The wrapper at services/api-gateway/src/routers/fhir.ts performs the
+ * full RBAC enforcement (care-team access, patient self-access, etc.); this
+ * raw router only guarantees that there IS an authenticated user and that
+ * importBundle is admin-only.
+ */
+export interface Context {
+  user: User | null;
+}
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+    },
+  });
+});
+
+const isAdmin = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  if (ctx.user.role !== "admin") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "importBundle requires admin role",
+    });
+  }
+  return next({
+    ctx: {
+      ...ctx,
+      user: ctx.user,
+    },
+  });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+const adminProcedure = t.procedure.use(isAdmin);
 
 function sanitizeResourceStrings(value: unknown): unknown {
   if (typeof value === "string") {
@@ -45,7 +99,7 @@ function sanitizeResourceStrings(value: unknown): unknown {
 }
 
 export const fhirGatewayRouter = t.router({
-  importBundle: t.procedure
+  importBundle: adminProcedure
     .input(z.object({
       bundle: fhirBundleSchema,
       source_system: z.string(),
@@ -72,7 +126,7 @@ export const fhirGatewayRouter = t.router({
       return { imported };
     }),
 
-  getByPatient: t.procedure
+  getByPatient: protectedProcedure
     .input(z.object({ patientId: z.string(), resourceType: z.string().optional() }))
     .query(async ({ input }) => {
       const db = getDb();
@@ -80,7 +134,7 @@ export const fhirGatewayRouter = t.router({
         .where(eq(fhirResources.patient_id, input.patientId));
     }),
 
-  exportPatient: t.procedure
+  exportPatient: protectedProcedure
     .input(z.object({ patientId: z.string() }))
     .query(async ({ input }) => {
       const db = getDb();


### PR DESCRIPTION
## Summary
Defense-in-depth fix for HIPAA P2 privacy issue #273: the raw FHIR gateway router previously used an unauthenticated `initTRPC.create()` with bare `t.procedure` on every procedure. If the raw router were ever mounted directly (dev mode, other internal consumer) without going through the api-gateway RBAC wrapper, full PHI export would have been unauthenticated.

The wrapper at `services/api-gateway/src/routers/fhir.ts` still performs the primary RBAC enforcement (care-team access, patient self-access). This PR adds a second auth layer to the raw router so it cannot leak PHI even when called directly.

## Changes
- `services/fhir-gateway/src/router.ts`
  - Typed tRPC context `{ user: User | null }` via `initTRPC.context<Context>().create()`
  - Added `isAuthenticated` middleware and `protectedProcedure`
  - Added `isAdmin` middleware and `adminProcedure` for `importBundle`
  - `getByPatient` and `exportPatient` now use `protectedProcedure` (reject when `ctx.user` is null)
  - `importBundle` now uses `adminProcedure` (reject non-admin users with FORBIDDEN)
  - Exports the `Context` type so callers can construct a typed caller
- `services/fhir-gateway/src/index.ts`
  - Re-exports `Context` as `FhirGatewayContext`
- `services/api-gateway/src/routers/fhir.ts`
  - Wrapper now constructs the inner caller per-request with `{ user: ctx.user }` (previously `fhirGatewayRouter.createCaller({})` at module scope). The wrapper's own admin check on `importBundle` is retained as belt-and-braces.
- `services/fhir-gateway/src/__tests__/router-auth.test.ts` (new)
  - 6 tests covering: UNAUTHORIZED on all three procedures when `user: null`, FORBIDDEN on `importBundle` for a patient role, admin happy path for `importBundle`, and `TRPCError` instance check.

## Test Plan
- [x] `pnpm test` in `services/fhir-gateway` — 21 tests pass (6 new + 15 existing)
- [x] `pnpm typecheck` at repo root — pass
- [x] `pnpm lint` at repo root — pass (pre-existing warnings in clinician-portal only)
- [ ] Manual: confirm existing e2e wrapper flows still work end-to-end

## Caveats
**Merge conflict warning:** PR #378 on branch `fix/274-fhir-import-audit` also modifies `services/fhir-gateway/src/router.ts` and `services/api-gateway/src/routers/fhir.ts` (adds audit writes on `importBundle` and threads `user_id` through). Expect a merge conflict between this PR and #378; resolve by combining the auth middleware from this PR with the audit logging from #378 — they are complementary.

Closes #273