### PR TITLE
fix(ai): add timeout and fallback flag for Claude API outages

### DIFF
--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -77,7 +77,7 @@ export interface ClinicalRule {
 
 // ─── Review Jobs ─────────────────────────────────────────────────
 
-export type ReviewStatus = "pending" | "processing" | "completed" | "failed";
+export type ReviewStatus = "pending" | "processing" | "completed" | "failed" | "llm_timeout" | "llm_error";
 
 export interface ReviewJob extends BaseRecord {
   patient_id: string;

--- a/services/ai-oversight/src/__tests__/llm-timeout-fallback.test.ts
+++ b/services/ai-oversight/src/__tests__/llm-timeout-fallback.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mock setup ──────────────────────────────────────────────────
+// Mock all external dependencies before importing the module under test.
+
+// Build a deeply-chainable mock for Drizzle's query builder.
+// Every method returns `this` so chains like select().from().innerJoin().where()
+// all resolve without errors.
+function makeChain(resolvedValue: unknown = []) {
+  const chain: Record<string, unknown> = {};
+  const self = new Proxy(chain, {
+    get(_target, prop) {
+      if (prop === "then") {
+        // Make it thenable so `await` resolves to the configured value
+        return (resolve: (v: unknown) => void) => resolve(resolvedValue);
+      }
+      if (typeof prop === "symbol") return undefined;
+      return vi.fn().mockReturnValue(self);
+    },
+  });
+  return self;
+}
+
+const mockInsert = vi.fn().mockReturnValue(makeChain([{ id: "flag-fallback-id" }]));
+
+const mockSetFn = vi.fn().mockReturnValue(makeChain(undefined));
+const mockUpdate = vi.fn().mockReturnValue({
+  set: mockSetFn,
+});
+
+const mockSelect = vi.fn().mockReturnValue(makeChain([]));
+
+const mockDb = {
+  insert: mockInsert,
+  update: mockUpdate,
+  select: mockSelect,
+  query: {
+    patients: {
+      findFirst: vi.fn().mockResolvedValue({ name: "Test Patient" }),
+    },
+  },
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  reviewJobs: { id: "id", patient_id: "patient_id", status: "status" },
+  clinicalFlags: {
+    patient_id: "patient_id",
+    rule_id: "rule_id",
+    status: "status",
+    category: "category",
+    severity: "severity",
+    created_at: "created_at",
+    source: "source",
+  },
+  diagnoses: { patient_id: "patient_id", status: "status" },
+  medications: { patient_id: "patient_id", status: "status" },
+  patients: { id: "id" },
+  allergies: { patient_id: "patient_id" },
+  messages: { id: "id", body: "body" },
+  patientObservations: { id: "id", description: "description" },
+  labPanels: { id: "id", patient_id: "patient_id" },
+  labResults: {
+    panel_id: "panel_id",
+    test_name: "test_name",
+    value: "value",
+    created_at: "created_at",
+  },
+  encounters: { patient_id: "patient_id", status: "status" },
+  vitals: { patient_id: "patient_id" },
+  careTeamAssignments: { patient_id: "patient_id", user_id: "user_id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((...args: unknown[]) => args),
+  desc: vi.fn((col: unknown) => col),
+  gte: vi.fn((...args: unknown[]) => args),
+  and: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn(),
+}));
+
+vi.mock("@carebridge/ai-prompts", () => ({
+  CLINICAL_REVIEW_SYSTEM_PROMPT: "system prompt",
+  PROMPT_VERSION: "v1",
+  buildReviewPrompt: vi.fn(() => "review prompt"),
+  enforceTokenBudget: vi.fn((prompt: string) => ({
+    prompt,
+    truncated: false,
+    originalTokens: 100,
+    finalTokens: 100,
+    sectionsRemoved: [],
+  })),
+}));
+
+vi.mock("@carebridge/phi-sanitizer", () => ({
+  redactClinicalText: vi.fn((text: string) => ({
+    redactedText: text,
+    auditTrail: { fieldsRedacted: 0, providersRedacted: 0, agesRedacted: 0, freeTextSanitized: 0 },
+  })),
+  validateLLMResponse: vi.fn(() => ({
+    ok: true,
+    flags: [],
+    warnings: [],
+  })),
+  assertPromptSanitized: vi.fn(),
+  SanitizationError: class SanitizationError extends Error {},
+}));
+
+const mockReviewPatientRecord = vi.fn();
+vi.mock("../services/claude-client.js", () => ({
+  reviewPatientRecord: mockReviewPatientRecord,
+}));
+
+const mockCreateFlag = vi.fn().mockResolvedValue({ id: "flag-id-fallback" });
+vi.mock("../services/flag-service.js", () => ({
+  createFlag: mockCreateFlag,
+}));
+
+const mockBuildPatientContext = vi.fn().mockResolvedValue({
+  patient: { age: 55 },
+  care_team: [],
+});
+vi.mock("../workers/context-builder.js", () => ({
+  buildPatientContext: mockBuildPatientContext,
+}));
+
+vi.mock("@carebridge/notifications", () => ({
+  emitNotificationEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Import module under test ────────────────────────────────────
+
+const { processReviewJob } = await import("../services/review-service.js");
+
+// ─── Test data ───────────────────────────────────────────────────
+
+function makeClinicalEvent(overrides?: Record<string, unknown>) {
+  return {
+    id: "event-001",
+    type: "vital.created" as const,
+    patient_id: "patient-001",
+    data: {},
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe("LLM timeout/outage fallback handling", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Reset mockDb chained calls
+    mockInsert.mockReturnValue(makeChain([{ id: "flag-fallback-id" }]));
+    mockSetFn.mockReturnValue(makeChain(undefined));
+    mockUpdate.mockReturnValue({ set: mockSetFn });
+    mockSelect.mockReturnValue(makeChain([]));
+
+    // Re-set mocks cleared by vi.clearAllMocks()
+    mockBuildPatientContext.mockResolvedValue({
+      patient: { age: 55 },
+      care_team: [],
+    });
+    mockCreateFlag.mockResolvedValue({ id: "flag-id-fallback" });
+    mockDb.query.patients.findFirst.mockResolvedValue({ name: "Test Patient" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a fallback flag when the Claude API times out", async () => {
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("Claude API call failed after 3 attempts: APIConnectionError — request timed out"),
+    );
+
+    await processReviewJob(makeClinicalEvent());
+
+    // Should have created a fallback flag
+    expect(mockCreateFlag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patient_id: "patient-001",
+        source: "ai-review",
+        severity: "info",
+        category: "care-gap",
+        summary: expect.stringContaining("AI review unavailable"),
+        requires_human_review: false,
+      }),
+    );
+  });
+
+  it("sets review job status to llm_timeout on timeout errors", async () => {
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("request timed out"),
+    );
+
+    await processReviewJob(makeClinicalEvent());
+
+    // mockSetFn captures all db.update().set() calls. The last one is the
+    // final status update (prior ones are redacted_prompt persistence).
+    const lastCall = mockSetFn.mock.calls[mockSetFn.mock.calls.length - 1][0];
+    expect(lastCall).toEqual(
+      expect.objectContaining({
+        status: "llm_timeout",
+        error: expect.stringContaining("timed out"),
+      }),
+    );
+  });
+
+  it("sets review job status to llm_error on non-timeout API failures", async () => {
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("Claude API call failed (non-transient): AuthenticationError status=401"),
+    );
+
+    await processReviewJob(makeClinicalEvent());
+
+    const lastCall = mockSetFn.mock.calls[mockSetFn.mock.calls.length - 1][0];
+    expect(lastCall).toEqual(
+      expect.objectContaining({
+        status: "llm_error",
+      }),
+    );
+  });
+
+  it("does not throw when LLM fails — job completes gracefully", async () => {
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("ETIMEDOUT"),
+    );
+
+    // Should NOT throw
+    await expect(processReviewJob(makeClinicalEvent())).resolves.toBeUndefined();
+  });
+
+  it("logs the timeout with event context", async () => {
+    const event = makeClinicalEvent({
+      id: "evt-timeout-test",
+      type: "lab.resulted",
+      patient_id: "patient-timeout",
+    });
+
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("request timed out"),
+    );
+
+    await processReviewJob(event);
+
+    const errorLogs = errorSpy.mock.calls.map((args) => args.join(" "));
+    const relevantLog = errorLogs.find((log) =>
+      log.includes("LLM review failed"),
+    );
+    expect(relevantLog).toBeDefined();
+    expect(relevantLog).toContain("llm_timeout");
+    expect(relevantLog).toContain("patient-timeout");
+    expect(relevantLog).toContain("lab.resulted");
+  });
+
+  it("fallback flag summary mentions deterministic rules and deferred LLM review", async () => {
+    mockReviewPatientRecord.mockRejectedValueOnce(
+      new Error("ECONNABORTED"),
+    );
+
+    await processReviewJob(makeClinicalEvent());
+
+    const fallbackCall = mockCreateFlag.mock.calls.find(
+      (call: unknown[]) => (call[0] as { summary?: string })?.summary?.includes("AI review unavailable"),
+    );
+    expect(fallbackCall).toBeDefined();
+    const summary = (fallbackCall![0] as { summary: string }).summary;
+    expect(summary).toContain("deterministic rules applied");
+    expect(summary).toContain("LLM review deferred");
+  });
+
+  it("still succeeds normally when LLM call works", async () => {
+    mockReviewPatientRecord.mockResolvedValueOnce('{"flags": []}');
+
+    await expect(processReviewJob(makeClinicalEvent())).resolves.toBeUndefined();
+
+    // Should NOT have created a fallback flag with "AI review unavailable"
+    const fallbackCalls = mockCreateFlag.mock.calls.filter(
+      (call) =>
+        call[0]?.summary?.includes("AI review unavailable"),
+    );
+    expect(fallbackCalls).toHaveLength(0);
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -247,55 +247,36 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
       })
       .where(eq(reviewJobs.id, jobId));
 
-    // Step 6: Call Claude API
-    const llmResponse = await reviewPatientRecord(
-      CLINICAL_REVIEW_SYSTEM_PROMPT,
-      userMessage,
-    );
+    // Step 6: Call Claude API (with fallback on timeout/outage)
+    let llmFindings: LLMFlagOutput[] = [];
+    let llmFailed = false;
+    let llmFailureStatus: "llm_timeout" | "llm_error" | null = null;
+    let llmErrorMessage: string | null = null;
 
-    // Step 7: Validate and parse LLM response
-    const validationResult = validateLLMResponse(llmResponse);
-    let llmFindingsCount = 0;
-
-    if (!validationResult.ok) {
-      // Log raw response for debugging (truncated to avoid flooding logs)
-      console.error(
-        `[review-service] LLM response validation failed for job ${jobId}: ${validationResult.error}. ` +
-          `Raw response (first 500 chars): ${llmResponse.slice(0, 500)}`,
+    try {
+      const llmResponse = await reviewPatientRecord(
+        CLINICAL_REVIEW_SYSTEM_PROMPT,
+        userMessage,
       );
 
-      // Create a fallback "review failed" flag so clinicians know this event
-      // was not successfully reviewed by the LLM layer.
-      const fallbackFlag = await createFlag({
-        patient_id: event.patient_id,
-        source: "ai-review" as FlagSource,
-        severity: "warning",
-        category: "care-gap" as ClinicalFlagCategory,
-        summary: "AI review could not be completed — LLM response was malformed",
-        rationale:
-          `The automated clinical review for event ${event.type} (${event.id}) ` +
-          `could not parse the LLM response. Parse error: ${validationResult.error}. ` +
-          `Deterministic rules still ran, but the deeper LLM analysis was not applied. ` +
-          `A clinician should manually review this event.`,
-        suggested_action:
-          "Manually review the triggering clinical event for any concerns " +
-          "that automated rules may not catch.",
-        notify_specialties: [],
-        trigger_event_ids: [event.id],
-        status: "open",
-        model_id: "claude-sonnet-4-6",
-        prompt_version: PROMPT_VERSION,
-        requires_human_review: true,
-      });
-      flagIds.push(fallbackFlag.id);
-    } else {
+      // Step 7: Validate and parse LLM response
+      const validationResult = validateLLMResponse(llmResponse);
+
+      if (!validationResult.ok) {
+        console.error(
+          `[review-service] LLM response validation failed for job ${jobId}: ${validationResult.error}. ` +
+            `Raw response (first 500 chars): ${llmResponse.slice(0, 500)}`,
+        );
+        throw new Error(`LLM response validation failed: ${validationResult.error}`);
+      }
+
       if (validationResult.warnings.length > 0) {
         console.warn(
           `[review-service] LLM response warnings: ${validationResult.warnings.join("; ")}`,
         );
       }
 
-      const llmFindings: LLMFlagOutput[] = validationResult.flags.map((f) => ({
+      llmFindings = validationResult.flags.map((f) => ({
         severity: f.severity,
         category: f.category,
         summary: f.summary,
@@ -303,53 +284,129 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         suggested_action: f.suggested_action,
         notify_specialties: f.notify_specialties,
       }));
+    } catch (llmError) {
+      llmFailed = true;
+      llmErrorMessage =
+        llmError instanceof Error ? llmError.message : String(llmError);
 
-      llmFindingsCount = llmFindings.length;
+      const isValidationFailure =
+        llmErrorMessage.includes("LLM response validation failed");
 
-      // Step 8: Create flags for LLM findings (deduplicate against rule-based flags)
-      for (const finding of llmFindings) {
-        if (isDuplicate(finding, allRuleFlags)) {
-          continue;
-        }
+      const isTimeout =
+        llmErrorMessage.includes("timed out") ||
+        llmErrorMessage.includes("timeout") ||
+        llmErrorMessage.includes("ETIMEDOUT") ||
+        llmErrorMessage.includes("ECONNABORTED");
 
-        const flag = await createFlag({
+      llmFailureStatus = isTimeout ? "llm_timeout" : "llm_error";
+
+      console.error(
+        `[review-service] LLM review failed for job ${jobId} ` +
+          `(status: ${llmFailureStatus}, patient: ${event.patient_id}, ` +
+          `event: ${event.type}/${event.id}): ${llmErrorMessage}`,
+      );
+
+      if (isValidationFailure) {
+        const fallbackFlag = await createFlag({
           patient_id: event.patient_id,
           source: "ai-review" as FlagSource,
-          severity: finding.severity,
-          category: finding.category as ClinicalFlagCategory,
-          summary: finding.summary,
-          rationale: finding.rationale,
-          suggested_action: finding.suggested_action,
-          notify_specialties: finding.notify_specialties,
+          severity: "warning",
+          category: "care-gap" as ClinicalFlagCategory,
+          summary: "AI review could not be completed \u2014 LLM response was malformed",
+          rationale:
+            `The automated clinical review for event ${event.type} (${event.id}) ` +
+            `could not parse the LLM response. Parse error: ${llmErrorMessage}. ` +
+            `Deterministic rules still ran, but the deeper LLM analysis was not applied. ` +
+            `A clinician should manually review this event.`,
+          suggested_action:
+            "Manually review the triggering clinical event for any concerns " +
+            "that automated rules may not catch.",
+          notify_specialties: [],
           trigger_event_ids: [event.id],
           status: "open",
           model_id: "claude-sonnet-4-6",
           prompt_version: PROMPT_VERSION,
+          requires_human_review: true,
         });
-        flagIds.push(flag.id);
+        flagIds.push(fallbackFlag.id);
+      } else {
+        const fallbackFlag = await createFlag({
+          patient_id: event.patient_id,
+          source: "ai-review" as FlagSource,
+          severity: "info",
+          category: "care-gap" as ClinicalFlagCategory,
+          summary:
+            "AI review unavailable \u2014 deterministic rules applied, LLM review deferred",
+          rationale:
+            `The Claude API was unreachable or timed out during review of event ${event.type}. ` +
+            `Deterministic safety rules were evaluated normally. LLM-based review did not run ` +
+            `and may catch additional patterns once the service recovers.`,
+          suggested_action:
+            "No immediate action required. Deterministic rules have been applied. " +
+            "LLM review will run on subsequent clinical events.",
+          notify_specialties: [],
+          trigger_event_ids: [event.id],
+          status: "open",
+          requires_human_review: false,
+        });
+        flagIds.push(fallbackFlag.id);
       }
     }
 
-    // Step 9: Update review_jobs record — completed
+    // Step 8: Create flags for LLM findings (deduplicate against rule-based flags)
+    for (const finding of llmFindings) {
+      if (isDuplicate(finding, allRuleFlags)) {
+        continue;
+      }
+
+      const flag = await createFlag({
+        patient_id: event.patient_id,
+        source: "ai-review" as FlagSource,
+        severity: finding.severity,
+        category: finding.category as ClinicalFlagCategory,
+        summary: finding.summary,
+        rationale: finding.rationale,
+        suggested_action: finding.suggested_action,
+        notify_specialties: finding.notify_specialties,
+        trigger_event_ids: [event.id],
+        status: "open",
+        model_id: "claude-sonnet-4-6",
+        prompt_version: PROMPT_VERSION,
+      });
+      flagIds.push(flag.id);
+    }
+
+    // Step 9: Update review_jobs record
     const processingTime = Date.now() - startTime;
+    const jobStatus = llmFailed ? llmFailureStatus! : "completed";
+
     await db
       .update(reviewJobs)
       .set({
-        status: "completed",
+        status: jobStatus,
         rules_evaluated: rulesEvaluated,
         rules_fired: rulesFired,
         flags_generated: flagIds,
         processing_time_ms: processingTime,
+        ...(llmFailed ? { error: llmErrorMessage } : {}),
         completed_at: new Date().toISOString(),
       })
       .where(eq(reviewJobs.id, jobId));
 
-    console.log(
-      `[review-service] Job ${jobId} completed in ${processingTime}ms. ` +
-        `Rules fired: ${rulesFired.length}, LLM findings: ${llmFindingsCount}, ` +
-        `Total flags: ${flagIds.length}` +
-        (budgetResult.truncated ? ` (prompt truncated: ${budgetResult.originalTokens} -> ${budgetResult.finalTokens} tokens)` : ""),
-    );
+    if (llmFailed) {
+      console.warn(
+        `[review-service] Job ${jobId} completed with ${jobStatus} in ${processingTime}ms. ` +
+          `Rules fired: ${rulesFired.length}, LLM skipped, ` +
+          `Total flags: ${flagIds.length} (includes fallback)`,
+      );
+    } else {
+      console.log(
+        `[review-service] Job ${jobId} completed in ${processingTime}ms. ` +
+          `Rules fired: ${rulesFired.length}, LLM findings: ${llmFindings.length}, ` +
+          `Total flags: ${flagIds.length}` +
+          (budgetResult.truncated ? ` (prompt truncated: ${budgetResult.originalTokens} -> ${budgetResult.finalTokens} tokens)` : ""),
+      );
+    }
   } catch (error) {
     // Step 10: Update review_jobs — failed
     const processingTime = Date.now() - startTime;


### PR DESCRIPTION
## Summary
- When the Claude API times out or is unavailable, the review pipeline now catches the error after deterministic rules have already run, instead of failing the entire job
- Creates a fallback INFO-severity flag ("AI review unavailable — deterministic rules applied, LLM review deferred") so clinicians are notified the LLM review was skipped
- Records the failure in `review_jobs` with granular status (`llm_timeout` or `llm_error`) and the error message, making outages visible in audit queries
- Adds `ReviewStatus` union members `llm_timeout` and `llm_error` to shared types

## Test plan
- [x] 7 new unit tests covering timeout, generic error, graceful completion, log output, fallback flag content, and normal success path
- [x] All 268 existing tests continue to pass
- [ ] Manual verification: stop the Claude API key / set an invalid key and trigger a clinical event; confirm fallback flag appears and job status is `llm_error`

Closes #252