### PR TITLE
refactor(portal): extract shared AuthGuard to portal-shared

### DIFF
--- a/apps/clinician-portal/src/lib/auth-guard.tsx
+++ b/apps/clinician-portal/src/lib/auth-guard.tsx
@@ -1,29 +1,3 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useAuth } from "./auth";
-
-/**
- * Wraps a page component and redirects to /login if not authenticated.
- */
-export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, hydrated } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (hydrated && !isAuthenticated) {
-      router.replace("/login");
-    }
-  }, [hydrated, isAuthenticated, router]);
-
-  if (!hydrated || !isAuthenticated) {
-    return (
-      <div style={{ padding: 40, color: "var(--text-muted)" }}>
-        {hydrated ? "Redirecting to login..." : "Loading..."}
-      </div>
-    );
-  }
-
-  return <>{children}</>;
-}
+export { AuthGuard } from "@carebridge/portal-shared/auth-guard";

--- a/packages/portal-shared/package.json
+++ b/packages/portal-shared/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./trpc": "./src/trpc.ts",
     "./auth": "./src/auth.tsx",
-    "./providers": "./src/providers.tsx"
+    "./providers": "./src/providers.tsx",
+    "./auth-guard": "./src/auth-guard.tsx"
   },
   "dependencies": {
     "@trpc/client": "^11.0.0",
@@ -15,9 +16,13 @@
     "@tanstack/react-query": "^5.60.0",
     "react": "^19.0.0"
   },
+  "peerDependencies": {
+    "next": ">=14.0.0"
+  },
   "devDependencies": {
     "@carebridge/api-gateway": "workspace:*",
     "@types/react": "^19.0.0",
+    "next": "^15.1.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/portal-shared/src/auth-guard.tsx
+++ b/packages/portal-shared/src/auth-guard.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "./auth";
+
+/**
+ * Wraps a page component and redirects to /login if not authenticated.
+ */
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, hydrated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (hydrated && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [hydrated, isAuthenticated, router]);
+
+  if (!hydrated || !isAuthenticated) {
+    return (
+      <div style={{ padding: 40, color: "var(--text-muted)" }}>
+        {hydrated ? "Redirecting to login..." : "Loading..."}
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
+      next:
+        specifier: ^15.1.0
+        version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -5371,8 +5374,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5391,7 +5394,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5402,22 +5405,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5428,7 +5431,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Extract `AuthGuard` component from `apps/clinician-portal/src/lib/auth-guard.tsx` into `packages/portal-shared/src/auth-guard.tsx` so both portals can share it
- Add `./auth-guard` export to portal-shared package.json
- Add `next` as a peer dependency in portal-shared (needed for `useRouter` from `next/navigation`)
- Clinician portal now re-exports `AuthGuard` from the shared package

Closes #412

## Test plan
- [x] `pnpm build` passes for all packages
- [ ] Verify clinician portal auth guard behavior unchanged (redirect to /login when unauthenticated)
- [ ] Verify patient portal can import `@carebridge/portal-shared/auth-guard` and use `AuthGuard`