### PR TITLE
fix(gateway): redact patient IDs from operational server logs

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/redactor.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/redactor.test.ts
@@ -7,6 +7,8 @@ import {
   redactAgeInFreeText,
   redactClinicalText,
   redactPatientName,
+  redactPatientId,
+  redactUrlIds,
   redactMRN,
   redactDates,
   redactFacilityNames,
@@ -394,5 +396,48 @@ describe("redactClinicalText — full pipeline expansion", () => {
     expect(result.auditTrail.facilitiesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.phonesRedacted).toBeGreaterThan(0);
     expect(result.auditTrail.addressesRedacted).toBeGreaterThan(0);
+  });
+});
+
+describe("redactPatientId", () => {
+  it("truncates a UUID to first 8 chars plus mask", () => {
+    const id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    expect(redactPatientId(id)).toBe("a1b2c3d4****");
+  });
+
+  it("returns **** for empty string", () => {
+    expect(redactPatientId("")).toBe("****");
+  });
+
+  it("returns **** for short IDs", () => {
+    expect(redactPatientId("abc")).toBe("****");
+  });
+
+  it("handles exactly 8 character IDs", () => {
+    expect(redactPatientId("a1b2c3d4")).toBe("****");
+  });
+
+  it("handles 9+ character IDs", () => {
+    expect(redactPatientId("a1b2c3d4e")).toBe("a1b2c3d4****");
+  });
+});
+
+describe("redactUrlIds", () => {
+  it("redacts UUIDs in a tRPC URL query parameter", () => {
+    const url = '/trpc/patients.getById?input={"id":"a1b2c3d4-e5f6-7890-abcd-ef1234567890"}';
+    const result = redactUrlIds(url);
+    expect(result).toBe('/trpc/patients.getById?input={"id":"a1b2c3d4****"}');
+    expect(result).not.toContain("ef1234567890");
+  });
+
+  it("redacts multiple UUIDs in a URL", () => {
+    const url = "/patients/a1b2c3d4-e5f6-7890-abcd-ef1234567890/notes/f1e2d3c4-b5a6-0987-fedc-ba0987654321";
+    const result = redactUrlIds(url);
+    expect(result).toBe("/patients/a1b2c3d4****/notes/f1e2d3c4****");
+  });
+
+  it("leaves non-UUID content untouched", () => {
+    const url = "/trpc/health?foo=bar";
+    expect(redactUrlIds(url)).toBe(url);
   });
 });

--- a/packages/phi-sanitizer/src/redactor.ts
+++ b/packages/phi-sanitizer/src/redactor.ts
@@ -336,6 +336,32 @@ export function assertPromptSanitized(text: string): void {
 }
 
 /**
+ * Redact a patient ID (UUID) for safe use in operational logs.
+ * Retains the first 8 characters for correlation and masks the rest,
+ * so DevOps/SRE teams can cross-reference without exposing full PHI.
+ *
+ * Example: "a1b2c3d4-e5f6-..." → "a1b2c3d4****"
+ */
+export function redactPatientId(id: string): string {
+  if (!id || id.length <= 8) return "****";
+  return id.substring(0, 8) + "****";
+}
+
+/**
+ * Redact UUIDs embedded in a URL path or query string.
+ * Useful for Fastify request log serializers to prevent patient IDs
+ * from appearing in operational logs via tRPC input parameters.
+ *
+ * Matches standard UUID format: 8-4-4-4-12 hex characters.
+ */
+export function redactUrlIds(url: string): string {
+  return url.replace(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+    (match) => match.substring(0, 8) + "****",
+  );
+}
+
+/**
  * Full redaction pipeline: sanitize free text, redact provider names,
  * band ages, and produce an audit trail.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       '@carebridge/patient-records':
         specifier: workspace:*
         version: link:../patient-records
+      '@carebridge/phi-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/phi-sanitizer
       '@carebridge/redis-config':
         specifier: workspace:*
         version: link:../../packages/redis-config
@@ -598,6 +601,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/phi-sanitizer':
+        specifier: workspace:*
+        version: link:../../packages/phi-sanitizer
       '@carebridge/redis-config':
         specifier: workspace:*
         version: link:../../packages/redis-config

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -32,6 +32,7 @@ import {
 import type { LLMFlagOutput } from "@carebridge/ai-prompts";
 import {
   redactClinicalText,
+  redactPatientId,
   validateLLMResponse,
 } from "@carebridge/phi-sanitizer";
 
@@ -186,7 +187,7 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
 
     if (budgetResult.truncated) {
       console.warn(
-        `[review-service] Token budget exceeded for patient ${event.patient_id}. ` +
+        `[review-service] Token budget exceeded for patient ${redactPatientId(event.patient_id)}. ` +
           `Original: ${budgetResult.originalTokens} tokens, ` +
           `Final: ${budgetResult.finalTokens} tokens. ` +
           `Sections trimmed: ${budgetResult.sectionsRemoved.join(", ")}`,

--- a/services/ai-oversight/src/workers/escalation-worker.ts
+++ b/services/ai-oversight/src/workers/escalation-worker.ts
@@ -15,6 +15,7 @@
 import { Queue, Worker } from "bullmq";
 import type { Job } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { getDb } from "@carebridge/db-schema";
 import { clinicalFlags } from "@carebridge/db-schema";
 import { eq, and, lt, isNull } from "drizzle-orm";
@@ -97,7 +98,7 @@ async function checkAndEscalate(): Promise<{ escalated: number }> {
 
       console.log(
         `[escalation-worker] Escalated flag ${flag.id} ` +
-          `(severity: ${flag.severity}, patient: ${flag.patient_id}, ` +
+          `(severity: ${flag.severity}, patient: ${redactPatientId(flag.patient_id)}, ` +
           `age: ${Math.round((now - new Date(flag.created_at).getTime()) / 60000)}min)`,
       );
     }

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -10,6 +10,7 @@ import { Worker, Queue } from "bullmq";
 import type { Job } from "bullmq";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { processReviewJob } from "../services/review-service.js";
 
 const QUEUE_NAME = "clinical-events";
@@ -36,7 +37,7 @@ export function startReviewWorker(): Worker {
 
       console.log(
         `[review-worker] Processing job ${job.id} — event: ${event.type} ` +
-          `for patient ${event.patient_id}`,
+          `for patient ${redactPatientId(event.patient_id)}`,
       );
 
       const startTime = Date.now();
@@ -81,7 +82,6 @@ export function startReviewWorker(): Worker {
 
     console.error(
       `[review-worker] Job ${job?.id} failed (attempt ${attemptsMade}/${maxAttempts}): ${error.message}`,
-      { jobData: job?.data },
     );
 
     if (isExhausted && job != null) {

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -25,6 +25,7 @@
     "@carebridge/scheduling": "workspace:*",
     "@carebridge/redis-config": "workspace:*",
     "@carebridge/fhir-gateway": "workspace:*",
+    "@carebridge/phi-sanitizer": "workspace:*",
     "bullmq": "^5.0.0",
     "fastify": "^5.2.0",
     "@fastify/cookie": "^11.0.0",

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -10,6 +10,7 @@ import { createContext } from "./context.js";
 import { authMiddleware } from "./middleware/auth.js";
 import { auditMiddleware } from "./middleware/audit.js";
 import { registerNotificationSSE } from "./routes/notifications-sse.js";
+import { redactUrlIds } from "@carebridge/phi-sanitizer";
 import { startBackgroundWorkers } from "./workers.js";
 
 const API_PORT = Number(process.env.API_PORT) || 4000;
@@ -59,6 +60,16 @@ async function main() {
   const server = Fastify({
     logger: {
       level: process.env.LOG_LEVEL ?? "info",
+      serializers: {
+        req(request) {
+          return {
+            method: request.method,
+            url: redactUrlIds(request.url),
+            hostname: request.hostname,
+            remoteAddress: request.ip,
+          };
+        },
+      },
     },
   });
 

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/phi-sanitizer": "workspace:*",
     "@carebridge/redis-config": "workspace:*",
     "@trpc/server": "^11.0.0",
     "bullmq": "^5.0.0",

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -20,6 +20,7 @@ import { eq, and, isNull, inArray } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { NotificationEvent } from "../queue.js";
 import { publishNotification } from "../publish.js";
+import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { filterRecipientsBySpecialty } from "./specialty-filter.js";
 import type { CandidateRecipient } from "./specialty-filter.js";
 
@@ -136,7 +137,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   if (recipientIds.length === 0) {
     console.log(
       `[dispatch-worker] No recipients found for flag ${event.flag_id} ` +
-        `(patient: ${event.patient_id}, specialties: ${event.notify_specialties.join(", ")})`,
+        `(patient: ${redactPatientId(event.patient_id)}, specialties: ${event.notify_specialties.join(", ")})`,
     );
     return 0;
   }
@@ -205,7 +206,7 @@ export function startDispatchWorker(): Worker {
 
       console.log(
         `[dispatch-worker] Processing job ${job.id} — flag: ${event.flag_id} ` +
-          `(severity: ${event.severity}, patient: ${event.patient_id})`,
+          `(severity: ${event.severity}, patient: ${redactPatientId(event.patient_id)})`,
       );
 
       const startTime = Date.now();


### PR DESCRIPTION
## Summary
- Add `redactPatientId()` and `redactUrlIds()` helpers to `@carebridge/phi-sanitizer` that truncate UUIDs to the first 8 characters plus `****` for safe operational logging
- Replace all `console.log/warn/error` statements in ai-oversight workers, review-service, and dispatch-worker that previously logged full patient UUIDs in plain text
- Add a Fastify request serializer to the API gateway that redacts UUIDs from logged URL paths and tRPC query parameters
- Remove raw `jobData` dump from review-worker failure handler (contained full `ClinicalEvent` with `patient_id`)
- Add unit tests for both new helpers

## Test plan
- [x] All 56 phi-sanitizer unit tests pass (including 8 new tests for `redactPatientId` and `redactUrlIds`)
- [x] TypeScript compiles cleanly
- [ ] Verify in dev: `pnpm dev` and trigger a clinical event — confirm console output shows truncated patient IDs (e.g., `a1b2c3d4****`)
- [ ] Verify API gateway request logs show redacted UUIDs in URLs

Closes #223