### PR TITLE
fix(db): link patient user accounts to patient records in seed script

### DIFF
--- a/tooling/seed/index.ts
+++ b/tooling/seed/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { drizzle } from "drizzle-orm/postgres-js";
+import { eq } from "drizzle-orm";
 import postgres from "postgres";
 import * as schema from "@carebridge/db-schema";
 import { hmacForIndex } from "@carebridge/db-schema";
@@ -237,6 +238,11 @@ async function seed() {
     { id: uuid(), patient_id: patient2Id, name: "Metformin", dose_amount: 500, dose_unit: "mg", route: "oral", frequency: "twice daily", status: "active", started_at: daysAgo(60), prescribed_by: "Dr. Smith", ordering_provider_id: drSmith, source_system: "internal", created_at: daysAgo(60), updated_at: daysAgo(60) },
     { id: uuid(), patient_id: patient2Id, name: "Lisinopril", dose_amount: 10, dose_unit: "mg", route: "oral", frequency: "once daily", status: "active", started_at: daysAgo(60), prescribed_by: "Dr. Smith", ordering_provider_id: drSmith, source_system: "internal", created_at: daysAgo(60), updated_at: daysAgo(60) },
   ]);
+
+  // ─── Link patient users to patient records ──────────────────────
+  await db.update(schema.users)
+    .set({ patient_id: dvtPatientId })
+    .where(eq(schema.users.id, patientUser));
 
   console.log("Seed complete.");
   console.log(`  DVT scenario patient: ${dvtPatientId} (Margaret Chen, MRN: MCH-2026-0042)`);


### PR DESCRIPTION
## Summary
- The seed script creates a patient user (`patient@carebridge.dev`) and patient records but never sets the `patient_id` foreign key on the users table (added in migration 0022)
- After creating the DVT scenario patient record, the seed now updates the patient user's `patient_id` to reference the correct patient record
- Adds the `eq` import from `drizzle-orm` needed for the update query

## Test plan
- [ ] Run `pnpm db:seed` on a fresh database and verify the patient user row has `patient_id` set
- [ ] Confirm `pnpm build` passes (verified locally)
- [ ] Log in as `patient@carebridge.dev` and verify patient portal resolves the linked patient record

Closes #424