### PR TITLE
fix(ai): evaluate diastolic BP for hypertensive emergency detection

### DIFF
--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -13,6 +13,19 @@ export interface VitalRange {
   criticalHigh?: number;
 }
 
+/** Diastolic-specific thresholds for blood pressure evaluation */
+export interface DiastolicRange {
+  criticalLow: number;
+  criticalHigh: number;
+  warningHigh: number;
+}
+
+export const DIASTOLIC_DANGER_ZONE: DiastolicRange = {
+  criticalLow: 60,
+  criticalHigh: 120,
+  warningHigh: 90,
+};
+
 export const VITAL_DANGER_ZONES: Record<VitalType, VitalRange> = {
   blood_pressure: { min: 60, max: 250, criticalLow: 70, criticalHigh: 180 },
   heart_rate: { min: 20, max: 300, criticalLow: 40, criticalHigh: 200 },
@@ -133,4 +146,15 @@ export function isCriticalVital(type: VitalType, value: number): boolean {
   if (range.criticalLow !== undefined && value <= range.criticalLow) return true;
   if (range.criticalHigh !== undefined && value >= range.criticalHigh) return true;
   return false;
+}
+
+/** Severity level for diastolic evaluation */
+export type DiastolicSeverity = "critical" | "warning" | null;
+
+/** Check diastolic BP and return severity (critical, warning, or null) */
+export function checkDiastolicBP(diastolic: number): DiastolicSeverity {
+  if (diastolic < DIASTOLIC_DANGER_ZONE.criticalLow) return "critical";
+  if (diastolic >= DIASTOLIC_DANGER_ZONE.criticalHigh) return "critical";
+  if (diastolic >= DIASTOLIC_DANGER_ZONE.warningHigh) return "warning";
+  return null;
 }

--- a/services/ai-oversight/src/__tests__/rules.test.ts
+++ b/services/ai-oversight/src/__tests__/rules.test.ts
@@ -17,6 +17,11 @@ vi.mock("@carebridge/medical-logic", () => ({
     blood_pressure: { min: 60, max: 250, criticalLow: 70, criticalHigh: 180 },
     blood_glucose: { min: 10, max: 800, criticalLow: 54, criticalHigh: 400 },
   },
+  DIASTOLIC_DANGER_ZONE: {
+    criticalLow: 60,
+    criticalHigh: 120,
+    warningHigh: 90,
+  },
   isCriticalVital: (type: string, value: number) => {
     const zones: Record<string, { criticalLow?: number; criticalHigh?: number }> = {
       heart_rate: { criticalLow: 40, criticalHigh: 200 },
@@ -30,6 +35,12 @@ vi.mock("@carebridge/medical-logic", () => ({
     if (zone.criticalLow !== undefined && value <= zone.criticalLow) return true;
     if (zone.criticalHigh !== undefined && value >= zone.criticalHigh) return true;
     return false;
+  },
+  checkDiastolicBP: (diastolic: number) => {
+    if (diastolic < 60) return "critical";
+    if (diastolic >= 120) return "critical";
+    if (diastolic >= 90) return "warning";
+    return null;
   },
 }));
 
@@ -77,6 +88,105 @@ describe("checkCriticalValues", () => {
     });
 
     expect(flags).toHaveLength(0);
+  });
+
+  it("returns no diastolic flag for normal BP (120/80)", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-1",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 120, value_secondary: 80, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(flags).toHaveLength(0);
+  });
+
+  it("flags systolic crisis (190/90) as critical", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-2",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 190, value_secondary: 90, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Systolic 190 >= 180 triggers systolic critical flag
+    const systolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-BLOOD_PRESSURE");
+    expect(systolicFlag).toBeDefined();
+    expect(systolicFlag!.severity).toBe("critical");
+  });
+
+  it("flags diastolic crisis (145/125) as critical — hypertensive emergency", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-3",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 145, value_secondary: 125, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Systolic 145 is NOT critical (< 180), but diastolic 125 >= 120 is critical
+    const systolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-BLOOD_PRESSURE");
+    expect(systolicFlag).toBeUndefined();
+
+    const diastolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-DIASTOLIC_BP");
+    expect(diastolicFlag).toBeDefined();
+    expect(diastolicFlag!.severity).toBe("critical");
+    expect(diastolicFlag!.summary).toContain("diastolic");
+    expect(diastolicFlag!.summary).toContain("145/125");
+  });
+
+  it("flags both systolic and diastolic when both critical (200/130)", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-4",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 200, value_secondary: 130, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    const systolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-BLOOD_PRESSURE");
+    expect(systolicFlag).toBeDefined();
+    expect(systolicFlag!.severity).toBe("critical");
+
+    const diastolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-DIASTOLIC_BP");
+    expect(diastolicFlag).toBeDefined();
+    expect(diastolicFlag!.severity).toBe("critical");
+  });
+
+  it("flags isolated diastolic high (135/95) as warning", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-5",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 135, value_secondary: 95, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Systolic 135 is not critical
+    const systolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-BLOOD_PRESSURE");
+    expect(systolicFlag).toBeUndefined();
+
+    // Diastolic 95 >= 90 triggers warning
+    const diastolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-DIASTOLIC_BP");
+    expect(diastolicFlag).toBeDefined();
+    expect(diastolicFlag!.severity).toBe("warning");
+  });
+
+  it("flags critically low diastolic (130/50) as critical hypotension", () => {
+    const flags = checkCriticalValues({
+      id: "evt-bp-6",
+      type: "vital.created",
+      patient_id: "p-1",
+      data: { type: "blood_pressure", value_primary: 130, value_secondary: 50, unit: "mmHg" },
+      timestamp: new Date().toISOString(),
+    });
+
+    const diastolicFlag = flags.find((f) => f.rule_id === "CRITICAL-VITAL-DIASTOLIC_BP");
+    expect(diastolicFlag).toBeDefined();
+    expect(diastolicFlag!.severity).toBe("critical");
+    expect(diastolicFlag!.summary).toContain("low");
   });
 
   it("flags critical lab results with explicit critical flag", () => {

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -8,7 +8,7 @@
 import type { VitalType } from "@carebridge/shared-types";
 import { COMMON_LAB_TESTS } from "@carebridge/shared-types";
 import type { ClinicalEvent, FlagSeverity, FlagCategory } from "@carebridge/shared-types";
-import { VITAL_DANGER_ZONES, isCriticalVital } from "@carebridge/medical-logic";
+import { VITAL_DANGER_ZONES, DIASTOLIC_DANGER_ZONE, isCriticalVital, checkDiastolicBP } from "@carebridge/medical-logic";
 
 export interface RuleFlag {
   severity: FlagSeverity;
@@ -51,6 +51,39 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
         notify_specialties: [],
         rule_id: `CRITICAL-VITAL-${vitalType.toUpperCase()}`,
       });
+    }
+
+    // Evaluate diastolic BP independently for blood pressure vitals
+    if (vitalType === "blood_pressure") {
+      const diastolic = event.data.value_secondary as number | undefined;
+      if (diastolic !== undefined) {
+        const diastolicSeverity = checkDiastolicBP(diastolic);
+        if (diastolicSeverity) {
+          const direction = diastolic < DIASTOLIC_DANGER_ZONE.criticalLow ? "low" : "high";
+          const displayBP = value !== undefined ? `${value}/${diastolic}` : `${diastolic}`;
+          flags.push({
+            severity: diastolicSeverity,
+            category: "critical-value",
+            summary: `Critically ${direction} diastolic blood pressure: ${displayBP} ${(event.data.unit as string) ?? "mmHg"}`.trim(),
+            rationale:
+              `Patient's diastolic blood pressure of ${diastolic} mmHg is in the ${diastolicSeverity} range. ` +
+              `Diastolic thresholds: critical low < ${DIASTOLIC_DANGER_ZONE.criticalLow}, ` +
+              `warning high >= ${DIASTOLIC_DANGER_ZONE.warningHigh}, ` +
+              `critical high >= ${DIASTOLIC_DANGER_ZONE.criticalHigh}. ` +
+              (diastolicSeverity === "critical" && direction === "high"
+                ? `Diastolic >= ${DIASTOLIC_DANGER_ZONE.criticalHigh} mmHg indicates hypertensive emergency. Immediate assessment required.`
+                : diastolicSeverity === "critical" && direction === "low"
+                  ? `Diastolic < ${DIASTOLIC_DANGER_ZONE.criticalLow} mmHg indicates significant hypotension. Immediate assessment required.`
+                  : `Diastolic >= ${DIASTOLIC_DANGER_ZONE.warningHigh} mmHg indicates hypertension requiring clinical evaluation.`),
+            suggested_action:
+              diastolicSeverity === "critical"
+                ? `Assess patient immediately. ${direction === "high" ? "Evaluate for hypertensive emergency — risk of stroke, aortic dissection, and end-organ damage. Initiate IV antihypertensive therapy per protocol." : "Evaluate for causes of hypotension and initiate fluid resuscitation or vasopressor support as indicated."}`
+                : `Evaluate patient for hypertension. Consider repeat measurement, medication review, and initiation or adjustment of antihypertensive therapy.`,
+            notify_specialties: diastolicSeverity === "critical" ? ["cardiology"] : [],
+            rule_id: `CRITICAL-VITAL-DIASTOLIC_BP`,
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds diastolic blood pressure thresholds (`DIASTOLIC_DANGER_ZONE`) to `@carebridge/medical-logic` with critical high (>=120 mmHg), warning high (>=90 mmHg), and critical low (<60 mmHg)
- Adds `checkDiastolicBP()` helper that returns severity level for a diastolic reading
- Updates `checkCriticalValues()` in the ai-oversight rules engine to independently evaluate `event.data.value_secondary` (diastolic) for blood pressure vitals, so isolated diastolic emergencies are no longer silently missed
- Adds 6 new test cases covering normal BP, systolic-only crisis, diastolic-only crisis, both critical, isolated diastolic warning, and critically low diastolic

## Test plan
- [x] Normal BP (120/80) produces no flags
- [x] Systolic crisis (190/90) still flags as critical (existing behavior preserved)
- [x] Diastolic crisis (145/125) now flags as critical — this was the missed case
- [x] Both critical (200/130) produces two independent flags
- [x] Isolated diastolic high (135/95) flags as warning
- [x] Critically low diastolic (130/50) flags as critical hypotension
- [x] All 22 tests in rules.test.ts pass

Closes #202