### PR TITLE
feat(ai): add serotonin syndrome drug interaction rules

### DIFF
--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { checkDrugInteractions } from "./drug-interactions.js";
+
+describe("checkDrugInteractions", () => {
+  describe("serotonin syndrome — SSRI/SNRI + tramadol", () => {
+    it("flags sertraline + tramadol", () => {
+      const flags = checkDrugInteractions(["sertraline 50mg", "tramadol 50mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-TRAMADOL");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags fluoxetine + ultram (brand name)", () => {
+      const flags = checkDrugInteractions(["fluoxetine 20mg", "ultram 100mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-TRAMADOL");
+      expect(match).toBeDefined();
+    });
+
+    it("flags SNRI venlafaxine + tramadol", () => {
+      const flags = checkDrugInteractions(["venlafaxine 75mg", "tramadol 50mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-TRAMADOL");
+      expect(match).toBeDefined();
+    });
+
+    it("flags duloxetine + tramadol", () => {
+      const flags = checkDrugInteractions(["duloxetine 60mg", "tramadol 50mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-TRAMADOL");
+      expect(match).toBeDefined();
+    });
+  });
+
+  describe("serotonin syndrome — SSRI/SNRI + linezolid", () => {
+    it("flags sertraline + linezolid", () => {
+      const flags = checkDrugInteractions(["sertraline 100mg", "linezolid 600mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-LINEZOLID");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags escitalopram + zyvox (brand name)", () => {
+      const flags = checkDrugInteractions(["escitalopram 10mg", "zyvox 600mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-LINEZOLID");
+      expect(match).toBeDefined();
+    });
+
+    it("flags SNRI desvenlafaxine + linezolid", () => {
+      const flags = checkDrugInteractions([
+        "desvenlafaxine 50mg",
+        "linezolid 600mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-LINEZOLID");
+      expect(match).toBeDefined();
+    });
+  });
+
+  describe("serotonin syndrome — SSRI/SNRI + dextromethorphan", () => {
+    it("flags paroxetine + dextromethorphan", () => {
+      const flags = checkDrugInteractions([
+        "paroxetine 20mg",
+        "dextromethorphan 30mg",
+      ]);
+      const match = flags.find(
+        (f) => f.rule_id === "DI-SEROTONIN-DEXTROMETHORPHAN",
+      );
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+  });
+
+  describe("serotonin syndrome — SSRI/SNRI + methylene blue", () => {
+    it("flags citalopram + methylene blue", () => {
+      const flags = checkDrugInteractions([
+        "citalopram 20mg",
+        "methylene blue 1mg/kg",
+      ]);
+      const match = flags.find(
+        (f) => f.rule_id === "DI-SEROTONIN-METHYLENE-BLUE",
+      );
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+  });
+
+  describe("existing SSRI/SNRI + MAOI rule still works", () => {
+    it("flags fluoxetine + phenelzine", () => {
+      const flags = checkDrugInteractions(["fluoxetine 20mg", "phenelzine 15mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-SSRI-MAOI");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+  });
+
+  describe("existing SSRI/SNRI + triptan rule still works", () => {
+    it("flags sertraline + sumatriptan", () => {
+      const flags = checkDrugInteractions([
+        "sertraline 50mg",
+        "sumatriptan 100mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-SSRI-TRIPTAN");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+  });
+
+  describe("no false positives", () => {
+    it("does not flag unrelated medications", () => {
+      const flags = checkDrugInteractions([
+        "sertraline 50mg",
+        "acetaminophen 500mg",
+      ]);
+      const serotoninFlags = flags.filter((f) =>
+        f.rule_id.startsWith("DI-SEROTONIN"),
+      );
+      expect(serotoninFlags).toHaveLength(0);
+    });
+
+    it("does not flag a single serotonergic agent alone", () => {
+      const flags = checkDrugInteractions(["sertraline 50mg"]);
+      const serotoninFlags = flags.filter((f) =>
+        f.rule_id.startsWith("DI-SEROTONIN"),
+      );
+      expect(serotoninFlags).toHaveLength(0);
+    });
+
+    it("does not flag tramadol without an SSRI/SNRI", () => {
+      const flags = checkDrugInteractions([
+        "tramadol 50mg",
+        "acetaminophen 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-SEROTONIN-TRAMADOL");
+      expect(match).toBeUndefined();
+    });
+  });
+
+  describe("multiple serotonergic interactions detected simultaneously", () => {
+    it("flags both tramadol and linezolid when combined with an SSRI", () => {
+      const flags = checkDrugInteractions([
+        "sertraline 50mg",
+        "tramadol 50mg",
+        "linezolid 600mg",
+      ]);
+      const tramadolFlag = flags.find(
+        (f) => f.rule_id === "DI-SEROTONIN-TRAMADOL",
+      );
+      const linezolidFlag = flags.find(
+        (f) => f.rule_id === "DI-SEROTONIN-LINEZOLID",
+      );
+      expect(tramadolFlag).toBeDefined();
+      expect(linezolidFlag).toBeDefined();
+    });
+  });
+});

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -107,6 +107,66 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
     notify_specialties: ["psychiatry"],
   },
   {
+    id: "DI-SEROTONIN-TRAMADOL",
+    drugA: /fluoxetine|sertraline|paroxetine|citalopram|escitalopram|fluvoxamine|venlafaxine|duloxetine|desvenlafaxine/i,
+    drugB: /tramadol|ultram/i,
+    severity: "critical",
+    summary: "SSRI/SNRI + Tramadol: serotonin syndrome risk",
+    rationale:
+      "Tramadol has serotonin-norepinephrine reuptake inhibitor activity in addition to its opioid effects. " +
+      "Combined with SSRIs or SNRIs, the additive serotonergic activity significantly increases the risk of " +
+      "serotonin syndrome — a potentially fatal toxidrome characterized by hyperthermia, rigidity, myoclonus, " +
+      "and autonomic instability. This is a commonly encountered combination in patients with comorbid pain and depression.",
+    suggested_action:
+      "Avoid combination. Use a non-serotonergic analgesic (e.g., acetaminophen, non-tramadol opioid if needed). " +
+      "If co-prescribing is unavoidable, use lowest effective doses and counsel patient on serotonin syndrome symptoms.",
+    notify_specialties: ["psychiatry", "pain_management"],
+  },
+  {
+    id: "DI-SEROTONIN-LINEZOLID",
+    drugA: /fluoxetine|sertraline|paroxetine|citalopram|escitalopram|fluvoxamine|venlafaxine|duloxetine|desvenlafaxine/i,
+    drugB: /linezolid|zyvox/i,
+    severity: "critical",
+    summary: "SSRI/SNRI + Linezolid: serotonin syndrome risk (MAOI activity)",
+    rationale:
+      "Linezolid is a reversible, nonselective MAO inhibitor. When combined with serotonergic antidepressants, " +
+      "it can precipitate serotonin syndrome. This interaction is frequently missed because linezolid is prescribed " +
+      "as an antibiotic rather than a psychiatric medication. Cases of fatal serotonin syndrome have been reported.",
+    suggested_action:
+      "CONTRAINDICATED combination. Use an alternative antibiotic (e.g., vancomycin, daptomycin) if possible. " +
+      "If linezolid is essential, discontinue SSRI/SNRI and monitor closely for serotonin syndrome for 2 weeks (5 weeks for fluoxetine).",
+    notify_specialties: ["psychiatry", "infectious_disease"],
+  },
+  {
+    id: "DI-SEROTONIN-DEXTROMETHORPHAN",
+    drugA: /fluoxetine|sertraline|paroxetine|citalopram|escitalopram|fluvoxamine|venlafaxine|duloxetine|desvenlafaxine/i,
+    drugB: /dextromethorphan|robitussin|delsym/i,
+    severity: "warning",
+    summary: "SSRI/SNRI + Dextromethorphan: serotonin syndrome risk",
+    rationale:
+      "Dextromethorphan has serotonergic activity via sigma-1 receptor agonism and serotonin reuptake inhibition. " +
+      "Combined with SSRIs/SNRIs, particularly CYP2D6 inhibitors like fluoxetine and paroxetine which also " +
+      "increase dextromethorphan levels, the risk of serotonin syndrome is elevated.",
+    suggested_action:
+      "Advise patient to avoid OTC cough products containing dextromethorphan. Use non-serotonergic cough suppressant alternatives.",
+    notify_specialties: ["psychiatry"],
+  },
+  {
+    id: "DI-SEROTONIN-METHYLENE-BLUE",
+    drugA: /fluoxetine|sertraline|paroxetine|citalopram|escitalopram|fluvoxamine|venlafaxine|duloxetine|desvenlafaxine/i,
+    drugB: /methylene blue|methylthioninium/i,
+    severity: "critical",
+    summary: "SSRI/SNRI + Methylene blue: serotonin syndrome risk (potent MAO-A inhibitor)",
+    rationale:
+      "Intravenous methylene blue is a potent MAO-A inhibitor. When administered to patients on serotonergic " +
+      "antidepressants, it can precipitate severe serotonin syndrome. Multiple fatalities have been reported. " +
+      "This interaction is frequently missed in surgical and procedural settings.",
+    suggested_action:
+      "CONTRAINDICATED combination. Discontinue SSRI/SNRI before elective procedures requiring methylene blue. " +
+      "In emergencies, use lowest dose and monitor intensively for serotonin syndrome.",
+    notify_specialties: ["psychiatry", "anesthesiology"],
+  },
+  {
     id: "DI-DIGOXIN-AMIODARONE",
     drugA: /digoxin|lanoxin/i,
     drugB: /amiodarone|pacerone|cordarone/i,


### PR DESCRIPTION
## Summary

- Add four new deterministic drug interaction rules detecting serotonin syndrome risk from commonly missed combinations: SSRI/SNRI + tramadol, SSRI/SNRI + linezolid, SSRI/SNRI + dextromethorphan, and SSRI/SNRI + methylene blue
- Tramadol and linezolid rules are severity `critical`; dextromethorphan is `warning`; methylene blue is `critical`
- Includes 15 test cases covering new rules, existing rule regression, false-positive checks, and multi-drug detection

Closes #207

## Test plan

- [x] All 15 new tests pass (`pnpm --filter @carebridge/ai-oversight test`)
- [x] Existing drug interaction rules (SSRI+MAOI, SSRI+triptan) still detected correctly
- [x] No false positives for unrelated medication combinations
- [x] Multiple serotonergic interactions flagged simultaneously when applicable