### PR TITLE
fix(ai): add error handling and DB fallback for clinical event emission

### DIFF
--- a/packages/db-schema/drizzle/0025_failed_clinical_events.sql
+++ b/packages/db-schema/drizzle/0025_failed_clinical_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "failed_clinical_events" (
+  "id" text PRIMARY KEY NOT NULL,
+  "event_type" text NOT NULL,
+  "patient_id" text NOT NULL,
+  "event_payload" jsonb NOT NULL,
+  "error_message" text,
+  "status" text NOT NULL DEFAULT 'pending',
+  "retry_count" real NOT NULL DEFAULT 0,
+  "created_at" text NOT NULL,
+  "processed_at" text
+);
+
+CREATE INDEX IF NOT EXISTS "idx_failed_events_status" ON "failed_clinical_events" ("status", "created_at");

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -108,6 +108,20 @@ export const procedures = pgTable("procedures", {
   index("idx_procedures_patient").on(table.patient_id, table.status),
 ]);
 
+export const failedClinicalEvents = pgTable("failed_clinical_events", {
+  id: text("id").primaryKey(),
+  event_type: text("event_type").notNull(),
+  patient_id: text("patient_id").notNull(),
+  event_payload: jsonb("event_payload").notNull(),
+  error_message: text("error_message"),
+  status: text("status").notNull().default("pending"), // pending, retried, failed
+  retry_count: real("retry_count").notNull().default(0),
+  created_at: text("created_at").notNull(),
+  processed_at: text("processed_at"),
+}, (table) => [
+  index("idx_failed_events_status").on(table.status, table.created_at),
+]);
+
 export const events = pgTable("events", {
   id: text("id").primaryKey(),
   patient_id: text("patient_id").notNull().references(() => patients.id),

--- a/services/clinical-data/src/__tests__/events.test.ts
+++ b/services/clinical-data/src/__tests__/events.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+// ── Mock BullMQ ─────────────────────────────────────────────────
+const addMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("bullmq", () => ({
+  Queue: vi.fn().mockImplementation(() => ({ add: addMock })),
+}));
+
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({}),
+}));
+
+// ── Mock DB ─────────────────────────────────────────────────────
+const insertValuesMock = vi.fn().mockResolvedValue(undefined);
+const insertMock = vi.fn(() => ({ values: insertValuesMock }));
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock }),
+  failedClinicalEvents: { id: "id" },
+}));
+
+// ── Import after mocks ──────────────────────────────────────────
+const { emitClinicalEvent } = await import("../events.js");
+
+const sampleEvent: ClinicalEvent = {
+  id: "evt-1",
+  type: "medication.created",
+  patient_id: "patient-1",
+  timestamp: "2026-04-12T00:00:00.000Z",
+  data: { resourceId: "med-1", name: "Aspirin", status: "active" },
+};
+
+describe("emitClinicalEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds event to BullMQ queue on success", async () => {
+    await emitClinicalEvent(sampleEvent);
+
+    expect(addMock).toHaveBeenCalledWith(sampleEvent.type, sampleEvent);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to DB outbox when queue fails", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis connection refused"));
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(insertMock).toHaveBeenCalled();
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "medication.created",
+        patient_id: "patient-1",
+        event_payload: sampleEvent,
+        error_message: "Redis connection refused",
+        status: "pending",
+        retry_count: 0,
+      }),
+    );
+  });
+
+  it("logs critical error when both queue and DB fallback fail", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis down"));
+    insertValuesMock.mockRejectedValueOnce(new Error("DB down"));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[CRITICAL]"),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("medication.created"),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("does not throw when queue fails — caller mutation succeeds", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis down"));
+
+    await expect(emitClinicalEvent(sampleEvent)).resolves.toBeUndefined();
+  });
+
+  it("does not throw when both queue and DB fail — caller mutation succeeds", async () => {
+    addMock.mockRejectedValueOnce(new Error("Redis down"));
+    insertValuesMock.mockRejectedValueOnce(new Error("DB down"));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(emitClinicalEvent(sampleEvent)).resolves.toBeUndefined();
+    consoleSpy.mockRestore();
+  });
+
+  it("handles non-Error queue failures gracefully", async () => {
+    addMock.mockRejectedValueOnce("string error");
+
+    await emitClinicalEvent(sampleEvent);
+
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error_message: "string error",
+      }),
+    );
+  });
+});

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -1,5 +1,6 @@
 import { Queue } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
 export type { ClinicalEvent };
@@ -17,5 +18,30 @@ const clinicalEventsQueue = new Queue("clinical-events", {
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  await clinicalEventsQueue.add(event.type, event);
+  try {
+    await clinicalEventsQueue.add(event.type, event);
+  } catch (queueError) {
+    // Redis/BullMQ unavailable — persist to DB outbox for later retry
+    try {
+      const db = getDb();
+      await db.insert(failedClinicalEvents).values({
+        id: crypto.randomUUID(),
+        event_type: event.type,
+        patient_id: event.patient_id,
+        event_payload: event,
+        error_message: queueError instanceof Error ? queueError.message : String(queueError),
+        status: "pending",
+        retry_count: 0,
+        created_at: new Date().toISOString(),
+      });
+    } catch (dbError) {
+      // Both Redis and DB fallback failed — log critical error as last resort
+      console.error(
+        `[CRITICAL] Failed to emit clinical event and DB fallback also failed. ` +
+        `Event type: ${event.type}, patient: ${event.patient_id}. ` +
+        `Queue error: ${queueError instanceof Error ? queueError.message : String(queueError)}. ` +
+        `DB error: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
+      );
+    }
+  }
 }

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -1,5 +1,6 @@
 import { Queue } from "bullmq";
 import { getRedisConnection } from "@carebridge/redis-config";
+import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
 export type { ClinicalEvent };
@@ -17,5 +18,30 @@ const clinicalEventsQueue = new Queue("clinical-events", {
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  await clinicalEventsQueue.add(event.type, event);
+  try {
+    await clinicalEventsQueue.add(event.type, event);
+  } catch (queueError) {
+    // Redis/BullMQ unavailable — persist to DB outbox for later retry
+    try {
+      const db = getDb();
+      await db.insert(failedClinicalEvents).values({
+        id: crypto.randomUUID(),
+        event_type: event.type,
+        patient_id: event.patient_id,
+        event_payload: event,
+        error_message: queueError instanceof Error ? queueError.message : String(queueError),
+        status: "pending",
+        retry_count: 0,
+        created_at: new Date().toISOString(),
+      });
+    } catch (dbError) {
+      // Both Redis and DB fallback failed — log critical error as last resort
+      console.error(
+        `[CRITICAL] Failed to emit clinical event and DB fallback also failed. ` +
+        `Event type: ${event.type}, patient: ${event.patient_id}. ` +
+        `Queue error: ${queueError instanceof Error ? queueError.message : String(queueError)}. ` +
+        `DB error: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Wraps `emitClinicalEvent()` in try/catch in both `clinical-data` and `clinical-notes` services so Redis/BullMQ failures no longer silently drop events or crash the parent clinical data mutation
- On queue failure, persists the event to a new `failed_clinical_events` PostgreSQL outbox table (with status, retry_count, error details) for later reconciliation
- If the DB fallback also fails, logs a `[CRITICAL]` error to stderr as a last resort — the caller's mutation still succeeds
- Adds Drizzle schema definition, migration `0025_failed_clinical_events.sql`, and 6 unit tests covering success, queue failure + DB fallback, double failure, and logging

Closes #217

## Test plan
- [x] All 6 new `events.test.ts` tests pass
- [ ] Verify migration runs cleanly against dev DB (`pnpm db:migrate`)
- [ ] Manual: stop Redis, create a vital — confirm DB write succeeds and row appears in `failed_clinical_events`
- [ ] Manual: restart Redis — confirm normal queue flow resumes