### PR TITLE
feat(notes): implement H&P, Discharge, and Consult note templates

### DIFF
--- a/services/clinical-notes/src/router.ts
+++ b/services/clinical-notes/src/router.ts
@@ -10,15 +10,18 @@ import type { NoteTemplateType } from "@carebridge/shared-types";
 import * as noteService from "./services/note-service.js";
 import { createSOAPTemplate } from "./templates/soap.js";
 import { createProgressTemplate } from "./templates/progress.js";
+import { createHAndPTemplate } from "./templates/h-and-p.js";
+import { createDischargeTemplate } from "./templates/discharge.js";
+import { createConsultTemplate } from "./templates/consult.js";
 
 const t = initTRPC.create();
 
 const templateBuilders: Record<NoteTemplateType, (() => ReturnType<typeof createSOAPTemplate>) | null> = {
   soap: createSOAPTemplate,
   progress: createProgressTemplate,
-  h_and_p: null,
-  discharge: null,
-  consult: null,
+  h_and_p: createHAndPTemplate,
+  discharge: createDischargeTemplate,
+  consult: createConsultTemplate,
 };
 
 export const clinicalNotesRouter = t.router({

--- a/services/clinical-notes/src/templates/consult.ts
+++ b/services/clinical-notes/src/templates/consult.ts
@@ -1,0 +1,101 @@
+import type { NoteSection } from "@carebridge/shared-types";
+
+/**
+ * Creates a Consultation Note template with structured sections
+ * for specialist evaluation and recommendations.
+ */
+export function createConsultTemplate(): NoteSection[] {
+  return [
+    {
+      key: "reason_for_consultation",
+      label: "Reason for Consultation",
+      fields: [
+        {
+          key: "reason_for_consultation",
+          label: "Reason for Consultation",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "hpi",
+      label: "History of Present Illness",
+      fields: [
+        {
+          key: "hpi",
+          label: "History of Present Illness",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "relevant_history",
+      label: "Relevant History",
+      fields: [
+        {
+          key: "relevant_history",
+          label: "Relevant History",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "physical_exam",
+      label: "Physical Exam",
+      fields: [
+        {
+          key: "physical_exam",
+          label: "Physical Exam",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "data_review",
+      label: "Data Review",
+      fields: [
+        {
+          key: "data_review",
+          label: "Data Review",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "impression",
+      label: "Impression",
+      fields: [
+        {
+          key: "impression",
+          label: "Impression",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "recommendations",
+      label: "Recommendations",
+      fields: [
+        {
+          key: "recommendations",
+          label: "Recommendations",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+  ];
+}

--- a/services/clinical-notes/src/templates/discharge.ts
+++ b/services/clinical-notes/src/templates/discharge.ts
@@ -1,0 +1,101 @@
+import type { NoteSection } from "@carebridge/shared-types";
+
+/**
+ * Creates a Discharge Summary template with structured sections
+ * covering the hospital stay, outcomes, and post-discharge plan.
+ */
+export function createDischargeTemplate(): NoteSection[] {
+  return [
+    {
+      key: "admission_diagnosis",
+      label: "Admission Diagnosis",
+      fields: [
+        {
+          key: "admission_diagnosis",
+          label: "Admission Diagnosis",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "discharge_diagnosis",
+      label: "Discharge Diagnosis",
+      fields: [
+        {
+          key: "discharge_diagnosis",
+          label: "Discharge Diagnosis",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "hospital_course",
+      label: "Hospital Course",
+      fields: [
+        {
+          key: "hospital_course",
+          label: "Hospital Course",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "procedures",
+      label: "Procedures",
+      fields: [
+        {
+          key: "procedures",
+          label: "Procedures",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "discharge_medications",
+      label: "Discharge Medications",
+      fields: [
+        {
+          key: "discharge_medications",
+          label: "Discharge Medications",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "follow_up",
+      label: "Follow-Up",
+      fields: [
+        {
+          key: "follow_up",
+          label: "Follow-Up",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "discharge_instructions",
+      label: "Discharge Instructions",
+      fields: [
+        {
+          key: "discharge_instructions",
+          label: "Discharge Instructions",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+  ];
+}

--- a/services/clinical-notes/src/templates/h-and-p.ts
+++ b/services/clinical-notes/src/templates/h-and-p.ts
@@ -1,0 +1,193 @@
+import type { NoteSection } from "@carebridge/shared-types";
+import { ROS_SYMPTOMS } from "@carebridge/shared-types";
+
+/**
+ * Creates a History & Physical note template with comprehensive
+ * sections for initial patient evaluation and examination.
+ */
+export function createHAndPTemplate(): NoteSection[] {
+  return [
+    {
+      key: "chief_complaint",
+      label: "Chief Complaint",
+      fields: [
+        {
+          key: "chief_complaint",
+          label: "Chief Complaint",
+          value: null,
+          field_type: "text",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "hpi",
+      label: "History of Present Illness",
+      fields: [
+        {
+          key: "hpi",
+          label: "History of Present Illness",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "review_of_systems",
+      label: "Review of Systems",
+      fields: [
+        {
+          key: "ros",
+          label: "Review of Systems",
+          value: [],
+          field_type: "multiselect",
+          source: "new_entry",
+          options: Object.entries(ROS_SYMPTOMS).flatMap(([system, symptoms]) =>
+            symptoms.map((s) => `${system}: ${s}`),
+          ),
+        },
+      ],
+    },
+    {
+      key: "past_medical_history",
+      label: "Past Medical History",
+      fields: [
+        {
+          key: "pmh",
+          label: "Past Medical History",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "past_surgical_history",
+      label: "Past Surgical History",
+      fields: [
+        {
+          key: "psh",
+          label: "Past Surgical History",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "family_history",
+      label: "Family History",
+      fields: [
+        {
+          key: "family_history",
+          label: "Family History",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "social_history",
+      label: "Social History",
+      fields: [
+        {
+          key: "social_history",
+          label: "Social History",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "physical_exam",
+      label: "Physical Exam",
+      fields: [
+        {
+          key: "general",
+          label: "General",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "heent",
+          label: "HEENT",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "cardiovascular",
+          label: "Cardiovascular",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "respiratory",
+          label: "Respiratory",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "abdomen",
+          label: "Abdomen",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "neurological",
+          label: "Neurological",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "musculoskeletal",
+          label: "Musculoskeletal",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+        {
+          key: "skin",
+          label: "Skin",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "assessment",
+      label: "Assessment",
+      fields: [
+        {
+          key: "assessment",
+          label: "Assessment",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+    {
+      key: "plan",
+      label: "Plan",
+      fields: [
+        {
+          key: "plan",
+          label: "Plan",
+          value: null,
+          field_type: "textarea",
+          source: "new_entry",
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add three new clinical note templates: History & Physical (H&P), Discharge Summary, and Consultation Note
- Register all three in the `templateBuilders` map in the clinical-notes router, replacing the previous `null` entries
- H&P includes comprehensive sections with physical exam subsystems and ROS multiselect; Discharge covers hospital course through discharge instructions; Consult covers specialist evaluation and recommendations

Closes #395

## Test plan
- [ ] Verify `templates.list` now returns all five template types
- [ ] Verify `templates.get({ type: "h_and_p" })` returns the expected sections
- [ ] Verify `templates.get({ type: "discharge" })` returns the expected sections
- [ ] Verify `templates.get({ type: "consult" })` returns the expected sections
- [ ] Confirm `pnpm build` passes cleanly