### PR TITLE
fix(notifications): publish to Redis pub/sub for SSE delivery

### DIFF
--- a/services/notifications/src/__tests__/publish.test.ts
+++ b/services/notifications/src/__tests__/publish.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { publishNotification, setPublisher } from "../publish.js";
+
+/**
+ * Tests for Redis pub/sub notification publishing.
+ *
+ * Verifies that notification creation correctly publishes to the expected
+ * Redis channel with the payload format the SSE endpoint consumes.
+ */
+
+function createMockRedis() {
+  return {
+    publish: vi.fn().mockResolvedValue(1),
+    quit: vi.fn().mockResolvedValue("OK"),
+  };
+}
+
+describe("publishNotification", () => {
+  let mockRedis: ReturnType<typeof createMockRedis>;
+
+  beforeEach(() => {
+    mockRedis = createMockRedis();
+    setPublisher(mockRedis as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("publishes to the correct Redis channel for a user", async () => {
+    const userId = "user-abc-123";
+    const payload = {
+      id: "notif-001",
+      type: "ai-flag",
+      title: "CRITICAL: Clinical flag — drug interaction",
+      body: "Potential interaction between warfarin and aspirin",
+      link: "/patients?flagId=flag-001",
+      related_flag_id: "flag-001",
+      created_at: "2026-04-12T10:00:00.000Z",
+    };
+
+    await publishNotification(userId, payload);
+
+    expect(mockRedis.publish).toHaveBeenCalledTimes(1);
+    expect(mockRedis.publish).toHaveBeenCalledWith(
+      `notifications:${userId}`,
+      JSON.stringify(payload),
+    );
+  });
+
+  it("publishes JSON matching the format the SSE endpoint expects", async () => {
+    const payload = {
+      id: "notif-002",
+      type: "ai-flag",
+      title: "Warning: Clinical flag — critical lab value",
+      created_at: "2026-04-12T11:00:00.000Z",
+    };
+
+    await publishNotification("user-xyz", payload);
+
+    const publishedMessage = mockRedis.publish.mock.calls[0][1] as string;
+    const parsed = JSON.parse(publishedMessage);
+
+    // SSE endpoint forwards the raw message as event data.
+    // Verify required fields are present.
+    expect(parsed).toHaveProperty("id");
+    expect(parsed).toHaveProperty("type");
+    expect(parsed).toHaveProperty("title");
+    expect(parsed).toHaveProperty("created_at");
+  });
+
+  it("handles optional fields (body, link, related_flag_id) gracefully", async () => {
+    const payload = {
+      id: "notif-003",
+      type: "system",
+      title: "Test notification",
+      created_at: "2026-04-12T12:00:00.000Z",
+    };
+
+    await publishNotification("user-abc", payload);
+
+    const publishedMessage = mockRedis.publish.mock.calls[0][1] as string;
+    const parsed = JSON.parse(publishedMessage);
+
+    expect(parsed.body).toBeUndefined();
+    expect(parsed.link).toBeUndefined();
+    expect(parsed.related_flag_id).toBeUndefined();
+  });
+
+  it("does not publish when userId is empty", async () => {
+    const payload = {
+      id: "notif-004",
+      type: "ai-flag",
+      title: "Should not be published",
+      created_at: "2026-04-12T13:00:00.000Z",
+    };
+
+    await publishNotification("", payload);
+
+    expect(mockRedis.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes to distinct channels for different users", async () => {
+    const payload = {
+      id: "notif-005",
+      type: "ai-flag",
+      title: "Shared flag",
+      created_at: "2026-04-12T14:00:00.000Z",
+    };
+
+    await publishNotification("user-a", payload);
+    await publishNotification("user-b", payload);
+
+    expect(mockRedis.publish).toHaveBeenCalledTimes(2);
+    expect(mockRedis.publish).toHaveBeenCalledWith(
+      "notifications:user-a",
+      expect.any(String),
+    );
+    expect(mockRedis.publish).toHaveBeenCalledWith(
+      "notifications:user-b",
+      expect.any(String),
+    );
+  });
+});

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -1,3 +1,4 @@
 export { notificationsRouter, type NotificationsRouter } from "./router.js";
 export { emitNotificationEvent, type NotificationEvent } from "./queue.js";
 export { startDispatchWorker } from "./workers/dispatch-worker.js";
+export { publishNotification, getPublisher, setPublisher, type NotificationPayload } from "./publish.js";

--- a/services/notifications/src/index.ts
+++ b/services/notifications/src/index.ts
@@ -1,4 +1,4 @@
 export { notificationsRouter, type NotificationsRouter } from "./router.js";
 export { emitNotificationEvent, type NotificationEvent } from "./queue.js";
 export { startDispatchWorker } from "./workers/dispatch-worker.js";
-export { publishNotification, getPublisher, setPublisher, type NotificationPayload } from "./publish.js";
+export { publishNotification, type NotificationPayload } from "./publish.js";

--- a/services/notifications/src/publish.ts
+++ b/services/notifications/src/publish.ts
@@ -1,0 +1,63 @@
+/**
+ * Redis pub/sub publisher for real-time notification delivery via SSE.
+ *
+ * Publishes notification payloads to `notifications:{userId}` channels.
+ * The SSE endpoint in api-gateway subscribes to these channels and forwards
+ * messages to connected clients.
+ */
+
+import Redis from "ioredis";
+
+export interface NotificationPayload {
+  id: string;
+  type: string;
+  title: string;
+  body?: string;
+  link?: string;
+  related_flag_id?: string;
+  created_at: string;
+}
+
+let publisherClient: Redis | null = null;
+
+/**
+ * Get (or create) the shared Redis publisher client.
+ *
+ * The client connects eagerly (no lazyConnect) so that publish calls
+ * are sent immediately rather than buffered in an offline queue that
+ * is never drained.
+ */
+export function getPublisher(): Redis {
+  if (!publisherClient) {
+    publisherClient = new Redis({
+      host: process.env.REDIS_HOST ?? "localhost",
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
+      ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
+    });
+  }
+  return publisherClient;
+}
+
+/**
+ * Replace the publisher instance (used by tests to inject a mock/spy).
+ */
+export function setPublisher(client: Redis): void {
+  publisherClient = client;
+}
+
+/**
+ * Publish a notification to the Redis channel for a specific user.
+ *
+ * The channel format `notifications:{userId}` matches what the SSE
+ * endpoint in api-gateway subscribes to.
+ */
+export async function publishNotification(
+  userId: string,
+  payload: NotificationPayload,
+): Promise<void> {
+  if (!userId) return;
+  const channel = `notifications:${userId}`;
+  const publisher = getPublisher();
+  await publisher.publish(channel, JSON.stringify(payload));
+}

--- a/services/notifications/src/router.ts
+++ b/services/notifications/src/router.ts
@@ -51,16 +51,26 @@ export const notificationsRouter = t.router({
       };
       await db.insert(notifications).values(notification);
 
-      // Publish to Redis pub/sub for real-time SSE delivery
-      await publishNotification(notification.user_id, {
-        id: notification.id,
-        type: notification.type,
-        title: notification.title,
-        body: notification.body,
-        link: notification.link,
-        related_flag_id: notification.related_flag_id,
-        created_at: notification.created_at,
-      });
+      // Publish to Redis pub/sub for real-time SSE delivery.
+      // Best-effort: a Redis outage should not fail the mutation after
+      // the notification row has already been persisted.
+      try {
+        await publishNotification(notification.user_id, {
+          id: notification.id,
+          type: notification.type,
+          title: notification.title,
+          body: notification.body,
+          link: notification.link,
+          related_flag_id: notification.related_flag_id,
+          created_at: notification.created_at,
+        });
+      } catch (error) {
+        console.error("[notifications] Failed to publish notification to Redis", {
+          notificationId: notification.id,
+          userId: notification.user_id,
+          error,
+        });
+      }
 
       return notification;
     }),

--- a/services/notifications/src/router.ts
+++ b/services/notifications/src/router.ts
@@ -4,6 +4,7 @@ import { getDb } from "@carebridge/db-schema";
 import { notifications, notificationPreferences } from "@carebridge/db-schema";
 import { eq, and, desc } from "drizzle-orm";
 import crypto from "node:crypto";
+import { publishNotification } from "./publish.js";
 
 const t = initTRPC.create();
 
@@ -49,6 +50,18 @@ export const notificationsRouter = t.router({
         created_at: new Date().toISOString(),
       };
       await db.insert(notifications).values(notification);
+
+      // Publish to Redis pub/sub for real-time SSE delivery
+      await publishNotification(notification.user_id, {
+        id: notification.id,
+        type: notification.type,
+        title: notification.title,
+        body: notification.body,
+        link: notification.link,
+        related_flag_id: notification.related_flag_id,
+        created_at: notification.created_at,
+      });
+
       return notification;
     }),
   getPreferences: t.procedure

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -17,20 +17,11 @@ import { getRedisConnection } from "@carebridge/redis-config";
 import { getDb } from "@carebridge/db-schema";
 import { notifications, users } from "@carebridge/db-schema";
 import { eq, and, inArray } from "drizzle-orm";
-import Redis from "ioredis";
 import crypto from "node:crypto";
 import type { NotificationEvent } from "../queue.js";
+import { publishNotification } from "../publish.js";
 import { filterRecipientsBySpecialty } from "./specialty-filter.js";
 import type { CandidateRecipient } from "./specialty-filter.js";
-
-/** Redis publisher client for SSE real-time delivery. */
-const redisPublisher = new Redis({
-  host: process.env.REDIS_HOST ?? "localhost",
-  port: Number(process.env.REDIS_PORT ?? 6379),
-  ...(process.env.REDIS_PASSWORD ? { password: process.env.REDIS_PASSWORD } : {}),
-  ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
-  lazyConnect: true,
-});
 
 const QUEUE_NAME = "notifications";
 const DLQ_NAME = "notifications-failed";
@@ -161,8 +152,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
 
   // Publish to Redis pub/sub for real-time SSE delivery
   for (const record of notificationRecords) {
-    const channel = `notifications:${record.user_id}`;
-    await redisPublisher.publish(channel, JSON.stringify({
+    await publishNotification(record.user_id, {
       id: record.id,
       type: record.type,
       title: record.title,
@@ -170,7 +160,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
       link: record.link,
       related_flag_id: record.related_flag_id,
       created_at: record.created_at,
-    }));
+    });
   }
 
   console.log(

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -150,17 +150,27 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   // Batch insert all notifications
   await db.insert(notifications).values(notificationRecords);
 
-  // Publish to Redis pub/sub for real-time SSE delivery
+  // Publish to Redis pub/sub for real-time SSE delivery.
+  // Best-effort: failures are logged but do not cause job retry
+  // (which would duplicate the already-inserted notification rows).
   for (const record of notificationRecords) {
-    await publishNotification(record.user_id, {
-      id: record.id,
-      type: record.type,
-      title: record.title,
-      body: record.body,
-      link: record.link,
-      related_flag_id: record.related_flag_id,
-      created_at: record.created_at,
-    });
+    try {
+      await publishNotification(record.user_id, {
+        id: record.id,
+        type: record.type,
+        title: record.title,
+        body: record.body,
+        link: record.link,
+        related_flag_id: record.related_flag_id,
+        created_at: record.created_at,
+      });
+    } catch (error) {
+      console.error("[dispatch-worker] Failed to publish notification to Redis", {
+        notificationId: record.id,
+        userId: record.user_id,
+        error,
+      });
+    }
   }
 
   console.log(


### PR DESCRIPTION
## Summary
- The dispatch worker's Redis publisher was created with `lazyConnect: true` but `.connect()` was never called, so publish commands were queued in the offline buffer and never sent to Redis
- Extracted a shared `publish.ts` module that creates the Redis client with eager connection (no `lazyConnect`) and exposes `publishNotification()` 
- Wired the publish call into both the BullMQ dispatch worker and the tRPC `create` mutation, so all notification creation paths publish to `notifications:{userId}` channels
- Added tests covering channel routing, payload format matching SSE expectations, empty userId handling, and multi-user dispatch

## Test plan
- [x] `pnpm --filter @carebridge/notifications test` — 18 tests pass (13 specialty-filter + 5 new publish tests)
- [x] `pnpm build` — full monorepo builds cleanly
- [ ] Manual: create a clinical flag and verify SSE endpoint delivers the notification in real time

Closes #401