### PR TITLE
fix(auth): validate ownership before family access revoke/cancel

### DIFF
--- a/packages/db-schema/drizzle/0025_family_access.sql
+++ b/packages/db-schema/drizzle/0025_family_access.sql
@@ -1,0 +1,37 @@
+-- Family access tables: relationships and invites
+-- See issue #305 for security context
+
+CREATE TABLE IF NOT EXISTS "family_relationships" (
+  "id" text PRIMARY KEY NOT NULL,
+  "patient_id" text NOT NULL REFERENCES "users"("id"),
+  "caregiver_id" text NOT NULL REFERENCES "users"("id"),
+  "relationship_type" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'active',
+  "granted_at" text NOT NULL,
+  "revoked_at" text,
+  "revoked_by" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_family_rel_patient" ON "family_relationships" ("patient_id");
+CREATE INDEX IF NOT EXISTS "idx_family_rel_caregiver" ON "family_relationships" ("caregiver_id");
+CREATE INDEX IF NOT EXISTS "idx_family_rel_status" ON "family_relationships" ("status");
+
+CREATE TABLE IF NOT EXISTS "family_invites" (
+  "id" text PRIMARY KEY NOT NULL,
+  "patient_id" text NOT NULL REFERENCES "users"("id"),
+  "invitee_email" text NOT NULL,
+  "relationship_type" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "token" text NOT NULL UNIQUE,
+  "expires_at" text NOT NULL,
+  "cancelled_at" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_family_invite_patient" ON "family_invites" ("patient_id");
+CREATE INDEX IF NOT EXISTS "idx_family_invite_email" ON "family_invites" ("invitee_email");
+CREATE INDEX IF NOT EXISTS "idx_family_invite_status" ON "family_invites" ("status");
+CREATE INDEX IF NOT EXISTS "idx_family_invite_token" ON "family_invites" ("token");

--- a/packages/db-schema/src/schema/family-access.ts
+++ b/packages/db-schema/src/schema/family-access.ts
@@ -1,0 +1,60 @@
+/**
+ * Family access schema.
+ *
+ * Patients can invite family members / caregivers to view a subset of
+ * their health information. Each invitation creates a pending invite;
+ * once accepted the invite transitions into an active relationship.
+ *
+ * Ownership invariant: only the patient who granted access (or an admin)
+ * may revoke a relationship or cancel a pending invite.
+ */
+
+import { pgTable, text, index } from "drizzle-orm/pg-core";
+import { users } from "./auth.js";
+
+/**
+ * Active family-access relationships.
+ *
+ * `patient_id` is the user who granted access.
+ * `caregiver_id` is the user who received access.
+ */
+export const familyRelationships = pgTable("family_relationships", {
+  id: text("id").primaryKey(),
+  patient_id: text("patient_id").notNull().references(() => users.id),
+  caregiver_id: text("caregiver_id").notNull().references(() => users.id),
+  relationship_type: text("relationship_type").notNull(), // spouse, parent, child, sibling, other
+  status: text("status").notNull().default("active"), // active, revoked
+  granted_at: text("granted_at").notNull(),
+  revoked_at: text("revoked_at"),
+  revoked_by: text("revoked_by"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull(),
+}, (table) => [
+  index("idx_family_rel_patient").on(table.patient_id),
+  index("idx_family_rel_caregiver").on(table.caregiver_id),
+  index("idx_family_rel_status").on(table.status),
+]);
+
+/**
+ * Pending family-access invitations.
+ *
+ * `patient_id` is the user who sent the invite.
+ * `invitee_email` is the email address of the person being invited.
+ */
+export const familyInvites = pgTable("family_invites", {
+  id: text("id").primaryKey(),
+  patient_id: text("patient_id").notNull().references(() => users.id),
+  invitee_email: text("invitee_email").notNull(),
+  relationship_type: text("relationship_type").notNull(),
+  status: text("status").notNull().default("pending"), // pending, accepted, cancelled, expired
+  token: text("token").notNull().unique(),
+  expires_at: text("expires_at").notNull(),
+  cancelled_at: text("cancelled_at"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull(),
+}, (table) => [
+  index("idx_family_invite_patient").on(table.patient_id),
+  index("idx_family_invite_email").on(table.invitee_email),
+  index("idx_family_invite_status").on(table.status),
+  index("idx_family_invite_token").on(table.token),
+]);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -11,3 +11,4 @@ export * from "./patient-observations.js";
 export * from "./scheduling.js";
 export * from "./emergency-access.js";
 export * from "./fhir.js";
+export * from "./family-access.js";

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -9,6 +9,7 @@ import { schedulingRbacRouter } from "./routers/scheduling.js";
 import { emergencyAccessRbacRouter } from "./routers/emergency-access.js";
 import { fhirRbacRouter } from "./routers/fhir.js";
 import { notificationsRbacRouter } from "./routers/notifications.js";
+import { familyAccessRbacRouter } from "./routers/family-access.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -28,6 +29,7 @@ export const appRouter = router({
   messaging: messagingRbacRouter,
   scheduling: schedulingRbacRouter,
   fhir: fhirRbacRouter,
+  familyAccess: familyAccessRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/routers/family-access.ts
+++ b/services/api-gateway/src/routers/family-access.ts
@@ -1,0 +1,132 @@
+/**
+ * RBAC-enforced family access router.
+ *
+ * Patients can invite family members to view their health information,
+ * revoke active relationships, and cancel pending invites.
+ *
+ * SECURITY: Both revokeAccess and cancelInvite validate that the caller
+ * owns the target relationship/invite before mutating. See issue #305.
+ */
+
+import { z } from "zod";
+import { TRPCError, initTRPC } from "@trpc/server";
+import type { Context } from "../context.js";
+import {
+  createFamilyInvite,
+  acceptFamilyInvite,
+  revokeFamilyAccess,
+  cancelFamilyInvite,
+  listFamilyRelationships,
+  listFamilyInvites,
+} from "@carebridge/auth/family-invite-flow";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Authentication required" });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+const createInviteSchema = z.object({
+  invitee_email: z.string().email(),
+  relationship_type: z.enum(["spouse", "parent", "child", "sibling", "other"]),
+});
+
+const revokeFamilyAccessSchema = z.object({
+  relationship_id: z.string().uuid(),
+});
+
+export const familyAccessRbacRouter = t.router({
+  /**
+   * Send a family access invite. Only patients can invite caregivers.
+   */
+  createInvite: protectedProcedure
+    .input(createInviteSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (ctx.user.role !== "patient") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only patients can invite family members.",
+        });
+      }
+
+      return createFamilyInvite(
+        ctx.user.id,
+        input.invitee_email,
+        input.relationship_type,
+      );
+    }),
+
+  /**
+   * Accept a family access invite using the invite token.
+   */
+  acceptInvite: protectedProcedure
+    .input(z.object({ invite_token: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      return acceptFamilyInvite(input.invite_token, ctx.user.id);
+    }),
+
+  /**
+   * Revoke an active family access relationship.
+   *
+   * The service layer validates that the caller is either the patient
+   * who granted access, the caregiver being revoked, or an admin.
+   */
+  revokeAccess: protectedProcedure
+    .input(revokeFamilyAccessSchema)
+    .mutation(async ({ ctx, input }) => {
+      await revokeFamilyAccess(
+        input.relationship_id,
+        ctx.user.id,
+        ctx.user.role,
+      );
+      return { revoked: true };
+    }),
+
+  /**
+   * Cancel a pending family access invite.
+   *
+   * The service layer validates that the caller is the patient who
+   * created the invite, or an admin.
+   */
+  cancelInvite: protectedProcedure
+    .input(z.object({ invite_id: z.string().uuid() }))
+    .mutation(async ({ ctx, input }) => {
+      await cancelFamilyInvite(
+        input.invite_id,
+        ctx.user.id,
+        ctx.user.role,
+      );
+      return { cancelled: true };
+    }),
+
+  /**
+   * List active family relationships for the current patient.
+   */
+  listRelationships: protectedProcedure.query(async ({ ctx }) => {
+    if (ctx.user.role !== "patient" && ctx.user.role !== "admin") {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Only patients and admins can list family relationships.",
+      });
+    }
+    return listFamilyRelationships(ctx.user.id);
+  }),
+
+  /**
+   * List pending invites for the current patient.
+   */
+  listInvites: protectedProcedure.query(async ({ ctx }) => {
+    if (ctx.user.role !== "patient" && ctx.user.role !== "admin") {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Only patients and admins can list family invites.",
+      });
+    }
+    return listFamilyInvites(ctx.user.id);
+  }),
+});

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./family-invite-flow": {
+      "types": "./dist/family-invite-flow.d.ts",
+      "default": "./dist/family-invite-flow.js"
     }
   },
   "scripts": {

--- a/services/auth/src/__tests__/family-invite-flow.test.ts
+++ b/services/auth/src/__tests__/family-invite-flow.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for family access ownership validation (issue #305).
+ *
+ * Verifies that revokeFamilyAccess and cancelFamilyInvite reject
+ * callers who do not own the target relationship/invite.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+// ---------------------------------------------------------------------------
+// Mock @carebridge/db-schema
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+let relationshipRows: Row[] = [];
+let inviteRows: Row[] = [];
+const insertedRows: Row[] = [];
+const updatedSets: Row[] = [];
+
+function makeSelectChain(rows: Row[]) {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  (chain as { then?: unknown }).then = (onFulfilled: (r: Row[]) => unknown) =>
+    Promise.resolve(rows).then(onFulfilled);
+  return chain;
+}
+
+let selectTarget: "relationships" | "invites" = "relationships";
+
+const mockDb = {
+  select: vi.fn(() => {
+    const target = selectTarget;
+    return makeSelectChain(target === "relationships" ? relationshipRows : inviteRows);
+  }),
+  insert: vi.fn(() => ({
+    values: vi.fn((row: Row) => {
+      insertedRows.push(row);
+      return Promise.resolve();
+    }),
+  })),
+  update: vi.fn(() => ({
+    set: vi.fn((row: Row) => ({
+      where: vi.fn(() => {
+        updatedSets.push(row);
+        return Promise.resolve();
+      }),
+    })),
+  })),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  familyRelationships: {
+    __table: "family_relationships",
+    id: "family_relationships.id",
+    patient_id: "family_relationships.patient_id",
+    caregiver_id: "family_relationships.caregiver_id",
+    status: "family_relationships.status",
+  },
+  familyInvites: {
+    __table: "family_invites",
+    id: "family_invites.id",
+    patient_id: "family_invites.patient_id",
+    token: "family_invites.token",
+    status: "family_invites.status",
+  },
+  auditLog: {
+    __table: "audit_log",
+    id: "audit_log.id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: "eq", a, b })),
+  and: vi.fn((...args: unknown[]) => ({ op: "and", args })),
+}));
+
+// Import AFTER mocks are installed
+const {
+  revokeFamilyAccess,
+  cancelFamilyInvite,
+} = await import("../family-invite-flow.js");
+
+// ---------------------------------------------------------------------------
+
+const PATIENT_A = "patient-aaa";
+const PATIENT_B = "patient-bbb";
+const CAREGIVER = "caregiver-ccc";
+const ADMIN = "admin-ddd";
+const REL_ID = "rel-123";
+const INVITE_ID = "inv-456";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  relationshipRows = [];
+  inviteRows = [];
+  insertedRows.length = 0;
+  updatedSets.length = 0;
+  selectTarget = "relationships";
+});
+
+// ---------------------------------------------------------------------------
+// revokeFamilyAccess
+// ---------------------------------------------------------------------------
+
+describe("revokeFamilyAccess", () => {
+  const activeRelationship = {
+    id: REL_ID,
+    patient_id: PATIENT_A,
+    caregiver_id: CAREGIVER,
+    status: "active",
+    relationship_type: "spouse",
+    granted_at: "2026-01-01T00:00:00.000Z",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("allows the owning patient to revoke", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [activeRelationship];
+
+    await revokeFamilyAccess(REL_ID, PATIENT_A, "patient");
+
+    expect(updatedSets.length).toBeGreaterThanOrEqual(1);
+    expect(updatedSets[0]).toMatchObject({ status: "revoked" });
+  });
+
+  it("allows the caregiver to revoke their own access", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [activeRelationship];
+
+    await revokeFamilyAccess(REL_ID, CAREGIVER, "patient");
+
+    expect(updatedSets.length).toBeGreaterThanOrEqual(1);
+    expect(updatedSets[0]).toMatchObject({ status: "revoked" });
+  });
+
+  it("allows an admin to revoke any relationship", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [activeRelationship];
+
+    await revokeFamilyAccess(REL_ID, ADMIN, "admin");
+
+    expect(updatedSets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a different patient (FORBIDDEN)", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [activeRelationship];
+
+    await expect(
+      revokeFamilyAccess(REL_ID, PATIENT_B, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await revokeFamilyAccess(REL_ID, PATIENT_B, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("throws NOT_FOUND for nonexistent relationship", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [];
+
+    await expect(
+      revokeFamilyAccess("nonexistent", PATIENT_A, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await revokeFamilyAccess("nonexistent", PATIENT_A, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("throws BAD_REQUEST for already-revoked relationship", async () => {
+    selectTarget = "relationships";
+    relationshipRows = [{ ...activeRelationship, status: "revoked" }];
+
+    await expect(
+      revokeFamilyAccess(REL_ID, PATIENT_A, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await revokeFamilyAccess(REL_ID, PATIENT_A, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelFamilyInvite
+// ---------------------------------------------------------------------------
+
+describe("cancelFamilyInvite", () => {
+  const pendingInvite = {
+    id: INVITE_ID,
+    patient_id: PATIENT_A,
+    invitee_email: "family@example.com",
+    relationship_type: "spouse",
+    status: "pending",
+    token: "some-token",
+    expires_at: new Date(Date.now() + 86400000).toISOString(),
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("allows the owning patient to cancel", async () => {
+    selectTarget = "invites";
+    inviteRows = [pendingInvite];
+
+    await cancelFamilyInvite(INVITE_ID, PATIENT_A, "patient");
+
+    expect(updatedSets.length).toBeGreaterThanOrEqual(1);
+    expect(updatedSets[0]).toMatchObject({ status: "cancelled" });
+  });
+
+  it("allows an admin to cancel any invite", async () => {
+    selectTarget = "invites";
+    inviteRows = [pendingInvite];
+
+    await cancelFamilyInvite(INVITE_ID, ADMIN, "admin");
+
+    expect(updatedSets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects a different patient (FORBIDDEN)", async () => {
+    selectTarget = "invites";
+    inviteRows = [pendingInvite];
+
+    await expect(
+      cancelFamilyInvite(INVITE_ID, PATIENT_B, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await cancelFamilyInvite(INVITE_ID, PATIENT_B, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("throws NOT_FOUND for nonexistent invite", async () => {
+    selectTarget = "invites";
+    inviteRows = [];
+
+    await expect(
+      cancelFamilyInvite("nonexistent", PATIENT_A, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await cancelFamilyInvite("nonexistent", PATIENT_A, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("throws BAD_REQUEST for non-pending invite", async () => {
+    selectTarget = "invites";
+    inviteRows = [{ ...pendingInvite, status: "accepted" }];
+
+    await expect(
+      cancelFamilyInvite(INVITE_ID, PATIENT_A, "patient"),
+    ).rejects.toThrow(TRPCError);
+
+    try {
+      await cancelFamilyInvite(INVITE_ID, PATIENT_A, "patient");
+    } catch (err) {
+      expect((err as TRPCError).code).toBe("BAD_REQUEST");
+    }
+  });
+});

--- a/services/auth/src/family-invite-flow.ts
+++ b/services/auth/src/family-invite-flow.ts
@@ -1,0 +1,252 @@
+/**
+ * Family access service layer.
+ *
+ * Provides invite, accept, revoke, and cancel operations for patient-to-
+ * caregiver family access relationships.
+ *
+ * SECURITY: Every mutation validates ownership — the caller must be the
+ * patient who created the relationship/invite, the affected caregiver,
+ * or an admin. See issue #305.
+ */
+
+import { TRPCError } from "@trpc/server";
+import {
+  getDb,
+  familyRelationships,
+  familyInvites,
+  auditLog,
+} from "@carebridge/db-schema";
+import { eq, and } from "drizzle-orm";
+import crypto from "node:crypto";
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ---- Invite creation ----
+
+export async function createFamilyInvite(
+  patientId: string,
+  inviteeEmail: string,
+  relationshipType: string,
+): Promise<{ id: string; token: string; expires_at: string }> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + INVITE_TTL_MS).toISOString();
+
+  await db.insert(familyInvites).values({
+    id,
+    patient_id: patientId,
+    invitee_email: inviteeEmail,
+    relationship_type: relationshipType,
+    status: "pending",
+    token,
+    expires_at: expiresAt,
+    created_at: now,
+    updated_at: now,
+  });
+
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: patientId,
+    action: "family_invite_created",
+    resource_type: "family_invite",
+    resource_id: id,
+    details: JSON.stringify({ invitee_email: inviteeEmail, relationship_type: relationshipType }),
+    timestamp: now,
+  });
+
+  return { id, token, expires_at: expiresAt };
+}
+
+// ---- Accept invite ----
+
+export async function acceptFamilyInvite(
+  inviteToken: string,
+  caregiverId: string,
+): Promise<{ relationship_id: string }> {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  const [invite] = await db
+    .select()
+    .from(familyInvites)
+    .where(and(eq(familyInvites.token, inviteToken), eq(familyInvites.status, "pending")))
+    .limit(1);
+
+  if (!invite) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Invalid or expired invite." });
+  }
+
+  if (new Date(invite.expires_at) < new Date()) {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "This invite has expired." });
+  }
+
+  // Transition invite to accepted
+  await db
+    .update(familyInvites)
+    .set({ status: "accepted", updated_at: now })
+    .where(eq(familyInvites.id, invite.id));
+
+  // Create the active relationship
+  const relId = crypto.randomUUID();
+  await db.insert(familyRelationships).values({
+    id: relId,
+    patient_id: invite.patient_id,
+    caregiver_id: caregiverId,
+    relationship_type: invite.relationship_type,
+    status: "active",
+    granted_at: now,
+    created_at: now,
+    updated_at: now,
+  });
+
+  return { relationship_id: relId };
+}
+
+// ---- Revoke relationship ----
+
+/**
+ * Revoke a family access relationship.
+ *
+ * Ownership check: the caller must be the patient who granted access,
+ * the caregiver whose access is being revoked, or an admin.
+ * Throws FORBIDDEN if the caller does not own the relationship.
+ */
+export async function revokeFamilyAccess(
+  relationshipId: string,
+  callerId: string,
+  callerRole: string,
+): Promise<void> {
+  const db = getDb();
+
+  const [rel] = await db
+    .select()
+    .from(familyRelationships)
+    .where(eq(familyRelationships.id, relationshipId))
+    .limit(1);
+
+  if (!rel) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Relationship not found." });
+  }
+
+  if (rel.status === "revoked") {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Relationship is already revoked." });
+  }
+
+  // Ownership validation (issue #305)
+  const isOwner = rel.patient_id === callerId;
+  const isCaregiver = rel.caregiver_id === callerId;
+  const isAdmin = callerRole === "admin";
+
+  if (!isOwner && !isCaregiver && !isAdmin) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have permission to revoke this relationship.",
+    });
+  }
+
+  const now = new Date().toISOString();
+  await db
+    .update(familyRelationships)
+    .set({ status: "revoked", revoked_at: now, revoked_by: callerId, updated_at: now })
+    .where(eq(familyRelationships.id, relationshipId));
+
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: callerId,
+    action: "family_access_revoked",
+    resource_type: "family_relationship",
+    resource_id: relationshipId,
+    details: JSON.stringify({
+      patient_id: rel.patient_id,
+      caregiver_id: rel.caregiver_id,
+    }),
+    timestamp: now,
+  });
+}
+
+// ---- Cancel invite ----
+
+/**
+ * Cancel a pending family access invite.
+ *
+ * Ownership check: only the patient who created the invite (or an admin)
+ * may cancel it. Throws FORBIDDEN otherwise.
+ */
+export async function cancelFamilyInvite(
+  inviteId: string,
+  callerId: string,
+  callerRole: string,
+): Promise<void> {
+  const db = getDb();
+
+  const [invite] = await db
+    .select()
+    .from(familyInvites)
+    .where(eq(familyInvites.id, inviteId))
+    .limit(1);
+
+  if (!invite) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Invite not found." });
+  }
+
+  if (invite.status !== "pending") {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Invite is not pending." });
+  }
+
+  // Ownership validation (issue #305)
+  const isOwner = invite.patient_id === callerId;
+  const isAdmin = callerRole === "admin";
+
+  if (!isOwner && !isAdmin) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have permission to cancel this invite.",
+    });
+  }
+
+  const now = new Date().toISOString();
+  await db
+    .update(familyInvites)
+    .set({ status: "cancelled", cancelled_at: now, updated_at: now })
+    .where(eq(familyInvites.id, inviteId));
+
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: callerId,
+    action: "family_invite_cancelled",
+    resource_type: "family_invite",
+    resource_id: inviteId,
+    details: JSON.stringify({ patient_id: invite.patient_id }),
+    timestamp: now,
+  });
+}
+
+// ---- List helpers ----
+
+export async function listFamilyRelationships(patientId: string) {
+  const db = getDb();
+  return db
+    .select()
+    .from(familyRelationships)
+    .where(
+      and(
+        eq(familyRelationships.patient_id, patientId),
+        eq(familyRelationships.status, "active"),
+      ),
+    );
+}
+
+export async function listFamilyInvites(patientId: string) {
+  const db = getDb();
+  return db
+    .select()
+    .from(familyInvites)
+    .where(
+      and(
+        eq(familyInvites.patient_id, patientId),
+        eq(familyInvites.status, "pending"),
+      ),
+    );
+}

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,5 +1,13 @@
 export { authRouter, type AuthRouter, type Context as AuthContext } from "./router.js";
 export { emergencyAccessRouter, type EmergencyAccessRouter } from "./emergency-access.js";
+export {
+  createFamilyInvite,
+  acceptFamilyInvite,
+  revokeFamilyAccess,
+  cancelFamilyInvite,
+  listFamilyRelationships,
+  listFamilyInvites,
+} from "./family-invite-flow.js";
 export { cleanupExpiredSessions } from "./session-cleanup.js";
 export { startCleanupWorker } from "./cleanup-worker.js";
 export { signJWT, verifyJWT, JWTError, JWTExpiredError, type JWTPayload } from "./jwt.js";


### PR DESCRIPTION
## Summary

- Add family access schema (relationships + invites tables) with migration
- Implement `revokeFamilyAccess` and `cancelFamilyInvite` service functions with ownership validation: callers must be the owning patient, the affected caregiver, or an admin
- Wire family access router into the API gateway with full CRUD (create invite, accept, revoke, cancel, list)
- Add 11 unit tests covering ownership enforcement, FORBIDDEN rejection for non-owners, NOT_FOUND for missing records, and BAD_REQUEST for invalid state transitions

## Test plan

- [x] `revokeFamilyAccess` allows owning patient to revoke
- [x] `revokeFamilyAccess` allows the caregiver to revoke their own access
- [x] `revokeFamilyAccess` allows admin to revoke any relationship
- [x] `revokeFamilyAccess` rejects a different patient with FORBIDDEN
- [x] `revokeFamilyAccess` throws NOT_FOUND for nonexistent relationship
- [x] `revokeFamilyAccess` throws BAD_REQUEST for already-revoked relationship
- [x] `cancelFamilyInvite` allows owning patient to cancel
- [x] `cancelFamilyInvite` allows admin to cancel any invite
- [x] `cancelFamilyInvite` rejects a different patient with FORBIDDEN
- [x] `cancelFamilyInvite` throws NOT_FOUND for nonexistent invite
- [x] `cancelFamilyInvite` throws BAD_REQUEST for non-pending invite

Closes #305