### PR TITLE
fix(auth): add centralized checkPermission helper for RBAC enforcement (#279)

### DIFF
--- a/packages/shared-types/src/auth.ts
+++ b/packages/shared-types/src/auth.ts
@@ -101,3 +101,23 @@ export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
     "admin:users", "admin:rules",
   ],
 };
+
+/**
+ * Centralized permission check for RBAC enforcement.
+ *
+ * Returns `true` when the user's role grants the given permission per
+ * `ROLE_PERMISSIONS`, otherwise `false`. An unknown permission string
+ * (one not present in any role's grant list) always returns `false`.
+ *
+ * Callers that need to short-circuit a request should use
+ * `assertPermission` from `services/api-gateway/src/middleware/rbac.ts`,
+ * which wraps this helper and throws a tRPC `FORBIDDEN` error on denial.
+ *
+ * This helper lives in `@carebridge/shared-types` so every service and
+ * app can import it without a framework-specific dependency.
+ */
+export function hasPermission(user: User, permission: string): boolean {
+  const grants = ROLE_PERMISSIONS[user.role];
+  if (!grants) return false;
+  return (grants as readonly string[]).includes(permission);
+}

--- a/services/api-gateway/src/middleware/rbac.test.ts
+++ b/services/api-gateway/src/middleware/rbac.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { assertCareTeamAccess, clearCareTeamCache } from "./rbac.js";
+import { TRPCError } from "@trpc/server";
+import type { User } from "@carebridge/shared-types";
+import { hasPermission } from "@carebridge/shared-types";
+import { assertCareTeamAccess, assertPermission, clearCareTeamCache } from "./rbac.js";
+
+function makeUser(role: User["role"]): User {
+  return {
+    id: `user-${role}`,
+    email: `${role}@example.test`,
+    name: `${role} user`,
+    role,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  };
+}
 
 // Mock the db-schema module so we never hit a real database.
 const selectMock = vi.fn();
@@ -101,5 +116,40 @@ describe("care-team cache", () => {
     expect(a).toBe(true);
     expect(b).toBe(false);
     expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("hasPermission", () => {
+  it("returns true when the role's grant list contains the permission", () => {
+    expect(hasPermission(makeUser("physician"), "sign:notes")).toBe(true);
+  });
+
+  it("returns false when the role does not have the permission", () => {
+    expect(hasPermission(makeUser("nurse"), "sign:notes")).toBe(false);
+  });
+
+  it("returns false for patient users attempting clinician permissions", () => {
+    expect(hasPermission(makeUser("patient"), "sign:notes")).toBe(false);
+  });
+
+  it("returns false for unknown permission strings", () => {
+    expect(hasPermission(makeUser("admin"), "launch:missiles")).toBe(false);
+  });
+});
+
+describe("assertPermission", () => {
+  it("throws TRPCError(FORBIDDEN) when the user lacks the permission", () => {
+    let caught: unknown;
+    try {
+      assertPermission(makeUser("nurse"), "sign:notes");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe("FORBIDDEN");
+  });
+
+  it("does not throw when the user has the permission", () => {
+    expect(() => assertPermission(makeUser("physician"), "sign:notes")).not.toThrow();
   });
 });

--- a/services/api-gateway/src/middleware/rbac.test.ts
+++ b/services/api-gateway/src/middleware/rbac.test.ts
@@ -152,4 +152,29 @@ describe("assertPermission", () => {
   it("does not throw when the user has the permission", () => {
     expect(() => assertPermission(makeUser("physician"), "sign:notes")).not.toThrow();
   });
+
+  it("defaults to a generic message that does not leak the permission key (PR #381 Copilot review)", () => {
+    try {
+      assertPermission(makeUser("nurse"), "admin:users");
+    } catch (err) {
+      const msg = (err as TRPCError).message;
+      // Generic default — does NOT contain the internal permission identifier.
+      expect(msg).toBe("Access denied");
+      expect(msg).not.toContain("admin:users");
+    }
+  });
+
+  it("honours an explicit domain-appropriate message when provided", () => {
+    try {
+      assertPermission(
+        makeUser("nurse"),
+        "admin:users",
+        "Only admins can revoke emergency access",
+      );
+    } catch (err) {
+      expect((err as TRPCError).message).toBe(
+        "Only admins can revoke emergency access",
+      );
+    }
+  });
 });

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -1,8 +1,28 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
+import { TRPCError } from "@trpc/server";
 import type { User } from "@carebridge/shared-types";
+import { hasPermission } from "@carebridge/shared-types";
 import { getDb, careTeamAssignments, auditLog } from "@carebridge/db-schema";
 import { eq, and, isNull } from "drizzle-orm";
 import crypto from "node:crypto";
+
+/**
+ * tRPC-side RBAC enforcement: throws `FORBIDDEN` when the user's role
+ * does not grant the requested permission per `ROLE_PERMISSIONS`.
+ *
+ * Prefer this over inline `user.role !== "admin"` checks so that all
+ * permission logic flows through a single source of truth. Extending
+ * a role's capabilities is then a one-line change in `ROLE_PERMISSIONS`
+ * rather than a grep-and-edit across every router.
+ */
+export function assertPermission(user: User, permission: string): void {
+  if (!hasPermission(user, permission)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `Access denied: missing permission "${permission}"`,
+    });
+  }
+}
 
 /**
  * Log an RBAC access denial to the audit trail.

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -15,11 +15,21 @@ import crypto from "node:crypto";
  * a role's capabilities is then a one-line change in `ROLE_PERMISSIONS`
  * rather than a grep-and-edit across every router.
  */
-export function assertPermission(user: User, permission: string): void {
+export function assertPermission(
+  user: User,
+  permission: string,
+  message = "Access denied",
+): void {
   if (!hasPermission(user, permission)) {
+    // Default message is intentionally generic — exposing the raw
+    // permission key in the user-facing error leaks RBAC internals.
+    // Callers can pass a domain-appropriate message (e.g. "Only admins
+    // can revoke emergency access") to improve UX without revealing
+    // the underlying permission identifier.
+    // Per Copilot review on PR #381.
     throw new TRPCError({
       code: "FORBIDDEN",
-      message: `Access denied: missing permission "${permission}"`,
+      message,
     });
   }
 }

--- a/services/api-gateway/src/routers/emergency-access.ts
+++ b/services/api-gateway/src/routers/emergency-access.ts
@@ -12,6 +12,7 @@ import { emergencyAccess, auditLog } from "@carebridge/db-schema";
 import { eq, and, gt, isNull, desc } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
+import { assertPermission } from "../middleware/rbac.js";
 
 const t = initTRPC.context<Context>().create();
 
@@ -94,9 +95,9 @@ export const emergencyAccessRbacRouter = t.router({
   revoke: protectedProcedure
     .input(z.object({ accessId: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      if (ctx.user.role !== "admin") {
-        throw new TRPCError({ code: "FORBIDDEN", message: "Only admins can revoke emergency access" });
-      }
+      // Centralized RBAC: `admin:users` is only granted to the admin role
+      // in ROLE_PERMISSIONS, so this replaces the previous inline role check.
+      assertPermission(ctx.user, "admin:users");
       const db = getDb();
       await db.update(emergencyAccess)
         .set({ revoked_at: new Date().toISOString(), revoked_by: ctx.user.id })

--- a/services/api-gateway/src/routers/emergency-access.ts
+++ b/services/api-gateway/src/routers/emergency-access.ts
@@ -97,7 +97,13 @@ export const emergencyAccessRbacRouter = t.router({
     .mutation(async ({ ctx, input }) => {
       // Centralized RBAC: `admin:users` is only granted to the admin role
       // in ROLE_PERMISSIONS, so this replaces the previous inline role check.
-      assertPermission(ctx.user, "admin:users");
+      // Pass the original human-readable message so the FORBIDDEN response
+      // doesn't leak the internal permission identifier.
+      assertPermission(
+        ctx.user,
+        "admin:users",
+        "Only admins can revoke emergency access",
+      );
       const db = getDb();
       await db.update(emergencyAccess)
         .set({ revoked_at: new Date().toISOString(), revoked_by: ctx.user.id })


### PR DESCRIPTION
## Summary
`ROLE_PERMISSIONS` in `packages/shared-types/src/auth.ts` has been sitting unused since day one — role gating has been done ad hoc per route (`if (user.role !== "admin") throw FORBIDDEN`), which makes it easy to forget enforcement when adding a new endpoint and hard to evolve a role's capabilities without grepping every router.

This PR adds the missing plumbing:

- `hasPermission(user, permission)` in `@carebridge/shared-types` — framework-agnostic, importable from any service or app.
- `assertPermission(user, permission)` in `services/api-gateway/src/middleware/rbac.ts` — thin wrapper that throws `TRPCError({ code: "FORBIDDEN" })` on denial.

To show the pattern in practice, one existing ad hoc check is migrated: `emergencyAccess.revoke` no longer compares `ctx.user.role !== "admin"` inline — it calls `assertPermission(ctx.user, "admin:users")` instead. Because `admin:users` is only granted to the admin role in `ROLE_PERMISSIONS`, the behavior is identical.

This is deliberately a first step toward centralized RBAC. Follow-up work can migrate the remaining inline role checks in `emergency-access.ts`, `scheduling.ts`, `fhir.ts`, and others to `assertPermission` (there are a dozen or so — out of scope for a single PR).

## Changes
- `packages/shared-types/src/auth.ts` — export `hasPermission(user, permission): boolean`
- `services/api-gateway/src/middleware/rbac.ts` — export `assertPermission(user, permission): void`
- `services/api-gateway/src/routers/emergency-access.ts` — migrate `revoke` to use `assertPermission`
- `services/api-gateway/src/middleware/rbac.test.ts` — six TDD cases covering the helper contract

## Test Plan
- [x] `hasPermission(physician, "sign:notes")` returns `true`
- [x] `hasPermission(nurse, "sign:notes")` returns `false`
- [x] `hasPermission(patient, "sign:notes")` returns `false`
- [x] Unknown permission string returns `false`
- [x] `assertPermission` throws `TRPCError(FORBIDDEN)` when denied
- [x] `assertPermission` does not throw when allowed
- [x] `pnpm typecheck` passes across all 34 packages
- [x] `pnpm lint` passes
- [x] `pnpm --filter @carebridge/api-gateway test rbac.test.ts` — 12/12 passing

Closes #279