### PR TITLE
fix(clinical): restrict patient role from creating diagnoses and allergies

### DIFF
--- a/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted ensures these are available when vi.mock factories run
+// ---------------------------------------------------------------------------
+
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const DIAGNOSIS_ID = "aaaa1111-1111-4111-8111-111111111111";
+const ALLERGY_ID = "bbbb1111-1111-4111-8111-111111111111";
+const ROLE_IDS: Record<string, string> = {
+  nurse: "33333333-3333-4333-8333-333333333333",
+  physician: "44444444-4444-4444-8444-444444444444",
+  specialist: "55555555-5555-4555-8555-555555555555",
+  admin: "66666666-6666-4666-8666-666666666666",
+  patient: PATIENT_ID,
+  family_caregiver: "77777777-7777-4777-8777-777777777777",
+};
+
+const mocks = vi.hoisted(() => {
+  const fn = vi.fn;
+  // DB mock chain
+  function makeSelectChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = fn(() => chain);
+    chain.where = fn(() => chain);
+    chain.limit = fn(async () => [{ patient_id: "22222222-2222-4222-8222-222222222222" }]);
+    return chain;
+  }
+  return {
+    mockDb: {
+      select: fn(() => makeSelectChain()),
+      insert: fn(() => ({ values: fn() })),
+    },
+    createDiagnosis: fn(async (input: unknown) => ({
+      id: "aaaa1111-1111-4111-8111-111111111111",
+      ...(input as Record<string, unknown>),
+    })),
+    updateDiagnosis: fn(async (id: string, data: unknown) => ({
+      id,
+      ...(data as Record<string, unknown>),
+    })),
+    createAllergy: fn(async (input: unknown) => ({
+      id: "bbbb1111-1111-4111-8111-111111111111",
+      ...(input as Record<string, unknown>),
+    })),
+    updateAllergy: fn(async (id: string, data: unknown) => ({
+      id,
+      ...(data as Record<string, unknown>),
+    })),
+  };
+});
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  hmacForIndex: (v: string) => `hmac:${v}`,
+  patients: { id: "patients.id" },
+  diagnoses: { id: "diagnoses.id", patient_id: "diagnoses.patient_id" },
+  allergies: { id: "allergies.id", patient_id: "allergies.patient_id" },
+  careTeamMembers: { patient_id: "care_team_members.patient_id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+}));
+
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@carebridge/patient-records", () => ({
+  listObservationsByPatient: vi.fn(),
+  createObservation: vi.fn(),
+  createDiagnosis: mocks.createDiagnosis,
+  updateDiagnosis: mocks.updateDiagnosis,
+  createAllergy: mocks.createAllergy,
+  updateAllergy: mocks.updateAllergy,
+}));
+
+vi.mock("@carebridge/validators", async () => {
+  const { z } = await import("zod");
+  return {
+    createPatientSchema: z.object({ mrn: z.string().optional() }),
+    updatePatientSchema: z.object({}),
+    createDiagnosisSchema: z.object({
+      patient_id: z.string().uuid(),
+      icd10_code: z.string(),
+      description: z.string(),
+      status: z.string().optional().default("active"),
+    }),
+    updateDiagnosisSchema: z.object({
+      status: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    createAllergySchema: z.object({
+      patient_id: z.string().uuid(),
+      allergen: z.string(),
+      reaction: z.string(),
+      severity: z.string(),
+    }),
+    updateAllergySchema: z.object({
+      severity: z.string().optional(),
+      reaction: z.string().optional(),
+    }),
+  };
+});
+
+import { patientRecordsRbacRouter } from "../routers/patient-records.js";
+import type { Context } from "../context.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function makeContext(user: User | null): Context {
+  return {
+    db: mocks.mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+}
+
+function callerFor(user: User | null) {
+  return patientRecordsRbacRouter.createCaller(makeContext(user));
+}
+
+const diagnosisInput = {
+  patient_id: PATIENT_ID,
+  icd10_code: "C50.9",
+  description: "Breast cancer, unspecified",
+  status: "active",
+};
+
+const allergyInput = {
+  patient_id: PATIENT_ID,
+  allergen: "Penicillin",
+  reaction: "Hives and swelling",
+  severity: "moderate",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("patientRecordsRbacRouter — diagnoses role restrictions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects patient from creating a diagnosis (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("patient", PATIENT_ID));
+    await expect(caller.diagnoses.create(diagnosisInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("rejects family_caregiver from creating a diagnosis (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(caller.diagnoses.create(diagnosisInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("rejects patient from updating a diagnosis (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("patient", PATIENT_ID));
+    await expect(
+      caller.diagnoses.update({ id: DIAGNOSIS_ID, status: "resolved" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.updateDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("rejects family_caregiver from updating a diagnosis (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(
+      caller.diagnoses.update({ id: DIAGNOSIS_ID, status: "resolved" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.updateDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("allows a physician to create a diagnosis", async () => {
+    const caller = callerFor(makeUser("physician"));
+    await expect(caller.diagnoses.create(diagnosisInput)).resolves.toBeDefined();
+    expect(mocks.createDiagnosis).toHaveBeenCalled();
+  });
+
+  it("allows a specialist to create a diagnosis", async () => {
+    const caller = callerFor(makeUser("specialist"));
+    await expect(caller.diagnoses.create(diagnosisInput)).resolves.toBeDefined();
+    expect(mocks.createDiagnosis).toHaveBeenCalled();
+  });
+
+  it("allows a nurse to create a diagnosis", async () => {
+    const caller = callerFor(makeUser("nurse"));
+    await expect(caller.diagnoses.create(diagnosisInput)).resolves.toBeDefined();
+    expect(mocks.createDiagnosis).toHaveBeenCalled();
+  });
+
+  it("allows an admin to create a diagnosis", async () => {
+    const caller = callerFor(makeUser("admin"));
+    await expect(caller.diagnoses.create(diagnosisInput)).resolves.toBeDefined();
+    expect(mocks.createDiagnosis).toHaveBeenCalled();
+  });
+});
+
+describe("patientRecordsRbacRouter — allergies role restrictions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects patient from creating an allergy (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("patient", PATIENT_ID));
+    await expect(caller.allergies.create(allergyInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createAllergy).not.toHaveBeenCalled();
+  });
+
+  it("rejects family_caregiver from creating an allergy (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(caller.allergies.create(allergyInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createAllergy).not.toHaveBeenCalled();
+  });
+
+  it("rejects patient from updating an allergy (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("patient", PATIENT_ID));
+    await expect(
+      caller.allergies.update({ id: ALLERGY_ID, severity: "severe" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.updateAllergy).not.toHaveBeenCalled();
+  });
+
+  it("rejects family_caregiver from updating an allergy (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(
+      caller.allergies.update({ id: ALLERGY_ID, severity: "severe" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.updateAllergy).not.toHaveBeenCalled();
+  });
+
+  it("allows a physician to create an allergy", async () => {
+    const caller = callerFor(makeUser("physician"));
+    await expect(caller.allergies.create(allergyInput)).resolves.toBeDefined();
+    expect(mocks.createAllergy).toHaveBeenCalled();
+  });
+
+  it("allows a specialist to create an allergy", async () => {
+    const caller = callerFor(makeUser("specialist"));
+    await expect(caller.allergies.create(allergyInput)).resolves.toBeDefined();
+    expect(mocks.createAllergy).toHaveBeenCalled();
+  });
+
+  it("allows a nurse to create an allergy", async () => {
+    const caller = callerFor(makeUser("nurse"));
+    await expect(caller.allergies.create(allergyInput)).resolves.toBeDefined();
+    expect(mocks.createAllergy).toHaveBeenCalled();
+  });
+
+  it("allows an admin to create an allergy", async () => {
+    const caller = callerFor(makeUser("admin"));
+    await expect(caller.allergies.create(allergyInput)).resolves.toBeDefined();
+    expect(mocks.createAllergy).toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
@@ -141,14 +141,14 @@ const diagnosisInput = {
   patient_id: PATIENT_ID,
   icd10_code: "C50.9",
   description: "Breast cancer, unspecified",
-  status: "active",
+  status: "active" as const,
 };
 
 const allergyInput = {
   patient_id: PATIENT_ID,
   allergen: "Penicillin",
   reaction: "Hives and swelling",
-  severity: "moderate",
+  severity: "moderate" as const,
 };
 
 // ---------------------------------------------------------------------------

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -160,7 +160,7 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createDiagnosisSchema)
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot create clinical diagnoses",
@@ -173,7 +173,7 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateDiagnosisSchema))
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot update clinical diagnoses",
@@ -210,7 +210,7 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createAllergySchema)
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot create clinical allergies",
@@ -223,7 +223,7 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateAllergySchema))
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot update clinical allergies",

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -160,6 +160,12 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createDiagnosisSchema)
       .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Patients cannot create clinical diagnoses",
+          });
+        }
         await enforcePatientAccess(ctx.user, input.patient_id);
         return createDiagnosis(input);
       }),
@@ -167,6 +173,12 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateDiagnosisSchema))
       .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Patients cannot update clinical diagnoses",
+          });
+        }
         const { id, ...data } = input;
         // Look up the diagnosis to get the patient_id for access check
         const db = getDb();
@@ -198,6 +210,12 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createAllergySchema)
       .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Patients cannot create clinical allergies",
+          });
+        }
         await enforcePatientAccess(ctx.user, input.patient_id);
         return createAllergy(input);
       }),
@@ -205,6 +223,12 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateAllergySchema))
       .mutation(async ({ ctx, input }) => {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message: "Patients cannot update clinical allergies",
+          });
+        }
         const { id, ...data } = input;
         const db = getDb();
         const [existing] = await db

--- a/services/api-gateway/vitest.config.ts
+++ b/services/api-gateway/vitest.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
         __dirname,
         "../../services/auth/src/index.ts",
       ),
+      "@carebridge/patient-records": path.resolve(
+        __dirname,
+        "../../services/patient-records/src/index.ts",
+      ),
+      "@carebridge/clinical-notes": path.resolve(
+        __dirname,
+        "../../services/clinical-notes/src/index.ts",
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Adds role checks to `diagnoses.create`, `diagnoses.update`, `allergies.create`, and `allergies.update` mutations in the patient-records router
- Rejects `patient` and `family_caregiver` roles with `TRPCError(FORBIDDEN)` before any DB access occurs
- Only clinicians (physician, specialist, nurse) and admin can write clinical diagnoses and allergies

## Test plan
- [x] 16 new unit tests covering all role permutations for diagnoses and allergies create/update
- [x] All existing api-gateway tests continue to pass (97 tests across 11 suites)

Closes #413