### PR TITLE
fix(infra,fhir,gateway): migration journal, FHIR RBAC layering, dev rate limit

### DIFF
--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -36,6 +36,132 @@
       "when": 1744041600000,
       "tag": "0004_mfa_and_llm_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1744128000000,
+      "tag": "0005_refresh_token",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1744214400000,
+      "tag": "0006_audit_log_procedure_patient",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1744300800000,
+      "tag": "0008_encrypt_patient_name",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1744387200000,
+      "tag": "0009_icd10_snomed_coding",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1744473600000,
+      "tag": "0010_add_vitals_loinc_code",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1744560000000,
+      "tag": "0011_encrypt_clinical_narratives",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1744646400000,
+      "tag": "0012_audit_log_immutability",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1744732800000,
+      "tag": "0013_encounters_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1744819200000,
+      "tag": "0014_llm_compliance_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1744905600000,
+      "tag": "0015_requires_human_review_boolean",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1744992000000,
+      "tag": "0016_notification_phi_encryption",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1745078400000,
+      "tag": "0017_messaging_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1745164800000,
+      "tag": "0018_patient_observations",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1745251200000,
+      "tag": "0019_scheduling_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1745337600000,
+      "tag": "0020_emergency_access",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1745424000000,
+      "tag": "0021_notification_preferences",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1745510400000,
+      "tag": "0022_user_patient_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1745596800000,
+      "tag": "0023_audit_log_status",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api-gateway/src/routers/fhir.ts
+++ b/services/api-gateway/src/routers/fhir.ts
@@ -58,7 +58,7 @@ export const fhirRbacRouter = t.router({
     .input(z.object({ patientId: z.string() }))
     .query(async ({ ctx, input }) => {
       await enforcePatientAccess(ctx.user, input.patientId);
-      const caller = fhirGatewayRouter.createCaller({ user: ctx.user });
+      const caller = fhirGatewayRouter.createCaller({ user: ctx.user, rbacVerified: true });
       return caller.exportPatient(input);
     }),
 
@@ -66,7 +66,7 @@ export const fhirRbacRouter = t.router({
     .input(z.object({ patientId: z.string(), resourceType: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       await enforcePatientAccess(ctx.user, input.patientId);
-      const caller = fhirGatewayRouter.createCaller({ user: ctx.user });
+      const caller = fhirGatewayRouter.createCaller({ user: ctx.user, rbacVerified: true });
       return caller.getByPatient(input);
     }),
 

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -93,17 +93,20 @@ async function main() {
   // Global rate limit: 100 requests per minute per IP across all API endpoints.
   // Protects PHI endpoints from enumeration and abuse.
   //
-  // The auth.login procedure gets a stricter per-IP limit of 5 req/min.
-  // At ~30 ms/scrypt check, the default would allow ~3300 guesses/second;
-  // this cap reduces that to 5 attempts per minute per IP.
+  // The auth.login procedure gets a stricter per-IP limit of 5 req/min
+  // in production. At ~30 ms/scrypt check, the default would allow
+  // ~3300 guesses/second; this cap reduces that to 5 attempts per minute
+  // per IP. In development, the login limit is raised to 60 req/min to
+  // avoid blocking manual and automated testing.
+  const isDev = process.env.NODE_ENV !== "production";
   await server.register(rateLimit, {
     global: true,
     max: (req, _key) => {
       if (req.url?.startsWith("/trpc/auth.login")) {
-        return 5;
+        return isDev ? 60 : 5;
       }
       if (req.url?.startsWith("/trpc/auth.refreshSession")) {
-        return 5;
+        return isDev ? 60 : 5;
       }
       return 100;
     },

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -98,14 +98,11 @@ async function main() {
   // ~3300 guesses/second; this cap reduces that to 5 attempts per minute
   // per IP. In development, the login limit is raised to 60 req/min to
   // avoid blocking manual and automated testing.
-  const isDev = process.env.NODE_ENV !== "production";
+  const isDev = process.env.NODE_ENV === "development";
   await server.register(rateLimit, {
     global: true,
     max: (req, _key) => {
-      if (req.url?.startsWith("/trpc/auth.login")) {
-        return isDev ? 60 : 5;
-      }
-      if (req.url?.startsWith("/trpc/auth.refreshSession")) {
+      if (req.url?.startsWith("/trpc/auth.login") || req.url?.startsWith("/trpc/auth.refreshSession")) {
         return isDev ? 60 : 5;
       }
       return 100;

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -176,4 +176,42 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
       ).resolves.toEqual([]);
     });
   });
+
+  describe("rbacVerified context flag (gateway RBAC pre-authorization)", () => {
+    const physicianUser = {
+      ...patientUser,
+      id: "user-physician-1",
+      role: "physician" as const,
+      specialty: "Hematology/Oncology",
+    };
+
+    it("allows a clinician through when rbacVerified is true", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+        rbacVerified: true,
+      });
+      await expect(
+        caller.getByPatient({ patientId: "any-patient" }),
+      ).resolves.toEqual([]);
+    });
+
+    it("still rejects a clinician when rbacVerified is false", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+        rbacVerified: false,
+      });
+      await expect(
+        caller.getByPatient({ patientId: "any-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("still rejects a clinician when rbacVerified is not set", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+      });
+      await expect(
+        caller.getByPatient({ patientId: "any-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
 });

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -185,7 +185,7 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
       specialty: "Hematology/Oncology",
     };
 
-    it("allows a clinician through when rbacVerified is true", async () => {
+    it("allows a clinician through getByPatient when rbacVerified is true", async () => {
       const caller = fhirGatewayRouter.createCaller({
         user: physicianUser,
         rbacVerified: true,
@@ -195,7 +195,7 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
       ).resolves.toEqual([]);
     });
 
-    it("still rejects a clinician when rbacVerified is false", async () => {
+    it("still rejects a clinician on getByPatient when rbacVerified is false", async () => {
       const caller = fhirGatewayRouter.createCaller({
         user: physicianUser,
         rbacVerified: false,
@@ -205,12 +205,43 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     });
 
-    it("still rejects a clinician when rbacVerified is not set", async () => {
+    it("still rejects a clinician on getByPatient when rbacVerified is not set", async () => {
       const caller = fhirGatewayRouter.createCaller({
         user: physicianUser,
       });
       await expect(
         caller.getByPatient({ patientId: "any-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("allows a clinician through exportPatient when rbacVerified is true", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+        rbacVerified: true,
+      });
+      // DB mock returns [] for patients, so exportPatient will throw NOT_FOUND
+      // — but NOT FORBIDDEN, proving the rbacVerified flag was accepted.
+      await expect(
+        caller.exportPatient({ patientId: "any-patient" }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("rejects a clinician on exportPatient when rbacVerified is false", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+        rbacVerified: false,
+      });
+      await expect(
+        caller.exportPatient({ patientId: "any-patient" }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects a clinician on exportPatient when rbacVerified is not set", async () => {
+      const caller = fhirGatewayRouter.createCaller({
+        user: physicianUser,
+      });
+      await expect(
+        caller.exportPatient({ patientId: "any-patient" }),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     });
   });

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -39,6 +39,12 @@ import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
  */
 export interface Context {
   user: User | null;
+  /**
+   * When true, the caller (api-gateway RBAC wrapper) has already verified
+   * care-team access for the target patient. The raw router's
+   * assertRawPatientAccess will skip its own restrictive check.
+   */
+  rbacVerified?: boolean;
 }
 
 const t = initTRPC.context<Context>().create();
@@ -92,6 +98,7 @@ const adminProcedure = t.procedure.use(isAdmin);
  * access. Per Copilot review on PR #379.
  *
  * Allowed:
+ *   - rbacVerified context flag: gateway already ran care-team check
  *   - admin role: full access
  *   - patient role: self-access only (user.id === patientId)
  *
@@ -103,7 +110,9 @@ const adminProcedure = t.procedure.use(isAdmin);
 function assertRawPatientAccess(
   user: User,
   patientId: string,
+  rbacVerified?: boolean,
 ): void {
+  if (rbacVerified) return;
   if (user.role === "admin") return;
   if (user.role === "patient" && user.id === patientId) return;
   throw new TRPCError({
@@ -202,7 +211,7 @@ export const fhirGatewayRouter = t.router({
   getByPatient: protectedProcedure
     .input(z.object({ patientId: z.string(), resourceType: z.string().optional() }))
     .query(async ({ ctx, input }) => {
-      assertRawPatientAccess(ctx.user, input.patientId);
+      assertRawPatientAccess(ctx.user, input.patientId, ctx.rbacVerified);
       const db = getDb();
       return db.select().from(fhirResources)
         .where(eq(fhirResources.patient_id, input.patientId));
@@ -211,7 +220,7 @@ export const fhirGatewayRouter = t.router({
   exportPatient: protectedProcedure
     .input(z.object({ patientId: z.string() }))
     .query(async ({ ctx, input }) => {
-      assertRawPatientAccess(ctx.user, input.patientId);
+      assertRawPatientAccess(ctx.user, input.patientId, ctx.rbacVerified);
       const db = getDb();
       const { patientId } = input;
 

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -98,8 +98,8 @@ const adminProcedure = t.procedure.use(isAdmin);
  * access. Per Copilot review on PR #379.
  *
  * Allowed:
+ *   - admin role: full access (unconditional)
  *   - rbacVerified context flag: gateway already ran care-team check
- *   - admin role: full access
  *   - patient role: self-access only (user.id === patientId)
  *
  * Clinicians (physician/specialist/nurse) are deliberately NOT allowed

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,24 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalPassThroughEnv": [
+    "DATABASE_URL",
+    "REDIS_URL",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_PASSWORD",
+    "PHI_ENCRYPTION_KEY",
+    "PHI_HMAC_KEY",
+    "SESSION_SECRET",
+    "JWT_SECRET",
+    "API_PORT",
+    "API_HOST",
+    "NODE_ENV",
+    "NEXT_PUBLIC_API_URL",
+    "CORS_ORIGIN",
+    "ANTHROPIC_API_KEY",
+    "HEALTH_PORT",
+    "CAREBRIDGE_DEV_AUTH"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- Register migrations 0005–0023 in the Drizzle journal so `pnpm db:migrate` applies them
- Add `globalPassThroughEnv` to `turbo.json` so env vars reach child processes during `turbo run dev`
- Fix FHIR export RBAC layering: clinicians authorized by the gateway wrapper were rejected by the raw router's defense-in-depth guard. Added `rbacVerified` context flag.
- Raise auth login rate limit from 5/min to 60/min in non-production environments

## Test plan
- [ ] `pnpm db:migrate` applies all 23 migrations on a clean DB
- [ ] `pnpm db:seed` succeeds
- [ ] `pnpm test` — all 30 suites pass (including 3 new FHIR RBAC tests)
- [ ] Clinician can call `fhir.exportPatient` and get a full FHIR R4 bundle
- [ ] Direct raw FHIR router callers (no `rbacVerified`) still blocked for clinicians
- [ ] Login rate limit is 60/min in dev, 5/min in production