### PR TITLE
fix(portal): use patient_id for direct record lookup instead of name-match fallback

### DIFF
--- a/apps/patient-portal/app/health-summary/page.tsx
+++ b/apps/patient-portal/app/health-summary/page.tsx
@@ -27,7 +27,7 @@ export default function HealthSummaryPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const diagnosesQuery = trpc.patients.diagnoses.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -67,6 +67,12 @@ export default function HealthSummaryPage() {
           Back to Dashboard
         </button>
       </div>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {/* Active Diagnoses */}
       <section style={{ marginBottom: "2rem" }}>

--- a/apps/patient-portal/app/labs/page.tsx
+++ b/apps/patient-portal/app/labs/page.tsx
@@ -23,7 +23,7 @@ export default function LabsPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const labsQuery = trpc.clinicalData.labs.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -55,6 +55,12 @@ export default function LabsPage() {
           Back to Dashboard
         </button>
       </div>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {labsQuery.isLoading && (
         <p style={{ color: "#999" }}>Loading lab results...</p>

--- a/apps/patient-portal/app/messages/page.tsx
+++ b/apps/patient-portal/app/messages/page.tsx
@@ -23,7 +23,7 @@ export default function PatientMessagesPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const conversationsQuery = trpc.messaging.listConversations.useQuery(
     undefined,
@@ -137,6 +137,12 @@ export default function PatientMessagesPage() {
           </button>
         </div>
       </div>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {/* Compose new message */}
       {showCompose && (

--- a/apps/patient-portal/app/notes/page.tsx
+++ b/apps/patient-portal/app/notes/page.tsx
@@ -19,7 +19,7 @@ export default function NotesPage() {
   const router = useRouter();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const notesQuery = trpc.notes.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -53,6 +53,12 @@ export default function NotesPage() {
         These are your signed clinical notes from your care team. Under the 21st Century Cures Act,
         you have the right to access these documents.
       </p>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {notesQuery.isLoading && <p style={{ color: "#999" }}>Loading notes...</p>}
       {notesQuery.isError && <p style={{ color: "#ef4444" }}>Failed to load notes.</p>}

--- a/apps/patient-portal/app/page.tsx
+++ b/apps/patient-portal/app/page.tsx
@@ -27,7 +27,7 @@ function PatientDashboard() {
   const router = useRouter();
 
   const healthQuery = trpc.healthCheck.useQuery();
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const medsQuery = trpc.clinicalData.medications.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -79,6 +79,23 @@ function PatientDashboard() {
           Sign Out
         </button>
       </div>
+
+      {isUnlinked && (
+        <div
+          style={{
+            backgroundColor: "#7f1d1d",
+            border: "1px solid #ef4444",
+            borderRadius: "8px",
+            padding: "1.25rem",
+            marginBottom: "1rem",
+            color: "#fca5a5",
+            fontSize: "0.9rem",
+          }}
+        >
+          <strong>Account not linked.</strong> Your account is not linked to a patient
+          record. Please contact your care team or call the front desk to resolve this.
+        </div>
+      )}
 
       <div
         style={{

--- a/apps/patient-portal/app/refill/page.tsx
+++ b/apps/patient-portal/app/refill/page.tsx
@@ -10,7 +10,7 @@ export default function RefillPage() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const medsQuery = trpc.clinicalData.medications.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -108,6 +108,12 @@ export default function RefillPage() {
         Select a medication to request a refill. Your prescribing provider will receive
         the request and can approve or deny it.
       </p>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {medsQuery.isLoading && <p style={{ color: "#999" }}>Loading medications...</p>}
 

--- a/apps/patient-portal/app/symptoms/page.tsx
+++ b/apps/patient-portal/app/symptoms/page.tsx
@@ -30,7 +30,7 @@ export default function SymptomsPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const { patient: myRecord, isLoading: patientLoading } = useMyPatientRecord();
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
 
   const observationsQuery = trpc.patients.observations.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -107,6 +107,12 @@ export default function SymptomsPage() {
         in a separate &quot;Patient Signals&quot; section — they won&apos;t clutter your clinical chart
         but will help ensure nothing important is missed.
       </p>
+
+      {isUnlinked && (
+        <p style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your care team.
+        </p>
+      )}
 
       {submitted && (
         <div style={{ backgroundColor: "#16a34a20", border: "1px solid #16a34a", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#16a34a" }}>

--- a/apps/patient-portal/src/lib/use-my-patient.ts
+++ b/apps/patient-portal/src/lib/use-my-patient.ts
@@ -1,12 +1,10 @@
 /**
  * Shared hook to resolve the current patient's record.
  *
- * Uses user.patient_id (set on the users table) instead of the fragile
- * name-match + fallback-to-first pattern that could expose PHI.
- *
- * Falls back to patients.getById if patient_id is available on the user,
- * otherwise falls back to name-match (legacy compat) but WITHOUT the
- * dangerous data[0] fallback.
+ * Uses user.patient_id (set on the users table) for a direct lookup via
+ * patients.getById. If the user account has no patient_id linked, the hook
+ * returns an explicit `isUnlinked` flag so pages can show an error state
+ * instead of silently falling back to another patient's data.
  */
 
 import { useAuth } from "./auth";
@@ -15,32 +13,18 @@ import { trpc } from "./trpc";
 export function useMyPatientRecord() {
   const { user } = useAuth();
 
-  // Preferred path: direct lookup by patient_id
+  const hasPatientId = !!user?.patient_id;
+
   const directQuery = trpc.patients.getById.useQuery(
     { id: user?.patient_id ?? "" },
-    { enabled: !!user?.patient_id },
+    { enabled: hasPatientId },
   );
-
-  // Legacy fallback: find by name (without dangerous data[0] fallback)
-  const listQuery = trpc.patients.list.useQuery(
-    undefined,
-    { enabled: !!user && !user.patient_id },
-  );
-
-  if (user?.patient_id && directQuery.data) {
-    return {
-      patient: directQuery.data,
-      isLoading: directQuery.isLoading,
-      isError: directQuery.isError,
-    };
-  }
-
-  // Legacy name-match — NO fallback to first record
-  const nameMatch = listQuery.data?.find((p) => p.name === user?.name) ?? null;
 
   return {
-    patient: nameMatch,
-    isLoading: listQuery.isLoading,
-    isError: listQuery.isError,
+    patient: hasPatientId ? (directQuery.data ?? null) : null,
+    isLoading: hasPatientId ? directQuery.isLoading : false,
+    isError: hasPatientId ? directQuery.isError : false,
+    /** True when the user account is not linked to any patient record. */
+    isUnlinked: !!user && !user.patient_id,
   };
 }

--- a/services/api-gateway/src/middleware/auth.ts
+++ b/services/api-gateway/src/middleware/auth.ts
@@ -181,6 +181,7 @@ export async function authMiddleware(
     email: row.email,
     name: row.name,
     role: row.role as User["role"],
+    patient_id: row.patient_id ?? undefined,
     specialty: row.specialty ?? undefined,
     department: row.department ?? undefined,
     is_active: row.is_active,

--- a/services/auth/src/router.ts
+++ b/services/auth/src/router.ts
@@ -232,6 +232,7 @@ function buildUserResponse(row: {
   email: string;
   name: string;
   role: string;
+  patient_id: string | null;
   specialty: string | null;
   department: string | null;
   is_active: boolean;
@@ -243,6 +244,7 @@ function buildUserResponse(row: {
     email: row.email,
     name: row.name,
     role: row.role as User["role"],
+    patient_id: row.patient_id ?? undefined,
     specialty: row.specialty ?? undefined,
     department: row.department ?? undefined,
     is_active: row.is_active,

--- a/tooling/seed/index.ts
+++ b/tooling/seed/index.ts
@@ -45,6 +45,9 @@ async function seed() {
   const nurseRachel = uuid();
   const patientUser = uuid();
 
+  // Generate dvtPatientId early so the patient user can reference it.
+  const dvtPatientId = uuid();
+
   await db.insert(schema.users).values([
     {
       id: drSmith,
@@ -87,6 +90,7 @@ async function seed() {
       password_hash: devPasswordHash,
       name: "Demo Patient",
       role: "patient",
+      patient_id: dvtPatientId,
       is_active: true,
       created_at: now(),
       updated_at: now(),
@@ -94,7 +98,6 @@ async function seed() {
   ]).onConflictDoNothing();
 
   // ─── The DVT Scenario Patient ───────────────────────────────────
-  const dvtPatientId = uuid();
 
   await db.insert(schema.patients).values({
     id: dvtPatientId,


### PR DESCRIPTION
## Summary
- Remove the dangerous `patientsQuery.data?.find(p => p.name === user?.name) ?? patientsQuery.data?.[0]` pattern from `useMyPatientRecord` that could expose another patient's PHI when names don't match
- Hook now uses `user.patient_id` for a direct `patients.getById` query with no fallback
- Both the auth service (`buildUserResponse`) and the API gateway auth middleware now include `patient_id` in the user object
- Seed script links the demo patient user to the DVT scenario patient record via `patient_id`
- All 7 patient portal pages handle the new `isUnlinked` error state with a clear message

## Affected files
- `apps/patient-portal/src/lib/use-my-patient.ts` — rewrote hook to use direct lookup only
- `apps/patient-portal/app/{page,labs,notes,messages,symptoms,refill,health-summary}/page.tsx` — added `isUnlinked` error handling
- `services/auth/src/router.ts` — added `patient_id` to `buildUserResponse`
- `services/api-gateway/src/middleware/auth.ts` — added `patient_id` to user object
- `tooling/seed/index.ts` — set `patient_id` on patient user account

## Test plan
- [ ] Log in as `patient@carebridge.dev` and verify dashboard shows correct patient data (Margaret Chen)
- [ ] Verify all sub-pages (labs, notes, messages, symptoms, refill, health-summary) load correctly
- [ ] Temporarily remove `patient_id` from user and verify error message appears instead of another patient's data
- [ ] Run `pnpm build` — passes clean

Closes #420