### PR TITLE
feat(ai): add pregnancy-teratogenic drug contraindication rules

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -246,3 +246,143 @@ describe("ONCO-ANTICOAG-HELD-001 — Anticoagulant held/discontinued with active
     expect(flag).toBeUndefined();
   });
 });
+
+describe("OBSTETRIC-TERATOGEN-X-001 — Pregnancy + Category X teratogen", () => {
+  const pregnantCtx = (meds: string[], overrides: Partial<PatientContext> = {}): PatientContext => ({
+    active_diagnoses: ["Pregnancy, first trimester"],
+    active_diagnosis_codes: ["Z34.01"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: ["obstetrics"],
+    ...overrides,
+  });
+
+  it.each([
+    ["isotretinoin"],
+    ["warfarin"],
+    ["methotrexate"],
+    ["thalidomide"],
+    ["misoprostol"],
+    ["finasteride"],
+    ["dutasteride"],
+  ])("fires CRITICAL for Category X drug: %s", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx([drug]));
+    const flag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+    expect(flag!.category).toBe("medication-safety");
+    expect(flag!.notify_specialties).toContain("obstetrics");
+  });
+
+  it("fires when pregnancy detected by ICD-10 O-code", () => {
+    const ctx = pregnantCtx(["Warfarin 5mg"], {
+      active_diagnoses: ["Supervision of normal pregnancy"],
+      active_diagnosis_codes: ["O09.91"],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("fires when pregnancy detected by description only (no ICD code)", () => {
+    const ctx = pregnantCtx(["Isotretinoin 20mg"], {
+      active_diagnoses: ["Pregnant, 12 weeks gestational age"],
+      active_diagnosis_codes: [""],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("does NOT fire without pregnancy diagnosis", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Acne vulgaris"],
+      active_diagnosis_codes: ["L70.0"],
+      active_medications: ["isotretinoin"],
+      new_symptoms: [],
+      care_team_specialties: [],
+    };
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire without teratogenic medication", () => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx(["acetaminophen"]));
+    const flag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001");
+    expect(flag).toBeUndefined();
+  });
+});
+
+describe("OBSTETRIC-TERATOGEN-D-001 — Pregnancy + Category D teratogen", () => {
+  const pregnantCtx = (meds: string[], overrides: Partial<PatientContext> = {}): PatientContext => ({
+    active_diagnoses: ["Pregnancy, second trimester"],
+    active_diagnosis_codes: ["Z34.02"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: ["obstetrics"],
+    ...overrides,
+  });
+
+  it.each([
+    ["valproic acid"],
+    ["carbamazepine"],
+    ["phenytoin"],
+    ["lithium"],
+    ["tetracycline"],
+    ["doxycycline"],
+  ])("fires WARNING for Category D drug: %s", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx([drug]));
+    const flag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-D-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+    expect(flag!.category).toBe("medication-safety");
+    expect(flag!.notify_specialties).toContain("obstetrics");
+  });
+
+  it("fires when pregnancy detected by Z33 code", () => {
+    const ctx = pregnantCtx(["Lithium 300mg"], {
+      active_diagnoses: ["Pregnant state, incidental"],
+      active_diagnosis_codes: ["Z33.1"],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "OBSTETRIC-TERATOGEN-D-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("does NOT fire without pregnancy diagnosis", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Bipolar disorder"],
+      active_diagnosis_codes: ["F31.9"],
+      active_medications: ["lithium"],
+      new_symptoms: [],
+      care_team_specialties: ["psychiatry"],
+    };
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "OBSTETRIC-TERATOGEN-D-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire without Category D medication", () => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx(["acetaminophen"]));
+    const flag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-D-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("fires both X and D rules when patient has drugs from both categories", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      pregnantCtx(["warfarin", "valproic acid"]),
+    );
+    const xFlag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-X-001");
+    const dFlag = flags.find((f) => f.rule_id === "OBSTETRIC-TERATOGEN-D-001");
+    expect(xFlag).toBeDefined();
+    expect(xFlag!.severity).toBe("critical");
+    expect(dFlag).toBeDefined();
+    expect(dFlag!.severity).toBe("warning");
+  });
+});

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -34,6 +34,21 @@ export interface PatientContext {
   recent_labs?: Array<{ name: string; value: number }>;
 }
 
+/** ICD-10 pattern for pregnancy-related diagnoses (Z33, Z34, O00-O9A). */
+const PREGNANCY_ICD10_PATTERN = /^(Z3[34]|O[0-9][0-9A]|O9A)\b/;
+
+/** Pregnancy description pattern. */
+const PREGNANCY_DESCRIPTION_PATTERN =
+  /pregnan|gestational|gravid|obstetric|prenatal|antepartum|trimester/i;
+
+/** FDA Category X teratogenic drugs — high risk of fetal harm, contraindicated in pregnancy. */
+const CATEGORY_X_TERATOGEN_PATTERN =
+  /isotretinoin|accutane|warfarin|coumadin|methotrexate|trexall|thalidomide|thalomid|misoprostol|cytotec|finasteride|propecia|proscar|dutasteride|avodart/i;
+
+/** FDA Category D teratogenic drugs — evidence of fetal risk, use only if benefit outweighs risk. */
+const CATEGORY_D_TERATOGEN_PATTERN =
+  /valproic acid|depakote|depakene|carbamazepine|tegretol|phenytoin|dilantin|lithium|lithobid|eskalith|tetracycline|doxycycline|vibramycin/i;
+
 /** Anticoagulant name pattern shared across rules. */
 const ANTICOAGULANT_PATTERN =
   /warfarin|coumadin|heparin|enoxaparin|lovenox|rivaroxaban|xarelto|apixaban|eliquis|dabigatran|pradaxa|edoxaban|savaysa|fondaparinux|arixtra/i;
@@ -270,6 +285,71 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     suggested_action:
       "Increase glucose monitoring frequency. Consider prophylactic insulin dose adjustment. Review steroid taper plan.",
     notify_specialties: ["endocrinology"],
+  },
+  {
+    id: "OBSTETRIC-TERATOGEN-X-001",
+    name: "Pregnancy + FDA Category X teratogenic medication",
+    check: (ctx: PatientContext) => {
+      const isPregnant =
+        ctx.active_diagnosis_codes.some((code) =>
+          PREGNANCY_ICD10_PATTERN.test(code),
+        ) ||
+        ctx.active_diagnoses.some((d) =>
+          PREGNANCY_DESCRIPTION_PATTERN.test(d),
+        );
+      const onCategoryX = ctx.active_medications.some((m) =>
+        CATEGORY_X_TERATOGEN_PATTERN.test(m),
+      );
+      return isPregnant && onCategoryX;
+    },
+    severity: "critical" as const,
+    category: "medication-safety" as const,
+    summary:
+      "Pregnant patient on FDA Category X teratogenic medication — contraindicated, high risk of fetal harm",
+    rationale:
+      "FDA Pregnancy Category X: studies in animals or humans have demonstrated fetal abnormalities " +
+      "and/or there is positive evidence of human fetal risk. The risk of use in pregnant patients " +
+      "clearly outweighs any possible benefit. Category X drugs include isotretinoin (severe craniofacial, " +
+      "cardiac, and CNS defects), warfarin (fetal warfarin syndrome, CNS abnormalities), methotrexate " +
+      "(spontaneous abortion, craniofacial defects), thalidomide (phocomelia), misoprostol (uterine " +
+      "contractions, fetal death), and finasteride/dutasteride (abnormal external genitalia in male fetus).",
+    suggested_action:
+      "IMMEDIATE medication review required. Discontinue Category X medication and switch to a pregnancy-safe " +
+      "alternative. Consult obstetrics and maternal-fetal medicine. Assess fetal exposure duration and " +
+      "consider teratology counseling.",
+    notify_specialties: ["obstetrics", "pharmacology"],
+  },
+  {
+    id: "OBSTETRIC-TERATOGEN-D-001",
+    name: "Pregnancy + FDA Category D teratogenic medication",
+    check: (ctx: PatientContext) => {
+      const isPregnant =
+        ctx.active_diagnosis_codes.some((code) =>
+          PREGNANCY_ICD10_PATTERN.test(code),
+        ) ||
+        ctx.active_diagnoses.some((d) =>
+          PREGNANCY_DESCRIPTION_PATTERN.test(d),
+        );
+      const onCategoryD = ctx.active_medications.some((m) =>
+        CATEGORY_D_TERATOGEN_PATTERN.test(m),
+      );
+      return isPregnant && onCategoryD;
+    },
+    severity: "warning" as const,
+    category: "medication-safety" as const,
+    summary:
+      "Pregnant patient on FDA Category D medication — evidence of fetal risk, review benefit vs. risk",
+    rationale:
+      "FDA Pregnancy Category D: there is positive evidence of human fetal risk based on adverse reaction " +
+      "data, but potential benefits may warrant use in pregnant patients despite the risk. Category D drugs " +
+      "include valproic acid (neural tube defects, cognitive impairment), carbamazepine (neural tube defects, " +
+      "craniofacial abnormalities), phenytoin (fetal hydantoin syndrome), lithium (Ebstein's cardiac anomaly), " +
+      "tetracycline (permanent tooth discoloration, bone growth inhibition), and doxycycline (same class risks).",
+    suggested_action:
+      "Urgent medication review. Evaluate whether benefit outweighs fetal risk. Consider switching to a " +
+      "pregnancy-safe alternative. Consult obstetrics and relevant specialty. If continued, ensure informed " +
+      "consent and enhanced fetal monitoring.",
+    notify_specialties: ["obstetrics", "pharmacology"],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds two new deterministic rules to the AI oversight cross-specialty engine to detect teratogenic medications prescribed to pregnant patients
- **OBSTETRIC-TERATOGEN-X-001** (CRITICAL): fires for FDA Category X drugs — isotretinoin, warfarin, methotrexate, thalidomide, misoprostol, finasteride, dutasteride
- **OBSTETRIC-TERATOGEN-D-001** (WARNING): fires for FDA Category D drugs — valproic acid, carbamazepine, phenytoin, lithium, tetracycline, doxycycline
- Pregnancy detected via ICD-10 codes (Z33, Z34, O00-O9A) or diagnosis description pattern matching

## Test plan
- [x] 7 Category X drug tests (one per drug, all fire CRITICAL)
- [x] 6 Category D drug tests (one per drug, all fire WARNING)
- [x] ICD-10 O-code detection test
- [x] Z33 code detection test
- [x] Description-only detection test (no ICD code)
- [x] Negative: no pregnancy diagnosis with teratogen
- [x] Negative: pregnancy with non-teratogenic medication
- [x] Combined: both X and D drugs fire both rules independently
- [x] All 35 tests pass (including existing rules)

Closes #206