### PR TITLE
ci: unblock pre-existing build and test failures blocking marathon PRs

### DIFF
--- a/apps/patient-portal/app/notes/page.tsx
+++ b/apps/patient-portal/app/notes/page.tsx
@@ -63,7 +63,30 @@ export default function NotesPage() {
 
       {visibleNotes.map((note) => {
         const isExpanded = expandedId === note.id;
-        const sections = (note.sections ?? []) as Array<{ heading: string; content: string }>;
+        // The persisted note schema stores each section as
+        // { label, key, fields[], free_text? }. The patient view only renders
+        // a section heading and a flattened text body, so map the structured
+        // shape into the simple { heading, content } pairs the markup below
+        // expects.
+        const rawSections = note.sections ?? [];
+        const sections = rawSections.map((section) => {
+          const fieldText = section.fields
+            .filter(
+              (f) =>
+                f.value !== null && f.value !== undefined && f.value !== "",
+            )
+            .map((f) => {
+              const rendered = Array.isArray(f.value)
+                ? f.value.join(", ")
+                : String(f.value);
+              return `${f.label}: ${rendered}`;
+            })
+            .join("\n");
+          const content = [section.free_text, fieldText]
+            .filter((part) => part && part.length > 0)
+            .join("\n\n");
+          return { heading: section.label, content };
+        });
 
         return (
           <div

--- a/packages/portal-shared/src/auth.tsx
+++ b/packages/portal-shared/src/auth.tsx
@@ -10,6 +10,10 @@ export interface User {
   role: string;
   specialty?: string;
   department?: string;
+  // Patient-role users link to their patient record via this id. Set on the
+  // users table by the auth service. Used by useMyPatientRecord to do a direct
+  // lookup instead of the legacy fragile name-match.
+  patient_id?: string;
 }
 
 export interface AuthContextValue {

--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mock db-schema BEFORE importing the module under test.
 const diagnosesSelect = vi.fn();
 const medicationsSelect = vi.fn();
+const allergiesSelect = vi.fn();
 const labsSelect = vi.fn();
 
-// The real module uses three parallel select() calls inside Promise.all.
+// The real module uses four parallel select() calls inside Promise.all.
 // We return a different chain per call via mockImplementation sequencing.
 const selectMock = vi
   .fn()
@@ -17,7 +18,11 @@ const selectMock = vi
   .mockImplementationOnce(() => ({
     from: () => ({ where: () => medicationsSelect() }),
   }))
-  // Call 3: lab_results JOIN lab_panels
+  // Call 3: allergies
+  .mockImplementationOnce(() => ({
+    from: () => ({ where: () => allergiesSelect() }),
+  }))
+  // Call 4: lab_results JOIN lab_panels
   .mockImplementationOnce(() => ({
     from: () => ({
       innerJoin: () => ({
@@ -32,6 +37,7 @@ vi.mock("@carebridge/db-schema", () => ({
   getDb: () => ({ select: selectMock }),
   diagnoses: {},
   medications: {},
+  allergies: { patient_id: "patient_id" },
   patients: {},
   labPanels: { id: "id", patient_id: "patient_id" },
   labResults: {
@@ -61,7 +67,11 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     selectMock.mockClear();
     diagnosesSelect.mockClear();
     medicationsSelect.mockClear();
+    allergiesSelect.mockClear();
     labsSelect.mockClear();
+
+    // Default: empty allergies. Tests that care about allergies override.
+    allergiesSelect.mockResolvedValue([]);
 
     // Re-prime the sequenced mock implementations (they are consumed per call).
     selectMock
@@ -70,6 +80,9 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
       }))
       .mockImplementationOnce(() => ({
         from: () => ({ where: () => medicationsSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => allergiesSelect() }),
       }))
       .mockImplementationOnce(() => ({
         from: () => ({

--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -1,42 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock db-schema BEFORE importing the module under test.
+//
+// The real module uses four parallel select() calls inside Promise.all
+// (diagnoses, medications, allergies, recent labs join). We return a
+// different chain per call via sequenced mockImplementationOnce primings
+// inside beforeEach — the top-level selectMock starts empty and is primed
+// fresh per test so unconsumed implementations never bleed across tests.
 const diagnosesSelect = vi.fn();
 const medicationsSelect = vi.fn();
 const allergiesSelect = vi.fn();
 const labsSelect = vi.fn();
-
-// The real module uses four parallel select() calls inside Promise.all.
-// We return a different chain per call via mockImplementation sequencing.
-const selectMock = vi
-  .fn()
-  // Call 1: diagnoses
-  .mockImplementationOnce(() => ({
-    from: () => ({ where: () => diagnosesSelect() }),
-  }))
-  // Call 2: medications
-  .mockImplementationOnce(() => ({
-    from: () => ({ where: () => medicationsSelect() }),
-  }))
-  // Call 3: allergies
-  .mockImplementationOnce(() => ({
-    from: () => ({ where: () => allergiesSelect() }),
-  }))
-  // Call 4: lab_results JOIN lab_panels
-  .mockImplementationOnce(() => ({
-    from: () => ({
-      innerJoin: () => ({
-        where: () => ({
-          orderBy: () => labsSelect(),
-        }),
-      }),
-    }),
-  }));
+const selectMock = vi.fn();
 
 vi.mock("@carebridge/db-schema", () => ({
   getDb: () => ({ select: selectMock }),
-  diagnoses: {},
-  medications: {},
+  diagnoses: { patient_id: "patient_id" },
+  medications: { patient_id: "patient_id" },
   allergies: { patient_id: "patient_id" },
   patients: {},
   labPanels: { id: "id", patient_id: "patient_id" },
@@ -64,11 +44,14 @@ const stubEvent: ClinicalEvent = {
 
 describe("buildPatientContextForRules — recent_labs wiring", () => {
   beforeEach(() => {
-    selectMock.mockClear();
-    diagnosesSelect.mockClear();
-    medicationsSelect.mockClear();
-    allergiesSelect.mockClear();
-    labsSelect.mockClear();
+    // mockReset (not mockClear) — clears the mockImplementationOnce queue too,
+    // so each test starts from an empty implementation sequence and tests
+    // can't bleed unconsumed implementations into each other.
+    selectMock.mockReset();
+    diagnosesSelect.mockReset();
+    medicationsSelect.mockReset();
+    allergiesSelect.mockReset();
+    labsSelect.mockReset();
 
     // Default: empty allergies. Tests that care about allergies override.
     allergiesSelect.mockResolvedValue([]);

--- a/services/ai-oversight/src/__tests__/flag-service.test.ts
+++ b/services/ai-oversight/src/__tests__/flag-service.test.ts
@@ -25,6 +25,14 @@ vi.mock("@carebridge/db-schema", () => ({
   },
 }));
 
+// Stub @carebridge/notifications so importing flag-service does not pull in
+// BullMQ + Redis at module-load time. Without this mock the import-time
+// notification queue connection ECONNREFUSEs in CI (no Redis service) and the
+// tests time out at 5s.
+vi.mock("@carebridge/notifications", () => ({
+  emitNotificationEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { createFlag } from "../services/flag-service.js";
 
 beforeEach(() => {

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -17,6 +17,10 @@ import {
   careTeamMembers,
 } from "@carebridge/db-schema";
 import { createPatientSchema, updatePatientSchema } from "@carebridge/validators";
+import {
+  listObservationsByPatient,
+  createObservation,
+} from "@carebridge/patient-records";
 import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
@@ -167,6 +171,54 @@ export const patientRecordsRbacRouter = t.router({
           .select()
           .from(careTeamMembers)
           .where(eq(careTeamMembers.patient_id, input.patientId));
+      }),
+  }),
+
+  observations: t.router({
+    getByPatient: protectedProcedure
+      .input(
+        z.object({
+          patientId: z.string(),
+          limit: z.number().optional().default(20),
+        }),
+      )
+      .query(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        return listObservationsByPatient(input.patientId, input.limit);
+      }),
+
+    create: protectedProcedure
+      .input(
+        z.object({
+          patientId: z.string(),
+          observationType: z.enum([
+            "pain",
+            "neurological",
+            "gastrointestinal",
+            "respiratory",
+            "skin",
+            "cardiovascular",
+            "general",
+            "medication_side_effect",
+          ]),
+          description: z.string().min(1),
+          structuredData: z
+            .object({
+              location: z.string().optional(),
+              severity: z.number().min(1).max(10),
+              duration: z.string().optional(),
+              frequency: z.string().optional(),
+              associated_activities: z.string().optional(),
+            })
+            .optional(),
+          severitySelfAssessment: z
+            .enum(["mild", "moderate", "severe"])
+            .optional(),
+        }),
+      )
+      .mutation(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patientId);
+        return createObservation(input);
       }),
   }),
 });

--- a/services/patient-records/src/index.ts
+++ b/services/patient-records/src/index.ts
@@ -1,1 +1,7 @@
-export { patientRecordsRouter, type PatientRecordsRouter } from "./router.js";
+export {
+  patientRecordsRouter,
+  type PatientRecordsRouter,
+  listObservationsByPatient,
+  createObservation,
+  type ObservationCreateInput,
+} from "./router.js";

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -80,66 +80,122 @@ export const patientRecordsRouter = t.router({
     /** List observations for a patient, most recent first. */
     getByPatient: t.procedure
       .input(z.object({ patientId: z.string(), limit: z.number().optional().default(20) }))
-      .query(async ({ input }) => {
-        const db = getDb();
-        return db.select().from(patientObservations)
-          .where(eq(patientObservations.patient_id, input.patientId))
-          .orderBy(desc(patientObservations.created_at))
-          .limit(input.limit);
-      }),
+      .query(({ input }) => listObservationsByPatient(input.patientId, input.limit)),
 
     /** Create a new patient observation. Emits patient.observation event for AI oversight. */
     create: t.procedure
-      .input(z.object({
-        patientId: z.string(),
-        observationType: z.enum(["pain", "neurological", "gastrointestinal", "respiratory", "skin", "cardiovascular", "general", "medication_side_effect"]),
-        description: z.string().min(1),
-        structuredData: z.object({
-          location: z.string().optional(),
-          severity: z.number().min(1).max(10),
-          duration: z.string().optional(),
-          frequency: z.string().optional(),
-          associated_activities: z.string().optional(),
-        }).optional(),
-        severitySelfAssessment: z.enum(["mild", "moderate", "severe"]).optional(),
-      }))
-      .mutation(async ({ input }) => {
-        const db = getDb();
-        const now = new Date().toISOString();
-        const id = crypto.randomUUID();
-
-        const observation = {
-          id,
-          patient_id: input.patientId,
-          observation_type: input.observationType,
-          description: input.description,
-          structured_data: input.structuredData ?? null,
-          severity_self_assessment: input.severitySelfAssessment ?? null,
-          created_at: now,
-          updated_at: now,
-        };
-
-        await db.insert(patientObservations).values(observation);
-
-        // Emit patient.observation event for AI oversight screening.
-        // IMPORTANT: Do NOT include description (PHI) in the event payload.
-        // The AI oversight worker reads the observation from DB where Drizzle
-        // handles transparent decryption of the encrypted description field.
-        await clinicalEventsQueue.add("patient.observation", {
-          id: crypto.randomUUID(),
-          type: "patient.observation",
-          patient_id: input.patientId,
-          data: {
-            observation_id: id,
-            observation_type: input.observationType,
-            severity_self_assessment: input.severitySelfAssessment,
-          },
-          timestamp: now,
-        });
-
-        return observation;
-      }),
+      .input(
+        z.object({
+          patientId: z.string(),
+          observationType: z.enum([
+            "pain",
+            "neurological",
+            "gastrointestinal",
+            "respiratory",
+            "skin",
+            "cardiovascular",
+            "general",
+            "medication_side_effect",
+          ]),
+          description: z.string().min(1),
+          structuredData: z
+            .object({
+              location: z.string().optional(),
+              severity: z.number().min(1).max(10),
+              duration: z.string().optional(),
+              frequency: z.string().optional(),
+              associated_activities: z.string().optional(),
+            })
+            .optional(),
+          severitySelfAssessment: z.enum(["mild", "moderate", "severe"]).optional(),
+        }),
+      )
+      .mutation(({ input }) => createObservation(input)),
   }),
 });
+
+// ---------------------------------------------------------------------------
+// Observation service helpers — exported for the api-gateway RBAC wrapper.
+// The raw `observations` sub-router stays here for backward compatibility,
+// but the gateway wrapper now imports the helper functions directly so it can
+// run enforcePatientAccess() before delegating to the persistence layer.
+// ---------------------------------------------------------------------------
+
+export const observationCreateSchema = z.object({
+  patientId: z.string(),
+  observationType: z.enum([
+    "pain",
+    "neurological",
+    "gastrointestinal",
+    "respiratory",
+    "skin",
+    "cardiovascular",
+    "general",
+    "medication_side_effect",
+  ]),
+  description: z.string().min(1),
+  structuredData: z
+    .object({
+      location: z.string().optional(),
+      severity: z.number().min(1).max(10),
+      duration: z.string().optional(),
+      frequency: z.string().optional(),
+      associated_activities: z.string().optional(),
+    })
+    .optional(),
+  severitySelfAssessment: z.enum(["mild", "moderate", "severe"]).optional(),
+});
+
+export type ObservationCreateInput = z.infer<typeof observationCreateSchema>;
+
+export async function listObservationsByPatient(
+  patientId: string,
+  limit = 20,
+) {
+  const db = getDb();
+  return db
+    .select()
+    .from(patientObservations)
+    .where(eq(patientObservations.patient_id, patientId))
+    .orderBy(desc(patientObservations.created_at))
+    .limit(limit);
+}
+
+export async function createObservation(input: ObservationCreateInput) {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+
+  const observation = {
+    id,
+    patient_id: input.patientId,
+    observation_type: input.observationType,
+    description: input.description,
+    structured_data: input.structuredData ?? null,
+    severity_self_assessment: input.severitySelfAssessment ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await db.insert(patientObservations).values(observation);
+
+  // Emit patient.observation event for AI oversight screening.
+  // IMPORTANT: Do NOT include description (PHI) in the event payload.
+  // The AI oversight worker reads the observation from DB where Drizzle
+  // handles transparent decryption of the encrypted description field.
+  await clinicalEventsQueue.add("patient.observation", {
+    id: crypto.randomUUID(),
+    type: "patient.observation",
+    patient_id: input.patientId,
+    data: {
+      observation_id: id,
+      observation_type: input.observationType,
+      severity_self_assessment: input.severitySelfAssessment,
+    },
+    timestamp: now,
+  });
+
+  return observation;
+}
 
 export type PatientRecordsRouter = typeof patientRecordsRouter;


### PR DESCRIPTION
## Summary

Four pre-existing failures on \`main\` were blocking CI on every open PR (the marathon HIPAA fixes #368–#381 plus this one). Bundling all four into one focused unblock so the test/build/typecheck CI jobs can pass.

## Why this is one PR, not four

Each fix on its own would still leave CI red on every other PR. Splitting them across four PRs means three of them sit waiting on the fourth — and any new PR opened in the meantime would also be red. One PR is the cleanest unblock, and each commit is self-contained:

1. \`test(ai): add allergies to db-schema mock\` (\`095f05b\`)
2. \`ci: unblock pre-existing build and test failures\` (\`8beadd1\`)

## Root causes

### 1. \`build-patient-context.test.ts\` mock missing \`allergies\`

\`services/ai-oversight/src/services/review-service.ts:353\` queries the \`allergies\` table inside the same \`Promise.all\` block as \`diagnoses\`, \`medications\`, and \`lab_results\` — 4 parallel \`select()\` calls. The test mock at \`services/ai-oversight/src/__tests__/build-patient-context.test.ts\` only sequenced 3 \`selectMock\` implementations and never exported \`allergies\`. All 3 tests in the \"recent_labs wiring\" describe block failed.

### 2. \`flag-service.test.ts\` import-time Redis ECONNREFUSED

\`flag-service.ts\` imports \`emitNotificationEvent\` from \`@carebridge/notifications\`, which instantiates a \`new Queue(\"clinical-events\", { connection: getRedisConnection() })\` at module-load time. CI has no Redis service, so the connection ECONNREFUSEs and the tests time out at 5s. Adding a \`vi.mock(\"@carebridge/notifications\")\` breaks the import-time dependency without touching runtime behaviour.

### 3. \`portal-shared\` \`User\` interface missing \`patient_id\`

PR #367 introduced \`user.patient_id\` as the canonical way for \`useMyPatientRecord\` to look up a patient by id instead of fragile name-match. The \`packages/portal-shared/src/auth.tsx\` \`User\` interface was never updated. The patient-portal has been failing \`tsc\` with TS2339 (\`Property 'patient_id' does not exist on type 'User'\`) ever since. One-line type addition.

### 4. \`patient-records.observations\` not in the gateway RBAC wrapper

PR #347 added the \`patient symptom journal\` sub-router to the raw \`patient-records\` service but never wired it through the api-gateway RBAC wrapper. \`apps/patient-portal/app/symptoms/page.tsx\` calls \`trpc.patients.observations.getByPatient\` which doesn't exist on the gateway \`AppRouter\` shape, so \`tsc\` fails. Extract \`listObservationsByPatient\` and \`createObservation\` as exported helper functions in \`@carebridge/patient-records\`, then mount them on the wrapper behind \`enforcePatientAccess\` so client calls go through the standard HIPAA gate (and the symptoms feature actually works at runtime, which it didn't before).

### 5. \`patient-portal/notes/page.tsx\` section type mismatch

The persisted note schema stores sections as \`{ label, key, fields[], free_text? }\` but the patient view cast them to \`{ heading, content }\`, which \`tsc\` correctly rejects. Map the structured shape into the simple \`{ heading, content }\` pairs the existing markup expects — join field labels and free-text into one body string.

## Test Plan

- [x] \`pnpm build\` — 19/19 pass (was failing on \`@carebridge/patient-portal\`)
- [x] \`pnpm typecheck\` — 34/34 pass
- [x] \`pnpm lint\` — 19/19 pass
- [x] \`pnpm -F @carebridge/ai-oversight test\` — **50/50 pass in 534ms** (was 3 failures + 3 timeouts)
- [x] No production behaviour changes outside the patient-portal section rendering and the symptom journal becoming functional

## After this lands

The 14 marathon HIPAA PRs (#368–#381) all branched from main before this fix exists, so they need their CI re-run. Either: (a) merge this first and let GitHub re-trigger CI on the next push to each marathon branch, or (b) rebase each marathon branch on the new main. Recommend (a) — push an empty commit on each (or use \`gh pr ready --undo\` then \`gh pr ready\`) to retrigger CI without rewriting history.