### PR TITLE
fix(ai): add unique constraint to prevent duplicate open clinical flags

### DIFF
--- a/packages/db-schema/drizzle/0024_flag_dedup_constraint.sql
+++ b/packages/db-schema/drizzle/0024_flag_dedup_constraint.sql
@@ -1,0 +1,15 @@
+-- Prevent duplicate open clinical flags via partial unique indexes.
+-- Closes the TOCTOU race window in flag-service.ts where concurrent
+-- workers could both SELECT (no dup) then INSERT (two identical flags).
+
+-- Rule-based flags: only one open flag per (patient, rule) at a time.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_flags_open_rule_dedup
+  ON clinical_flags (patient_id, rule_id)
+  WHERE status = 'open' AND rule_id IS NOT NULL;
+
+-- LLM-generated flags (no rule_id): only one open flag per
+-- (patient, category, severity) at a time. Application-level 24h
+-- window check remains as an additional safeguard.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_flags_open_llm_dedup
+  ON clinical_flags (patient_id, category, severity)
+  WHERE status = 'open' AND rule_id IS NULL;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1745596800000,
       "tag": "0023_audit_log_status",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1745683200000,
+      "tag": "0024_flag_dedup_constraint",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -1,4 +1,5 @@
-import { pgTable, text, integer, boolean, jsonb, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pgTable, text, integer, boolean, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
 import { patients } from "./patients.js";
 
 export const clinicalFlags = pgTable("clinical_flags", {
@@ -30,6 +31,12 @@ export const clinicalFlags = pgTable("clinical_flags", {
 }, (table) => [
   index("idx_flags_patient").on(table.patient_id, table.status),
   index("idx_flags_severity").on(table.severity, table.status),
+  uniqueIndex("idx_flags_open_rule_dedup")
+    .on(table.patient_id, table.rule_id)
+    .where(sql`status = 'open' AND rule_id IS NOT NULL`),
+  uniqueIndex("idx_flags_open_llm_dedup")
+    .on(table.patient_id, table.category, table.severity)
+    .where(sql`status = 'open' AND rule_id IS NULL`),
 ]);
 
 export const clinicalRules = pgTable("clinical_rules", {

--- a/services/ai-oversight/src/__tests__/flag-service.test.ts
+++ b/services/ai-oversight/src/__tests__/flag-service.test.ts
@@ -7,6 +7,8 @@ const mockWhere = vi.fn();
 const mockLimit = vi.fn();
 const mockInsert = vi.fn();
 const mockValues = vi.fn();
+const mockOnConflictDoNothing = vi.fn();
+const mockReturning = vi.fn();
 
 const mockDb = {
   select: mockSelect,
@@ -44,9 +46,12 @@ beforeEach(() => {
   mockWhere.mockReturnValue({ limit: mockLimit });
   mockLimit.mockResolvedValue([]);
 
-  // Default chain: insert().values() -> void
+  // Default chain: insert().values().onConflictDoNothing().returning() -> [record]
   mockInsert.mockReturnValue({ values: mockValues });
-  mockValues.mockResolvedValue(undefined);
+  mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+  mockOnConflictDoNothing.mockReturnValue({ returning: mockReturning });
+  // By default, returning() resolves with a single-element array (insert succeeded)
+  mockReturning.mockResolvedValue([{ id: "inserted" }]);
 });
 
 describe("createFlag", () => {
@@ -139,6 +144,64 @@ describe("createFlag", () => {
 
     expect(mockInsert).not.toHaveBeenCalled();
     expect(result.id).toBe("existing-llm-flag");
+  });
+
+  it("returns existing flag when DB unique constraint prevents duplicate insert (TOCTOU race)", async () => {
+    // Simulate the race: application-level SELECT found nothing, but a
+    // concurrent worker inserted between our SELECT and INSERT, so
+    // ON CONFLICT DO NOTHING fires and returning() yields [].
+    mockReturning.mockResolvedValueOnce([]);
+
+    // The follow-up SELECT to fetch the winner's flag
+    const winnerFlag = {
+      id: "winner-flag-id",
+      ...baseFlag,
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+    // First call: dedup SELECT -> [] (no dup found at app level)
+    // Second call (after conflict): fetch winner -> [winnerFlag]
+    mockLimit
+      .mockResolvedValueOnce([])       // initial dedup check
+      .mockResolvedValueOnce([winnerFlag]); // post-conflict fetch
+
+    const result = await createFlag(baseFlag);
+
+    expect(result.id).toBe("winner-flag-id");
+    // Insert was attempted (but suppressed by DB constraint)
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns existing flag when DB unique constraint prevents duplicate LLM flag insert", async () => {
+    const llmFlag = {
+      patient_id: "patient-1",
+      source: "ai-review" as const,
+      severity: "warning" as const,
+      category: "cross-specialty" as const,
+      summary: "LLM finding",
+      rationale: "Analysis",
+      suggested_action: "Review",
+      notify_specialties: ["pharmacy"],
+      trigger_event_ids: ["evt-4"],
+      status: "open" as const,
+    };
+
+    const winnerFlag = {
+      id: "winner-llm-flag",
+      ...llmFlag,
+      created_at: new Date().toISOString(),
+    };
+
+    // ON CONFLICT DO NOTHING returns empty
+    mockReturning.mockResolvedValueOnce([]);
+    // First SELECT (app-level dedup) -> no match; second SELECT (post-conflict) -> winner
+    mockLimit
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([winnerFlag]);
+
+    const result = await createFlag(llmFlag);
+
+    expect(result.id).toBe("winner-llm-flag");
+    expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
   it("creates a new LLM flag when no duplicate exists within 24h window", async () => {

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -90,7 +90,48 @@ export async function createFlag(
     created_at: now,
   };
 
-  await db.insert(clinicalFlags).values(record);
+  // Use ON CONFLICT DO NOTHING to handle the race condition where a
+  // concurrent worker inserts a duplicate between our SELECT and INSERT.
+  // The unique partial indexes (idx_flags_open_rule_dedup and
+  // idx_flags_open_llm_dedup) enforce dedup at the DB level.
+  const inserted = await db
+    .insert(clinicalFlags)
+    .values(record)
+    .onConflictDoNothing()
+    .returning();
+
+  // If the insert was suppressed by the unique constraint, fetch and
+  // return the existing flag that won the race.
+  if (inserted.length === 0) {
+    if (flag.rule_id) {
+      const existing = await db
+        .select()
+        .from(clinicalFlags)
+        .where(
+          and(
+            eq(clinicalFlags.patient_id, flag.patient_id),
+            eq(clinicalFlags.rule_id, flag.rule_id),
+            eq(clinicalFlags.status, "open"),
+          ),
+        )
+        .limit(1);
+      return existing[0] as unknown as ClinicalFlag;
+    } else {
+      const existing = await db
+        .select()
+        .from(clinicalFlags)
+        .where(
+          and(
+            eq(clinicalFlags.patient_id, flag.patient_id),
+            eq(clinicalFlags.category, flag.category),
+            eq(clinicalFlags.severity, flag.severity),
+            eq(clinicalFlags.status, "open"),
+          ),
+        )
+        .limit(1);
+      return existing[0] as unknown as ClinicalFlag;
+    }
+  }
 
   recordFlagCreated({ rule_id: flag.rule_id, source: flag.source });
 


### PR DESCRIPTION
## Summary
- Adds two partial unique indexes on `clinical_flags` to enforce dedup at the DB level, closing the TOCTOU race window where concurrent workers could both find no existing flag and both insert duplicates
- `idx_flags_open_rule_dedup`: unique on `(patient_id, rule_id)` where `status = 'open' AND rule_id IS NOT NULL`
- `idx_flags_open_llm_dedup`: unique on `(patient_id, category, severity)` where `status = 'open' AND rule_id IS NULL`
- Flag creation now uses `ON CONFLICT DO NOTHING` and falls back to fetching the existing flag when the constraint fires
- Drizzle schema updated to reflect the new unique indexes
- Two new tests verify the conflict-handling path for both rule-based and LLM flags

## Changes
- `packages/db-schema/drizzle/0024_flag_dedup_constraint.sql` — new migration
- `packages/db-schema/drizzle/meta/_journal.json` — journal entry for migration 0024
- `packages/db-schema/src/schema/ai-flags.ts` — `uniqueIndex` definitions added
- `services/ai-oversight/src/services/flag-service.ts` — `onConflictDoNothing()` + fallback fetch
- `services/ai-oversight/src/__tests__/flag-service.test.ts` — two new race-condition tests

## Test plan
- [x] All 95 ai-oversight tests pass (11 files, including 7 flag-service tests)
- [x] db-schema builds cleanly with new unique index definitions
- [ ] Run `pnpm db:migrate` against a real PostgreSQL to verify migration applies
- [ ] Manually verify with concurrent flag creation that only one flag is created

Closes #209