### PR TITLE
fix(portal): add loading and success feedback to flag action buttons

### DIFF
--- a/apps/clinician-portal/app/inbox/page.tsx
+++ b/apps/clinician-portal/app/inbox/page.tsx
@@ -42,7 +42,10 @@ function InboxContent() {
   const [activeAction, setActiveAction] = useState<FlagAction | null>(null);
   const [activePatientId, setActivePatientId] = useState<string | null>(null);
 
+  const [showSuccess, setShowSuccess] = useState(false);
+
   const onSuccess = async () => {
+    setShowSuccess(true);
     await utils.aiOversight.flags.getAllOpen.invalidate();
     if (activePatientId) {
       await utils.aiOversight.flags.getByPatient.invalidate({
@@ -52,9 +55,12 @@ function InboxContent() {
         patientId: activePatientId,
       });
     }
-    setActiveFlag(null);
-    setActiveAction(null);
-    setActivePatientId(null);
+    setTimeout(() => {
+      setShowSuccess(false);
+      setActiveFlag(null);
+      setActiveAction(null);
+      setActivePatientId(null);
+    }, 1200);
   };
 
   const acknowledgeMutation =
@@ -233,18 +239,21 @@ function InboxContent() {
                   <button
                     className="btn btn-success btn-sm"
                     onClick={() => openModal(flag, "acknowledge")}
+                    disabled={isSubmitting}
                   >
                     Acknowledge
                   </button>
                   <button
                     className="btn btn-primary btn-sm"
                     onClick={() => openModal(flag, "resolve")}
+                    disabled={isSubmitting}
                   >
                     Resolve
                   </button>
                   <button
                     className="btn btn-ghost btn-sm"
                     onClick={() => openModal(flag, "dismiss")}
+                    disabled={isSubmitting}
                   >
                     Dismiss
                   </button>
@@ -268,13 +277,14 @@ function InboxContent() {
         flag={activeFlag}
         action={activeAction}
         onCancel={() => {
-          if (isSubmitting) return;
+          if (isSubmitting || showSuccess) return;
           setActiveFlag(null);
           setActiveAction(null);
           setActivePatientId(null);
         }}
         onConfirm={handleConfirm}
         isSubmitting={isSubmitting}
+        isSuccess={showSuccess}
       />
     </>
   );

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -390,12 +390,18 @@ function FlagsTab({ patientId }: { patientId: string }) {
   );
   const [activeAction, setActiveAction] = useState<FlagAction | null>(null);
 
+  const [showSuccess, setShowSuccess] = useState(false);
+
   const onSuccess = async () => {
+    setShowSuccess(true);
     await utils.aiOversight.flags.getByPatient.invalidate({ patientId });
     await utils.aiOversight.flags.getOpenCount.invalidate({ patientId });
     await utils.aiOversight.flags.getAllOpen.invalidate();
-    setActiveFlag(null);
-    setActiveAction(null);
+    setTimeout(() => {
+      setShowSuccess(false);
+      setActiveFlag(null);
+      setActiveAction(null);
+    }, 1200);
   };
 
   const acknowledgeMutation =
@@ -480,18 +486,21 @@ function FlagsTab({ patientId }: { patientId: string }) {
               <button
                 className="btn btn-success btn-sm"
                 onClick={() => openModal(flag, "acknowledge")}
+                disabled={isSubmitting}
               >
                 Acknowledge
               </button>
               <button
                 className="btn btn-primary btn-sm"
                 onClick={() => openModal(flag, "resolve")}
+                disabled={isSubmitting}
               >
                 Resolve
               </button>
               <button
                 className="btn btn-ghost btn-sm"
                 onClick={() => openModal(flag, "dismiss")}
+                disabled={isSubmitting}
               >
                 Dismiss
               </button>
@@ -503,12 +512,13 @@ function FlagsTab({ patientId }: { patientId: string }) {
         flag={activeFlag}
         action={activeAction}
         onCancel={() => {
-          if (isSubmitting) return;
+          if (isSubmitting || showSuccess) return;
           setActiveFlag(null);
           setActiveAction(null);
         }}
         onConfirm={handleConfirm}
         isSubmitting={isSubmitting}
+        isSuccess={showSuccess}
       />
     </div>
   );

--- a/apps/clinician-portal/src/components/flag-action-modal.tsx
+++ b/apps/clinician-portal/src/components/flag-action-modal.tsx
@@ -17,6 +17,7 @@ interface FlagActionModalProps {
   onCancel: () => void;
   onConfirm: (reason: string) => void;
   isSubmitting?: boolean;
+  isSuccess?: boolean;
 }
 
 /**
@@ -32,6 +33,7 @@ export function FlagActionModal({
   onCancel,
   onConfirm,
   isSubmitting = false,
+  isSuccess = false,
 }: FlagActionModalProps) {
   const [reason, setReason] = useState("");
 
@@ -175,30 +177,50 @@ export function FlagActionModal({
           </div>
         )}
 
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "flex-end",
-            gap: 8,
-          }}
-        >
-          <button
-            type="button"
-            className="btn btn-ghost"
-            onClick={onCancel}
-            disabled={isSubmitting}
+        {isSuccess ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+              padding: "12px 0 4px",
+              color: "var(--success, #22c55e)",
+              fontWeight: 500,
+              fontSize: 14,
+            }}
+            role="status"
+            aria-live="polite"
           >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className={confirmClass}
-            onClick={() => canSubmit && onConfirm(reason.trim())}
-            disabled={!canSubmit || isSubmitting}
+            <span aria-hidden="true" style={{ fontSize: 18 }}>{"\u2713"}</span>
+            Flag {action === "acknowledge" ? "acknowledged" : action === "resolve" ? "resolved" : "dismissed"} successfully
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: 8,
+            }}
           >
-            {isSubmitting ? "Saving..." : confirmLabels[action]}
-          </button>
-        </div>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={onCancel}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={confirmClass}
+              onClick={() => canSubmit && onConfirm(reason.trim())}
+              disabled={!canSubmit || isSubmitting}
+            >
+              {isSubmitting ? "Saving..." : confirmLabels[action]}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Disable Acknowledge/Resolve/Dismiss buttons on flag list items while any flag mutation is in-flight, preventing double-submission
- Add `isSuccess` prop to `FlagActionModal` that renders a green checkmark confirmation message for 1.2 seconds before auto-closing
- Applied consistently to both the patient detail AI Flags tab (`/patients/[id]?tab=flags`) and the inbox page (`/inbox`)

## Test plan
- [ ] Open a patient with AI flags, click Acknowledge — confirm button shows "Saving..." then a green checkmark before modal closes
- [ ] While mutation is in-flight, verify all flag action buttons in the list are disabled
- [ ] Repeat for Resolve and Dismiss actions (with required reason text)
- [ ] Test the same flows on the `/inbox` page
- [ ] Verify modal cannot be dismissed by clicking backdrop or Cancel while submitting or showing success

Closes #180