### PR TITLE
fix(portal): add loading indicators to patient chart data tabs

### DIFF
--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -1016,3 +1016,9 @@ tr:hover td {
   flex-shrink: 0;
   line-height: 1;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation-duration: 3s;
+  }
+}

--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -967,3 +967,52 @@ tr:hover td {
     flex: 1;
   }
 }
+
+/* Loading spinner */
+@keyframes cb-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 24px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.loading-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border-light);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: cb-spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+.error-indicator {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 32px 24px;
+  color: var(--critical);
+  font-size: 13px;
+}
+
+.error-icon {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--critical);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 12px;
+  flex-shrink: 0;
+  line-height: 1;
+}

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -22,16 +22,18 @@ const tabs = [
 
 function LoadingState({ label }: { label: string }) {
   return (
-    <div style={{ padding: 24, color: "var(--text-muted)" }}>
-      Loading {label}...
+    <div className="loading-indicator" role="status" aria-label={`Loading ${label}`}>
+      <div className="loading-spinner" aria-hidden="true" />
+      <span>Loading {label}...</span>
     </div>
   );
 }
 
 function ErrorState({ label }: { label: string }) {
   return (
-    <div style={{ padding: 24, color: "var(--critical)" }}>
-      Failed to load {label}. Is the API running?
+    <div className="error-indicator" role="alert">
+      <div className="error-icon" aria-hidden="true">!</div>
+      <span>Failed to load {label}. Is the API running?</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced plain-text `LoadingState` with an animated spinner indicator using CSS keyframe animation, plus `role="status"` and `aria-label` for accessibility
- Replaced plain-text `ErrorState` with a styled error icon indicator plus `role="alert"` for screen readers
- Added `.loading-indicator`, `.loading-spinner`, `.error-indicator`, and `.error-icon` CSS classes to `globals.css`
- All 5 patient chart tabs (Overview, Vitals, Labs, Medications, AI Flags) already check `isLoading`/`isError` and render these components, so the visual fix applies everywhere

## Test plan
- [ ] Navigate to a patient detail page and switch between all 5 tabs; confirm each shows the animated spinner while data loads
- [ ] Throttle network in devtools to observe the loading state more easily
- [ ] Verify the error state renders correctly by stopping the API and switching tabs
- [ ] Confirm the spinner animation is smooth and the error icon is visible against the dark background

Closes #181