### PR TITLE
fix(ai): synchronous allergy check before medication prescription

### DIFF
--- a/services/clinical-data/src/__tests__/medication-repo.test.ts
+++ b/services/clinical-data/src/__tests__/medication-repo.test.ts
@@ -9,7 +9,17 @@ const updateSetMock = vi.fn(() => ({ where: updateSetWhereMock }));
 const updateMock = vi.fn(() => ({ set: updateSetMock }));
 
 const selectFromWhereLimitMock = vi.fn();
-const selectFromWhereMock = vi.fn(() => ({ limit: selectFromWhereLimitMock }));
+/** Where mock returns a thenable with .limit() support.
+ * Allergy queries await where() directly; other queries chain .limit(). */
+let allergyResults: unknown[] = [];
+const selectFromWhereMock = vi.fn(() => {
+  const obj = {
+    limit: selectFromWhereLimitMock,
+    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(allergyResults).then(resolve, reject),
+  };
+  return obj;
+});
 const selectFromMock = vi.fn(() => ({
   where: selectFromWhereMock,
   orderBy: vi.fn().mockReturnValue({ where: selectFromWhereMock }),
@@ -29,6 +39,9 @@ vi.mock("@carebridge/db-schema", () => ({
     created_at: "created_at",
   },
   medLogs: {},
+  allergies: {
+    patient_id: "patient_id",
+  },
 }));
 
 // ── Mock events ──────────────────────────────────────────────────
@@ -146,5 +159,79 @@ describe("updateMedication", () => {
 
     await expect(updateMedication("nonexistent", { status: "discontinued" }))
       .rejects.toThrow("Medication nonexistent not found");
+  });
+});
+
+describe("allergy safety check", () => {
+  it("blocks medication that directly matches a patient allergy", async () => {
+    allergyResults = [
+      {
+        id: "allergy-1",
+        patient_id: PATIENT_ID,
+        allergen: "Penicillin",
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Penicillin V" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Penicillin/);
+
+    // Must NOT have inserted into the database
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks medication that cross-reacts with a patient allergy (penicillin → amoxicillin)", async () => {
+    allergyResults = [
+      {
+        id: "allergy-2",
+        patient_id: PATIENT_ID,
+        allergen: "Penicillin",
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Amoxicillin 500mg" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Amoxicillin.*Penicillin.*penicillin/);
+
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("allows medication when no allergy conflicts exist", async () => {
+    allergyResults = [
+      {
+        id: "allergy-3",
+        patient_id: PATIENT_ID,
+        allergen: "Penicillin",
+        rxnorm_code: null,
+        severity: "moderate",
+        reaction: "rash",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ];
+
+    const result = await createMedication(sampleMedInput); // Enoxaparin — no penicillin cross-reactivity
+
+    expect(result.name).toBe("Enoxaparin");
+    expect(insertMock).toHaveBeenCalledOnce();
+  });
+
+  it("allows medication when patient has no allergies", async () => {
+    allergyResults = [];
+
+    const result = await createMedication(sampleMedInput);
+
+    expect(result.name).toBe("Enoxaparin");
+    expect(insertMock).toHaveBeenCalledOnce();
   });
 });

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -1,8 +1,144 @@
 import { eq, and, desc } from "drizzle-orm";
-import { getDb, medications, medLogs } from "@carebridge/db-schema";
+import { getDb, medications, medLogs, allergies } from "@carebridge/db-schema";
 import type { CreateMedicationInput, UpdateMedicationInput } from "@carebridge/validators";
 import type { Medication, MedLog, MedStatus } from "@carebridge/shared-types";
 import { emitClinicalEvent } from "../events.js";
+
+// ─── Allergy cross-reactivity map ─────────────────────────────────
+// Maps allergen name patterns to medication name patterns that belong to
+// the same drug class or share cross-reactive ingredients.
+
+const CROSS_REACTIVITY_MAP: Array<{
+  allergenPattern: RegExp;
+  medicationPattern: RegExp;
+  class: string;
+}> = [
+  {
+    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
+    medicationPattern: /penicillin|amoxicillin|ampicillin|augmentin|amoxil|piperacillin|nafcillin|oxacillin|dicloxacillin/i,
+    class: "penicillin",
+  },
+  {
+    allergenPattern: /cephalosporin|cefazolin|ceftriaxone|cephalexin/i,
+    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime|ceftazidime|cefdinir|cefpodoxime|cefotaxime/i,
+    class: "cephalosporin",
+  },
+  {
+    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
+    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime/i,
+    class: "penicillin-cephalosporin-cross",
+  },
+  {
+    allergenPattern: /sulfa|sulfamethoxazole|bactrim|septra|trimethoprim/i,
+    medicationPattern: /sulfamethoxazole|bactrim|septra|sulfasalazine|sulfadiazine|dapsone/i,
+    class: "sulfonamide",
+  },
+  {
+    allergenPattern: /nsaid|ibuprofen|naproxen|aspirin/i,
+    medicationPattern: /ibuprofen|naproxen|diclofenac|celecoxib|indomethacin|ketorolac|meloxicam|piroxicam|aspirin/i,
+    class: "NSAID",
+  },
+  {
+    allergenPattern: /codeine|morphine|opioid/i,
+    medicationPattern: /codeine|morphine|hydrocodone|oxycodone|fentanyl|tramadol|hydromorphone|meperidine/i,
+    class: "opioid",
+  },
+  {
+    allergenPattern: /fluoroquinolone|ciprofloxacin|levofloxacin/i,
+    medicationPattern: /ciprofloxacin|levofloxacin|moxifloxacin|norfloxacin|ofloxacin/i,
+    class: "fluoroquinolone",
+  },
+  {
+    allergenPattern: /ace inhibitor|lisinopril|enalapril/i,
+    medicationPattern: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
+    class: "ACE inhibitor",
+  },
+  {
+    allergenPattern: /statin|atorvastatin|simvastatin/i,
+    medicationPattern: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
+    class: "statin",
+  },
+  {
+    allergenPattern: /macrolide|azithromycin|erythromycin|clarithromycin/i,
+    medicationPattern: /azithromycin|erythromycin|clarithromycin|fidaxomicin/i,
+    class: "macrolide",
+  },
+  {
+    allergenPattern: /tetracycline|doxycycline|minocycline/i,
+    medicationPattern: /tetracycline|doxycycline|minocycline|tigecycline/i,
+    class: "tetracycline",
+  },
+  {
+    allergenPattern: /benzodiazepine|diazepam|lorazepam|alprazolam/i,
+    medicationPattern: /diazepam|lorazepam|alprazolam|clonazepam|midazolam|temazepam|triazolam/i,
+    class: "benzodiazepine",
+  },
+];
+
+export interface AllergyConflict {
+  allergen: string;
+  severity: string | null;
+  reaction: string | null;
+  matchType: "direct" | "cross-reactivity";
+  drugClass?: string;
+}
+
+/**
+ * Check a medication name against a patient's allergy list.
+ * Returns any conflicts found via direct name match or cross-reactivity class.
+ */
+export async function checkAllergyConflicts(
+  patientId: string,
+  medicationName: string,
+): Promise<AllergyConflict[]> {
+  const db = getDb();
+  const patientAllergies = await db
+    .select()
+    .from(allergies)
+    .where(eq(allergies.patient_id, patientId));
+
+  if (patientAllergies.length === 0) return [];
+
+  const conflicts: AllergyConflict[] = [];
+  const medLower = medicationName.toLowerCase();
+
+  for (const allergy of patientAllergies) {
+    const allergenLower = allergy.allergen.toLowerCase();
+
+    // Strategy 1: Direct name match
+    if (
+      medLower.includes(allergenLower) ||
+      allergenLower.includes(medLower.split(" ")[0])
+    ) {
+      conflicts.push({
+        allergen: allergy.allergen,
+        severity: allergy.severity,
+        reaction: allergy.reaction,
+        matchType: "direct",
+      });
+      continue; // Don't double-match via cross-reactivity
+    }
+
+    // Strategy 2: Cross-reactivity class matching
+    for (const mapping of CROSS_REACTIVITY_MAP) {
+      if (
+        mapping.allergenPattern.test(allergy.allergen) &&
+        mapping.medicationPattern.test(medicationName)
+      ) {
+        conflicts.push({
+          allergen: allergy.allergen,
+          severity: allergy.severity,
+          reaction: allergy.reaction,
+          matchType: "cross-reactivity",
+          drugClass: mapping.class,
+        });
+        break; // One cross-reactivity match per allergy is enough
+      }
+    }
+  }
+
+  return conflicts;
+}
 
 /**
  * Creates a new medication record and emits a "medication.created" event.
@@ -11,6 +147,20 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
   const db = getDb();
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
+
+  // Synchronous allergy safety check — blocks prescription of allergenic drugs
+  const allergyConflicts = await checkAllergyConflicts(input.patient_id, input.name);
+  if (allergyConflicts.length > 0) {
+    const details = allergyConflicts.map((c) => {
+      const base = `allergy to "${c.allergen}" (severity: ${c.severity ?? "unknown"}, reaction: ${c.reaction ?? "not specified"})`;
+      return c.matchType === "cross-reactivity"
+        ? `${base} — cross-reactivity via ${c.drugClass} class`
+        : base;
+    });
+    throw new Error(
+      `ALLERGY_CONFLICT: Medication "${input.name}" conflicts with patient allergies: ${details.join("; ")}`,
+    );
+  }
 
   const record: typeof medications.$inferInsert = {
     id,

--- a/services/clinical-data/src/router.ts
+++ b/services/clinical-data/src/router.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from "@trpc/server";
+import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   createVitalSchema,
@@ -70,7 +70,17 @@ const medicationsRouter = t.router({
   create: t.procedure
     .input(createMedicationSchema)
     .mutation(async ({ input }) => {
-      return medicationRepo.createMedication(input);
+      try {
+        return await medicationRepo.createMedication(input);
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith("ALLERGY_CONFLICT:")) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: err.message.replace("ALLERGY_CONFLICT: ", ""),
+          });
+        }
+        throw err;
+      }
     }),
 
   update: t.procedure


### PR DESCRIPTION
## Summary
- Adds synchronous pre-save allergy validation in the medication create path (`medication-repo.ts`), blocking prescriptions that conflict with documented patient allergies
- Uses direct name matching and drug-class cross-reactivity detection (12 drug classes including penicillin/cephalosporin cross-reactivity)
- Router catches allergy conflicts and returns `TRPCError` with `CONFLICT` code so clients get immediate, clear rejection
- Adds 4 test cases: direct allergy match, cross-reactivity (penicillin → amoxicillin), no-conflict pass-through, and no-allergy pass-through

## Test plan
- [x] Patient with penicillin allergy + amoxicillin prescribed → throws ALLERGY_CONFLICT error
- [x] Patient with penicillin allergy + enoxaparin prescribed → succeeds (no cross-reactivity)
- [x] Patient with no allergies → medication created normally
- [x] Direct allergen name match blocks prescription
- [x] All 34 clinical-data tests pass
- [x] All 80 passing ai-oversight tests still pass (4 pre-existing failures from package resolution)

Closes #201