### PR TITLE
feat(clinical): add create/update procedures for diagnoses and allergies

### DIFF
--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -101,6 +101,7 @@ export type ClinicalEventType =
   | "diagnosis.added"
   | "diagnosis.updated"
   | "allergy.added"
+  | "allergy.updated"
   | "fhir.imported"
   | "message.received"
   | "patient.observation";

--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -99,6 +99,8 @@ export type ClinicalEventType =
   | "note.signed"
   | "procedure.completed"
   | "diagnosis.added"
+  | "diagnosis.updated"
+  | "allergy.added"
   | "fhir.imported"
   | "message.received"
   | "patient.observation";

--- a/packages/validators/src/__tests__/diagnoses-allergies.test.ts
+++ b/packages/validators/src/__tests__/diagnoses-allergies.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import {
+  createDiagnosisSchema,
+  updateDiagnosisSchema,
+  diagnosisStatusSchema,
+  createAllergySchema,
+  updateAllergySchema,
+  allergySeveritySchema,
+} from "../clinical-data.js";
+
+// ─── Diagnosis Validators ──────────────────────────────────────
+
+describe("createDiagnosisSchema", () => {
+  const validDiagnosis = {
+    patient_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    icd10_code: "C50.9",
+    description: "Breast cancer, unspecified",
+    status: "active" as const,
+  };
+
+  it("accepts valid diagnosis with required fields", () => {
+    const result = createDiagnosisSchema.safeParse(validDiagnosis);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid diagnosis with all optional fields", () => {
+    const result = createDiagnosisSchema.safeParse({
+      ...validDiagnosis,
+      onset_date: "2024-01-15",
+      snomed_code: "254837009",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults status to active", () => {
+    const { status, ...withoutStatus } = validDiagnosis;
+    const result = createDiagnosisSchema.safeParse(withoutStatus);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.status).toBe("active");
+    }
+  });
+
+  it("rejects missing patient_id", () => {
+    const { patient_id, ...rest } = validDiagnosis;
+    const result = createDiagnosisSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid patient_id (not UUID)", () => {
+    const result = createDiagnosisSchema.safeParse({
+      ...validDiagnosis,
+      patient_id: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid ICD-10 code", () => {
+    const invalidCodes = ["abc", "123", "C5", "c50.9"];
+    for (const code of invalidCodes) {
+      const result = createDiagnosisSchema.safeParse({
+        ...validDiagnosis,
+        icd10_code: code,
+      });
+      expect(result.success, `Expected "${code}" to fail`).toBe(false);
+    }
+  });
+
+  it("accepts valid ICD-10 codes", () => {
+    const validCodes = ["C50", "A01", "C50.9", "C50.911"];
+    for (const code of validCodes) {
+      const result = createDiagnosisSchema.safeParse({
+        ...validDiagnosis,
+        icd10_code: code,
+      });
+      expect(result.success, `Expected "${code}" to pass`).toBe(true);
+    }
+  });
+
+  it("rejects empty description", () => {
+    const result = createDiagnosisSchema.safeParse({
+      ...validDiagnosis,
+      description: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects description exceeding 2000 chars", () => {
+    const result = createDiagnosisSchema.safeParse({
+      ...validDiagnosis,
+      description: "X".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid onset_date format", () => {
+    const result = createDiagnosisSchema.safeParse({
+      ...validDiagnosis,
+      onset_date: "01/15/2024",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid diagnosis statuses", () => {
+    for (const status of ["active", "chronic", "resolved"]) {
+      const result = diagnosisStatusSchema.safeParse(status);
+      expect(result.success, `Expected status "${status}" to pass`).toBe(true);
+    }
+  });
+
+  it("rejects invalid diagnosis status", () => {
+    const result = diagnosisStatusSchema.safeParse("pending");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateDiagnosisSchema", () => {
+  it("accepts partial update with status only", () => {
+    const result = updateDiagnosisSchema.safeParse({ status: "resolved" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts partial update with description only", () => {
+    const result = updateDiagnosisSchema.safeParse({ description: "Updated description" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty object (no updates)", () => {
+    const result = updateDiagnosisSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid status value", () => {
+    const result = updateDiagnosisSchema.safeParse({ status: "invalid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Allergy Validators ────────────────────────────────────────
+
+describe("createAllergySchema", () => {
+  const validAllergy = {
+    patient_id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    allergen: "Penicillin",
+    reaction: "Hives and swelling",
+    severity: "moderate" as const,
+  };
+
+  it("accepts valid allergy with all required fields", () => {
+    const result = createAllergySchema.safeParse(validAllergy);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing allergen", () => {
+    const { allergen, ...rest } = validAllergy;
+    const result = createAllergySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty allergen", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      allergen: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects allergen exceeding 200 chars", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      allergen: "A".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing reaction", () => {
+    const { reaction, ...rest } = validAllergy;
+    const result = createAllergySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects reaction exceeding 500 chars", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      reaction: "R".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing severity", () => {
+    const { severity, ...rest } = validAllergy;
+    const result = createAllergySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid severity levels", () => {
+    for (const severity of ["mild", "moderate", "severe", "critical"]) {
+      const result = allergySeveritySchema.safeParse(severity);
+      expect(result.success, `Expected severity "${severity}" to pass`).toBe(true);
+    }
+  });
+
+  it("rejects invalid severity value", () => {
+    const result = allergySeveritySchema.safeParse("extreme");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid patient_id", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      patient_id: "not-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateAllergySchema", () => {
+  it("accepts partial update with severity only", () => {
+    const result = updateAllergySchema.safeParse({ severity: "severe" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts partial update with reaction only", () => {
+    const result = updateAllergySchema.safeParse({ reaction: "Updated reaction" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty object (no updates)", () => {
+    const result = updateAllergySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid severity value", () => {
+    const result = updateAllergySchema.safeParse({ severity: "invalid" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validators/src/clinical-data.ts
+++ b/packages/validators/src/clinical-data.ts
@@ -92,7 +92,7 @@ export const diagnosisStatusSchema = z.enum(["active", "chronic", "resolved"]);
 
 export const createDiagnosisSchema = z.object({
   patient_id: z.string().uuid(),
-  icd10_code: z.string().regex(/^[A-Z]\d{2}(\.\d{1,4})?$/, "Invalid ICD-10-CM code format"),
+  icd10_code: icd10CodeSchema,
   description: z.string().min(1).max(2000),
   status: diagnosisStatusSchema.default("active"),
   onset_date: z.string().date().optional(),

--- a/packages/validators/src/clinical-data.ts
+++ b/packages/validators/src/clinical-data.ts
@@ -86,6 +86,46 @@ export const createLabPanelSchema = z.object({
 
 export type CreateLabPanelInput = z.infer<typeof createLabPanelSchema>;
 
+// ─── Diagnoses ──────────────────────────────────────────────────
+
+export const diagnosisStatusSchema = z.enum(["active", "chronic", "resolved"]);
+
+export const createDiagnosisSchema = z.object({
+  patient_id: z.string().uuid(),
+  icd10_code: z.string().regex(/^[A-Z]\d{2}(\.\d{1,4})?$/, "Invalid ICD-10-CM code format"),
+  description: z.string().min(1).max(2000),
+  status: diagnosisStatusSchema.default("active"),
+  onset_date: z.string().date().optional(),
+  snomed_code: z.string().max(20).optional(),
+});
+
+export const updateDiagnosisSchema = z.object({
+  status: diagnosisStatusSchema.optional(),
+  description: z.string().min(1).max(2000).optional(),
+});
+
+export type CreateDiagnosisInput = z.infer<typeof createDiagnosisSchema>;
+export type UpdateDiagnosisInput = z.infer<typeof updateDiagnosisSchema>;
+
+// ─── Allergies ──────────────────────────────────────────────────
+
+export const allergySeveritySchema = z.enum(["mild", "moderate", "severe", "critical"]);
+
+export const createAllergySchema = z.object({
+  patient_id: z.string().uuid(),
+  allergen: z.string().min(1).max(200),
+  reaction: z.string().min(1).max(500),
+  severity: allergySeveritySchema,
+});
+
+export const updateAllergySchema = z.object({
+  severity: allergySeveritySchema.optional(),
+  reaction: z.string().min(1).max(500).optional(),
+});
+
+export type CreateAllergyInput = z.infer<typeof createAllergySchema>;
+export type UpdateAllergyInput = z.infer<typeof updateAllergySchema>;
+
 // ─── Procedures ──────────────────────────────────────────────────
 
 export const procedureStatusSchema = z.enum(["scheduled", "in_progress", "completed", "cancelled"]);

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -3,3 +3,4 @@ export * from "./clinical-data.js";
 export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";
+

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -20,7 +20,17 @@ import { createPatientSchema, updatePatientSchema } from "@carebridge/validators
 import {
   listObservationsByPatient,
   createObservation,
+  createDiagnosis,
+  updateDiagnosis,
+  createAllergy,
+  updateAllergy,
 } from "@carebridge/patient-records";
+import {
+  createDiagnosisSchema,
+  updateDiagnosisSchema,
+  createAllergySchema,
+  updateAllergySchema,
+} from "@carebridge/validators";
 import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
@@ -146,6 +156,31 @@ export const patientRecordsRbacRouter = t.router({
           .from(diagnoses)
           .where(eq(diagnoses.patient_id, input.patientId));
       }),
+
+    create: protectedProcedure
+      .input(createDiagnosisSchema)
+      .mutation(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patient_id);
+        return createDiagnosis(input);
+      }),
+
+    update: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }).merge(updateDiagnosisSchema))
+      .mutation(async ({ ctx, input }) => {
+        const { id, ...data } = input;
+        // Look up the diagnosis to get the patient_id for access check
+        const db = getDb();
+        const [existing] = await db
+          .select()
+          .from(diagnoses)
+          .where(eq(diagnoses.id, id))
+          .limit(1);
+        if (!existing) {
+          throw new TRPCError({ code: "NOT_FOUND", message: `Diagnosis ${id} not found` });
+        }
+        await enforcePatientAccess(ctx.user, existing.patient_id);
+        return updateDiagnosis(id, data);
+      }),
   }),
 
   allergies: t.router({
@@ -158,6 +193,30 @@ export const patientRecordsRbacRouter = t.router({
           .select()
           .from(allergies)
           .where(eq(allergies.patient_id, input.patientId));
+      }),
+
+    create: protectedProcedure
+      .input(createAllergySchema)
+      .mutation(async ({ ctx, input }) => {
+        await enforcePatientAccess(ctx.user, input.patient_id);
+        return createAllergy(input);
+      }),
+
+    update: protectedProcedure
+      .input(z.object({ id: z.string().uuid() }).merge(updateAllergySchema))
+      .mutation(async ({ ctx, input }) => {
+        const { id, ...data } = input;
+        const db = getDb();
+        const [existing] = await db
+          .select()
+          .from(allergies)
+          .where(eq(allergies.id, id))
+          .limit(1);
+        if (!existing) {
+          throw new TRPCError({ code: "NOT_FOUND", message: `Allergy ${id} not found` });
+        }
+        await enforcePatientAccess(ctx.user, existing.patient_id);
+        return updateAllergy(id, data);
       }),
   }),
 

--- a/services/patient-records/src/index.ts
+++ b/services/patient-records/src/index.ts
@@ -4,4 +4,8 @@ export {
   listObservationsByPatient,
   createObservation,
   type ObservationCreateInput,
+  createDiagnosis,
+  updateDiagnosis,
+  createAllergy,
+  updateAllergy,
 } from "./router.js";

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -2,7 +2,14 @@ import { initTRPC } from "@trpc/server";
 import { z } from "zod";
 import { getDb, hmacForIndex } from "@carebridge/db-schema";
 import { patients, diagnoses, allergies, careTeamMembers, patientObservations } from "@carebridge/db-schema";
-import { createPatientSchema, updatePatientSchema } from "@carebridge/validators";
+import {
+  createPatientSchema,
+  updatePatientSchema,
+  createDiagnosisSchema,
+  updateDiagnosisSchema,
+  createAllergySchema,
+  updateAllergySchema,
+} from "@carebridge/validators";
 import { eq, desc } from "drizzle-orm";
 import { Queue } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
@@ -54,12 +61,20 @@ export const patientRecordsRouter = t.router({
     return db.select().from(patients);
   }),
 
-  // Stub: diagnoses, allergies, care team
   diagnoses: t.router({
     getByPatient: t.procedure.input(z.object({ patientId: z.string() })).query(async ({ input }) => {
       const db = getDb();
       return db.select().from(diagnoses).where(eq(diagnoses.patient_id, input.patientId));
     }),
+    create: t.procedure.input(createDiagnosisSchema).mutation(async ({ input }) => {
+      return createDiagnosis(input);
+    }),
+    update: t.procedure
+      .input(z.object({ id: z.string().uuid() }).merge(updateDiagnosisSchema))
+      .mutation(async ({ input }) => {
+        const { id, ...data } = input;
+        return updateDiagnosis(id, data);
+      }),
   }),
 
   allergies: t.router({
@@ -67,6 +82,15 @@ export const patientRecordsRouter = t.router({
       const db = getDb();
       return db.select().from(allergies).where(eq(allergies.patient_id, input.patientId));
     }),
+    create: t.procedure.input(createAllergySchema).mutation(async ({ input }) => {
+      return createAllergy(input);
+    }),
+    update: t.procedure
+      .input(z.object({ id: z.string().uuid() }).merge(updateAllergySchema))
+      .mutation(async ({ input }) => {
+        const { id, ...data } = input;
+        return updateAllergy(id, data);
+      }),
   }),
 
   careTeam: t.router({
@@ -196,6 +220,129 @@ export async function createObservation(input: ObservationCreateInput) {
   });
 
   return observation;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnosis helpers
+// ---------------------------------------------------------------------------
+
+export async function createDiagnosis(input: z.infer<typeof createDiagnosisSchema>) {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+
+  const record = {
+    id,
+    patient_id: input.patient_id,
+    icd10_code: input.icd10_code,
+    description: input.description,
+    status: input.status ?? "active",
+    onset_date: input.onset_date ?? null,
+    snomed_code: input.snomed_code ?? null,
+    created_at: now,
+  };
+
+  await db.insert(diagnoses).values(record);
+
+  await clinicalEventsQueue.add("diagnosis.added", {
+    id: crypto.randomUUID(),
+    type: "diagnosis.added",
+    patient_id: input.patient_id,
+    data: { resourceId: id, icd10_code: input.icd10_code, status: record.status },
+    timestamp: now,
+  });
+
+  return record;
+}
+
+export async function updateDiagnosis(
+  id: string,
+  input: z.infer<typeof updateDiagnosisSchema>,
+) {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const [existing] = await db.select().from(diagnoses).where(eq(diagnoses.id, id)).limit(1);
+  if (!existing) {
+    throw new Error(`Diagnosis ${id} not found`);
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (input.status !== undefined) updates.status = input.status;
+  if (input.description !== undefined) updates.description = input.description;
+
+  if (Object.keys(updates).length === 0) {
+    return existing;
+  }
+
+  await db.update(diagnoses).set(updates).where(eq(diagnoses.id, id));
+
+  await clinicalEventsQueue.add("diagnosis.updated", {
+    id: crypto.randomUUID(),
+    type: "diagnosis.updated",
+    patient_id: existing.patient_id,
+    data: { resourceId: id, changedFields: Object.keys(updates) },
+    timestamp: now,
+  });
+
+  const [updated] = await db.select().from(diagnoses).where(eq(diagnoses.id, id)).limit(1);
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Allergy helpers
+// ---------------------------------------------------------------------------
+
+export async function createAllergy(input: z.infer<typeof createAllergySchema>) {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+
+  const record = {
+    id,
+    patient_id: input.patient_id,
+    allergen: input.allergen,
+    reaction: input.reaction,
+    severity: input.severity,
+    created_at: now,
+  };
+
+  await db.insert(allergies).values(record);
+
+  await clinicalEventsQueue.add("allergy.added", {
+    id: crypto.randomUUID(),
+    type: "allergy.added",
+    patient_id: input.patient_id,
+    data: { resourceId: id, allergen: input.allergen, severity: input.severity },
+    timestamp: now,
+  });
+
+  return record;
+}
+
+export async function updateAllergy(
+  id: string,
+  input: z.infer<typeof updateAllergySchema>,
+) {
+  const db = getDb();
+
+  const [existing] = await db.select().from(allergies).where(eq(allergies.id, id)).limit(1);
+  if (!existing) {
+    throw new Error(`Allergy ${id} not found`);
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (input.severity !== undefined) updates.severity = input.severity;
+  if (input.reaction !== undefined) updates.reaction = input.reaction;
+
+  if (Object.keys(updates).length === 0) {
+    return existing;
+  }
+
+  await db.update(allergies).set(updates).where(eq(allergies.id, id));
+
+  const [updated] = await db.select().from(allergies).where(eq(allergies.id, id)).limit(1);
+  return updated;
 }
 
 export type PatientRecordsRouter = typeof patientRecordsRouter;

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -248,7 +248,7 @@ export async function createDiagnosis(input: z.infer<typeof createDiagnosisSchem
     id: crypto.randomUUID(),
     type: "diagnosis.added",
     patient_id: input.patient_id,
-    data: { resourceId: id, icd10_code: input.icd10_code, status: record.status },
+    data: { diagnosis_id: id, icd10_code: input.icd10_code, status: record.status },
     timestamp: now,
   });
 
@@ -268,7 +268,16 @@ export async function updateDiagnosis(
   }
 
   const updates: Record<string, unknown> = {};
-  if (input.status !== undefined) updates.status = input.status;
+  if (input.status !== undefined) {
+    updates.status = input.status;
+    // Populate resolved_date for FHIR Condition export and patient portal display
+    if (input.status === "resolved") {
+      updates.resolved_date = now;
+    } else if (existing.status === "resolved") {
+      // Transitioning away from resolved — clear the date
+      updates.resolved_date = null;
+    }
+  }
   if (input.description !== undefined) updates.description = input.description;
 
   if (Object.keys(updates).length === 0) {
@@ -281,7 +290,7 @@ export async function updateDiagnosis(
     id: crypto.randomUUID(),
     type: "diagnosis.updated",
     patient_id: existing.patient_id,
-    data: { resourceId: id, changedFields: Object.keys(updates) },
+    data: { diagnosis_id: id, changedFields: Object.keys(updates) },
     timestamp: now,
   });
 
@@ -313,7 +322,7 @@ export async function createAllergy(input: z.infer<typeof createAllergySchema>) 
     id: crypto.randomUUID(),
     type: "allergy.added",
     patient_id: input.patient_id,
-    data: { resourceId: id, allergen: input.allergen, severity: input.severity },
+    data: { allergy_id: id, allergen: input.allergen, severity: input.severity },
     timestamp: now,
   });
 
@@ -325,6 +334,7 @@ export async function updateAllergy(
   input: z.infer<typeof updateAllergySchema>,
 ) {
   const db = getDb();
+  const now = new Date().toISOString();
 
   const [existing] = await db.select().from(allergies).where(eq(allergies.id, id)).limit(1);
   if (!existing) {
@@ -340,6 +350,14 @@ export async function updateAllergy(
   }
 
   await db.update(allergies).set(updates).where(eq(allergies.id, id));
+
+  await clinicalEventsQueue.add("allergy.updated", {
+    id: crypto.randomUUID(),
+    type: "allergy.updated",
+    patient_id: existing.patient_id,
+    data: { allergy_id: id, changedFields: Object.keys(updates) },
+    timestamp: now,
+  });
 
   const [updated] = await db.select().from(allergies).where(eq(allergies.id, id)).limit(1);
   return updated;


### PR DESCRIPTION
## Summary
- Add `diagnoses.create` and `diagnoses.update` mutations to patient-records service with clinical event emission (`diagnosis.added`, `diagnosis.updated`)
- Add `allergies.create` and `allergies.update` mutations with clinical event emission (`allergy.added`)
- Add Zod validators (`createDiagnosisSchema`, `updateDiagnosisSchema`, `createAllergySchema`, `updateAllergySchema`) in `@carebridge/validators`
- Add RBAC-enforced wrappers in the api-gateway using the existing `enforcePatientAccess` pattern
- Add `diagnosis.updated` and `allergy.added` to `ClinicalEventType` in shared-types
- Add 30 validator unit tests covering all new schemas

## Test plan
- [x] All 69 validator tests pass (`pnpm --filter @carebridge/validators test`)
- [x] `@carebridge/shared-types`, `@carebridge/validators`, `@carebridge/patient-records`, and `@carebridge/api-gateway` all build cleanly
- [ ] Manual smoke test: create a diagnosis via tRPC and verify the clinical event appears in the BullMQ queue
- [ ] Manual smoke test: create an allergy and verify RBAC denies access for unauthorized users

Closes #396