### PR TITLE
feat(ai): add deterministic screening rules for patient observations

### DIFF
--- a/services/ai-oversight/src/__tests__/observation-screening.test.ts
+++ b/services/ai-oversight/src/__tests__/observation-screening.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { screenPatientObservation } from "../rules/observation-screening.js";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+/**
+ * Helper to build a patient.observation event with a given description.
+ */
+function makeObservationEvent(description: string): ClinicalEvent {
+  return {
+    id: "evt-obs-1",
+    type: "patient.observation",
+    patient_id: "p-1",
+    data: {
+      observation_id: "obs-1",
+      observation_type: "neurological",
+      observation_description: description,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+describe("screenPatientObservation", () => {
+  // ── Critical patterns ────────────────────────────────────────────
+
+  it("flags 'worst headache ever' as critical", () => {
+    const event = makeObservationEvent("I have the worst headache of my life");
+    const flags = screenPatientObservation(event);
+
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.rule_id).toBe("OBS-SEVERE-HEADACHE");
+    expect(flags[0]!.category).toBe("patient-reported");
+    expect(flags[0]!.notify_specialties).toContain("neurology");
+  });
+
+  it("flags 'worst headache' with surrounding text", () => {
+    const event = makeObservationEvent(
+      "Started having the worst headache around noon, still not going away",
+    );
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const headacheFlag = flags.find((f) => f.rule_id === "OBS-SEVERE-HEADACHE");
+    expect(headacheFlag).toBeDefined();
+    expect(headacheFlag!.severity).toBe("critical");
+  });
+
+  it("flags chest pain as critical", () => {
+    const event = makeObservationEvent("Having chest pain when I walk");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const chestFlag = flags.find((f) => f.rule_id === "OBS-CHEST-PAIN");
+    expect(chestFlag).toBeDefined();
+    expect(chestFlag!.severity).toBe("critical");
+  });
+
+  it("flags breathing difficulty as critical", () => {
+    const event = makeObservationEvent("I can't breathe well at night");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const breathFlag = flags.find((f) => f.rule_id === "OBS-BREATHING");
+    expect(breathFlag).toBeDefined();
+    expect(breathFlag!.severity).toBe("critical");
+  });
+
+  it("flags suicidal ideation as critical", () => {
+    const event = makeObservationEvent("I just want to die");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const suicidalFlag = flags.find((f) => f.rule_id === "OBS-SUICIDAL");
+    expect(suicidalFlag).toBeDefined();
+    expect(suicidalFlag!.severity).toBe("critical");
+    expect(suicidalFlag!.notify_specialties).toContain("psychiatry");
+  });
+
+  it("flags stroke symptoms as critical", () => {
+    const event = makeObservationEvent("I have slurred speech and sudden numbness on one side");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const strokeFlag = flags.find((f) => f.rule_id === "OBS-STROKE-SYMPTOMS");
+    expect(strokeFlag).toBeDefined();
+    expect(strokeFlag!.severity).toBe("critical");
+  });
+
+  // ── High/warning patterns ────────────────────────────────────────
+
+  it("flags 'blood in stool' as warning", () => {
+    const event = makeObservationEvent("I noticed blood in stool this morning");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const bleedFlag = flags.find((f) => f.rule_id === "OBS-BLEEDING");
+    expect(bleedFlag).toBeDefined();
+    expect(bleedFlag!.severity).toBe("warning");
+  });
+
+  it("flags severe pain as warning", () => {
+    const event = makeObservationEvent("Experiencing severe pain in my lower back");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const painFlag = flags.find((f) => f.rule_id === "OBS-SEVERE-PAIN");
+    expect(painFlag).toBeDefined();
+    expect(painFlag!.severity).toBe("warning");
+  });
+
+  it("flags fainting as warning", () => {
+    const event = makeObservationEvent("I fainted twice today");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const faintFlag = flags.find((f) => f.rule_id === "OBS-FAINTING");
+    expect(faintFlag).toBeDefined();
+    expect(faintFlag!.severity).toBe("warning");
+  });
+
+  it("flags seizure as warning", () => {
+    const event = makeObservationEvent("I had what I think was a seizure");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const seizureFlag = flags.find((f) => f.rule_id === "OBS-SEIZURE");
+    expect(seizureFlag).toBeDefined();
+    expect(seizureFlag!.severity).toBe("warning");
+  });
+
+  it("flags high fever as warning", () => {
+    const event = makeObservationEvent("I have a high fever that won't go down");
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(1);
+    const feverFlag = flags.find((f) => f.rule_id === "OBS-HIGH-FEVER");
+    expect(feverFlag).toBeDefined();
+    expect(feverFlag!.severity).toBe("warning");
+  });
+
+  // ── No-match cases ───────────────────────────────────────────────
+
+  it("returns no flags for 'mild nausea'", () => {
+    const event = makeObservationEvent("Feeling a bit of mild nausea after meals");
+    const flags = screenPatientObservation(event);
+
+    expect(flags).toHaveLength(0);
+  });
+
+  it("returns no flags for benign observation", () => {
+    const event = makeObservationEvent("Slept well last night, appetite is improving");
+    const flags = screenPatientObservation(event);
+
+    expect(flags).toHaveLength(0);
+  });
+
+  it("returns no flags for empty description", () => {
+    const event: ClinicalEvent = {
+      id: "evt-obs-empty",
+      type: "patient.observation",
+      patient_id: "p-1",
+      data: {
+        observation_id: "obs-2",
+        observation_type: "general",
+      },
+      timestamp: new Date().toISOString(),
+    };
+    const flags = screenPatientObservation(event);
+
+    expect(flags).toHaveLength(0);
+  });
+
+  // ── Multiple matches ─────────────────────────────────────────────
+
+  it("returns multiple flags when description matches several patterns", () => {
+    const event = makeObservationEvent(
+      "Having chest pain, can't breathe, and the worst headache of my life",
+    );
+    const flags = screenPatientObservation(event);
+
+    expect(flags.length).toBeGreaterThanOrEqual(3);
+
+    const ruleIds = flags.map((f) => f.rule_id);
+    expect(ruleIds).toContain("OBS-CHEST-PAIN");
+    expect(ruleIds).toContain("OBS-BREATHING");
+    expect(ruleIds).toContain("OBS-SEVERE-HEADACHE");
+  });
+
+  // ── Works without LLM ────────────────────────────────────────────
+
+  it("operates purely on keyword matching with no external dependencies", () => {
+    // This test verifies the function is self-contained and deterministic.
+    // No mocks needed — it does not call any API or database.
+    const event = makeObservationEvent("kill myself");
+    const flags = screenPatientObservation(event);
+
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.rule_id).toBe("OBS-SUICIDAL");
+  });
+});

--- a/services/ai-oversight/src/__tests__/observation-screening.test.ts
+++ b/services/ai-oversight/src/__tests__/observation-screening.test.ts
@@ -88,14 +88,14 @@ describe("screenPatientObservation", () => {
 
   // ── High/warning patterns ────────────────────────────────────────
 
-  it("flags 'blood in stool' as warning", () => {
+  it("flags 'blood in stool' as critical", () => {
     const event = makeObservationEvent("I noticed blood in stool this morning");
     const flags = screenPatientObservation(event);
 
     expect(flags.length).toBeGreaterThanOrEqual(1);
     const bleedFlag = flags.find((f) => f.rule_id === "OBS-BLEEDING");
     expect(bleedFlag).toBeDefined();
-    expect(bleedFlag!.severity).toBe("warning");
+    expect(bleedFlag!.severity).toBe("critical");
   });
 
   it("flags severe pain as warning", () => {

--- a/services/ai-oversight/src/rules/observation-screening.ts
+++ b/services/ai-oversight/src/rules/observation-screening.ts
@@ -1,0 +1,214 @@
+/**
+ * Patient observation screening rules.
+ *
+ * Screens patient-reported observations (symptom journal) for urgent clinical
+ * signals using deterministic keyword matching. This ensures critical symptoms
+ * like "worst headache of my life" are flagged even when the LLM layer is
+ * unavailable or delayed.
+ *
+ * Applies the same urgent keyword patterns used for message screening, but
+ * targets the observation `description` field. Only fires on
+ * `patient.observation` events.
+ */
+
+import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
+import type { RuleFlag } from "./critical-values.js";
+
+interface ObservationKeywordPattern {
+  id: string;
+  pattern: RegExp;
+  severity: FlagSeverity;
+  summary: string;
+  rationale: string;
+  suggested_action: string;
+  notify_specialties: string[];
+}
+
+/**
+ * Critical keyword patterns — symptoms that demand immediate clinical review.
+ */
+const CRITICAL_PATTERNS: ObservationKeywordPattern[] = [
+  {
+    id: "OBS-CHEST-PAIN",
+    pattern: /chest\s*pain|chest\s*tightness|chest\s*pressure|angina/i,
+    severity: "critical",
+    summary: "Patient reports chest pain/pressure in symptom journal",
+    rationale:
+      "Patient described chest pain or pressure symptoms in a symptom observation. " +
+      "This could indicate acute coronary syndrome, pulmonary embolism, or other " +
+      "cardiac emergency requiring immediate evaluation.",
+    suggested_action:
+      "Contact patient immediately. If symptoms are active, advise calling 911. " +
+      "Assess onset, duration, severity, and associated symptoms.",
+    notify_specialties: ["cardiology"],
+  },
+  {
+    id: "OBS-BREATHING",
+    pattern: /can'?t\s*breathe|difficulty\s*breathing|short(ness)?\s*(of)?\s*breath|severe\s*sob|gasping/i,
+    severity: "critical",
+    summary: "Patient reports difficulty breathing in symptom journal",
+    rationale:
+      "Patient described respiratory distress in a symptom observation. This could indicate " +
+      "pulmonary embolism, CHF exacerbation, severe asthma attack, or other respiratory emergency.",
+    suggested_action:
+      "Contact patient immediately. If active respiratory distress, advise calling 911. " +
+      "Assess oxygen saturation if available, onset, and progression.",
+    notify_specialties: ["pulmonology"],
+  },
+  {
+    id: "OBS-SEVERE-HEADACHE",
+    pattern: /worst\s*headache|thunderclap\s*headache|sudden\s*severe\s*headache|worst\s*head\s*pain/i,
+    severity: "critical",
+    summary: "Patient reports sudden severe headache in symptom journal",
+    rationale:
+      "Patient described a sudden severe or 'worst ever' headache. This pattern is concerning for " +
+      "subarachnoid hemorrhage, cerebral venous thrombosis, or other intracranial emergency. " +
+      "Particularly dangerous in patients with DVT/VTE history or anticoagulation.",
+    suggested_action:
+      "Contact patient immediately. Consider emergent CT/CTA. If patient is on anticoagulation " +
+      "or has VTE history, this is a neurovascular emergency until proven otherwise.",
+    notify_specialties: ["neurology"],
+  },
+  {
+    id: "OBS-STROKE-SYMPTOMS",
+    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my|arm|leg)/i,
+    severity: "critical",
+    summary: "Patient describes possible stroke symptoms in symptom journal",
+    rationale:
+      "Patient described symptoms consistent with acute stroke (FAST criteria: face droop, " +
+      "arm weakness, speech difficulty). Time-sensitive — every minute matters for thrombolysis eligibility.",
+    suggested_action:
+      "IMMEDIATE: If symptoms are current, advise calling 911 immediately. " +
+      "Document last known well time. Do not delay for further assessment.",
+    notify_specialties: ["neurology"],
+  },
+  {
+    id: "OBS-SUICIDAL",
+    pattern: /suicid|want\s*to\s*die|kill\s*myself|end\s*(my|it)\s*(life|all)|don'?t\s*want\s*to\s*live|no\s*reason\s*to\s*live/i,
+    severity: "critical",
+    summary: "Patient expresses suicidal ideation in symptom journal",
+    rationale:
+      "Patient's observation contains language suggesting suicidal ideation. This requires " +
+      "immediate clinical assessment and safety planning regardless of other conditions.",
+    suggested_action:
+      "IMMEDIATE: Contact patient by phone. Assess imminent risk. If unable to reach, " +
+      "consider welfare check. Involve behavioral health crisis team. Document safety plan.",
+    notify_specialties: ["psychiatry"],
+  },
+  {
+    id: "OBS-ALLERGIC-REACTION",
+    pattern: /swelling\s*(of\s*)?(my\s*)?(face|throat|tongue|lips)|anaphyla|throat\s*(closing|swelling|tight)|hives\s*all\s*over|can'?t\s*swallow/i,
+    severity: "critical",
+    summary: "Patient describes possible anaphylaxis/allergic reaction in symptom journal",
+    rationale:
+      "Patient described symptoms consistent with severe allergic reaction or anaphylaxis. " +
+      "This is a medical emergency requiring immediate intervention.",
+    suggested_action:
+      "IMMEDIATE: If symptoms are active, advise calling 911 and using epinephrine auto-injector if available. " +
+      "Review current medications for potential culprit.",
+    notify_specialties: [],
+  },
+];
+
+/**
+ * High-severity keyword patterns — urgent but not immediately life-threatening.
+ */
+const HIGH_PATTERNS: ObservationKeywordPattern[] = [
+  {
+    id: "OBS-BLEEDING",
+    pattern: /blood\s*in\s*(stool|urine|vomit)|coughing\s*(up\s*)?blood|bleeding\s*(a\s*lot|heavily|won'?t\s*stop)|hemoptysis|hematuria|melena|hematemesis/i,
+    severity: "warning",
+    summary: "Patient reports significant bleeding in symptom journal",
+    rationale:
+      "Patient described significant bleeding symptoms. This is particularly dangerous in patients " +
+      "on anticoagulants, post-procedure, or with known bleeding disorders.",
+    suggested_action:
+      "Contact patient to assess volume and duration. Check current medications for anticoagulants. " +
+      "Consider ED referral if hemodynamically significant.",
+    notify_specialties: ["hematology"],
+  },
+  {
+    id: "OBS-SEVERE-PAIN",
+    pattern: /severe\s*pain|excruciating|unbearable\s*pain|10\s*out\s*of\s*10|10\/10\s*pain/i,
+    severity: "warning",
+    summary: "Patient reports severe pain in symptom journal",
+    rationale:
+      "Patient described severe or excruciating pain. Uncontrolled severe pain warrants " +
+      "prompt clinical reassessment of diagnosis and pain management plan.",
+    suggested_action:
+      "Contact patient to assess pain location, quality, and associated symptoms. " +
+      "Consider whether current analgesic regimen is adequate.",
+    notify_specialties: [],
+  },
+  {
+    id: "OBS-FAINTING",
+    pattern: /faint(ed|ing)|passed?\s*out|lost?\s*consciousness|syncop/i,
+    severity: "warning",
+    summary: "Patient reports fainting/syncope in symptom journal",
+    rationale:
+      "Patient described syncope or near-syncope. This may indicate cardiac arrhythmia, " +
+      "orthostatic hypotension, vasovagal episode, or neurological event.",
+    suggested_action:
+      "Contact patient to assess circumstances, frequency, and associated symptoms. " +
+      "Consider cardiac workup and medication review.",
+    notify_specialties: ["cardiology"],
+  },
+  {
+    id: "OBS-SEIZURE",
+    pattern: /seizure|convuls|shaking\s*uncontrollably|epilep/i,
+    severity: "warning",
+    summary: "Patient reports seizure activity in symptom journal",
+    rationale:
+      "Patient described seizure or convulsion activity. New-onset seizures require " +
+      "urgent neurological evaluation to rule out structural or metabolic causes.",
+    suggested_action:
+      "Contact patient urgently. Assess whether seizure is new-onset or breakthrough. " +
+      "Consider neuroimaging if new-onset. Review medications for seizure threshold effects.",
+    notify_specialties: ["neurology"],
+  },
+  {
+    id: "OBS-HIGH-FEVER",
+    pattern: /high\s*fever|temperature\s*(of\s*)?(10[3-9]|1[1-9]\d)|fever\s*(won'?t|doesn'?t|not)\s*(go\s*down|break|respond)/i,
+    severity: "warning",
+    summary: "Patient reports high or persistent fever in symptom journal",
+    rationale:
+      "Patient reported high or unresponsive fever. In immunocompromised patients " +
+      "(chemotherapy, transplant, HIV), this can indicate febrile neutropenia or serious infection.",
+    suggested_action:
+      "Check patient's medication list for chemotherapy/immunosuppressants. " +
+      "If immunocompromised, treat as potential febrile neutropenia — advise ED evaluation.",
+    notify_specialties: ["oncology", "infectious_disease"],
+  },
+];
+
+const ALL_PATTERNS = [...CRITICAL_PATTERNS, ...HIGH_PATTERNS];
+
+/**
+ * Screen a patient observation for urgent symptoms.
+ *
+ * Checks the observation description text against urgent keyword patterns
+ * and returns clinical flags for any matches.
+ */
+export function screenPatientObservation(event: ClinicalEvent): RuleFlag[] {
+  const flags: RuleFlag[] = [];
+
+  const description = (event.data.observation_description as string) ?? "";
+
+  if (!description) return flags;
+
+  for (const entry of ALL_PATTERNS) {
+    if (entry.pattern.test(description)) {
+      flags.push({
+        severity: entry.severity,
+        category: "patient-reported" as FlagCategory,
+        summary: entry.summary,
+        rationale: entry.rationale,
+        suggested_action: entry.suggested_action,
+        notify_specialties: entry.notify_specialties,
+        rule_id: entry.id,
+      });
+    }
+  }
+
+  return flags;
+}

--- a/services/ai-oversight/src/rules/observation-screening.ts
+++ b/services/ai-oversight/src/rules/observation-screening.ts
@@ -6,8 +6,8 @@
  * like "worst headache of my life" are flagged even when the LLM layer is
  * unavailable or delayed.
  *
- * Applies the same urgent keyword patterns used for message screening, but
- * targets the observation `description` field. Only fires on
+ * Uses observation-specific keyword patterns (critical and warning tiers)
+ * targeting the observation `description` field. Only fires on
  * `patient.observation` events.
  */
 
@@ -71,7 +71,7 @@ const CRITICAL_PATTERNS: ObservationKeywordPattern[] = [
   },
   {
     id: "OBS-STROKE-SYMPTOMS",
-    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my|arm|leg)/i,
+    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my\s*)?(arm|leg)\b/i,
     severity: "critical",
     summary: "Patient describes possible stroke symptoms in symptom journal",
     rationale:
@@ -117,7 +117,7 @@ const HIGH_PATTERNS: ObservationKeywordPattern[] = [
   {
     id: "OBS-BLEEDING",
     pattern: /blood\s*in\s*(stool|urine|vomit)|coughing\s*(up\s*)?blood|bleeding\s*(a\s*lot|heavily|won'?t\s*stop)|hemoptysis|hematuria|melena|hematemesis/i,
-    severity: "warning",
+    severity: "critical",
     summary: "Patient reports significant bleeding in symptom journal",
     rationale:
       "Patient described significant bleeding symptoms. This is particularly dangerous in patients " +
@@ -200,7 +200,7 @@ export function screenPatientObservation(event: ClinicalEvent): RuleFlag[] {
     if (entry.pattern.test(description)) {
       flags.push({
         severity: entry.severity,
-        category: "patient-reported" as FlagCategory,
+        category: "patient-reported",
         summary: entry.summary,
         rationale: entry.rationale,
         suggested_action: entry.suggested_action,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -40,6 +40,7 @@ import { checkCrossSpecialtyPatterns } from "../rules/cross-specialty.js";
 import type { PatientContext } from "../rules/cross-specialty.js";
 import { checkDrugInteractions } from "../rules/drug-interactions.js";
 import { screenPatientMessage } from "../rules/message-screening.js";
+import { screenPatientObservation } from "../rules/observation-screening.js";
 import { checkAllergyMedication } from "../rules/allergy-medication.js";
 import type { RuleFlag } from "../rules/critical-values.js";
 import { buildPatientContext } from "../workers/context-builder.js";
@@ -135,8 +136,8 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
     }
 
     // 2f. Patient observation screening (only for patient.observation events)
-    // Same keyword patterns as message screening, applied to observation descriptions.
-    // Ensures the symptom journal has deterministic safety coverage even when LLM is unavailable.
+    // Dedicated keyword rules for observation descriptions (symptom journal).
+    // Ensures deterministic safety coverage even when the LLM layer is unavailable.
     if (event.type === "patient.observation" && event.data.observation_id) {
       rulesEvaluated.push("observation-screening");
 
@@ -148,9 +149,9 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
       if (obs?.description) {
         const enrichedEvent = {
           ...event,
-          data: { ...event.data, message_text: obs.description, sender_role: "patient" },
+          data: { ...event.data, observation_description: obs.description },
         };
-        const obsFlags = screenPatientMessage(enrichedEvent);
+        const obsFlags = screenPatientObservation(enrichedEvent);
         if (obsFlags.length > 0) {
           rulesFired.push("observation-screening");
           allRuleFlags.push(...obsFlags);


### PR DESCRIPTION
## Summary
- Add keyword-based deterministic screening for patient symptom journal observations (`patientObservations`) so critical symptoms are flagged even when the LLM review layer is unavailable
- Create `observation-screening.ts` with critical patterns (chest pain, breathing difficulty, worst headache, stroke symptoms, suicidal ideation, anaphylaxis) and warning patterns (bleeding, severe pain, fainting, seizure, high fever)
- Wire `screenPatientObservation` into the review pipeline for `patient.observation` events, replacing the previous inline approach that reused `screenPatientMessage` with synthetic data reshaping

## Test plan
- [x] "worst headache ever" triggers critical flag with OBS-SEVERE-HEADACHE rule
- [x] "mild nausea" produces no flags
- [x] Multiple patterns in one description produce multiple flags
- [x] Empty description produces no flags
- [x] All 16 tests pass: `pnpm --filter @carebridge/ai-oversight test`
- [x] Full build succeeds: `npx turbo build --filter=@carebridge/ai-oversight`

Closes #403