### PR TITLE
fix(portal): resolve hydration mismatch, tRPC batch format, and Redis connect race

### DIFF
--- a/apps/clinician-portal/app/login/page.tsx
+++ b/apps/clinician-portal/app/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const [step, setStep] = useState<LoginStep>("credentials");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
   const { setSession } = useAuth();
 
@@ -128,15 +129,37 @@ export default function LoginPage() {
                 >
                   Password
                 </label>
-                <input
-                  id="password"
-                  type="password"
-                  className="search-input"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  style={{ width: "100%" }}
-                />
+                <div style={{ position: "relative" }}>
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    className="search-input"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    style={{ width: "100%", paddingRight: 40 }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((p) => !p)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    style={{
+                      position: "absolute",
+                      right: 8,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: 4,
+                      fontSize: 18,
+                      color: "var(--text-muted)",
+                      lineHeight: 1,
+                    }}
+                  >
+                    {showPassword ? "\u{1F648}" : "\u{1F441}"}
+                  </button>
+                </div>
               </div>
 
               {error && (

--- a/apps/clinician-portal/app/sidebar.tsx
+++ b/apps/clinician-portal/app/sidebar.tsx
@@ -29,7 +29,7 @@ function getInitials(name: string): string {
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { user, clearSession, isAuthenticated } = useAuth();
+  const { user, clearSession, isAuthenticated, hydrated } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
 
   async function handleLogout() {
@@ -42,7 +42,7 @@ export function Sidebar() {
     router.push("/login");
   }
 
-  if (!isAuthenticated) return null;
+  if (!isAuthenticated || !hydrated) return null;
 
   return (
     <>

--- a/apps/clinician-portal/src/lib/auth-guard.tsx
+++ b/apps/clinician-portal/src/lib/auth-guard.tsx
@@ -8,19 +8,19 @@ import { useAuth } from "./auth";
  * Wraps a page component and redirects to /login if not authenticated.
  */
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, hydrated } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (hydrated && !isAuthenticated) {
       router.replace("/login");
     }
-  }, [isAuthenticated, router]);
+  }, [hydrated, isAuthenticated, router]);
 
-  if (!isAuthenticated) {
+  if (!hydrated || !isAuthenticated) {
     return (
       <div style={{ padding: 40, color: "var(--text-muted)" }}>
-        Redirecting to login...
+        {hydrated ? "Redirecting to login..." : "Loading..."}
       </div>
     );
   }

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const [step, setStep] = useState<LoginStep>("credentials");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
   const { setSession } = useAuth();
 
@@ -154,14 +155,36 @@ export default function LoginPage() {
                 >
                   Password
                 </label>
-                <input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  style={inputStyle}
-                />
+                <div style={{ position: "relative" }}>
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    required
+                    style={{ ...inputStyle, paddingRight: 40 }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((p) => !p)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    style={{
+                      position: "absolute",
+                      right: 8,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: 4,
+                      fontSize: 18,
+                      color: "#999",
+                      lineHeight: 1,
+                    }}
+                  >
+                    {showPassword ? "\u{1F648}" : "\u{1F441}"}
+                  </button>
+                </div>
               </div>
 
               {error && (

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -178,7 +178,7 @@ export default function LoginPage() {
                       cursor: "pointer",
                       padding: 4,
                       fontSize: 18,
-                      color: "#999",
+                      color: "var(--text-muted, #999)",
                       lineHeight: 1,
                     }}
                   >

--- a/apps/patient-portal/app/page.tsx
+++ b/apps/patient-portal/app/page.tsx
@@ -213,19 +213,21 @@ function PatientDashboard() {
 }
 
 export default function PatientHome() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, hydrated } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (hydrated && !isAuthenticated) {
       router.replace("/login");
     }
-  }, [isAuthenticated, router]);
+  }, [hydrated, isAuthenticated, router]);
 
-  if (!isAuthenticated) {
+  if (!hydrated || !isAuthenticated) {
     return (
       <main>
-        <p style={{ color: "#999" }}>Redirecting to login...</p>
+        <p style={{ color: "#999" }}>
+          {hydrated ? "Redirecting to login..." : "Loading..."}
+        </p>
       </main>
     );
   }

--- a/packages/portal-shared/src/auth.tsx
+++ b/packages/portal-shared/src/auth.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useState, useCallback, useEffect } from "react";
 import type { ReactNode } from "react";
 
 export interface User {
@@ -22,6 +22,8 @@ export interface AuthContextValue {
   setSession: (user: User, sessionId: string) => void;
   clearSession: () => void;
   isAuthenticated: boolean;
+  /** True after the initial localStorage read completes on the client. */
+  hydrated: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -30,20 +32,20 @@ const SESSION_KEY = "carebridge_session";
 const USER_KEY = "carebridge_user";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<User | null>(() => {
-    if (typeof window === "undefined") return null;
+  // Initialize as null on both server and client to avoid hydration mismatch.
+  // localStorage is read in useEffect after the first client render.
+  const [user, setUser] = useState<User | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
     try {
       const stored = localStorage.getItem(USER_KEY);
-      return stored ? (JSON.parse(stored) as User) : null;
-    } catch {
-      return null;
-    }
-  });
-
-  const [sessionId, setSessionId] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(SESSION_KEY);
-  });
+      if (stored) setUser(JSON.parse(stored) as User);
+    } catch { /* corrupt data — stay logged out */ }
+    setSessionId(localStorage.getItem(SESSION_KEY));
+    setHydrated(true);
+  }, []);
 
   const setSession = useCallback((u: User, sid: string) => {
     localStorage.setItem(SESSION_KEY, sid);
@@ -67,6 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSession,
         clearSession,
         isAuthenticated: !!user && !!sessionId,
+        hydrated,
       }}
     >
       {children}

--- a/packages/portal-shared/src/auth.tsx
+++ b/packages/portal-shared/src/auth.tsx
@@ -42,8 +42,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const stored = localStorage.getItem(USER_KEY);
       if (stored) setUser(JSON.parse(stored) as User);
-    } catch { /* corrupt data — stay logged out */ }
-    setSessionId(localStorage.getItem(SESSION_KEY));
+      setSessionId(localStorage.getItem(SESSION_KEY));
+    } catch { /* corrupt / blocked storage — stay logged out */ }
     setHydrated(true);
   }, []);
 

--- a/packages/portal-shared/src/trpc.ts
+++ b/packages/portal-shared/src/trpc.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { createTRPCReact, httpBatchLink } from "@trpc/react-query";
-import { createTRPCClient, httpBatchLink as vanillaHttpBatchLink } from "@trpc/client";
+import { createTRPCReact, httpLink } from "@trpc/react-query";
+import { createTRPCClient, httpLink as vanillaHttpLink } from "@trpc/client";
 import type { AppRouter } from "@carebridge/api-gateway/src/router.js";
 
 /**
@@ -17,17 +17,25 @@ function getSessionToken(): string | undefined {
   return localStorage.getItem("carebridge_session") ?? undefined;
 }
 
+function getApiUrl(): string {
+  return process.env.NEXT_PUBLIC_API_URL
+    ? `${process.env.NEXT_PUBLIC_API_URL}/trpc`
+    : "http://localhost:4000/trpc";
+}
+
+function authHeaders() {
+  const token = getSessionToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 /**
  * Create links array for the tRPC React provider.
  */
 export function getTRPCLinks() {
   return [
-    httpBatchLink({
-      url: process.env.NEXT_PUBLIC_API_URL ? `${process.env.NEXT_PUBLIC_API_URL}/trpc` : "http://localhost:4000/trpc",
-      headers() {
-        const token = getSessionToken();
-        return token ? { Authorization: `Bearer ${token}` } : {};
-      },
+    httpLink({
+      url: getApiUrl(),
+      headers: authHeaders,
     }),
   ];
 }
@@ -37,12 +45,9 @@ export function getTRPCLinks() {
  */
 export const trpcVanilla = createTRPCClient<AppRouter>({
   links: [
-    vanillaHttpBatchLink({
-      url: process.env.NEXT_PUBLIC_API_URL ? `${process.env.NEXT_PUBLIC_API_URL}/trpc` : "http://localhost:4000/trpc",
-      headers() {
-        const token = getSessionToken();
-        return token ? { Authorization: `Bearer ${token}` } : {};
-      },
+    vanillaHttpLink({
+      url: getApiUrl(),
+      headers: authHeaders,
     }),
   ],
 });

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -52,6 +52,9 @@ function resolveCorsOrigins(): string[] {
 async function main() {
   const corsOrigins = resolveCorsOrigins();
   const redisClient = createRedisClient();
+  // Eagerly connect so the rate-limiter's first command doesn't race against
+  // lazy-connect and fail with "Stream isn't writeable" (enableOfflineQueue is false).
+  await redisClient.connect();
 
   const server = Fastify({
     logger: {


### PR DESCRIPTION
## Summary
- Switch tRPC client from `httpBatchLink` to `httpLink` — fixes "Unable to transform response from server" login error
- Fix SSR hydration error in sidebar by deferring localStorage reads to `useEffect` with `hydrated` flag
- Fix AuthGuard navigation loop — "Open Chart" no longer bounces back to login
- Eagerly connect Redis before rate limiter registration — fixes "Stream isn't writeable" 500 errors
- Add password visibility toggle (eye icon) to both portal login pages

## Test plan
- [ ] Login works on clinician portal (no "Unable to transform" error)
- [ ] No hydration error in browser console
- [ ] "Open Chart" navigates to patient detail without redirect loop
- [ ] Patient portal login works
- [ ] Password toggle shows/hides password on both portals
- [ ] `pnpm test` passes