### PR TITLE
feat(ai): add age-stratified pediatric vital sign ranges

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -6,6 +6,10 @@ import {
   isCriticalVital,
   getVitalSeverity,
   VITAL_DANGER_ZONES,
+  PEDIATRIC_VITAL_RANGES,
+  classifyAgeGroup,
+  ageInYearsFromDOB,
+  getVitalRangeForAge,
 } from "../medical-validation.js";
 
 // ─── validateVital ──────────────────────────────────────────────
@@ -197,6 +201,38 @@ describe("isCriticalVital", () => {
   it("returns false for glucose 300 (above warningHigh but below criticalHigh)", () => {
     expect(isCriticalVital("blood_glucose", 300)).toBe(false);
   });
+
+  it("uses adult thresholds when no age is provided", () => {
+    expect(isCriticalVital("heart_rate", 150)).toBe(false);
+  });
+
+  it("flags HR 150 as critical for a toddler (age 2)", () => {
+    expect(isCriticalVital("heart_rate", 150, 2)).toBe(true);
+  });
+
+  it("does not flag HR 120 as critical for a toddler (age 2)", () => {
+    expect(isCriticalVital("heart_rate", 120, 2)).toBe(false);
+  });
+
+  it("flags HR 165 as critical for a neonate (age 0.01)", () => {
+    expect(isCriticalVital("heart_rate", 165, 0.01)).toBe(true);
+  });
+
+  it("does not flag HR 140 as critical for a neonate (age 0.01)", () => {
+    expect(isCriticalVital("heart_rate", 140, 0.01)).toBe(false);
+  });
+
+  it("flags RR 55 as critical for an infant (age 0.5)", () => {
+    expect(isCriticalVital("respiratory_rate", 55, 0.5)).toBe(true);
+  });
+
+  it("flags low SBP for school-age child", () => {
+    expect(isCriticalVital("blood_pressure", 80, 8)).toBe(true);
+  });
+
+  it("uses adult thresholds for age 25", () => {
+    expect(isCriticalVital("heart_rate", 150, 25)).toBe(false);
+  });
 });
 
 // ─── getVitalSeverity ──────────────────────────────────────────
@@ -236,5 +272,84 @@ describe("getVitalSeverity", () => {
 
   it("returns critical for critically low heart rate", () => {
     expect(getVitalSeverity("heart_rate", 30)).toBe("critical");
+  });
+});
+
+// ─── classifyAgeGroup ──────────────────────────────────────────
+
+describe("classifyAgeGroup", () => {
+  it("classifies neonate (10 days old)", () => {
+    expect(classifyAgeGroup(10 / 365.25)).toBe("neonate");
+  });
+
+  it("classifies infant (6 months old)", () => {
+    expect(classifyAgeGroup(0.5)).toBe("infant");
+  });
+
+  it("classifies child (3 years old)", () => {
+    expect(classifyAgeGroup(3)).toBe("child");
+  });
+
+  it("classifies school age (10 years old)", () => {
+    expect(classifyAgeGroup(10)).toBe("school_age");
+  });
+
+  it("classifies adolescent (15 years old)", () => {
+    expect(classifyAgeGroup(15)).toBe("adolescent");
+  });
+
+  it("classifies adult (30 years old)", () => {
+    expect(classifyAgeGroup(30)).toBe("adult");
+  });
+
+  it("falls back to adult for negative age", () => {
+    expect(classifyAgeGroup(-1)).toBe("adult");
+  });
+});
+
+// ─── ageInYearsFromDOB ─────────────────────────────────────────
+
+describe("ageInYearsFromDOB", () => {
+  it("returns undefined for undefined DOB", () => {
+    expect(ageInYearsFromDOB(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for invalid DOB string", () => {
+    expect(ageInYearsFromDOB("not-a-date")).toBeUndefined();
+  });
+
+  it("computes correct age for a known reference date", () => {
+    const ref = new Date("2025-01-01T00:00:00Z");
+    const age = ageInYearsFromDOB("2020-01-01", ref);
+    expect(age).toBeCloseTo(5, 0);
+  });
+
+  it("returns undefined for future DOB", () => {
+    const ref = new Date("2025-01-01T00:00:00Z");
+    expect(ageInYearsFromDOB("2026-01-01", ref)).toBeUndefined();
+  });
+});
+
+// ─── getVitalRangeForAge ────────────────────────────────────────
+
+describe("getVitalRangeForAge", () => {
+  it("returns adult range when age is undefined", () => {
+    const range = getVitalRangeForAge("heart_rate");
+    expect(range).toEqual(VITAL_DANGER_ZONES.heart_rate);
+  });
+
+  it("returns pediatric range for child", () => {
+    const range = getVitalRangeForAge("heart_rate", 3);
+    expect(range).toEqual(PEDIATRIC_VITAL_RANGES.child.heart_rate);
+  });
+
+  it("falls back to adult range for vitals without pediatric data", () => {
+    const range = getVitalRangeForAge("blood_glucose", 3);
+    expect(range).toEqual(VITAL_DANGER_ZONES.blood_glucose);
+  });
+
+  it("returns adult range for age 20", () => {
+    const range = getVitalRangeForAge("heart_rate", 20);
+    expect(range).toEqual(VITAL_DANGER_ZONES.heart_rate);
   });
 });

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -28,6 +28,7 @@ export const DIASTOLIC_DANGER_ZONE: DiastolicRange = {
   warningHigh: 90,
 };
 
+/** Adult vital sign danger zones (default, used for age >= 18 or when age is unknown) */
 export const VITAL_DANGER_ZONES: Record<VitalType, VitalRange> = {
   blood_pressure: { min: 60, max: 250, criticalLow: 70, criticalHigh: 180 },
   heart_rate: { min: 20, max: 300, criticalLow: 40, criticalHigh: 200 },
@@ -38,6 +39,100 @@ export const VITAL_DANGER_ZONES: Record<VitalType, VitalRange> = {
   pain_level: { min: 0, max: 10 },
   blood_glucose: { min: 10, max: 800, criticalLow: 54, criticalHigh: 350, warningLow: 70, warningHigh: 250 },
 };
+
+// ─── Age-Stratified Vital Ranges (Pediatric) ───────────────────
+
+export type AgeGroup =
+  | "neonate"    // 0–28 days
+  | "infant"     // 1–12 months
+  | "child"      // 1–5 years
+  | "school_age" // 6–12 years
+  | "adolescent" // 13–17 years
+  | "adult";     // 18+ years
+
+/** Age-stratified vital sign ranges keyed by age group, then by vital type. */
+export const PEDIATRIC_VITAL_RANGES: Record<
+  Exclude<AgeGroup, "adult">,
+  Partial<Record<VitalType, VitalRange>>
+> = {
+  neonate: {
+    heart_rate: { min: 70, max: 220, criticalLow: 100, criticalHigh: 160 },
+    respiratory_rate: { min: 20, max: 80, criticalLow: 30, criticalHigh: 60 },
+    blood_pressure: { min: 40, max: 120, criticalLow: 60, criticalHigh: 90 },
+  },
+  infant: {
+    heart_rate: { min: 70, max: 200, criticalLow: 100, criticalHigh: 150 },
+    respiratory_rate: { min: 15, max: 70, criticalLow: 25, criticalHigh: 50 },
+    blood_pressure: { min: 50, max: 130, criticalLow: 70, criticalHigh: 100 },
+  },
+  child: {
+    heart_rate: { min: 50, max: 200, criticalLow: 80, criticalHigh: 130 },
+    respiratory_rate: { min: 12, max: 40, criticalLow: 20, criticalHigh: 30 },
+    blood_pressure: { min: 60, max: 140, criticalLow: 80, criticalHigh: 110 },
+  },
+  school_age: {
+    heart_rate: { min: 40, max: 200, criticalLow: 70, criticalHigh: 110 },
+    respiratory_rate: { min: 10, max: 35, criticalLow: 16, criticalHigh: 22 },
+    blood_pressure: { min: 60, max: 160, criticalLow: 85, criticalHigh: 120 },
+  },
+  adolescent: {
+    heart_rate: { min: 30, max: 250, criticalLow: 60, criticalHigh: 100 },
+    respiratory_rate: { min: 6, max: 40, criticalLow: 12, criticalHigh: 20 },
+    blood_pressure: { min: 60, max: 200, criticalLow: 95, criticalHigh: 140 },
+  },
+};
+
+/**
+ * Classify age in years into an age group.
+ * Fractional years are used for infants/neonates:
+ *  - neonate: 0 to ~0.077 years (28 days)
+ *  - infant: ~0.077 to 1 year
+ */
+export function classifyAgeGroup(ageYears: number): AgeGroup {
+  if (ageYears < 0) return "adult"; // invalid age, fall back to adult
+  if (ageYears < 28 / 365.25) return "neonate";
+  if (ageYears < 1) return "infant";
+  if (ageYears < 6) return "child";
+  if (ageYears < 13) return "school_age";
+  if (ageYears < 18) return "adolescent";
+  return "adult";
+}
+
+/**
+ * Compute age in fractional years from a date-of-birth ISO string.
+ * Returns undefined if dateOfBirth is falsy or unparseable.
+ */
+export function ageInYearsFromDOB(
+  dateOfBirth: string | undefined | null,
+  referenceDate?: Date
+): number | undefined {
+  if (!dateOfBirth) return undefined;
+  const dob = new Date(dateOfBirth);
+  if (isNaN(dob.getTime())) return undefined;
+  const ref = referenceDate ?? new Date();
+  const diffMs = ref.getTime() - dob.getTime();
+  if (diffMs < 0) return undefined;
+  return diffMs / (365.25 * 24 * 60 * 60 * 1000);
+}
+
+/**
+ * Return the appropriate VitalRange for the given vital type and patient age.
+ * Falls back to adult ranges when age is unknown or no pediatric range is defined
+ * for that vital type.
+ */
+export function getVitalRangeForAge(
+  vitalType: VitalType,
+  ageYears?: number | undefined
+): VitalRange {
+  const adultRange = VITAL_DANGER_ZONES[vitalType];
+  if (ageYears === undefined || ageYears === null) return adultRange;
+
+  const group = classifyAgeGroup(ageYears);
+  if (group === "adult") return adultRange;
+
+  const pediatricRange = PEDIATRIC_VITAL_RANGES[group]?.[vitalType];
+  return pediatricRange ?? adultRange;
+}
 
 export interface ValidationResult {
   valid: boolean;
@@ -145,9 +240,16 @@ export function validateLabResult(
   return { valid: errors.length === 0, warnings, errors };
 }
 
-/** Check if a vital value is in the critical range (used by rules engine) */
-export function isCriticalVital(type: VitalType, value: number): boolean {
-  const range = VITAL_DANGER_ZONES[type];
+/**
+ * Check if a vital value is in the critical range (used by rules engine).
+ * When ageYears is provided, uses age-appropriate pediatric thresholds.
+ */
+export function isCriticalVital(
+  type: VitalType,
+  value: number,
+  ageYears?: number | undefined
+): boolean {
+  const range = getVitalRangeForAge(type, ageYears);
   if (!range) return false;
   if (range.criticalLow !== undefined && value <= range.criticalLow) return true;
   if (range.criticalHigh !== undefined && value >= range.criticalHigh) return true;

--- a/packages/medical-logic/vitest.config.ts
+++ b/packages/medical-logic/vitest.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vitest/config";
+import path from "node:path";
 
 export default defineConfig({
   test: {
     globals: true,
+  },
+  resolve: {
+    alias: {
+      "@carebridge/shared-types": path.resolve(
+        __dirname,
+        "../shared-types/src/index.ts",
+      ),
+    },
   },
 });

--- a/services/ai-oversight/src/__tests__/rules.test.ts
+++ b/services/ai-oversight/src/__tests__/rules.test.ts
@@ -9,56 +9,57 @@ vi.mock("@carebridge/shared-types", () => ({
   },
 }));
 
-vi.mock("@carebridge/medical-logic", () => ({
-  VITAL_DANGER_ZONES: {
+vi.mock("@carebridge/medical-logic", () => {
+  const VITAL_DANGER_ZONES: Record<string, { min: number; max: number; criticalLow?: number; criticalHigh?: number; warningLow?: number; warningHigh?: number }> = {
     heart_rate: { min: 20, max: 300, criticalLow: 40, criticalHigh: 200 },
     o2_sat: { min: 50, max: 100, criticalLow: 85 },
     temperature: { min: 85, max: 115, criticalLow: 95, criticalHigh: 104 },
     blood_pressure: { min: 60, max: 250, criticalLow: 70, criticalHigh: 180 },
     blood_glucose: { min: 10, max: 800, criticalLow: 50, criticalHigh: 350, warningLow: 70, warningHigh: 250 },
-  },
-  DIASTOLIC_DANGER_ZONE: {
-    criticalLow: 60,
-    criticalHigh: 120,
-    warningHigh: 90,
-  },
-  isCriticalVital: (type: string, value: number) => {
-    const zones: Record<string, { criticalLow?: number; criticalHigh?: number }> = {
-      heart_rate: { criticalLow: 40, criticalHigh: 200 },
-      o2_sat: { criticalLow: 85 },
-      temperature: { criticalLow: 95, criticalHigh: 104 },
-      blood_pressure: { criticalLow: 70, criticalHigh: 180 },
-      blood_glucose: { criticalLow: 50, criticalHigh: 350 },
-    };
-    const zone = zones[type];
-    if (!zone) return false;
-    if (zone.criticalLow !== undefined && value <= zone.criticalLow) return true;
-    if (zone.criticalHigh !== undefined && value >= zone.criticalHigh) return true;
-    return false;
-  },
-  getVitalSeverity: (type: string, value: number) => {
-    const zones: Record<string, { criticalLow?: number; criticalHigh?: number; warningLow?: number; warningHigh?: number }> = {
-      heart_rate: { criticalLow: 40, criticalHigh: 200 },
-      o2_sat: { criticalLow: 85 },
-      temperature: { criticalLow: 95, criticalHigh: 104 },
-      blood_pressure: { criticalLow: 70, criticalHigh: 180 },
-      blood_glucose: { criticalLow: 50, criticalHigh: 350, warningLow: 70, warningHigh: 250 },
-    };
-    const zone = zones[type];
-    if (!zone) return null;
-    if (zone.criticalLow !== undefined && value <= zone.criticalLow) return "critical";
-    if (zone.criticalHigh !== undefined && value >= zone.criticalHigh) return "critical";
-    if (zone.warningLow !== undefined && value < zone.warningLow) return "warning";
-    if (zone.warningHigh !== undefined && value > zone.warningHigh) return "warning";
-    return null;
-  },
-  checkDiastolicBP: (diastolic: number) => {
-    if (diastolic < 60) return "critical";
-    if (diastolic >= 120) return "critical";
-    if (diastolic >= 90) return "warning";
-    return null;
-  },
-}));
+  };
+  return {
+    VITAL_DANGER_ZONES,
+    DIASTOLIC_DANGER_ZONE: {
+      criticalLow: 60,
+      criticalHigh: 120,
+      warningHigh: 90,
+    },
+    isCriticalVital: (type: string, value: number, _ageYears?: number) => {
+      const zone = VITAL_DANGER_ZONES[type];
+      if (!zone) return false;
+      if (zone.criticalLow !== undefined && value <= zone.criticalLow) return true;
+      if (zone.criticalHigh !== undefined && value >= zone.criticalHigh) return true;
+      return false;
+    },
+    getVitalSeverity: (type: string, value: number) => {
+      const zone = VITAL_DANGER_ZONES[type];
+      if (!zone) return null;
+      if (zone.criticalLow !== undefined && value <= zone.criticalLow) return "critical";
+      if (zone.criticalHigh !== undefined && value >= zone.criticalHigh) return "critical";
+      if (zone.warningLow !== undefined && value < zone.warningLow) return "warning";
+      if (zone.warningHigh !== undefined && value > zone.warningHigh) return "warning";
+      return null;
+    },
+    checkDiastolicBP: (diastolic: number) => {
+      if (diastolic < 60) return "critical";
+      if (diastolic >= 120) return "critical";
+      if (diastolic >= 90) return "warning";
+      return null;
+    },
+    ageInYearsFromDOB: (dob: string | undefined | null, refDate?: Date) => {
+      if (!dob) return undefined;
+      const d = new Date(dob);
+      if (isNaN(d.getTime())) return undefined;
+      const ref = refDate ?? new Date();
+      const diffMs = ref.getTime() - d.getTime();
+      if (diffMs < 0) return undefined;
+      return diffMs / (365.25 * 24 * 60 * 60 * 1000);
+    },
+    getVitalRangeForAge: (vitalType: string, _ageYears?: number) => {
+      return VITAL_DANGER_ZONES[vitalType] ?? { min: 0, max: 1000 };
+    },
+  };
+});
 
 import { checkCriticalValues } from "../rules/critical-values.js";
 import { checkCrossSpecialtyPatterns, type PatientContext } from "../rules/cross-specialty.js";

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -9,11 +9,10 @@ import type { VitalType } from "@carebridge/shared-types";
 import { COMMON_LAB_TESTS } from "@carebridge/shared-types";
 import type { ClinicalEvent, FlagSeverity, FlagCategory } from "@carebridge/shared-types";
 import {
-  VITAL_DANGER_ZONES,
   DIASTOLIC_DANGER_ZONE,
-  isCriticalVital,
-  getVitalSeverity,
   checkDiastolicBP,
+  getVitalRangeForAge,
+  ageInYearsFromDOB,
 } from "@carebridge/medical-logic";
 
 // ─── Explicit Critical Lab Thresholds ────────────────────────────
@@ -336,15 +335,24 @@ export interface RuleFlag {
 export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
   const flags: RuleFlag[] = [];
 
+  // Compute patient age from DOB when available (supports pediatric thresholds)
+  const patientDOB = event.data.patient_date_of_birth as string | undefined;
+  const patientAgeYears = ageInYearsFromDOB(patientDOB);
+
   if (event.type === "vital.created") {
     const vitalType = event.data.type as VitalType | undefined;
     const value = event.data.value_primary as number | undefined;
 
     if (vitalType && value !== undefined) {
-      const severity = getVitalSeverity(vitalType, value);
+      const range = getVitalRangeForAge(vitalType, patientAgeYears);
+
+      let severity: "critical" | "warning" | null = null;
+      if (range.criticalLow !== undefined && value <= range.criticalLow) severity = "critical";
+      else if (range.criticalHigh !== undefined && value >= range.criticalHigh) severity = "critical";
+      else if (range.warningLow !== undefined && value < range.warningLow) severity = "warning";
+      else if (range.warningHigh !== undefined && value > range.warningHigh) severity = "warning";
 
       if (severity) {
-        const range = VITAL_DANGER_ZONES[vitalType];
         const isLow =
           (range.criticalLow !== undefined && value <= range.criticalLow) ||
           (range.warningLow !== undefined && value < range.warningLow);


### PR DESCRIPTION
## Summary
- Add pediatric vital sign ranges for 5 age groups (neonate, infant, child, school-age, adolescent) covering heart rate, respiratory rate, and systolic blood pressure
- Export `getVitalRangeForAge()`, `classifyAgeGroup()`, and `ageInYearsFromDOB()` from `@carebridge/medical-logic`
- Update `isCriticalVital()` to accept optional `ageYears` parameter, falling back to adult thresholds when age is unknown
- Wire patient DOB (`patient_date_of_birth`) through the critical-values rule so pediatric thresholds apply automatically

## Test plan
- [x] 20 new unit tests covering all age groups, age classification, DOB parsing, and range selection
- [x] All 52 medical-validation tests pass
- [x] All 54 ai-oversight rules tests pass (mock updated for new exports)
- [ ] Manual verification: create a toddler patient and record HR 150 -- should not flag as critical

Closes #243