### PR TITLE
feat(ai): add weight-based dose validation for high-risk medications

### DIFF
--- a/packages/db-schema/drizzle/0030_patient_weight_kg.sql
+++ b/packages/db-schema/drizzle/0030_patient_weight_kg.sql
@@ -1,0 +1,7 @@
+-- Migration: Add weight_kg column to patients table
+--
+-- Supports weight-based dose validation in the AI oversight engine.
+-- Weight is stored in kilograms as a nullable real column — null indicates
+-- weight has not yet been documented for the patient.
+
+ALTER TABLE patients ADD COLUMN IF NOT EXISTS weight_kg REAL;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1746115200000,
       "tag": "0029_allergy_verification_status",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1746201600000,
+      "tag": "0030_patient_weight_kg",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { pgTable, text, boolean, index } from "drizzle-orm/pg-core";
+import { pgTable, text, boolean, real, index } from "drizzle-orm/pg-core";
 import { encryptedText } from "../encryption.js";
 
 export const patients = pgTable("patients", {
@@ -22,9 +22,8 @@ export const patients = pgTable("patients", {
   emergency_contact_name: encryptedText("emergency_contact_name"),
   emergency_contact_phone: encryptedText("emergency_contact_phone"),
   primary_provider_id: text("primary_provider_id"),
-  // Overall patient allergy status: distinguishes "confirmed no allergies" (nkda)
-  // from "never assessed" (unknown) and "has documented allergies" (has_allergies).
-  allergy_status: text("allergy_status").notNull().default("unknown"), // nkda, unknown, has_allergies
+  allergy_status: text("allergy_status").notNull().default("unknown"),
+  weight_kg: real("weight_kg"),
   created_at: text("created_at").notNull(),
   updated_at: text("updated_at").notNull(),
 });

--- a/packages/medical-logic/src/__tests__/weight-based-dosing.test.ts
+++ b/packages/medical-logic/src/__tests__/weight-based-dosing.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { checkWeightBasedDosing } from "../weight-based-dosing.js";
+
+// ─── No matching drug ──────────────────────────────────────────
+
+describe("checkWeightBasedDosing — unrecognized drug", () => {
+  it("returns no alerts for a drug without weight-based rules", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Amoxicillin",
+      doseMg: 500,
+      weightKg: 70,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+});
+
+// ─── Missing weight ────────────────────────────────────────────
+
+describe("checkWeightBasedDosing — missing weight", () => {
+  it("returns INFO when weight is undefined", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Acetaminophen",
+      doseMg: 1000,
+      weightKg: undefined,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("INFO");
+    expect(alerts[0].message).toContain("weight not documented");
+    expect(alerts[0].ruleId).toBe("DOSE-WT-APAP-001");
+  });
+
+  it("returns INFO when weight is null", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Vancomycin",
+      doseMg: 1000,
+      weightKg: null,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("INFO");
+  });
+});
+
+// ─── Invalid weight ────────────────────────────────────────────
+
+describe("checkWeightBasedDosing — invalid weight", () => {
+  it("returns WARNING for zero weight", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Gentamicin",
+      doseMg: 200,
+      weightKg: 0,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("WARNING");
+    expect(alerts[0].message).toContain("Invalid patient weight");
+  });
+
+  it("returns WARNING for negative weight", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Gentamicin",
+      doseMg: 200,
+      weightKg: -5,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("WARNING");
+  });
+});
+
+// ─── Acetaminophen (daily max) ─────────────────────────────────
+
+describe("checkWeightBasedDosing — Acetaminophen", () => {
+  it("returns no alerts for safe dose within weight-based and absolute limits", () => {
+    // 70 kg patient: max 75 * 70 = 5250 mg/day (capped at 4000 absolute)
+    // 500 mg x 4 = 2000 mg/day — well under both limits
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Acetaminophen",
+      doseMg: 500,
+      dosesPerDay: 4,
+      weightKg: 70,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("flags daily total exceeding absolute 4 g/day ceiling", () => {
+    // 1500 mg x 4 = 6000 mg/day — exceeds 4000 absolute
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Tylenol",
+      doseMg: 1500,
+      dosesPerDay: 4,
+      weightKg: 100,
+    });
+    expect(alerts.some((a) => a.severity === "WARNING" && a.message.includes("absolute maximum"))).toBe(true);
+  });
+
+  it("flags weight-based excess for small patient", () => {
+    // 40 kg patient: max 75 * 40 = 3000 mg/day
+    // 1000 mg x 4 = 4000 mg/day — exceeds weight limit
+    // Also exceeds absolute 4000 mg ceiling (need > 4000 for that check)
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Paracetamol",
+      doseMg: 1000,
+      dosesPerDay: 4,
+      weightKg: 40,
+    });
+    expect(alerts.some((a) => a.message.includes("weight-based maximum"))).toBe(true);
+  });
+
+  it("flags both weight-based and absolute excess when daily total exceeds both", () => {
+    // 40 kg patient: max 75 * 40 = 3000 mg/day, absolute 4000
+    // 1500 mg x 4 = 6000 mg/day — exceeds both
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Paracetamol",
+      doseMg: 1500,
+      dosesPerDay: 4,
+      weightKg: 40,
+    });
+    expect(alerts.some((a) => a.message.includes("weight-based maximum"))).toBe(true);
+    expect(alerts.some((a) => a.message.includes("absolute maximum"))).toBe(true);
+  });
+
+  it("defaults to 1 dose/day when dosesPerDay is omitted", () => {
+    // 70 kg patient, 1000 mg single dose, no dosesPerDay
+    // daily = 1000 mg, well under 4000 and 5250
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Acetaminophen",
+      doseMg: 1000,
+      weightKg: 70,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("matches case-insensitively", () => {
+    const alerts = checkWeightBasedDosing({
+      medicationName: "ACETAMINOPHEN",
+      doseMg: 1000,
+      dosesPerDay: 6,
+      weightKg: 50,
+    });
+    // 6000 mg/day for 50 kg patient (120 mg/kg/day > 75) and > 4000 absolute
+    expect(alerts.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── Ibuprofen (daily max) ─────────────────────────────────────
+
+describe("checkWeightBasedDosing — Ibuprofen", () => {
+  it("returns no alerts for safe daily ibuprofen dose", () => {
+    // 70 kg: max 40 * 70 = 2800 mg/day
+    // 400 mg x 3 = 1200 — safe
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Ibuprofen",
+      doseMg: 400,
+      dosesPerDay: 3,
+      weightKg: 70,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("flags high ibuprofen dose for small patient", () => {
+    // 30 kg: max 40 * 30 = 1200 mg/day
+    // 600 mg x 3 = 1800 — exceeds
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Advil",
+      doseMg: 600,
+      dosesPerDay: 3,
+      weightKg: 30,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("WARNING");
+    expect(alerts[0].ruleId).toBe("DOSE-WT-IBU-001");
+  });
+});
+
+// ─── Vancomycin (per-dose) ─────────────────────────────────────
+
+describe("checkWeightBasedDosing — Vancomycin", () => {
+  it("returns no alerts for typical vancomycin dose", () => {
+    // 70 kg: max 20 * 70 = 1400 mg per dose
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Vancomycin",
+      doseMg: 1000,
+      weightKg: 70,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("flags excessive vancomycin per-dose", () => {
+    // 60 kg: max 20 * 60 = 1200 mg per dose; giving 1500 exceeds
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Vancomycin",
+      doseMg: 1500,
+      weightKg: 60,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("WARNING");
+    expect(alerts[0].message).toContain("mg/kg");
+    expect(alerts[0].ruleId).toBe("DOSE-WT-VANC-001");
+  });
+});
+
+// ─── Gentamicin (per-dose) ─────────────────────────────────────
+
+describe("checkWeightBasedDosing — Gentamicin", () => {
+  it("returns no alerts for typical gentamicin dose", () => {
+    // 80 kg: max 7 * 80 = 560 mg per dose
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Gentamicin",
+      doseMg: 400,
+      weightKg: 80,
+    });
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("flags excessive gentamicin dose", () => {
+    // 50 kg: max 7 * 50 = 350; giving 500 exceeds
+    const alerts = checkWeightBasedDosing({
+      medicationName: "Gentamicin",
+      doseMg: 500,
+      weightKg: 50,
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe("WARNING");
+    expect(alerts[0].ruleId).toBe("DOSE-WT-GENT-001");
+  });
+});

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./trend-utils.js";
 export * from "./medical-validation.js";
+export * from "./weight-based-dosing.js";

--- a/packages/medical-logic/src/weight-based-dosing.ts
+++ b/packages/medical-logic/src/weight-based-dosing.ts
@@ -1,0 +1,166 @@
+/**
+ * Weight-based dose validation for high-risk medications.
+ *
+ * Flags when a prescribed dose exceeds weight-adjusted maximums for drugs
+ * where weight-based dosing is the clinical standard. When no patient weight
+ * is on file, emits an INFO-level suggestion to document weight.
+ *
+ * References:
+ *  - Acetaminophen: max 75 mg/kg/day, absolute cap 4 g/day
+ *  - Ibuprofen: max 40 mg/kg/day
+ *  - Vancomycin: typical 15–20 mg/kg per dose
+ *  - Gentamicin: typical 5–7 mg/kg per dose
+ */
+
+export type DoseAlertSeverity = "WARNING" | "INFO";
+
+export interface DoseAlert {
+  severity: DoseAlertSeverity;
+  message: string;
+  drugName: string;
+  ruleId: string;
+}
+
+export interface WeightBasedDoseInput {
+  /** Medication name (case-insensitive matching) */
+  medicationName: string;
+  /** Single dose amount in mg */
+  doseMg: number;
+  /** Number of doses per day (used for daily-max drugs like acetaminophen/ibuprofen) */
+  dosesPerDay?: number;
+  /** Patient weight in kilograms, or undefined if not documented */
+  weightKg?: number | null;
+}
+
+interface DrugRule {
+  /** Unique rule identifier */
+  ruleId: string;
+  /** Regex patterns to match medication names (case-insensitive) */
+  namePatterns: RegExp[];
+  /** Validation mode: "per-dose" checks a single dose, "daily" checks total daily dose */
+  mode: "per-dose" | "daily";
+  /** Max mg/kg (per-dose or per-day depending on mode) */
+  maxMgPerKg: number;
+  /** Absolute ceiling in mg (per-dose or per-day depending on mode), regardless of weight */
+  absoluteMaxMg?: number;
+  /** Human-readable dosing guidance for alert messages */
+  guidance: string;
+}
+
+const DRUG_RULES: DrugRule[] = [
+  {
+    ruleId: "DOSE-WT-APAP-001",
+    namePatterns: [/acetaminophen/i, /tylenol/i, /paracetamol/i],
+    mode: "daily",
+    maxMgPerKg: 75,
+    absoluteMaxMg: 4000,
+    guidance: "max 75 mg/kg/day, absolute max 4 g/day",
+  },
+  {
+    ruleId: "DOSE-WT-IBU-001",
+    namePatterns: [/ibuprofen/i, /advil/i, /motrin/i],
+    mode: "daily",
+    maxMgPerKg: 40,
+    absoluteMaxMg: undefined,
+    guidance: "max 40 mg/kg/day",
+  },
+  {
+    ruleId: "DOSE-WT-VANC-001",
+    namePatterns: [/vancomycin/i],
+    mode: "per-dose",
+    maxMgPerKg: 20,
+    absoluteMaxMg: undefined,
+    guidance: "typical 15-20 mg/kg per dose",
+  },
+  {
+    ruleId: "DOSE-WT-GENT-001",
+    namePatterns: [/gentamicin/i],
+    mode: "per-dose",
+    maxMgPerKg: 7,
+    absoluteMaxMg: undefined,
+    guidance: "typical 5-7 mg/kg per dose",
+  },
+];
+
+function matchDrugRule(medicationName: string): DrugRule | undefined {
+  const name = medicationName.trim();
+  return DRUG_RULES.find((rule) =>
+    rule.namePatterns.some((pattern) => pattern.test(name))
+  );
+}
+
+/**
+ * Check a medication dose against weight-based maximums.
+ *
+ * Returns an array of alerts (may be empty if no issues found).
+ */
+export function checkWeightBasedDosing(input: WeightBasedDoseInput): DoseAlert[] {
+  const alerts: DoseAlert[] = [];
+  const rule = matchDrugRule(input.medicationName);
+
+  if (!rule) return alerts;
+
+  // If weight is not documented, suggest documenting it
+  if (input.weightKg == null) {
+    alerts.push({
+      severity: "INFO",
+      message: `Patient weight not documented. Weight-based dosing check skipped for ${input.medicationName} (${rule.guidance}).`,
+      drugName: input.medicationName,
+      ruleId: rule.ruleId,
+    });
+    return alerts;
+  }
+
+  const weightKg = input.weightKg;
+
+  if (weightKg <= 0) {
+    alerts.push({
+      severity: "WARNING",
+      message: `Invalid patient weight (${weightKg} kg). Cannot perform weight-based dose check for ${input.medicationName}.`,
+      drugName: input.medicationName,
+      ruleId: rule.ruleId,
+    });
+    return alerts;
+  }
+
+  const weightBasedMax = rule.maxMgPerKg * weightKg;
+
+  if (rule.mode === "daily") {
+    const dosesPerDay = input.dosesPerDay ?? 1;
+    const dailyTotal = input.doseMg * dosesPerDay;
+
+    // Check absolute ceiling first
+    if (rule.absoluteMaxMg != null && dailyTotal > rule.absoluteMaxMg) {
+      alerts.push({
+        severity: "WARNING",
+        message: `${input.medicationName} daily total ${dailyTotal} mg exceeds absolute maximum of ${rule.absoluteMaxMg} mg/day (${rule.guidance}).`,
+        drugName: input.medicationName,
+        ruleId: rule.ruleId,
+      });
+    }
+
+    // Check weight-based limit
+    if (dailyTotal > weightBasedMax) {
+      const mgPerKgActual = Math.round((dailyTotal / weightKg) * 10) / 10;
+      alerts.push({
+        severity: "WARNING",
+        message: `${input.medicationName} daily total ${dailyTotal} mg (${mgPerKgActual} mg/kg/day) exceeds weight-based maximum of ${rule.maxMgPerKg} mg/kg/day for ${weightKg} kg patient (${rule.guidance}).`,
+        drugName: input.medicationName,
+        ruleId: rule.ruleId,
+      });
+    }
+  } else {
+    // per-dose mode
+    if (input.doseMg > weightBasedMax) {
+      const mgPerKgActual = Math.round((input.doseMg / weightKg) * 10) / 10;
+      alerts.push({
+        severity: "WARNING",
+        message: `${input.medicationName} dose ${input.doseMg} mg (${mgPerKgActual} mg/kg) exceeds weight-based maximum of ${rule.maxMgPerKg} mg/kg for ${weightKg} kg patient (${rule.guidance}).`,
+        drugName: input.medicationName,
+        ruleId: rule.ruleId,
+      });
+    }
+  }
+
+  return alerts;
+}


### PR DESCRIPTION
## Summary

- Adds `checkWeightBasedDosing()` to `@carebridge/medical-logic` that validates medication doses against weight-adjusted maximums for acetaminophen (75 mg/kg/day, 4g absolute cap), ibuprofen (40 mg/kg/day), vancomycin (20 mg/kg per dose), and gentamicin (7 mg/kg per dose)
- Adds `weight_kg` nullable column to the `patients` table with migration `0025_patient_weight_kg.sql`
- When patient weight is not documented, returns an INFO-level alert recommending weight documentation rather than silently skipping the check
- Includes 17 unit tests covering safe doses, excess doses, missing/invalid weight, brand-name matching, and case-insensitive lookup

Closes #229

## Test plan

- [x] 17 vitest tests pass for all drug rules, edge cases, and missing-weight scenarios
- [ ] Verify migration applies cleanly against dev database (`pnpm db:migrate`)
- [ ] Integration: confirm ai-oversight worker can import and call `checkWeightBasedDosing` with patient context