### PR TITLE
fix(ai): expand PHI de-identification before sending context to Claude API

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/redactor.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/redactor.test.ts
@@ -12,6 +12,7 @@ import {
   redactFacilityNames,
   redactPhones,
   redactAddresses,
+  redactSSN,
 } from "../redactor.js";
 
 describe("redactProviderNames", () => {
@@ -373,11 +374,35 @@ describe("redactAddresses", () => {
   });
 });
 
+describe("redactSSN", () => {
+  it("redacts standard SSN format NNN-NN-NNNN", () => {
+    const { redactedText, count } = redactSSN("Patient SSN 123-45-6789 on file.");
+    expect(redactedText).toContain("[SSN]");
+    expect(redactedText).not.toContain("123-45-6789");
+    expect(count).toBe(1);
+  });
+
+  it("redacts multiple SSNs", () => {
+    const { redactedText, count } = redactSSN(
+      "Primary: 111-22-3333, Spouse: 444-55-6666",
+    );
+    expect(redactedText).not.toContain("111-22-3333");
+    expect(redactedText).not.toContain("444-55-6666");
+    expect(count).toBe(2);
+  });
+
+  it("does not redact partial matches", () => {
+    const { redactedText, count } = redactSSN("Code 12-34-5678 is not an SSN.");
+    expect(redactedText).toBe("Code 12-34-5678 is not an SSN.");
+    expect(count).toBe(0);
+  });
+});
+
 describe("redactClinicalText — full pipeline expansion", () => {
   it("redacts all PHI categories through the pipeline", () => {
     const text =
       "Jane Doe (MRN: 12345678) seen on 03/15/2025 at Mercy General Hospital. " +
-      "Call (555) 123-4567. Address: 789 Elm Drive.";
+      "Call (555) 123-4567. Address: 789 Elm Drive. SSN: 123-45-6789.";
     const result = redactClinicalText(text, {
       patientName: "Jane Doe",
       facilityNames: ["Mercy General Hospital"],
@@ -388,11 +413,13 @@ describe("redactClinicalText — full pipeline expansion", () => {
     expect(result.redactedText).not.toContain("Mercy General Hospital");
     expect(result.redactedText).not.toContain("(555) 123-4567");
     expect(result.redactedText).not.toContain("789 Elm Drive");
+    expect(result.redactedText).not.toContain("123-45-6789");
     expect(result.auditTrail.patientNamesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.mrnsRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.datesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.facilitiesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.phonesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.addressesRedacted).toBeGreaterThan(0);
+    expect(result.auditTrail.ssnsRedacted).toBeGreaterThan(0);
   });
 });

--- a/packages/phi-sanitizer/src/redactor.ts
+++ b/packages/phi-sanitizer/src/redactor.ts
@@ -21,6 +21,7 @@ export interface AuditTrail {
   facilitiesRedacted: number;
   phonesRedacted: number;
   addressesRedacted: number;
+  ssnsRedacted: number;
 }
 
 const MRN_LABELED = /\bMRN[:\s#]*\d{6,12}\b/gi;
@@ -33,6 +34,7 @@ const PHONE_PAREN = /\(\d{3}\)\s*\d{3}-\d{4}/g;
 const PHONE_DASH = /\b\d{3}-\d{3}-\d{4}\b/g;
 const PHONE_SHORT = /\b\d{3}-\d{4}\b/g;
 const ADDRESS = /\b\d+\s+[A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*\s+(?:Street|St|Avenue|Ave|Road|Rd|Drive|Dr|Boulevard|Blvd|Lane|Ln|Court|Ct|Way)\b\.?/g;
+const SSN = /\b\d{3}-\d{2}-\d{4}\b/g;
 
 // ChatML / Llama delimiter patterns that could be used for injection
 const INJECTION_PATTERNS = [
@@ -292,6 +294,18 @@ export function redactAddresses(text: string): { redactedText: string; count: nu
 }
 
 /**
+ * Redact Social Security Numbers (NNN-NN-NNNN pattern).
+ */
+export function redactSSN(text: string): { redactedText: string; count: number } {
+  let count = 0;
+  const result = text.replace(SSN, () => {
+    count++;
+    return "[SSN]";
+  });
+  return { redactedText: result, count };
+}
+
+/**
  * Error thrown when a prompt fails the fail-closed PHI sanitization check.
  * Carries a list of violation labels (NOT the matching text) so callers can
  * log diagnostics without re-leaking PHI.
@@ -360,6 +374,7 @@ export function redactClinicalText(
     facilitiesRedacted: 0,
     phonesRedacted: 0,
     addressesRedacted: 0,
+    ssnsRedacted: 0,
   };
 
   // Step 1: sanitize free text
@@ -430,6 +445,13 @@ export function redactClinicalText(
     audit.addressesRedacted = r.count;
   }
 
+  // Step 10: redact SSNs
+  {
+    const r = redactSSN(current);
+    current = r.redactedText;
+    audit.ssnsRedacted = r.count;
+  }
+
   audit.fieldsRedacted =
     audit.providersRedacted +
     audit.agesRedacted +
@@ -439,7 +461,8 @@ export function redactClinicalText(
     audit.datesRedacted +
     audit.facilitiesRedacted +
     audit.phonesRedacted +
-    audit.addressesRedacted;
+    audit.addressesRedacted +
+    audit.ssnsRedacted;
 
   return {
     redactedText: current,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -21,6 +21,7 @@ import {
   patientObservations,
   labPanels,
   labResults,
+  encounters,
 } from "@carebridge/db-schema";
 import type { ClinicalEvent, FlagSource } from "@carebridge/shared-types";
 import {
@@ -193,18 +194,33 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
       );
     }
 
-    // Fetch patient name so it can be redacted. The DB layer decrypts
-    // `name` transparently on read.
-    const patientRow = await db.query.patients.findFirst({
-      where: eq(patients.id, event.patient_id),
-    });
+    // Fetch patient name and facility/location names so they can be redacted.
+    // The DB layer decrypts `name` transparently on read.
+    const [patientRow, patientEncounters] = await Promise.all([
+      db.query.patients.findFirst({
+        where: eq(patients.id, event.patient_id),
+      }),
+      db
+        .select({ location: encounters.location })
+        .from(encounters)
+        .where(eq(encounters.patient_id, event.patient_id)),
+    ]);
+
+    // Collect unique, non-empty facility/location names for redaction
+    const facilityNames = [
+      ...new Set(
+        patientEncounters
+          .map((e) => e.location)
+          .filter((loc): loc is string => typeof loc === "string" && loc.trim().length > 0),
+      ),
+    ];
 
     // Redact PHI from the assembled prompt before sending to the Claude API
     const redactionResult = redactClinicalText(budgetResult.prompt, {
       providerNames: reviewContext.care_team?.map((m) => m.name).filter(Boolean) as string[] | undefined,
       patientAge: reviewContext.patient?.age,
       patientName: patientRow?.name ?? undefined,
-      facilityNames: [],
+      facilityNames,
       referenceDate: new Date(),
     });
 


### PR DESCRIPTION
## Summary
- Add SSN redaction (`NNN-NN-NNNN` -> `[SSN]`) to the phi-sanitizer pipeline and audit trail
- Wire facility/location name redaction in review-service by fetching encounter locations from the database (was passing an empty array, making facility redaction a no-op)
- Add `ssnsRedacted` counter to `AuditTrail` for HIPAA breach forensics

## What was already working
The phi-sanitizer already had redaction functions for patient names, MRNs, dates (with relative date conversion), phone numbers, addresses, provider names, and age banding. The `assertPromptSanitized` fail-closed guard already checked for SSN patterns but would throw rather than redact. The review service already called `redactClinicalText` before sending prompts to the Claude API.

## What this PR fixes
1. **SSN redaction gap**: The SSN pattern was only in the fail-closed assertion guard (which throws and blocks the API call). Now SSNs are actively redacted to `[SSN]` in the pipeline so the prompt can proceed safely.
2. **Facility redaction was a no-op**: `review-service.ts` passed `facilityNames: []` to the redactor, so facility names were never actually stripped. Now it queries the `encounters` table for the patient's location values and passes them for redaction.

## Test plan
- [x] Added `redactSSN` unit tests (standard format, multiple SSNs, partial non-match)
- [x] Updated full-pipeline integration test to include SSN in the composite PHI string
- [x] All 67 phi-sanitizer tests pass
- [x] All 166 ai-oversight tests pass (2 pre-existing suite-level resolution failures unrelated to this change)

Closes #281