### PR TITLE
refactor(portal): extract shared PasswordInput component

### DIFF
--- a/apps/clinician-portal/app/login/page.tsx
+++ b/apps/clinician-portal/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
+import { PasswordInput } from "@carebridge/portal-shared/password-input";
 
 type LoginStep = "credentials" | "mfa";
 
@@ -16,7 +17,6 @@ export default function LoginPage() {
   const [step, setStep] = useState<LoginStep>("credentials");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
   const { setSession } = useAuth();
 
@@ -129,37 +129,14 @@ export default function LoginPage() {
                 >
                   Password
                 </label>
-                <div style={{ position: "relative" }}>
-                  <input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    className="search-input"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    style={{ width: "100%", paddingRight: 40 }}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((p) => !p)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
-                    style={{
-                      position: "absolute",
-                      right: 8,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      background: "none",
-                      border: "none",
-                      cursor: "pointer",
-                      padding: 4,
-                      fontSize: 18,
-                      color: "var(--text-muted)",
-                      lineHeight: 1,
-                    }}
-                  >
-                    {showPassword ? "\u{1F648}" : "\u{1F441}"}
-                  </button>
-                </div>
+                <PasswordInput
+                  id="password"
+                  className="search-input"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  style={{ width: "100%" }}
+                />
               </div>
 
               {error && (

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
+import { PasswordInput } from "@carebridge/portal-shared/password-input";
 
 type LoginStep = "credentials" | "mfa";
 
@@ -16,7 +17,6 @@ export default function LoginPage() {
   const [step, setStep] = useState<LoginStep>("credentials");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
   const { setSession } = useAuth();
 
@@ -155,36 +155,13 @@ export default function LoginPage() {
                 >
                   Password
                 </label>
-                <div style={{ position: "relative" }}>
-                  <input
-                    id="password"
-                    type={showPassword ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    required
-                    style={{ ...inputStyle, paddingRight: 40 }}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowPassword((p) => !p)}
-                    aria-label={showPassword ? "Hide password" : "Show password"}
-                    style={{
-                      position: "absolute",
-                      right: 8,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      background: "none",
-                      border: "none",
-                      cursor: "pointer",
-                      padding: 4,
-                      fontSize: 18,
-                      color: "var(--text-muted, #999)",
-                      lineHeight: 1,
-                    }}
-                  >
-                    {showPassword ? "\u{1F648}" : "\u{1F441}"}
-                  </button>
-                </div>
+                <PasswordInput
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  style={inputStyle}
+                />
               </div>
 
               {error && (

--- a/packages/portal-shared/package.json
+++ b/packages/portal-shared/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./trpc": "./src/trpc.ts",
     "./auth": "./src/auth.tsx",
-    "./providers": "./src/providers.tsx"
+    "./providers": "./src/providers.tsx",
+    "./password-input": "./src/password-input.tsx"
   },
   "dependencies": {
     "@trpc/client": "^11.0.0",

--- a/packages/portal-shared/src/password-input.tsx
+++ b/packages/portal-shared/src/password-input.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+
+export interface PasswordInputProps {
+  id: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  required?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function PasswordInput({
+  id,
+  value,
+  onChange,
+  required,
+  className,
+  style,
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        id={id}
+        type={showPassword ? "text" : "password"}
+        className={className}
+        value={value}
+        onChange={onChange}
+        required={required}
+        style={{ ...style, paddingRight: 40 }}
+      />
+      <button
+        type="button"
+        onClick={() => setShowPassword((p) => !p)}
+        aria-label={showPassword ? "Hide password" : "Show password"}
+        style={{
+          position: "absolute",
+          right: 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 4,
+          fontSize: 18,
+          color: "var(--text-muted, #999)",
+          lineHeight: 1,
+        }}
+      >
+        {showPassword ? "\u{1F648}" : "\u{1F441}"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract duplicate password input + eye toggle code from both clinician and patient portal login pages into a shared `PasswordInput` component in `@carebridge/portal-shared`
- New component manages show/hide state internally, accepts `id`, `value`, `onChange`, `required`, `className`, and `style` props
- Both login pages now import and use the shared component, removing ~30 lines of duplicated code

Closes #410

## Test plan
- [ ] Verify clinician portal login page renders password field with eye toggle
- [ ] Verify patient portal login page renders password field with eye toggle
- [ ] Verify show/hide password toggle works on both portals
- [ ] Verify `pnpm build` passes cleanly