### PR TITLE
fix(notifications): add graceful shutdown for Redis publisher client

### DIFF
--- a/services/notifications/src/__tests__/publish.test.ts
+++ b/services/notifications/src/__tests__/publish.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { publishNotification, setPublisher } from "../publish.js";
+import { publishNotification, setPublisher, shutdownPublisher, getPublisher } from "../publish.js";
 
 /**
  * Tests for Redis pub/sub notification publishing.
@@ -98,6 +98,34 @@ describe("publishNotification", () => {
     await publishNotification("", payload);
 
     expect(mockRedis.publish).not.toHaveBeenCalled();
+  });
+
+  it("shutdownPublisher calls quit and clears the singleton", async () => {
+    await shutdownPublisher();
+
+    expect(mockRedis.quit).toHaveBeenCalledTimes(1);
+
+    // After shutdown, getPublisher should create a new instance (not return
+    // the old mock). We inject a fresh mock to verify the singleton was cleared.
+    const freshMock = createMockRedis();
+    setPublisher(freshMock as never);
+    await publishNotification("user-check", {
+      id: "notif-shutdown",
+      type: "system",
+      title: "After shutdown",
+      created_at: "2026-04-12T15:00:00.000Z",
+    });
+    expect(freshMock.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("shutdownPublisher is a no-op when no publisher exists", async () => {
+    // Clear the publisher first by shutting down
+    await shutdownPublisher();
+    mockRedis.quit.mockClear();
+
+    // Second call should be a no-op
+    await shutdownPublisher();
+    expect(mockRedis.quit).not.toHaveBeenCalled();
   });
 
   it("publishes to distinct channels for different users", async () => {

--- a/services/notifications/src/publish.ts
+++ b/services/notifications/src/publish.ts
@@ -47,6 +47,19 @@ export function setPublisher(client: Redis): void {
 }
 
 /**
+ * Gracefully close the Redis publisher connection if one exists.
+ *
+ * After calling this the singleton is cleared so a subsequent
+ * `getPublisher()` call will create a fresh connection.
+ */
+export async function shutdownPublisher(): Promise<void> {
+  if (publisherClient) {
+    await publisherClient.quit();
+    publisherClient = null;
+  }
+}
+
+/**
  * Publish a notification to the Redis channel for a specific user.
  *
  * The channel format `notifications:{userId}` matches what the SSE

--- a/services/notifications/src/server.ts
+++ b/services/notifications/src/server.ts
@@ -7,6 +7,7 @@
 
 import { createServer } from "node:http";
 import { startDispatchWorker } from "./workers/dispatch-worker.js";
+import { shutdownPublisher } from "./publish.js";
 
 const HEALTH_PORT = Number(process.env.NOTIFICATION_HEALTH_PORT ?? 4002);
 
@@ -54,6 +55,7 @@ async function shutdown(signal: string) {
   console.log(`[notifications] Received ${signal}, shutting down…`);
   healthServer.close();
   await worker.close();
+  await shutdownPublisher();
   console.log("[notifications] Shutdown complete");
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- Add `shutdownPublisher()` to `services/notifications/src/publish.ts` that calls `quit()` on the Redis publisher singleton and sets it to `null`
- Call `shutdownPublisher()` in the existing SIGTERM/SIGINT shutdown handler in `server.ts`
- Add tests verifying shutdown calls quit and clears the singleton, and that a second call is a no-op

Closes #418

## Test plan
- [x] Existing publish tests still pass (5/5)
- [x] New shutdown tests pass (2/2) — verifies quit is called, singleton is cleared, and double-shutdown is safe