### PR TITLE
feat(clinical): add allergy verification status and patient NKDA tracking

### DIFF
--- a/packages/ai-prompts/src/clinical-review.ts
+++ b/packages/ai-prompts/src/clinical-review.ts
@@ -38,8 +38,9 @@ export interface ReviewContext {
   patient: {
     age: number;
     sex: string;
+    allergy_status?: "nkda" | "unknown" | "has_allergies";
     active_diagnoses: string[];
-    allergies: string[];
+    allergies: (string | { allergen: string; verification_status: string })[];
   };
   active_medications: {
     name: string;
@@ -80,6 +81,29 @@ export interface ReviewContext {
   }[];
 }
 
+function formatAllergies(context: ReviewContext): string {
+  if (context.patient.allergies.length > 0) {
+    return context.patient.allergies
+      .map((a) => {
+        if (typeof a === "string") return `  - ${a}`;
+        return `  - ${a.allergen} [${a.verification_status}]`;
+      })
+      .join("\n");
+  }
+
+  const status = context.patient.allergy_status ?? "unknown";
+  switch (status) {
+    case "nkda":
+      return "  NKDA (confirmed — no known drug allergies)";
+    case "unknown":
+      return "  ALLERGY STATUS UNKNOWN (never assessed — do NOT assume NKDA)";
+    case "has_allergies":
+      return "  Marked as having allergies but none documented (data gap)";
+    default:
+      return "  ALLERGY STATUS UNKNOWN (never assessed — do NOT assume NKDA)";
+  }
+}
+
 export function buildReviewPrompt(context: ReviewContext): string {
   return `PATIENT CLINICAL CONTEXT
 ========================
@@ -90,7 +114,7 @@ ${PROMPT_SECTIONS.DIAGNOSES}:
 ${context.patient.active_diagnoses.map((d) => `  - ${d}`).join("\n") || "  None documented"}
 
 ${PROMPT_SECTIONS.ALLERGIES}:
-${context.patient.allergies.map((a) => `  - ${a}`).join("\n") || "  NKDA"}
+${formatAllergies(context)}
 
 ${PROMPT_SECTIONS.MEDICATIONS}:
 ${context.active_medications.map((m) => `  - ${m.name} ${m.dose} ${m.route} ${m.frequency} (since ${m.started_at})`).join("\n") || "  None"}

--- a/packages/db-schema/drizzle/0029_allergy_verification_status.sql
+++ b/packages/db-schema/drizzle/0029_allergy_verification_status.sql
@@ -1,0 +1,7 @@
+-- Add verification_status to allergies table to distinguish confirmed,
+-- unconfirmed, entered_in_error, and refuted allergy records.
+ALTER TABLE "allergies" ADD COLUMN "verification_status" text NOT NULL DEFAULT 'unconfirmed';
+
+-- Add allergy_status to patients table to distinguish NKDA (confirmed no
+-- known drug allergies), unknown (never assessed), and has_allergies.
+ALTER TABLE "patients" ADD COLUMN "allergy_status" text NOT NULL DEFAULT 'unknown';

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1746028800000,
       "tag": "0028_encrypt_patient_diagnosis_notes",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1746115200000,
+      "tag": "0029_allergy_verification_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -22,6 +22,9 @@ export const patients = pgTable("patients", {
   emergency_contact_name: encryptedText("emergency_contact_name"),
   emergency_contact_phone: encryptedText("emergency_contact_phone"),
   primary_provider_id: text("primary_provider_id"),
+  // Overall patient allergy status: distinguishes "confirmed no allergies" (nkda)
+  // from "never assessed" (unknown) and "has documented allergies" (has_allergies).
+  allergy_status: text("allergy_status").notNull().default("unknown"), // nkda, unknown, has_allergies
   created_at: text("created_at").notNull(),
   updated_at: text("updated_at").notNull(),
 });
@@ -49,6 +52,9 @@ export const allergies = pgTable("allergies", {
   rxnorm_code: text("rxnorm_code"),
   reaction: encryptedText("reaction"),
   severity: text("severity"), // mild, moderate, severe
+  // Tracks clinical verification of this allergy record: confirmed (verified reaction),
+  // unconfirmed (reported but not verified), entered_in_error, or refuted (tested negative).
+  verification_status: text("verification_status").notNull().default("unconfirmed"), // confirmed, unconfirmed, entered_in_error, refuted
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_allergies_patient").on(table.patient_id),

--- a/packages/validators/src/__tests__/diagnoses-allergies.test.ts
+++ b/packages/validators/src/__tests__/diagnoses-allergies.test.ts
@@ -6,6 +6,8 @@ import {
   createAllergySchema,
   updateAllergySchema,
   allergySeveritySchema,
+  allergyVerificationStatusSchema,
+  patientAllergyStatusSchema,
 } from "../clinical-data.js";
 
 // ─── Diagnosis Validators ──────────────────────────────────────
@@ -212,6 +214,33 @@ describe("createAllergySchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("defaults verification_status to unconfirmed", () => {
+    const result = createAllergySchema.safeParse(validAllergy);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.verification_status).toBe("unconfirmed");
+    }
+  });
+
+  it("accepts explicit verification_status", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      verification_status: "confirmed",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.verification_status).toBe("confirmed");
+    }
+  });
+
+  it("rejects invalid verification_status", () => {
+    const result = createAllergySchema.safeParse({
+      ...validAllergy,
+      verification_status: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("updateAllergySchema", () => {
@@ -225,6 +254,11 @@ describe("updateAllergySchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts partial update with verification_status only", () => {
+    const result = updateAllergySchema.safeParse({ verification_status: "confirmed" });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts empty object (no updates)", () => {
     const result = updateAllergySchema.safeParse({});
     expect(result.success).toBe(true);
@@ -232,6 +266,43 @@ describe("updateAllergySchema", () => {
 
   it("rejects invalid severity value", () => {
     const result = updateAllergySchema.safeParse({ severity: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid verification_status value", () => {
+    const result = updateAllergySchema.safeParse({ verification_status: "maybe" });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Allergy Verification Status ──────────────────────────────
+
+describe("allergyVerificationStatusSchema", () => {
+  it("accepts all valid verification statuses", () => {
+    for (const status of ["confirmed", "unconfirmed", "entered_in_error", "refuted"]) {
+      const result = allergyVerificationStatusSchema.safeParse(status);
+      expect(result.success, `Expected verification status "${status}" to pass`).toBe(true);
+    }
+  });
+
+  it("rejects invalid verification status", () => {
+    const result = allergyVerificationStatusSchema.safeParse("pending");
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Patient Allergy Status ───────────────────────────────────
+
+describe("patientAllergyStatusSchema", () => {
+  it("accepts all valid patient allergy statuses", () => {
+    for (const status of ["nkda", "unknown", "has_allergies"]) {
+      const result = patientAllergyStatusSchema.safeParse(status);
+      expect(result.success, `Expected allergy status "${status}" to pass`).toBe(true);
+    }
+  });
+
+  it("rejects invalid patient allergy status", () => {
+    const result = patientAllergyStatusSchema.safeParse("none");
     expect(result.success).toBe(false);
   });
 });

--- a/packages/validators/src/clinical-data.ts
+++ b/packages/validators/src/clinical-data.ts
@@ -113,16 +113,31 @@ export type UpdateDiagnosisInput = z.infer<typeof updateDiagnosisSchema>;
 
 export const allergySeveritySchema = z.enum(["mild", "moderate", "severe", "critical"]);
 
+export const allergyVerificationStatusSchema = z.enum([
+  "confirmed",
+  "unconfirmed",
+  "entered_in_error",
+  "refuted",
+]);
+
+export const patientAllergyStatusSchema = z.enum([
+  "nkda",       // No Known Drug Allergies — actively confirmed
+  "unknown",    // Never assessed / not yet asked
+  "has_allergies",
+]);
+
 export const createAllergySchema = z.object({
   patient_id: z.string().uuid(),
   allergen: z.string().min(1).max(200),
   reaction: z.string().min(1).max(500),
   severity: allergySeveritySchema,
+  verification_status: allergyVerificationStatusSchema.default("unconfirmed"),
 });
 
 export const updateAllergySchema = z.object({
   severity: allergySeveritySchema.optional(),
   reaction: z.string().min(1).max(500).optional(),
+  verification_status: allergyVerificationStatusSchema.optional(),
 });
 
 export type CreateAllergyInput = z.infer<typeof createAllergySchema>;

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -197,8 +197,12 @@ export async function buildPatientContext(
     patient: {
       age,
       sex: patientRow?.biological_sex ?? "unknown",
+      allergy_status: (patientRow?.allergy_status as "nkda" | "unknown" | "has_allergies") ?? "unknown",
       active_diagnoses: activeDiagnoses.map((d) => d.description),
-      allergies: patientAllergies.map((a) => a.allergen),
+      allergies: patientAllergies.map((a) => ({
+        allergen: a.allergen,
+        verification_status: a.verification_status ?? "unconfirmed",
+      })),
     },
     active_medications: activeMeds.map((m) => ({
       name: m.name,

--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -53,6 +53,25 @@ const CLINICAL_STATUS_SYSTEM =
 const VERIFICATION_STATUS_SYSTEM =
   "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification";
 
+/**
+ * Map internal verification_status to FHIR R4 verificationStatus code.
+ * See https://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html
+ */
+function mapVerificationStatus(
+  status: string | null,
+): "confirmed" | "unconfirmed" | "entered-in-error" | "refuted" {
+  switch (status) {
+    case "confirmed":
+      return "confirmed";
+    case "entered_in_error":
+      return "entered-in-error";
+    case "refuted":
+      return "refuted";
+    default:
+      return "unconfirmed";
+  }
+}
+
 function mapSeverityToCriticality(
   severity: string | null,
 ): "low" | "high" | "unable-to-assess" {
@@ -133,7 +152,7 @@ export function toFhirAllergyIntolerance(
       coding: [
         {
           system: VERIFICATION_STATUS_SYSTEM,
-          code: "confirmed",
+          code: mapVerificationStatus(allergy.verification_status),
         },
       ],
     },

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -313,6 +313,7 @@ export async function createAllergy(input: z.infer<typeof createAllergySchema>) 
     allergen: input.allergen,
     reaction: input.reaction,
     severity: input.severity,
+    verification_status: input.verification_status ?? "unconfirmed",
     created_at: now,
   };
 
@@ -322,7 +323,7 @@ export async function createAllergy(input: z.infer<typeof createAllergySchema>) 
     id: crypto.randomUUID(),
     type: "allergy.added",
     patient_id: input.patient_id,
-    data: { allergy_id: id, allergen: input.allergen, severity: input.severity },
+    data: { allergy_id: id, allergen: input.allergen, severity: input.severity, verification_status: record.verification_status },
     timestamp: now,
   });
 
@@ -344,6 +345,7 @@ export async function updateAllergy(
   const updates: Record<string, unknown> = {};
   if (input.severity !== undefined) updates.severity = input.severity;
   if (input.reaction !== undefined) updates.reaction = input.reaction;
+  if (input.verification_status !== undefined) updates.verification_status = input.verification_status;
 
   if (Object.keys(updates).length === 0) {
     return existing;


### PR DESCRIPTION
## Summary
- Add `verification_status` column to `allergies` table with values: `confirmed`, `unconfirmed`, `entered_in_error`, `refuted` (defaults to `unconfirmed`)
- Add `allergy_status` column to `patients` table with values: `nkda`, `unknown`, `has_allergies` (defaults to `unknown`)
- Update validator schemas, patient-records service, FHIR AllergyIntolerance generator, and AI context builder to use the new fields
- AI prompt now renders "ALLERGY STATUS UNKNOWN (never assessed)" instead of defaulting to "NKDA" when no allergies are documented

## Test plan
- [x] Validator tests pass (78 tests including new coverage for verification_status and allergy_status enums)
- [x] FHIR allergy-intolerance tests pass (4 tests)
- [x] AI oversight tests pass (161 tests)
- [ ] Manual: create allergy with `verification_status: "confirmed"` and verify it persists
- [ ] Manual: verify FHIR export maps `entered_in_error` to `entered-in-error` per FHIR R4 spec
- [ ] Manual: run migration `0025_allergy_verification_status.sql` against dev DB

Closes #231