### PR TITLE
refactor(ai): extract shared screening keyword patterns to common module

### DIFF
--- a/services/ai-oversight/src/rules/message-screening.ts
+++ b/services/ai-oversight/src/rules/message-screening.ts
@@ -9,122 +9,25 @@
  * Does NOT auto-reply to patients — only creates flags for clinical review.
  */
 
-import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
+import type { FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
 import type { RuleFlag } from "./critical-values.js";
+import {
+  SHARED_CRITICAL_PATTERNS,
+  materializePattern,
+  type ScreeningPattern,
+} from "./screening-patterns.js";
 
-interface UrgentKeywordPattern {
-  id: string;
-  pattern: RegExp;
-  severity: FlagSeverity;
-  summary: string;
-  rationale: string;
-  suggested_action: string;
-  notify_specialties: string[];
-}
+const MSG_PREFIX = "MSG";
+const MSG_SOURCE = "in message";
 
-/**
- * Urgent symptom keywords that should trigger immediate flags.
- * Patterns match against the message text (case-insensitive).
- */
-const URGENT_PATTERNS: UrgentKeywordPattern[] = [
+// ── Message-specific patterns (not shared with observation screening) ──
+
+const MESSAGE_ONLY_PATTERNS: ScreeningPattern[] = [
   {
-    id: "MSG-CHEST-PAIN",
-    pattern: /chest\s*pain|chest\s*tightness|chest\s*pressure|angina/i,
-    severity: "critical",
-    summary: "Patient reports chest pain/pressure in message",
-    rationale:
-      "Patient described chest pain or pressure symptoms in a secure message. " +
-      "This could indicate acute coronary syndrome, pulmonary embolism, or other " +
-      "cardiac emergency requiring immediate evaluation.",
-    suggested_action:
-      "Contact patient immediately. If symptoms are active, advise calling 911. " +
-      "Assess onset, duration, severity, and associated symptoms.",
-    notify_specialties: ["cardiology"],
-  },
-  {
-    id: "MSG-BREATHING",
-    pattern: /can'?t\s*breathe|difficulty\s*breathing|short(ness)?\s*(of)?\s*breath|severe\s*sob|gasping/i,
-    severity: "critical",
-    summary: "Patient reports difficulty breathing in message",
-    rationale:
-      "Patient described respiratory distress in a secure message. This could indicate " +
-      "pulmonary embolism, CHF exacerbation, severe asthma attack, or other respiratory emergency.",
-    suggested_action:
-      "Contact patient immediately. If active respiratory distress, advise calling 911. " +
-      "Assess oxygen saturation if available, onset, and progression.",
-    notify_specialties: ["pulmonology"],
-  },
-  {
-    id: "MSG-SEVERE-HEADACHE",
-    pattern: /worst\s*headache|thunderclap\s*headache|sudden\s*severe\s*headache|worst\s*head\s*pain/i,
-    severity: "critical",
-    summary: "Patient reports sudden severe headache in message",
-    rationale:
-      "Patient described a sudden severe or 'worst ever' headache. This pattern is concerning for " +
-      "subarachnoid hemorrhage, cerebral venous thrombosis, or other intracranial emergency. " +
-      "Particularly dangerous in patients with DVT/VTE history or anticoagulation.",
-    suggested_action:
-      "Contact patient immediately. Consider emergent CT/CTA. If patient is on anticoagulation " +
-      "or has VTE history, this is a neurovascular emergency until proven otherwise.",
-    notify_specialties: ["neurology"],
-  },
-  {
-    id: "MSG-BLEEDING",
-    pattern: /bleeding\s*(a\s*lot|heavily|won'?t\s*stop|profuse)|blood\s*in\s*(stool|urine|vomit)|coughing\s*(up\s*)?blood|hemoptysis|hematuria|melena|hematemesis/i,
-    severity: "critical",
-    summary: "Patient reports significant bleeding in message",
-    rationale:
-      "Patient described significant bleeding symptoms. This is particularly dangerous in patients " +
-      "on anticoagulants, post-procedure, or with known bleeding disorders.",
-    suggested_action:
-      "Contact patient immediately. Check current medications for anticoagulants. " +
-      "Assess volume, duration, and hemodynamic stability. Consider ED referral.",
-    notify_specialties: ["hematology"],
-  },
-  {
-    id: "MSG-STROKE-SYMPTOMS",
-    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my|arm|leg)/i,
-    severity: "critical",
-    summary: "Patient describes possible stroke symptoms in message",
-    rationale:
-      "Patient described symptoms consistent with acute stroke (FAST criteria: face droop, " +
-      "arm weakness, speech difficulty). Time-sensitive — every minute matters for thrombolysis eligibility.",
-    suggested_action:
-      "IMMEDIATE: If symptoms are current, advise calling 911 immediately. " +
-      "Document last known well time. Do not delay for further assessment.",
-    notify_specialties: ["neurology"],
-  },
-  {
-    id: "MSG-SUICIDAL",
-    pattern: /suicid|want\s*to\s*die|kill\s*myself|end\s*(my|it)\s*(life|all)|don'?t\s*want\s*to\s*live|no\s*reason\s*to\s*live/i,
-    severity: "critical",
-    summary: "Patient expresses suicidal ideation in message",
-    rationale:
-      "Patient's message contains language suggesting suicidal ideation. This requires " +
-      "immediate clinical assessment and safety planning regardless of other conditions.",
-    suggested_action:
-      "IMMEDIATE: Contact patient by phone. Assess imminent risk. If unable to reach, " +
-      "consider welfare check. Involve behavioral health crisis team. Document safety plan.",
-    notify_specialties: ["psychiatry"],
-  },
-  {
-    id: "MSG-ALLERGIC-REACTION",
-    pattern: /swelling\s*(of\s*)?(my\s*)?(face|throat|tongue|lips)|anaphyla|throat\s*(closing|swelling|tight)|hives\s*all\s*over|can'?t\s*swallow/i,
-    severity: "critical",
-    summary: "Patient describes possible anaphylaxis/allergic reaction in message",
-    rationale:
-      "Patient described symptoms consistent with severe allergic reaction or anaphylaxis. " +
-      "This is a medical emergency requiring immediate intervention.",
-    suggested_action:
-      "IMMEDIATE: If symptoms are active, advise calling 911 and using epinephrine auto-injector if available. " +
-      "Review current medications for potential culprit.",
-    notify_specialties: [],
-  },
-  {
-    id: "MSG-FEVER-CHEMO",
+    ruleIdBase: "FEVER-CHEMO",
     pattern: /fever|temperature\s*(of\s*)?(10[1-9]|1[1-9]\d)|chills/i,
     severity: "warning",
-    summary: "Patient reports fever/chills in message",
+    summary: "Patient reports fever/chills {source}",
     rationale:
       "Patient reports fever or chills. In immunocompromised patients (chemotherapy, transplant, " +
       "HIV), fever can indicate febrile neutropenia or serious infection requiring emergent evaluation.",
@@ -135,10 +38,10 @@ const URGENT_PATTERNS: UrgentKeywordPattern[] = [
     notify_specialties: ["oncology", "infectious_disease"],
   },
   {
-    id: "MSG-FALL",
+    ruleIdBase: "FALL",
     pattern: /fell\s*(down|over)|had\s*a\s*fall|tripped\s*and\s*fell|lost\s*(my\s*)?balance\s*and\s*fell/i,
     severity: "warning",
-    summary: "Patient reports fall in message",
+    summary: "Patient reports fall {source}",
     rationale:
       "Patient reports a fall. This is particularly concerning in patients on anticoagulants " +
       "(risk of intracranial hemorrhage) or with osteoporosis (fracture risk).",
@@ -148,10 +51,10 @@ const URGENT_PATTERNS: UrgentKeywordPattern[] = [
     notify_specialties: [],
   },
   {
-    id: "MSG-NEW-WEAKNESS",
+    ruleIdBase: "NEW-WEAKNESS",
     pattern: /new\s*weakness|sudden\s*weakness|legs?\s*(gave|giving)\s*out|can'?t\s*stand|collapsed/i,
     severity: "warning",
-    summary: "Patient reports new weakness or collapse in message",
+    summary: "Patient reports new weakness or collapse {source}",
     rationale:
       "Patient describes new onset weakness or collapse. This could indicate neurological event, " +
       "cardiac arrhythmia, severe anemia, or medication side effect.",
@@ -160,6 +63,11 @@ const URGENT_PATTERNS: UrgentKeywordPattern[] = [
       "Consider neurological evaluation if focal weakness.",
     notify_specialties: ["neurology"],
   },
+];
+
+const ALL_MESSAGE_PATTERNS: ScreeningPattern[] = [
+  ...SHARED_CRITICAL_PATTERNS,
+  ...MESSAGE_ONLY_PATTERNS,
 ];
 
 /**
@@ -181,16 +89,17 @@ export function screenPatientMessage(event: ClinicalEvent): RuleFlag[] {
 
   if (!messageText) return flags;
 
-  for (const pattern of URGENT_PATTERNS) {
-    if (pattern.pattern.test(messageText)) {
+  for (const p of ALL_MESSAGE_PATTERNS) {
+    if (p.pattern.test(messageText)) {
+      const { rule_id, summary } = materializePattern(p, MSG_PREFIX, MSG_SOURCE);
       flags.push({
-        severity: pattern.severity,
+        severity: p.severity,
         category: "patient-reported" as FlagCategory,
-        summary: pattern.summary,
-        rationale: pattern.rationale,
-        suggested_action: pattern.suggested_action,
-        notify_specialties: pattern.notify_specialties,
-        rule_id: pattern.id,
+        summary,
+        rationale: p.rationale,
+        suggested_action: p.suggested_action,
+        notify_specialties: p.notify_specialties,
+        rule_id,
       });
     }
   }

--- a/services/ai-oversight/src/rules/observation-screening.ts
+++ b/services/ai-oversight/src/rules/observation-screening.ts
@@ -11,127 +11,25 @@
  * `patient.observation` events.
  */
 
-import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
+import type { FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
 import type { RuleFlag } from "./critical-values.js";
+import {
+  SHARED_CRITICAL_PATTERNS,
+  materializePattern,
+  type ScreeningPattern,
+} from "./screening-patterns.js";
 
-interface ObservationKeywordPattern {
-  id: string;
-  pattern: RegExp;
-  severity: FlagSeverity;
-  summary: string;
-  rationale: string;
-  suggested_action: string;
-  notify_specialties: string[];
-}
+const OBS_PREFIX = "OBS";
+const OBS_SOURCE = "in symptom journal";
 
-/**
- * Critical keyword patterns — symptoms that demand immediate clinical review.
- */
-const CRITICAL_PATTERNS: ObservationKeywordPattern[] = [
-  {
-    id: "OBS-CHEST-PAIN",
-    pattern: /chest\s*pain|chest\s*tightness|chest\s*pressure|angina/i,
-    severity: "critical",
-    summary: "Patient reports chest pain/pressure in symptom journal",
-    rationale:
-      "Patient described chest pain or pressure symptoms in a symptom observation. " +
-      "This could indicate acute coronary syndrome, pulmonary embolism, or other " +
-      "cardiac emergency requiring immediate evaluation.",
-    suggested_action:
-      "Contact patient immediately. If symptoms are active, advise calling 911. " +
-      "Assess onset, duration, severity, and associated symptoms.",
-    notify_specialties: ["cardiology"],
-  },
-  {
-    id: "OBS-BREATHING",
-    pattern: /can'?t\s*breathe|difficulty\s*breathing|short(ness)?\s*(of)?\s*breath|severe\s*sob|gasping/i,
-    severity: "critical",
-    summary: "Patient reports difficulty breathing in symptom journal",
-    rationale:
-      "Patient described respiratory distress in a symptom observation. This could indicate " +
-      "pulmonary embolism, CHF exacerbation, severe asthma attack, or other respiratory emergency.",
-    suggested_action:
-      "Contact patient immediately. If active respiratory distress, advise calling 911. " +
-      "Assess oxygen saturation if available, onset, and progression.",
-    notify_specialties: ["pulmonology"],
-  },
-  {
-    id: "OBS-SEVERE-HEADACHE",
-    pattern: /worst\s*headache|thunderclap\s*headache|sudden\s*severe\s*headache|worst\s*head\s*pain/i,
-    severity: "critical",
-    summary: "Patient reports sudden severe headache in symptom journal",
-    rationale:
-      "Patient described a sudden severe or 'worst ever' headache. This pattern is concerning for " +
-      "subarachnoid hemorrhage, cerebral venous thrombosis, or other intracranial emergency. " +
-      "Particularly dangerous in patients with DVT/VTE history or anticoagulation.",
-    suggested_action:
-      "Contact patient immediately. Consider emergent CT/CTA. If patient is on anticoagulation " +
-      "or has VTE history, this is a neurovascular emergency until proven otherwise.",
-    notify_specialties: ["neurology"],
-  },
-  {
-    id: "OBS-STROKE-SYMPTOMS",
-    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my\s*)?(arm|leg)\b/i,
-    severity: "critical",
-    summary: "Patient describes possible stroke symptoms in symptom journal",
-    rationale:
-      "Patient described symptoms consistent with acute stroke (FAST criteria: face droop, " +
-      "arm weakness, speech difficulty). Time-sensitive — every minute matters for thrombolysis eligibility.",
-    suggested_action:
-      "IMMEDIATE: If symptoms are current, advise calling 911 immediately. " +
-      "Document last known well time. Do not delay for further assessment.",
-    notify_specialties: ["neurology"],
-  },
-  {
-    id: "OBS-SUICIDAL",
-    pattern: /suicid|want\s*to\s*die|kill\s*myself|end\s*(my|it)\s*(life|all)|don'?t\s*want\s*to\s*live|no\s*reason\s*to\s*live/i,
-    severity: "critical",
-    summary: "Patient expresses suicidal ideation in symptom journal",
-    rationale:
-      "Patient's observation contains language suggesting suicidal ideation. This requires " +
-      "immediate clinical assessment and safety planning regardless of other conditions.",
-    suggested_action:
-      "IMMEDIATE: Contact patient by phone. Assess imminent risk. If unable to reach, " +
-      "consider welfare check. Involve behavioral health crisis team. Document safety plan.",
-    notify_specialties: ["psychiatry"],
-  },
-  {
-    id: "OBS-ALLERGIC-REACTION",
-    pattern: /swelling\s*(of\s*)?(my\s*)?(face|throat|tongue|lips)|anaphyla|throat\s*(closing|swelling|tight)|hives\s*all\s*over|can'?t\s*swallow/i,
-    severity: "critical",
-    summary: "Patient describes possible anaphylaxis/allergic reaction in symptom journal",
-    rationale:
-      "Patient described symptoms consistent with severe allergic reaction or anaphylaxis. " +
-      "This is a medical emergency requiring immediate intervention.",
-    suggested_action:
-      "IMMEDIATE: If symptoms are active, advise calling 911 and using epinephrine auto-injector if available. " +
-      "Review current medications for potential culprit.",
-    notify_specialties: [],
-  },
-];
+// ── Observation-specific patterns (not shared with message screening) ──
 
-/**
- * High-severity keyword patterns — urgent but not immediately life-threatening.
- */
-const HIGH_PATTERNS: ObservationKeywordPattern[] = [
+const OBSERVATION_ONLY_PATTERNS: ScreeningPattern[] = [
   {
-    id: "OBS-BLEEDING",
-    pattern: /blood\s*in\s*(stool|urine|vomit)|coughing\s*(up\s*)?blood|bleeding\s*(a\s*lot|heavily|won'?t\s*stop)|hemoptysis|hematuria|melena|hematemesis/i,
-    severity: "critical",
-    summary: "Patient reports significant bleeding in symptom journal",
-    rationale:
-      "Patient described significant bleeding symptoms. This is particularly dangerous in patients " +
-      "on anticoagulants, post-procedure, or with known bleeding disorders.",
-    suggested_action:
-      "Contact patient to assess volume and duration. Check current medications for anticoagulants. " +
-      "Consider ED referral if hemodynamically significant.",
-    notify_specialties: ["hematology"],
-  },
-  {
-    id: "OBS-SEVERE-PAIN",
+    ruleIdBase: "SEVERE-PAIN",
     pattern: /severe\s*pain|excruciating|unbearable\s*pain|10\s*out\s*of\s*10|10\/10\s*pain/i,
     severity: "warning",
-    summary: "Patient reports severe pain in symptom journal",
+    summary: "Patient reports severe pain {source}",
     rationale:
       "Patient described severe or excruciating pain. Uncontrolled severe pain warrants " +
       "prompt clinical reassessment of diagnosis and pain management plan.",
@@ -141,10 +39,10 @@ const HIGH_PATTERNS: ObservationKeywordPattern[] = [
     notify_specialties: [],
   },
   {
-    id: "OBS-FAINTING",
+    ruleIdBase: "FAINTING",
     pattern: /faint(ed|ing)|passed?\s*out|lost?\s*consciousness|syncop/i,
     severity: "warning",
-    summary: "Patient reports fainting/syncope in symptom journal",
+    summary: "Patient reports fainting/syncope {source}",
     rationale:
       "Patient described syncope or near-syncope. This may indicate cardiac arrhythmia, " +
       "orthostatic hypotension, vasovagal episode, or neurological event.",
@@ -154,10 +52,10 @@ const HIGH_PATTERNS: ObservationKeywordPattern[] = [
     notify_specialties: ["cardiology"],
   },
   {
-    id: "OBS-SEIZURE",
+    ruleIdBase: "SEIZURE",
     pattern: /seizure|convuls|shaking\s*uncontrollably|epilep/i,
     severity: "warning",
-    summary: "Patient reports seizure activity in symptom journal",
+    summary: "Patient reports seizure activity {source}",
     rationale:
       "Patient described seizure or convulsion activity. New-onset seizures require " +
       "urgent neurological evaluation to rule out structural or metabolic causes.",
@@ -167,10 +65,10 @@ const HIGH_PATTERNS: ObservationKeywordPattern[] = [
     notify_specialties: ["neurology"],
   },
   {
-    id: "OBS-HIGH-FEVER",
+    ruleIdBase: "HIGH-FEVER",
     pattern: /high\s*fever|temperature\s*(of\s*)?(10[3-9]|1[1-9]\d)|fever\s*(won'?t|doesn'?t|not)\s*(go\s*down|break|respond)/i,
     severity: "warning",
-    summary: "Patient reports high or persistent fever in symptom journal",
+    summary: "Patient reports high or persistent fever {source}",
     rationale:
       "Patient reported high or unresponsive fever. In immunocompromised patients " +
       "(chemotherapy, transplant, HIV), this can indicate febrile neutropenia or serious infection.",
@@ -181,7 +79,10 @@ const HIGH_PATTERNS: ObservationKeywordPattern[] = [
   },
 ];
 
-const ALL_PATTERNS = [...CRITICAL_PATTERNS, ...HIGH_PATTERNS];
+const ALL_OBSERVATION_PATTERNS: ScreeningPattern[] = [
+  ...SHARED_CRITICAL_PATTERNS,
+  ...OBSERVATION_ONLY_PATTERNS,
+];
 
 /**
  * Screen a patient observation for urgent symptoms.
@@ -196,16 +97,17 @@ export function screenPatientObservation(event: ClinicalEvent): RuleFlag[] {
 
   if (!description) return flags;
 
-  for (const entry of ALL_PATTERNS) {
-    if (entry.pattern.test(description)) {
+  for (const p of ALL_OBSERVATION_PATTERNS) {
+    if (p.pattern.test(description)) {
+      const { rule_id, summary } = materializePattern(p, OBS_PREFIX, OBS_SOURCE);
       flags.push({
-        severity: entry.severity,
-        category: "patient-reported",
-        summary: entry.summary,
-        rationale: entry.rationale,
-        suggested_action: entry.suggested_action,
-        notify_specialties: entry.notify_specialties,
-        rule_id: entry.id,
+        severity: p.severity,
+        category: "patient-reported" as FlagCategory,
+        summary,
+        rationale: p.rationale,
+        suggested_action: p.suggested_action,
+        notify_specialties: p.notify_specialties,
+        rule_id,
       });
     }
   }

--- a/services/ai-oversight/src/rules/screening-patterns.ts
+++ b/services/ai-oversight/src/rules/screening-patterns.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared keyword patterns for patient screening rules.
+ *
+ * Both message-screening and observation-screening need to detect the same
+ * urgent clinical signals (chest pain, stroke symptoms, suicidal ideation, etc.).
+ * This module is the single source of truth for those patterns so they cannot
+ * drift independently.
+ *
+ * Each entry defines the regex, default severity, clinical metadata, and a
+ * `ruleIdBase` that the consuming module prefixes with its own context
+ * (e.g. "MSG-" or "OBS-").
+ */
+
+import type { FlagSeverity } from "@carebridge/shared-types";
+
+export interface ScreeningPattern {
+  /** Base identifier — consumers prepend a context prefix (MSG- / OBS-). */
+  ruleIdBase: string;
+  /** Case-insensitive regex matched against free-text input. */
+  pattern: RegExp;
+  /** Default severity when the pattern fires. */
+  severity: FlagSeverity;
+  /** One-line clinical summary template. Use `{source}` as a placeholder
+   *  that consumers replace with context (e.g. "in message" / "in symptom journal"). */
+  summary: string;
+  rationale: string;
+  suggested_action: string;
+  notify_specialties: string[];
+}
+
+// ── Critical patterns — immediately life-threatening ──────────────────
+
+export const SHARED_CRITICAL_PATTERNS: ScreeningPattern[] = [
+  {
+    ruleIdBase: "CHEST-PAIN",
+    pattern: /chest\s*pain|chest\s*tightness|chest\s*pressure|angina/i,
+    severity: "critical",
+    summary: "Patient reports chest pain/pressure {source}",
+    rationale:
+      "Patient described chest pain or pressure symptoms. " +
+      "This could indicate acute coronary syndrome, pulmonary embolism, or other " +
+      "cardiac emergency requiring immediate evaluation.",
+    suggested_action:
+      "Contact patient immediately. If symptoms are active, advise calling 911. " +
+      "Assess onset, duration, severity, and associated symptoms.",
+    notify_specialties: ["cardiology"],
+  },
+  {
+    ruleIdBase: "BREATHING",
+    pattern: /can'?t\s*breathe|difficulty\s*breathing|short(ness)?\s*(of)?\s*breath|severe\s*sob|gasping/i,
+    severity: "critical",
+    summary: "Patient reports difficulty breathing {source}",
+    rationale:
+      "Patient described respiratory distress. This could indicate " +
+      "pulmonary embolism, CHF exacerbation, severe asthma attack, or other respiratory emergency.",
+    suggested_action:
+      "Contact patient immediately. If active respiratory distress, advise calling 911. " +
+      "Assess oxygen saturation if available, onset, and progression.",
+    notify_specialties: ["pulmonology"],
+  },
+  {
+    ruleIdBase: "SEVERE-HEADACHE",
+    pattern: /worst\s*headache|thunderclap\s*headache|sudden\s*severe\s*headache|worst\s*head\s*pain/i,
+    severity: "critical",
+    summary: "Patient reports sudden severe headache {source}",
+    rationale:
+      "Patient described a sudden severe or 'worst ever' headache. This pattern is concerning for " +
+      "subarachnoid hemorrhage, cerebral venous thrombosis, or other intracranial emergency. " +
+      "Particularly dangerous in patients with DVT/VTE history or anticoagulation.",
+    suggested_action:
+      "Contact patient immediately. Consider emergent CT/CTA. If patient is on anticoagulation " +
+      "or has VTE history, this is a neurovascular emergency until proven otherwise.",
+    notify_specialties: ["neurology"],
+  },
+  {
+    ruleIdBase: "STROKE-SYMPTOMS",
+    pattern: /face\s*droop|arm\s*weakness|slurred\s*speech|sudden\s*numbness|sudden\s*confusion|vision\s*loss|can'?t\s*move\s*(my\s*)?(arm|leg)\b/i,
+    severity: "critical",
+    summary: "Patient describes possible stroke symptoms {source}",
+    rationale:
+      "Patient described symptoms consistent with acute stroke (FAST criteria: face droop, " +
+      "arm weakness, speech difficulty). Time-sensitive — every minute matters for thrombolysis eligibility.",
+    suggested_action:
+      "IMMEDIATE: If symptoms are current, advise calling 911 immediately. " +
+      "Document last known well time. Do not delay for further assessment.",
+    notify_specialties: ["neurology"],
+  },
+  {
+    ruleIdBase: "SUICIDAL",
+    pattern: /suicid|want\s*to\s*die|kill\s*myself|end\s*(my|it)\s*(life|all)|don'?t\s*want\s*to\s*live|no\s*reason\s*to\s*live/i,
+    severity: "critical",
+    summary: "Patient expresses suicidal ideation {source}",
+    rationale:
+      "Patient's text contains language suggesting suicidal ideation. This requires " +
+      "immediate clinical assessment and safety planning regardless of other conditions.",
+    suggested_action:
+      "IMMEDIATE: Contact patient by phone. Assess imminent risk. If unable to reach, " +
+      "consider welfare check. Involve behavioral health crisis team. Document safety plan.",
+    notify_specialties: ["psychiatry"],
+  },
+  {
+    ruleIdBase: "ALLERGIC-REACTION",
+    pattern: /swelling\s*(of\s*)?(my\s*)?(face|throat|tongue|lips)|anaphyla|throat\s*(closing|swelling|tight)|hives\s*all\s*over|can'?t\s*swallow/i,
+    severity: "critical",
+    summary: "Patient describes possible anaphylaxis/allergic reaction {source}",
+    rationale:
+      "Patient described symptoms consistent with severe allergic reaction or anaphylaxis. " +
+      "This is a medical emergency requiring immediate intervention.",
+    suggested_action:
+      "IMMEDIATE: If symptoms are active, advise calling 911 and using epinephrine auto-injector if available. " +
+      "Review current medications for potential culprit.",
+    notify_specialties: [],
+  },
+  {
+    ruleIdBase: "BLEEDING",
+    pattern: /bleeding\s*(a\s*lot|heavily|won'?t\s*stop|profuse)|blood\s*in\s*(stool|urine|vomit)|coughing\s*(up\s*)?blood|hemoptysis|hematuria|melena|hematemesis/i,
+    severity: "critical",
+    summary: "Patient reports significant bleeding {source}",
+    rationale:
+      "Patient described significant bleeding symptoms. This is particularly dangerous in patients " +
+      "on anticoagulants, post-procedure, or with known bleeding disorders.",
+    suggested_action:
+      "Contact patient to assess volume and duration. Check current medications for anticoagulants. " +
+      "Consider ED referral if hemodynamically significant.",
+    notify_specialties: ["hematology"],
+  },
+];
+
+/**
+ * Build a concrete rule ID and summary from a shared pattern definition.
+ *
+ * @param p       - shared pattern entry
+ * @param prefix  - context prefix, e.g. "MSG" or "OBS"
+ * @param source  - human-readable source label, e.g. "in message" or "in symptom journal"
+ */
+export function materializePattern(
+  p: ScreeningPattern,
+  prefix: string,
+  source: string,
+): { rule_id: string; summary: string } {
+  return {
+    rule_id: `${prefix}-${p.ruleIdBase}`,
+    summary: p.summary.replace("{source}", source),
+  };
+}


### PR DESCRIPTION
## Summary
- Extracts 7 overlapping keyword patterns (chest pain, breathing, headache, stroke, suicidal, allergic reaction, bleeding) from `message-screening.ts` and `observation-screening.ts` into a new `screening-patterns.ts` module
- Adds a `materializePattern()` helper that stamps each shared pattern with a context-specific rule ID prefix (MSG-/OBS-) and summary source text
- Keeps screening-specific logic in each file: sender_role guard in messages, observation_description field access in observations, and context-unique patterns (fall, new-weakness, fever-chemo for messages; severe-pain, fainting, seizure, high-fever for observations)

## Test plan
- [x] All 23 message-screening tests pass (keyword detection, no false positives, edge cases)
- [x] All 16 observation-screening tests pass (critical, warning, no-match, multiple-match cases)
- [x] Rule IDs remain unchanged (MSG-CHEST-PAIN, OBS-CHEST-PAIN, etc.) so downstream consumers are unaffected

Closes #416