### PR TITLE
fix(ai): stratify ANTICOAG-BLEED severity to reduce alert fatigue

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -386,3 +386,128 @@ describe("OBSTETRIC-TERATOGEN-D-001 — Pregnancy + Category D teratogen", () =>
     expect(dFlag!.severity).toBe("warning");
   });
 });
+
+describe("ANTICOAG-BLEED-001 — severity stratification", () => {
+  const anticoagCtx = (
+    symptoms: string[],
+    overrides: Partial<PatientContext> = {},
+  ): PatientContext => ({
+    active_diagnoses: ["Atrial fibrillation"],
+    active_diagnosis_codes: ["I48.91"],
+    active_medications: ["Warfarin 5mg"],
+    new_symptoms: symptoms,
+    care_team_specialties: ["hematology"],
+    ...overrides,
+  });
+
+  // --- CRITICAL severity: frank hemorrhage ---
+
+  it.each([
+    ["GI hemorrhage"],
+    ["hematemesis"],
+    ["melena"],
+    ["hematochezia"],
+    ["hemoptysis"],
+    ["intracranial bleed"],
+    ["GI bleed"],
+    ["retroperitoneal hemorrhage"],
+    ["blood in stool"],
+  ])("fires CRITICAL for major hemorrhage term: %s", (symptom) => {
+    const flags = checkCrossSpecialtyPatterns(anticoagCtx([symptom]));
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  // --- WARNING severity: moderate bleeding ---
+
+  it.each([
+    ["hematuria"],
+    ["blood in urine"],
+    ["nosebleed"],
+    ["post-procedural bleeding"],
+    ["bleeding from wound site"],
+  ])("fires WARNING for moderate bleeding term: %s", (symptom) => {
+    const flags = checkCrossSpecialtyPatterns(anticoagCtx([symptom]));
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  // --- SUPPRESSED: minor bruising with normal/unknown INR ---
+
+  it.each([
+    ["minor bruising on arm"],
+    ["bruising at injection site"],
+    ["petechiae"],
+    ["ecchymosis"],
+    ["minor skin bleeding"],
+  ])("does NOT fire for minor bleeding with normal INR: %s", (symptom) => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx([symptom], { recent_labs: [{ name: "INR", value: 2.5 }] }),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire for minor bruising when INR is unknown", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx(["bruising on forearm"], { recent_labs: [] }),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeUndefined();
+  });
+
+  // --- Minor bleeding escalated when INR > 5.0 ---
+
+  it("fires WARNING for minor bruising when INR > 5.0", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx(["bruising on forearm"], {
+        recent_labs: [{ name: "INR", value: 6.2 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("fires WARNING for petechiae when INR > 5.0", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx(["petechiae on lower extremities"], {
+        recent_labs: [{ name: "INR", value: 7.0 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  // --- Does NOT fire without anticoagulant ---
+
+  it("does NOT fire without anticoagulant medication", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx(["hematemesis"], { active_medications: ["Metformin 500mg"] }),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeUndefined();
+  });
+
+  // --- Does NOT fire without bleeding symptom ---
+
+  it("does NOT fire without bleeding symptom", () => {
+    const flags = checkCrossSpecialtyPatterns(anticoagCtx(["headache"]));
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeUndefined();
+  });
+
+  // --- Mixed symptoms: critical overrides moderate ---
+
+  it("fires CRITICAL when both critical and minor symptoms present", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      anticoagCtx(["bruising on arm", "hematemesis"]),
+    );
+    const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+});

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -56,6 +56,55 @@ const ANTICOAGULANT_PATTERN =
 /** ICD-10 pattern for active VTE / DVT / PE diagnoses. */
 const VTE_ICD10_PATTERN = /^(I26|I80|I82)\./;
 
+/**
+ * ANTICOAG-BLEED severity stratification patterns.
+ *
+ * CRITICAL: frank hemorrhage terms that require immediate evaluation.
+ * WARNING: moderate bleeding that warrants prompt but not emergent review.
+ * MINOR: bruising / petechiae — expected in anticoagulated patients with
+ *        therapeutic INR. Suppressed unless INR > 5.0.
+ */
+const ANTICOAG_BLEED_CRITICAL_PATTERN =
+  /hemorrhage|haemorrhage|hematemesis|melena|hematochezia|hemoptysis|intracranial bleed|gi bleed|gastrointestinal bleed|retroperitoneal|blood in stool/i;
+
+const ANTICOAG_BLEED_WARNING_PATTERN =
+  /hematuria|blood in urine|epistaxis.*packing|post.?procedural bleeding|nosebleed/i;
+
+const ANTICOAG_BLEED_MINOR_PATTERN =
+  /bruis|petechiae|ecchymosis|minor.*bleeding/i;
+
+/**
+ * Classify a single symptom string into a bleeding severity tier.
+ * Minor is checked first so "minor skin bleeding" is not escalated by
+ * a generic "bleeding" match in the warning tier.
+ */
+function classifySymptomBleedingTier(symptom: string): "critical" | "warning" | "minor" | null {
+  if (ANTICOAG_BLEED_CRITICAL_PATTERN.test(symptom)) return "critical";
+  if (ANTICOAG_BLEED_MINOR_PATTERN.test(symptom)) return "minor";
+  if (ANTICOAG_BLEED_WARNING_PATTERN.test(symptom)) return "warning";
+  // Generic "bleeding" without minor qualifier → warning
+  if (/bleeding/i.test(symptom)) return "warning";
+  return null;
+}
+
+/**
+ * Return the highest bleeding severity tier across all symptoms.
+ */
+function classifyBleedingSeverity(symptoms: string[]): "critical" | "warning" | "minor" | null {
+  let highest: "critical" | "warning" | "minor" | null = null;
+  for (const s of symptoms) {
+    const tier = classifySymptomBleedingTier(s);
+    if (tier === "critical") return "critical";
+    if (tier === "warning") highest = "warning";
+    if (tier === "minor" && highest === null) highest = "minor";
+  }
+  return highest;
+}
+
+/** Matches any bleeding-related symptom across all severity tiers. */
+const ANTICOAG_BLEED_ANY_PATTERN =
+  /hemorrhage|haemorrhage|hematemesis|melena|hematochezia|hemoptysis|intracranial bleed|gi bleed|gastrointestinal bleed|retroperitoneal|blood in stool|hematuria|blood in urine|epistaxis|nosebleed|post.?procedural bleeding|bleeding|bruis|petechiae|ecchymosis/i;
+
 interface CrossSpecialtyRule {
   id: string;
   name: string;
@@ -125,10 +174,29 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       const onAnticoag = ctx.active_medications.some((m) =>
         /warfarin|coumadin|heparin|enoxaparin|lovenox|rivaroxaban|xarelto|apixaban|eliquis/i.test(m),
       );
-      const hasBleedingSymptom = ctx.new_symptoms.some((s) =>
-        /bleeding|blood in stool|blood in urine|hemoptysis|bruising|nosebleed|melena|hematuria|hematemesis/i.test(s),
+      if (!onAnticoag) return false;
+
+      const hasAnyBleedingSymptom = ctx.new_symptoms.some((s) =>
+        ANTICOAG_BLEED_ANY_PATTERN.test(s),
       );
-      return onAnticoag && hasBleedingSymptom;
+      if (!hasAnyBleedingSymptom) return false;
+
+      // Classify each symptom. Minor pattern is checked first so that
+      // "minor skin bleeding" is not escalated by a generic "bleeding" match.
+      const tier = classifyBleedingSeverity(ctx.new_symptoms);
+      if (tier === "critical" || tier === "warning") return true;
+
+      // Only minor bleeding — suppress unless INR is significantly elevated
+      // (> 5.0), since minor bruising is expected in 20-40% of
+      // anticoagulated patients with therapeutic INR.
+      const inr = ctx.recent_labs?.find((l) => /\bINR\b/i.test(l.name))?.value;
+      return inr !== undefined && inr > 5.0;
+    },
+    buildSeverity: (ctx: PatientContext) => {
+      const tier = classifyBleedingSeverity(ctx.new_symptoms);
+      if (tier === "critical") return "critical";
+      // Both "warning" and "minor" (INR > 5.0) map to warning severity
+      return "warning";
     },
     severity: "critical" as const,
     category: "cross-specialty" as const,


### PR DESCRIPTION
## Summary

- Stratifies ANTICOAG-BLEED-001 bleeding symptom matching into three severity tiers (critical, warning, suppressed) to eliminate false-positive alerts from minor bruising in anticoagulated patients
- Minor bleeding (bruising, petechiae, ecchymosis) is suppressed unless INR > 5.0, since cosmetic bruising is expected in 20-40% of patients on therapeutic anticoagulation
- Adds 25 new test cases covering all severity tiers, INR escalation, and edge cases

## Test plan

- [x] CRITICAL fires for frank hemorrhage terms (hematemesis, melena, hematochezia, hemoptysis, intracranial bleed, GI bleed, retroperitoneal, blood in stool)
- [x] WARNING fires for moderate bleeding (hematuria, blood in urine, nosebleed, post-procedural bleeding, generic "bleeding")
- [x] Suppressed for minor bruising/petechiae/ecchymosis with normal INR (2.5)
- [x] Suppressed for minor bruising with unknown INR
- [x] WARNING fires for minor bruising when INR > 5.0
- [x] CRITICAL overrides minor when both present
- [x] Does not fire without anticoagulant or without bleeding symptom
- [x] All 60 cross-specialty tests pass; all 186 runnable ai-oversight tests pass

Closes #208