### PR TITLE
fix(ai): deduplicate allergy-medication rule sequence IDs

### DIFF
--- a/services/ai-oversight/src/rules/allergy-medication.test.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { checkAllergyMedication } from "./allergy-medication.js";
+import type { PatientContext } from "./cross-specialty.js";
+
+function makeContext(
+  allergies: PatientContext["allergies"],
+  medications: string[],
+): PatientContext {
+  return {
+    active_diagnoses: [],
+    active_diagnosis_codes: [],
+    active_medications: medications,
+    new_symptoms: [],
+    care_team_specialties: [],
+    allergies,
+  };
+}
+
+describe("allergy-medication rule IDs", () => {
+  it("produces unique rule IDs across all flags in a single invocation", () => {
+    const ctx = makeContext(
+      [
+        { allergen: "Penicillin", severity: "severe", reaction: "anaphylaxis" },
+        { allergen: "Sulfa", severity: "moderate", reaction: "rash" },
+        { allergen: "Ibuprofen", severity: "mild", reaction: "hives" },
+      ],
+      [
+        "Amoxicillin 500mg",
+        "Cefazolin 1g",
+        "Sulfamethoxazole 800mg",
+        "Naproxen 500mg",
+      ],
+    );
+
+    const flags = checkAllergyMedication(ctx);
+    expect(flags.length).toBeGreaterThan(0);
+
+    const ruleIds = flags.map((f) => f.rule_id);
+    const uniqueIds = new Set(ruleIds);
+    expect(uniqueIds.size).toBe(ruleIds.length);
+  });
+
+  it("produces deterministic IDs across repeated calls", () => {
+    const ctx = makeContext(
+      [{ allergen: "Penicillin", severity: "severe", reaction: "anaphylaxis" }],
+      ["Amoxicillin 500mg"],
+    );
+
+    const first = checkAllergyMedication(ctx);
+    const second = checkAllergyMedication(ctx);
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.map((f) => f.rule_id)).toEqual(second.map((f) => f.rule_id));
+  });
+
+  it("generates distinct IDs for direct vs cross-reactivity matches", () => {
+    // Penicillin allergy with a penicillin drug (direct) vs cephalosporin (cross)
+    const ctx = makeContext(
+      [{ allergen: "Penicillin", severity: "severe", reaction: "anaphylaxis" }],
+      ["Penicillin V 500mg", "Cefazolin 1g"],
+    );
+
+    const flags = checkAllergyMedication(ctx);
+    const ruleIds = flags.map((f) => f.rule_id);
+    const uniqueIds = new Set(ruleIds);
+    expect(uniqueIds.size).toBe(ruleIds.length);
+  });
+
+  it("returns no flags when no allergies are present", () => {
+    const ctx = makeContext([], ["Amoxicillin 500mg"]);
+    expect(checkAllergyMedication(ctx)).toHaveLength(0);
+  });
+});

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -113,7 +113,20 @@ function mapAllergyToFlagSeverity(allergySeverity?: string | null): FlagSeverity
   }
 }
 
-let ruleSequence = 0;
+/**
+ * Build a deterministic rule ID from the allergen, medication, and match type.
+ * Uses a short hash to guarantee uniqueness without a mutable counter.
+ */
+function buildRuleId(allergen: string, medication: string, matchType: string): string {
+  const key = `${allergen.toLowerCase()}|${medication.toLowerCase()}|${matchType}`;
+  // Simple djb2 hash — deterministic, no collisions in practice for short clinical strings
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
+  }
+  const hex = (hash >>> 0).toString(16).padStart(8, "0").toUpperCase();
+  return `ALLERGY-MED-${matchType}-${hex}`;
+}
 
 /**
  * Check medications against patient allergies.
@@ -136,7 +149,6 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
 
       // Strategy 1: Direct name match (allergen name appears in medication name)
       if (medLower.includes(allergenLower) || allergenLower.includes(medLower.split(" ")[0])) {
-        ruleSequence++;
         flags.push({
           severity: mapAllergyToFlagSeverity(allergy.severity),
           category: "medication-safety" as FlagCategory,
@@ -149,7 +161,7 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
             `Verify allergy is current. If confirmed, discontinue "${med}" and select an alternative. ` +
             `If allergy was previously tolerated or is mild, document clinical decision to proceed.`,
           notify_specialties: ["pharmacy"],
-          rule_id: `ALLERGY-MED-${String(ruleSequence).padStart(3, "0")}`,
+          rule_id: buildRuleId(allergy.allergen, med, "DIRECT"),
         });
         break; // Don't double-flag same medication
       }
@@ -157,7 +169,6 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
       // Strategy 2: Cross-reactivity class matching
       for (const mapping of CROSS_REACTIVITY_MAP) {
         if (mapping.allergenPattern.test(allergy.allergen) && mapping.medicationPattern.test(med)) {
-          ruleSequence++;
           flags.push({
             severity: mapAllergyToFlagSeverity(allergy.severity),
             category: "medication-safety" as FlagCategory,
@@ -170,7 +181,7 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
               `Evaluate cross-reactivity risk for ${mapping.class} class. Consider alternative agent outside this class. ` +
               `If proceeding, ensure appropriate monitoring and have emergency treatment available.`,
             notify_specialties: ["pharmacy"],
-            rule_id: `ALLERGY-MED-${String(ruleSequence).padStart(3, "0")}`,
+            rule_id: buildRuleId(allergy.allergen, med, `CROSS-${mapping.class}`),
           });
           break; // Don't flag same medication multiple times
         }


### PR DESCRIPTION
## Summary
- Replace mutable module-level `ruleSequence` counter in `allergy-medication.ts` with deterministic hash-based rule IDs derived from allergen name, medication name, and match type (direct vs cross-reactivity class).
- The counter reset to 0 on service restart, causing rule ID collisions across different clinical events.
- Add tests validating uniqueness, determinism, and distinct IDs for direct vs cross-reactivity matches.

Closes #423

Also note: #179 was already closed (both `/notes` and `/schedule` pages exist).

## Test plan
- [x] All allergy-medication rule IDs are unique within a single invocation
- [x] Rule IDs are deterministic across repeated calls with the same input
- [x] Direct match and cross-reactivity match produce distinct IDs
- [x] No flags returned when no allergies present