### PR TITLE
fix(ai): tighten stroke regex to require body-part term

### DIFF
--- a/services/ai-oversight/src/__tests__/message-screening.test.ts
+++ b/services/ai-oversight/src/__tests__/message-screening.test.ts
@@ -83,6 +83,20 @@ describe("screenPatientMessage — urgent keyword detection", () => {
     expect(flags.some((f) => f.rule_id === "MSG-STROKE-SYMPTOMS")).toBe(true);
   });
 
+  it("flags stroke symptoms — can't move my arm", () => {
+    const flags = screenPatientMessage(
+      makeMessageEvent({ message_text: "I can't move my arm" }),
+    );
+    expect(flags.some((f) => f.rule_id === "MSG-STROKE-SYMPTOMS")).toBe(true);
+  });
+
+  it("flags stroke symptoms — cant move leg (no apostrophe)", () => {
+    const flags = screenPatientMessage(
+      makeMessageEvent({ message_text: "I cant move leg at all" }),
+    );
+    expect(flags.some((f) => f.rule_id === "MSG-STROKE-SYMPTOMS")).toBe(true);
+  });
+
   it("flags suicidal ideation — direct", () => {
     const flags = screenPatientMessage(
       makeMessageEvent({ message_text: "I want to kill myself" }),
@@ -180,6 +194,15 @@ describe("screenPatientMessage — no false positives", () => {
       }),
     );
     expect(flags).toHaveLength(0);
+  });
+
+  it("does not false-positive on 'can't move my appointment'", () => {
+    const flags = screenPatientMessage(
+      makeMessageEvent({
+        message_text: "I can't move my appointment to next week.",
+      }),
+    );
+    expect(flags.some((f) => f.rule_id === "MSG-STROKE-SYMPTOMS")).toBe(false);
   });
 });
 

--- a/services/ai-oversight/src/rules/message-screening.ts
+++ b/services/ai-oversight/src/rules/message-screening.ts
@@ -83,7 +83,7 @@ const URGENT_PATTERNS: UrgentKeywordPattern[] = [
   },
   {
     id: "MSG-STROKE-SYMPTOMS",
-    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my|arm|leg)/i,
+    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my\s*)?(arm|leg|hand|foot|side)\b/i,
     severity: "critical",
     summary: "Patient describes possible stroke symptoms in message",
     rationale:


### PR DESCRIPTION
## Summary
- Fixes the `MSG-STROKE-SYMPTOMS` regex in `message-screening.ts` which false-positived on phrases like "can't move my appointment"
- Changed `can'?t\s*move\s*(my|arm|leg)` to `can'?t\s*move\s*(my\s*)?(arm|leg|hand|foot|side)\b` so a body-part term is always required
- Matches the fix already applied to `observation-screening.ts` in PR #407

## Test plan
- [x] "can't move my arm" still triggers MSG-STROKE-SYMPTOMS
- [x] "cant move leg" (no apostrophe) still triggers MSG-STROKE-SYMPTOMS
- [x] "can't move my appointment" no longer triggers MSG-STROKE-SYMPTOMS
- [x] All 26 message-screening tests pass

Closes #419