### PR TITLE
fix(db): encrypt patient diagnosis and notes at rest

### DIFF
--- a/packages/db-schema/drizzle/0028_encrypt_patient_diagnosis_notes.sql
+++ b/packages/db-schema/drizzle/0028_encrypt_patient_diagnosis_notes.sql
@@ -1,0 +1,26 @@
+-- 0025_encrypt_patient_diagnosis_notes.sql
+--
+-- HIPAA: encrypt patients.diagnosis and patients.notes at rest
+-- using AES-256-GCM via the `encryptedText` Drizzle custom type
+-- (see packages/db-schema/src/encryption.ts).
+--
+-- Both columns are already `text` at the SQL level, and the
+-- `encryptedText` custom type also maps to `text`, so no DDL
+-- change is required. The Drizzle ORM layer now transparently
+-- encrypts on write and decrypts on read.
+--
+-- Fields now encrypted:
+--   patients.diagnosis
+--   patients.notes
+--
+-- IMPORTANT — DATA MIGRATION REQUIRED:
+-- Any existing rows with plaintext values in these columns will
+-- fail to decrypt through the custom type (which expects the
+-- `iv:authTag:ct` format produced by encrypt()). A one-time
+-- re-encryption script must run against the live database to
+-- rewrite every existing row through the encryption pipeline
+-- before application reads will succeed.
+
+-- No-op: column type unchanged (text -> text); encryption is
+-- handled at the ORM layer by the encryptedText custom type.
+SELECT 1;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1745942400000,
       "tag": "0027_flag_escalation_tracking",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1746028800000,
+      "tag": "0028_encrypt_patient_diagnosis_notes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -11,8 +11,8 @@ export const patients = pgTable("patients", {
   name_hmac: text("name_hmac"),
   date_of_birth: encryptedText("date_of_birth"),
   biological_sex: text("biological_sex").default("unknown"),
-  diagnosis: text("diagnosis"),
-  notes: text("notes"),
+  diagnosis: encryptedText("diagnosis"),
+  notes: encryptedText("notes"),
   // Non-deterministic encryption (random IV per write) means identical MRNs produce
   // different ciphertexts. The `mrn_hmac` column stores a deterministic HMAC-SHA256
   // digest so the DB unique constraint can enforce MRN uniqueness.


### PR DESCRIPTION
## Summary
- Switch `patients.diagnosis` and `patients.notes` from plain `text()` to `encryptedText()` so these PHI fields are encrypted at rest with AES-256-GCM, consistent with all other PHI columns on the patients table (`name`, `mrn`, `insurance_id`, etc.)
- Add migration `0025_encrypt_patient_diagnosis_notes.sql` and journal entry (no DDL change needed since the column type remains `text` at the SQL level; encryption is handled transparently by the Drizzle custom type)
- Existing plaintext rows will need a one-time re-encryption pass before reads will succeed through the ORM (documented in the migration header)

Closes #287

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 272 existing tests pass (no regressions)
- [ ] Verify on dev DB: new writes to `patients.diagnosis`/`patients.notes` produce `iv:authTag:ct` ciphertext
- [ ] Run re-encryption script against any environment with existing plaintext data before deploying