### PR TITLE
fix(notes): add optimistic locking to prevent concurrent edit overwrites

### DIFF
--- a/packages/validators/src/notes.ts
+++ b/packages/validators/src/notes.ts
@@ -30,6 +30,7 @@ export const createNoteSchema = z.object({
 
 export const updateNoteSchema = z.object({
   sections: z.array(noteSectionSchema).min(1),
+  expectedVersion: z.number().int().positive().optional(),
 });
 
 export const signNoteSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,6 +524,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   services/fhir-gateway:
     dependencies:
@@ -5371,8 +5374,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5391,7 +5394,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5402,22 +5405,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5428,7 +5431,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/services/clinical-notes/package.json
+++ b/services/clinical-notes/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "typescript": "^5.7.0",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/services/clinical-notes/src/__tests__/note-service.test.ts
+++ b/services/clinical-notes/src/__tests__/note-service.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock DB ──────────────────────────────────────────────────────
+const insertValuesMock = vi.fn().mockResolvedValue(undefined);
+const insertMock = vi.fn(() => ({ values: insertValuesMock }));
+
+const updateReturningMock = vi.fn();
+const updateSetWhereMock = vi.fn(() => ({ returning: updateReturningMock }));
+const updateSetMock = vi.fn(() => ({ where: updateSetWhereMock }));
+const updateMock = vi.fn(() => ({ set: updateSetMock }));
+
+const selectFromWhereLimitMock = vi.fn();
+const selectFromWhereMock = vi.fn(() => ({
+  limit: selectFromWhereLimitMock,
+}));
+const selectFromMock = vi.fn(() => ({
+  where: selectFromWhereMock,
+  orderBy: vi.fn().mockReturnValue({ where: selectFromWhereMock }),
+}));
+const selectMock = vi.fn(() => ({ from: selectFromMock }));
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({
+    insert: insertMock,
+    select: selectMock,
+    update: updateMock,
+  }),
+  clinicalNotes: {
+    id: "id",
+    patient_id: "patient_id",
+    provider_id: "provider_id",
+    version: "version",
+    created_at: "created_at",
+  },
+  noteVersions: {},
+}));
+
+// ── Mock events ──────────────────────────────────────────────────
+const emitClinicalEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock("../events.js", () => ({ emitClinicalEvent }));
+
+// ── Import after mocks ──────────────────────────────────────────
+const { updateNote, NoteConflictError } = await import(
+  "../services/note-service.js"
+);
+
+const NOTE_ID = "11111111-1111-1111-1111-111111111111";
+const PATIENT_ID = "22222222-2222-2222-2222-222222222222";
+const PROVIDER_ID = "33333333-3333-3333-3333-333333333333";
+
+const existingRow = {
+  id: NOTE_ID,
+  patient_id: PATIENT_ID,
+  provider_id: PROVIDER_ID,
+  encounter_id: null,
+  template_type: "soap",
+  sections: [{ key: "s", label: "Subjective", fields: [], free_text: "old" }],
+  version: 3,
+  status: "draft",
+  signed_at: null,
+  signed_by: null,
+  cosigned_at: null,
+  cosigned_by: null,
+  copy_forward_score: null,
+  source_system: null,
+  created_at: "2026-03-15T10:00:00.000Z",
+};
+
+const updatedSections = [
+  { key: "s", label: "Subjective", fields: [], free_text: "updated" },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("updateNote", () => {
+  it("updates a note without optimistic locking when expectedVersion is omitted", async () => {
+    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
+    updateReturningMock.mockResolvedValueOnce([{ id: NOTE_ID }]);
+
+    const result = await updateNote(NOTE_ID, { sections: updatedSections });
+
+    expect(result.version).toBe(4);
+    expect(result.sections).toEqual(updatedSections);
+    expect(updateSetWhereMock).toHaveBeenCalledOnce();
+  });
+
+  it("succeeds when expectedVersion matches the current version", async () => {
+    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
+    updateReturningMock.mockResolvedValueOnce([{ id: NOTE_ID }]);
+
+    const result = await updateNote(NOTE_ID, {
+      sections: updatedSections,
+      expectedVersion: 3,
+    });
+
+    expect(result.version).toBe(4);
+    expect(result.sections).toEqual(updatedSections);
+  });
+
+  it("throws NoteConflictError when expectedVersion does not match (concurrent modification)", async () => {
+    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
+    // Update returns 0 rows because version doesn't match
+    updateReturningMock.mockResolvedValueOnce([]);
+
+    const error = await updateNote(NOTE_ID, {
+      sections: updatedSections,
+      expectedVersion: 2, // stale version
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NoteConflictError);
+    expect((error as InstanceType<typeof NoteConflictError>).message).toBe(
+      "Note was modified by another user. Please refresh and try again.",
+    );
+    // Event should NOT have been emitted on conflict
+    expect(emitClinicalEvent).not.toHaveBeenCalled();
+  });
+
+  it("throws when note is not found", async () => {
+    selectFromWhereLimitMock.mockResolvedValueOnce([]);
+
+    await expect(
+      updateNote("nonexistent", { sections: updatedSections }),
+    ).rejects.toThrow("Note nonexistent not found");
+  });
+});

--- a/services/clinical-notes/src/router.ts
+++ b/services/clinical-notes/src/router.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from "@trpc/server";
+import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import {
   createNoteSchema,
@@ -8,6 +8,7 @@ import {
 } from "@carebridge/validators";
 import type { NoteTemplateType } from "@carebridge/shared-types";
 import * as noteService from "./services/note-service.js";
+import { NoteConflictError } from "./services/note-service.js";
 import { createSOAPTemplate } from "./templates/soap.js";
 import { createProgressTemplate } from "./templates/progress.js";
 import { createHAndPTemplate } from "./templates/h-and-p.js";
@@ -35,7 +36,14 @@ export const clinicalNotesRouter = t.router({
     .input(z.object({ id: z.string().uuid() }).merge(updateNoteSchema))
     .mutation(async ({ input }) => {
       const { id, ...rest } = input;
-      return noteService.updateNote(id, rest);
+      try {
+        return await noteService.updateNote(id, rest);
+      } catch (err) {
+        if (err instanceof NoteConflictError) {
+          throw new TRPCError({ code: "CONFLICT", message: err.message });
+        }
+        throw err;
+      }
     }),
 
   sign: t.procedure

--- a/services/clinical-notes/src/services/note-service.ts
+++ b/services/clinical-notes/src/services/note-service.ts
@@ -1,8 +1,18 @@
-import { eq, desc } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import { getDb, clinicalNotes, noteVersions } from "@carebridge/db-schema";
 import type { CreateNoteInput, UpdateNoteInput } from "@carebridge/validators";
 import type { ClinicalNote, NoteVersion } from "@carebridge/shared-types";
 import { emitClinicalEvent } from "../events.js";
+
+/**
+ * Thrown when an optimistic locking conflict is detected (concurrent modification).
+ */
+export class NoteConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoteConflictError";
+  }
+}
 
 /**
  * Creates a new clinical note, persists it, and emits a "note.saved" event.
@@ -82,14 +92,27 @@ export async function updateNote(
 
   const newVersion = existing.version + 1;
 
+  // Optimistic locking: when expectedVersion is provided, only update if the
+  // row hasn't been modified since the caller last read it.
+  const whereClause = input.expectedVersion
+    ? and(eq(clinicalNotes.id, noteId), eq(clinicalNotes.version, input.expectedVersion))
+    : eq(clinicalNotes.id, noteId);
+
   // Update the note with new sections and incremented version
-  await db
+  const result = await db
     .update(clinicalNotes)
     .set({
       sections: input.sections,
       version: newVersion,
     })
-    .where(eq(clinicalNotes.id, noteId));
+    .where(whereClause)
+    .returning({ id: clinicalNotes.id });
+
+  if (result.length === 0 && input.expectedVersion) {
+    throw new NoteConflictError(
+      "Note was modified by another user. Please refresh and try again.",
+    );
+  }
 
   await emitClinicalEvent({
     id: crypto.randomUUID(),

--- a/services/clinical-notes/vitest.config.ts
+++ b/services/clinical-notes/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@carebridge/shared-types": path.resolve(
+        __dirname,
+        "../../packages/shared-types/src/index.ts",
+      ),
+      "@carebridge/validators": path.resolve(
+        __dirname,
+        "../../packages/validators/src/index.ts",
+      ),
+      "@carebridge/db-schema": path.resolve(
+        __dirname,
+        "../../packages/db-schema/src/index.ts",
+      ),
+      "@carebridge/redis-config": path.resolve(
+        __dirname,
+        "../../packages/redis-config/src/index.ts",
+      ),
+    },
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,5 +4,6 @@ export default defineWorkspace([
   "packages/phi-sanitizer",
   "services/ai-oversight",
   "services/auth",
+  "services/clinical-notes",
   "services/fhir-gateway",
 ]);


### PR DESCRIPTION
## Summary
- Adds optional `expectedVersion` field to the note update input schema
- When provided, the UPDATE query includes a `WHERE version = expectedVersion` predicate so concurrent writes on the same note version return a CONFLICT error instead of silently overwriting
- Adds `NoteConflictError` in the service layer, caught by the router and mapped to a tRPC CONFLICT error
- Backwards compatible: omitting `expectedVersion` preserves the existing behavior

## Test plan
- [x] New unit tests covering: successful update without locking, successful update with matching version, conflict error on stale version, not-found error
- [x] All 18 previously passing test suites remain green
- [ ] Manual verification: two browser tabs editing the same note simultaneously should surface a conflict prompt

Closes #254