### PR TITLE
fix(ai): add error handling and fallback for clinical event emission

### DIFF
--- a/packages/db-schema/drizzle/0025_failed_clinical_events.sql
+++ b/packages/db-schema/drizzle/0025_failed_clinical_events.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "failed_clinical_events" (
+  "id" text PRIMARY KEY NOT NULL,
+  "event_type" text NOT NULL,
+  "event_payload" jsonb NOT NULL,
+  "error_message" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "retry_count" real DEFAULT 0 NOT NULL,
+  "created_at" text NOT NULL,
+  "retried_at" text
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_failed_clinical_events_status" ON "failed_clinical_events" USING btree ("status","created_at");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1745683200000,
       "tag": "0024_flag_dedup_constraint",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1745769600000,
+      "tag": "0025_failed_clinical_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -108,6 +108,19 @@ export const procedures = pgTable("procedures", {
   index("idx_procedures_patient").on(table.patient_id, table.status),
 ]);
 
+export const failedClinicalEvents = pgTable("failed_clinical_events", {
+  id: text("id").primaryKey(),
+  event_type: text("event_type").notNull(),
+  event_payload: jsonb("event_payload").notNull(),
+  error_message: text("error_message").notNull(),
+  status: text("status").notNull().default("pending"),
+  retry_count: real("retry_count").notNull().default(0),
+  created_at: text("created_at").notNull(),
+  retried_at: text("retried_at"),
+}, (table) => [
+  index("idx_failed_clinical_events_status").on(table.status, table.created_at),
+]);
+
 export const events = pgTable("events", {
   id: text("id").primaryKey(),
   patient_id: text("patient_id").notNull().references(() => patients.id),

--- a/services/clinical-data/src/__tests__/events.test.ts
+++ b/services/clinical-data/src/__tests__/events.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+// ── Mock BullMQ ────────────────────────────────────────────────────
+const addMock = vi.fn();
+vi.mock("bullmq", () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: addMock,
+  })),
+}));
+
+// ── Mock Redis ─────────────────────────────────────────────────────
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({}),
+}));
+
+// ── Mock DB ────────────────────────────────────────────────────────
+const insertValuesMock = vi.fn().mockResolvedValue(undefined);
+const insertMock = vi.fn(() => ({ values: insertValuesMock }));
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({
+    insert: insertMock,
+  }),
+  failedClinicalEvents: { _: "failedClinicalEvents" },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────
+const { emitClinicalEvent } = await import("../events.js");
+
+const sampleEvent: ClinicalEvent = {
+  id: "evt-001",
+  type: "vital.created",
+  patient_id: "patient-001",
+  timestamp: "2026-04-12T10:00:00.000Z",
+  data: { resourceId: "vital-001", vitalType: "heart_rate", value: 72 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("emitClinicalEvent", () => {
+  it("adds the event to the BullMQ queue on success", async () => {
+    addMock.mockResolvedValueOnce(undefined);
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(addMock).toHaveBeenCalledOnce();
+    expect(addMock).toHaveBeenCalledWith("vital.created", sampleEvent);
+  });
+
+  it("does not throw when BullMQ fails", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis connection refused"));
+
+    // Must not throw — the caller's DB write should still succeed
+    await expect(emitClinicalEvent(sampleEvent)).resolves.toBeUndefined();
+  });
+
+  it("persists the event to the fallback table when BullMQ fails", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis connection refused"));
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(insertMock).toHaveBeenCalledOnce();
+    expect(insertValuesMock).toHaveBeenCalledOnce();
+
+    const insertedRow = insertValuesMock.mock.calls[0][0];
+    expect(insertedRow).toMatchObject({
+      event_type: "vital.created",
+      event_payload: sampleEvent,
+      error_message: "Redis connection refused",
+      status: "pending",
+      retry_count: 0,
+    });
+    expect(insertedRow.id).toBeDefined();
+    expect(insertedRow.created_at).toBeDefined();
+  });
+
+  it("does not throw when both BullMQ and DB fallback fail", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis connection refused"));
+    insertValuesMock.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Still must not throw
+    await expect(emitClinicalEvent(sampleEvent)).resolves.toBeUndefined();
+
+    // Should log the critical failure
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[CRITICAL] Failed to persist clinical event to fallback table",
+      expect.objectContaining({
+        event: sampleEvent,
+        originalError: "Redis connection refused",
+        dbError: "DB connection lost",
+      }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs event details when BullMQ fails", async () => {
+    addMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[EVENT_EMISSION_FAILED] Clinical event could not be queued",
+      expect.objectContaining({
+        eventId: "evt-001",
+        eventType: "vital.created",
+        patientId: "patient-001",
+        error: "ECONNREFUSED",
+      }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("does not persist to fallback table when BullMQ succeeds", async () => {
+    addMock.mockResolvedValueOnce(undefined);
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -1,5 +1,6 @@
 import { Queue } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
 export type { ClinicalEvent };
@@ -16,6 +17,60 @@ const clinicalEventsQueue = new Queue("clinical-events", {
   },
 });
 
+/**
+ * Persists a failed clinical event to the database so it can be retried later.
+ * This is the fallback when Redis/BullMQ is unavailable.
+ */
+async function persistFailedEvent(
+  event: ClinicalEvent,
+  error: unknown,
+): Promise<void> {
+  const errorMessage =
+    error instanceof Error ? error.message : String(error);
+
+  try {
+    const db = getDb();
+    await db.insert(failedClinicalEvents).values({
+      id: crypto.randomUUID(),
+      event_type: event.type,
+      event_payload: event as unknown as Record<string, unknown>,
+      error_message: errorMessage,
+      status: "pending",
+      retry_count: 0,
+      created_at: new Date().toISOString(),
+    });
+  } catch (dbError) {
+    // Last resort: log to stderr so ops can see it in container logs
+    console.error(
+      "[CRITICAL] Failed to persist clinical event to fallback table",
+      {
+        event,
+        originalError: errorMessage,
+        dbError: dbError instanceof Error ? dbError.message : String(dbError),
+      },
+    );
+  }
+}
+
+/**
+ * Emits a clinical event to the BullMQ queue for AI oversight processing.
+ *
+ * On Redis/BullMQ failure the event is written to the `failed_clinical_events`
+ * PostgreSQL table so it can be retried later. The error is never propagated
+ * to the caller — the parent clinical data mutation must succeed even when the
+ * event pipeline is temporarily unavailable.
+ */
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  await clinicalEventsQueue.add(event.type, event);
+  try {
+    await clinicalEventsQueue.add(event.type, event);
+  } catch (error) {
+    console.error("[EVENT_EMISSION_FAILED] Clinical event could not be queued", {
+      eventId: event.id,
+      eventType: event.type,
+      patientId: event.patient_id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    await persistFailedEvent(event, error);
+  }
 }

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -1,5 +1,6 @@
 import { Queue } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
 export type { ClinicalEvent };
@@ -16,6 +17,60 @@ const clinicalEventsQueue = new Queue("clinical-events", {
   },
 });
 
+/**
+ * Persists a failed clinical event to the database so it can be retried later.
+ * This is the fallback when Redis/BullMQ is unavailable.
+ */
+async function persistFailedEvent(
+  event: ClinicalEvent,
+  error: unknown,
+): Promise<void> {
+  const errorMessage =
+    error instanceof Error ? error.message : String(error);
+
+  try {
+    const db = getDb();
+    await db.insert(failedClinicalEvents).values({
+      id: crypto.randomUUID(),
+      event_type: event.type,
+      event_payload: event as unknown as Record<string, unknown>,
+      error_message: errorMessage,
+      status: "pending",
+      retry_count: 0,
+      created_at: new Date().toISOString(),
+    });
+  } catch (dbError) {
+    // Last resort: log to stderr so ops can see it in container logs
+    console.error(
+      "[CRITICAL] Failed to persist clinical event to fallback table",
+      {
+        event,
+        originalError: errorMessage,
+        dbError: dbError instanceof Error ? dbError.message : String(dbError),
+      },
+    );
+  }
+}
+
+/**
+ * Emits a clinical event to the BullMQ queue for AI oversight processing.
+ *
+ * On Redis/BullMQ failure the event is written to the `failed_clinical_events`
+ * PostgreSQL table so it can be retried later. The error is never propagated
+ * to the caller — the parent clinical data mutation must succeed even when the
+ * event pipeline is temporarily unavailable.
+ */
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  await clinicalEventsQueue.add(event.type, event);
+  try {
+    await clinicalEventsQueue.add(event.type, event);
+  } catch (error) {
+    console.error("[EVENT_EMISSION_FAILED] Clinical event could not be queued", {
+      eventId: event.id,
+      eventType: event.type,
+      patientId: event.patient_id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    await persistFailedEvent(event, error);
+  }
 }


### PR DESCRIPTION
## Summary
- Wraps `emitClinicalEvent()` in try/catch in both `clinical-data` and `clinical-notes` services so Redis/BullMQ failures no longer silently drop events or crash the parent clinical data mutation
- On queue failure, persists the event to a new `failed_clinical_events` PostgreSQL outbox table (with status, retry_count, error details) for later reconciliation
- If the DB fallback also fails, logs a `[CRITICAL]` error to stderr as a last resort — the caller's mutation still succeeds
- Adds Drizzle schema definition, migration `0025_failed_clinical_events.sql`, and 6 unit tests covering success, queue failure + DB fallback, double failure, and logging

Closes #250

## Test plan
- [x] All 43 clinical-data tests pass (including 6 new `events.test.ts` tests)
- [ ] Verify migration runs cleanly against dev DB (`pnpm db:migrate`)
- [ ] Manual: stop Redis, create a vital — confirm DB write succeeds and row appears in `failed_clinical_events`
- [ ] Manual: restart Redis — confirm normal queue flow resumes