### PR TITLE
chore(notifications): remove dead publishNotificationToUser from SSE route

### DIFF
--- a/services/api-gateway/src/routes/notifications-sse.ts
+++ b/services/api-gateway/src/routes/notifications-sse.ts
@@ -77,24 +77,3 @@ export function registerNotificationSSE(server: FastifyInstance): void {
     },
   );
 }
-
-/**
- * Publish a notification to the Redis channel for a specific user.
- * Call this from the notification dispatch worker after creating records.
- */
-export async function publishNotificationToUser(
-  redisClient: Redis,
-  userId: string,
-  notification: {
-    id: string;
-    type: string;
-    title: string;
-    body?: string;
-    link?: string;
-    related_flag_id?: string;
-    created_at: string;
-  },
-): Promise<void> {
-  const channel = `notifications:${userId}`;
-  await redisClient.publish(channel, JSON.stringify(notification));
-}


### PR DESCRIPTION
## Summary
- Remove the unused `publishNotificationToUser` function from `services/api-gateway/src/routes/notifications-sse.ts`
- This function was superseded by `publishNotification` in `services/notifications/src/publish.ts` and was never imported or called anywhere in the codebase
- The SSE subscription endpoint (`registerNotificationSSE`) is preserved unchanged

Closes #415