### PR TITLE
feat(ai): expand drug interaction rules with high-priority pairs

### DIFF
--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -102,6 +102,126 @@ describe("checkDrugInteractions", () => {
     });
   });
 
+  describe("ACE inhibitor + potassium-sparing diuretic — hyperkalemia", () => {
+    it("flags lisinopril + spironolactone", () => {
+      const flags = checkDrugInteractions(["lisinopril 10mg", "spironolactone 25mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-ACE-KSPARING");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags enalapril + amiloride", () => {
+      const flags = checkDrugInteractions(["enalapril 5mg", "amiloride 5mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-ACE-KSPARING");
+      expect(match).toBeDefined();
+    });
+
+    it("flags ramipril + eplerenone (brand inspra)", () => {
+      const flags = checkDrugInteractions(["ramipril 5mg", "inspra 50mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-ACE-KSPARING");
+      expect(match).toBeDefined();
+    });
+
+    it("flags captopril + triamterene", () => {
+      const flags = checkDrugInteractions(["captopril 25mg", "triamterene 50mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-ACE-KSPARING");
+      expect(match).toBeDefined();
+    });
+  });
+
+  describe("lithium + ACE inhibitor — lithium toxicity", () => {
+    it("flags lithium + lisinopril", () => {
+      const flags = checkDrugInteractions(["lithium 300mg", "lisinopril 10mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-LITHIUM-ACE");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags lithobid + enalapril", () => {
+      const flags = checkDrugInteractions(["lithobid 450mg", "enalapril 5mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-LITHIUM-ACE");
+      expect(match).toBeDefined();
+    });
+
+    it("flags lithium + ramipril", () => {
+      const flags = checkDrugInteractions(["lithium 600mg", "ramipril 5mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-LITHIUM-ACE");
+      expect(match).toBeDefined();
+    });
+  });
+
+  describe("fluoroquinolone + corticosteroid — tendon rupture", () => {
+    it("flags ciprofloxacin + prednisone", () => {
+      const flags = checkDrugInteractions(["ciprofloxacin 500mg", "prednisone 20mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags levofloxacin + dexamethasone", () => {
+      const flags = checkDrugInteractions(["levofloxacin 750mg", "dexamethasone 4mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeDefined();
+    });
+
+    it("flags moxifloxacin + methylprednisolone", () => {
+      const flags = checkDrugInteractions(["moxifloxacin 400mg", "methylprednisolone 40mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeDefined();
+    });
+  });
+
+  describe("existing high-priority pairs coverage", () => {
+    it("flags warfarin + ibuprofen (NSAID)", () => {
+      const flags = checkDrugInteractions(["warfarin 5mg", "ibuprofen 400mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-WARFARIN-NSAID");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags digoxin + amiodarone", () => {
+      const flags = checkDrugInteractions(["digoxin 0.125mg", "amiodarone 200mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-DIGOXIN-AMIODARONE");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags opioid + benzodiazepine (FDA black box)", () => {
+      const flags = checkDrugInteractions(["oxycodone 10mg", "alprazolam 0.5mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-OPIOID-BENZO");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags metformin + contrast dye", () => {
+      const flags = checkDrugInteractions(["metformin 500mg", "iodinated contrast"]);
+      const match = flags.find((f) => f.rule_id === "DI-METFORMIN-CONTRAST");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags lithium + naproxen (NSAID)", () => {
+      const flags = checkDrugInteractions(["lithium 300mg", "naproxen 500mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-LITHIUM-NSAID");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("critical");
+    });
+
+    it("flags theophylline + ciprofloxacin", () => {
+      const flags = checkDrugInteractions(["theophylline 300mg", "ciprofloxacin 500mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-THEOPHYLLINE-CIPRO");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags potassium supplement + spironolactone", () => {
+      const flags = checkDrugInteractions(["potassium chloride 20mEq", "spironolactone 25mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-POTASSIUM-SPIRONOLACTONE");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+  });
+
   describe("no false positives", () => {
     it("does not flag unrelated medications", () => {
       const flags = checkDrugInteractions([

--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -169,6 +169,33 @@ describe("checkDrugInteractions", () => {
       const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
       expect(match).toBeDefined();
     });
+
+    it("does not flag fluoroquinolone + inhaled budesonide (alert fatigue guard)", () => {
+      const flags = checkDrugInteractions([
+        "ciprofloxacin 500mg",
+        "budesonide inhaler 180mcg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeUndefined();
+    });
+
+    it("does not flag fluoroquinolone + topical hydrocortisone (alert fatigue guard)", () => {
+      const flags = checkDrugInteractions([
+        "levofloxacin 500mg",
+        "hydrocortisone cream 2.5%",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeUndefined();
+    });
+
+    it("does not flag fluoroquinolone + intranasal triamcinolone (alert fatigue guard)", () => {
+      const flags = checkDrugInteractions([
+        "moxifloxacin 400mg",
+        "triamcinolone nasal spray 55mcg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-FLUOROQUINOLONE-CORTICOSTEROID");
+      expect(match).toBeUndefined();
+    });
   });
 
   describe("existing high-priority pairs coverage", () => {
@@ -217,6 +244,23 @@ describe("checkDrugInteractions", () => {
     it("flags potassium supplement + spironolactone", () => {
       const flags = checkDrugInteractions(["potassium chloride 20mEq", "spironolactone 25mg"]);
       const match = flags.find((f) => f.rule_id === "DI-POTASSIUM-SPIRONOLACTONE");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags warfarin + aspirin", () => {
+      const flags = checkDrugInteractions(["warfarin 5mg", "aspirin 81mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-WARFARIN-ASPIRIN");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags ACE inhibitor + potassium supplement", () => {
+      const flags = checkDrugInteractions([
+        "lisinopril 10mg",
+        "potassium chloride 20mEq",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-ACE-POTASSIUM");
       expect(match).toBeDefined();
       expect(match!.severity).toBe("warning");
     });

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -404,13 +404,15 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
   {
     id: "DI-FLUOROQUINOLONE-CORTICOSTEROID",
     drugA: /ciprofloxacin|cipro|levofloxacin|moxifloxacin|norfloxacin|ofloxacin|gemifloxacin/i,
-    drugB: /prednisone|prednisolone|methylprednisolone|dexamethasone|hydrocortisone|budesonide|triamcinolone/i,
+    drugB: /prednisone|prednisolone|methylprednisolone|dexamethasone/i,
     severity: "warning",
-    summary: "Fluoroquinolone + corticosteroid: increased tendon rupture risk",
+    summary: "Fluoroquinolone + systemic corticosteroid: increased tendon rupture risk",
     rationale:
       "Fluoroquinolones carry an FDA black box warning for tendinitis and tendon rupture. Concurrent " +
-      "corticosteroid use further increases this risk, particularly for the Achilles tendon. Risk is " +
-      "highest in patients over 60, organ transplant recipients, and those with renal impairment.",
+      "systemic corticosteroid use further increases this risk, particularly for the Achilles tendon. " +
+      "Risk is highest in patients over 60, organ transplant recipients, and those with renal impairment. " +
+      "Matcher limited to systemic agents (prednisone, prednisolone, methylprednisolone, dexamethasone) " +
+      "to avoid alert fatigue from inhaled/topical corticosteroids with minimal systemic exposure.",
     suggested_action:
       "Avoid combination when possible. If co-prescribed, counsel patient to discontinue fluoroquinolone " +
       "and seek medical attention at first sign of tendon pain or swelling. Consider alternative antibiotic.",

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -372,6 +372,51 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
     notify_specialties: ["cardiology", "infectious_disease"],
   },
   {
+    id: "DI-ACE-KSPARING",
+    drugA: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
+    drugB: /spironolactone|aldactone|eplerenone|inspra|amiloride|midamor|triamterene|dyrenium/i,
+    severity: "warning",
+    summary: "ACE inhibitor + potassium-sparing diuretic: hyperkalemia risk",
+    rationale:
+      "ACE inhibitors reduce aldosterone-mediated potassium excretion. Potassium-sparing diuretics " +
+      "further impair potassium elimination. The combined effect significantly increases the risk of " +
+      "life-threatening hyperkalemia, especially in patients with renal impairment or diabetes.",
+    suggested_action:
+      "Monitor serum potassium within 1 week of initiation and regularly thereafter. Check renal function. " +
+      "Use lowest effective doses. Counsel patient to avoid high-potassium foods and salt substitutes.",
+    notify_specialties: ["nephrology", "cardiology"],
+  },
+  {
+    id: "DI-LITHIUM-ACE",
+    drugA: /lithium|lithobid|eskalith/i,
+    drugB: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
+    severity: "warning",
+    summary: "Lithium + ACE inhibitor: lithium toxicity risk",
+    rationale:
+      "ACE inhibitors reduce renal blood flow and GFR, decreasing lithium clearance by up to 25-35%. " +
+      "This leads to lithium accumulation and increased risk of toxicity, presenting as tremor, ataxia, " +
+      "confusion, renal failure, seizures, and cardiac arrhythmias.",
+    suggested_action:
+      "Monitor lithium levels within 1 week of ACE inhibitor initiation and with dose changes. " +
+      "Consider reducing lithium dose. Ensure adequate hydration. Use ARBs with similar caution.",
+    notify_specialties: ["psychiatry", "nephrology"],
+  },
+  {
+    id: "DI-FLUOROQUINOLONE-CORTICOSTEROID",
+    drugA: /ciprofloxacin|cipro|levofloxacin|moxifloxacin|norfloxacin|ofloxacin|gemifloxacin/i,
+    drugB: /prednisone|prednisolone|methylprednisolone|dexamethasone|hydrocortisone|budesonide|triamcinolone/i,
+    severity: "warning",
+    summary: "Fluoroquinolone + corticosteroid: increased tendon rupture risk",
+    rationale:
+      "Fluoroquinolones carry an FDA black box warning for tendinitis and tendon rupture. Concurrent " +
+      "corticosteroid use further increases this risk, particularly for the Achilles tendon. Risk is " +
+      "highest in patients over 60, organ transplant recipients, and those with renal impairment.",
+    suggested_action:
+      "Avoid combination when possible. If co-prescribed, counsel patient to discontinue fluoroquinolone " +
+      "and seek medical attention at first sign of tendon pain or swelling. Consider alternative antibiotic.",
+    notify_specialties: ["orthopedics", "infectious_disease"],
+  },
+  {
     id: "DI-QTC-COMBO",
     drugA: /amiodarone|sotalol|dofetilide|dronedarone|haloperidol|thioridazine/i,
     drugB: /azithromycin|zithromax|erythromycin|clarithromycin|ondansetron|zofran|methadone|levofloxacin|moxifloxacin/i,


### PR DESCRIPTION
## Summary

- Adds 3 missing clinically significant drug interaction pairs: ACE inhibitors + potassium-sparing diuretics (hyperkalemia), Lithium + ACE inhibitors (lithium toxicity), Fluoroquinolones + corticosteroids (tendon rupture)
- The other 7 pairs requested in #227 (warfarin+NSAIDs, warfarin+aspirin, metformin+contrast, digoxin+amiodarone, lithium+NSAIDs, opioids+benzodiazepines, theophylline+fluoroquinolones, potassium supplements+ACE inhibitors) were already present
- Adds 21 new tests covering all requested interaction pairs (both new and existing)

Total deterministic interaction pairs: 29 (up from 26)

Closes #227

## Test plan

- [x] All 32 drug interaction tests pass (`vitest run drug-interactions.test.ts`)
- [ ] Verify new ACE+K-sparing rule fires for lisinopril+spironolactone, enalapril+amiloride, captopril+triamterene
- [ ] Verify lithium+ACE rule fires for lithium+lisinopril, lithobid+enalapril
- [ ] Verify fluoroquinolone+corticosteroid rule fires for cipro+prednisone, levofloxacin+dexamethasone
- [ ] Confirm no regressions in existing interaction detection