### PR TITLE
fix(portal): improve patient portal accessibility and surface error states

### DIFF
--- a/apps/patient-portal/app/health-summary/page.tsx
+++ b/apps/patient-portal/app/health-summary/page.tsx
@@ -69,7 +69,7 @@ export default function HealthSummaryPage() {
       </div>
 
       {isUnlinked && (
-        <p style={{ color: "#ef4444" }}>
+        <p role="alert" style={{ color: "#ef4444" }}>
           Your account is not linked to a patient record. Please contact your care team.
         </p>
       )}
@@ -80,7 +80,9 @@ export default function HealthSummaryPage() {
           Active Conditions ({activeDiagnoses.length})
         </h3>
 
-        {diagnosesQuery.isLoading ? (
+        {diagnosesQuery.isError ? (
+          <p role="alert" style={{ color: "#ef4444" }}>Failed to load diagnoses. Please try refreshing.</p>
+        ) : diagnosesQuery.isLoading ? (
           <p style={{ color: "#999" }}>Loading...</p>
         ) : activeDiagnoses.length === 0 ? (
           <p style={{ color: "#999", fontSize: "0.85rem" }}>No active diagnoses on file.</p>
@@ -139,7 +141,9 @@ export default function HealthSummaryPage() {
           Allergies ({allergies.length})
         </h3>
 
-        {allergiesQuery.isLoading ? (
+        {allergiesQuery.isError ? (
+          <p role="alert" style={{ color: "#ef4444" }}>Failed to load allergies. Please try refreshing.</p>
+        ) : allergiesQuery.isLoading ? (
           <p style={{ color: "#999" }}>Loading...</p>
         ) : allergies.length === 0 ? (
           <p style={{ color: "#999", fontSize: "0.85rem" }}>No known allergies on file.</p>
@@ -190,7 +194,9 @@ export default function HealthSummaryPage() {
           My Care Team ({careTeam.length})
         </h3>
 
-        {careTeamQuery.isLoading ? (
+        {careTeamQuery.isError ? (
+          <p role="alert" style={{ color: "#ef4444" }}>Failed to load care team. Please try refreshing.</p>
+        ) : careTeamQuery.isLoading ? (
           <p style={{ color: "#999" }}>Loading...</p>
         ) : careTeam.length === 0 ? (
           <p style={{ color: "#999", fontSize: "0.85rem" }}>No care team members on file.</p>

--- a/apps/patient-portal/app/labs/page.tsx
+++ b/apps/patient-portal/app/labs/page.tsx
@@ -67,7 +67,7 @@ export default function LabsPage() {
       )}
 
       {labsQuery.isError && (
-        <p style={{ color: "#ef4444" }}>Failed to load lab results.</p>
+        <p role="alert" style={{ color: "#ef4444" }}>Failed to load lab results.</p>
       )}
 
       {panels.length === 0 && !labsQuery.isLoading && (

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -165,7 +165,7 @@ export default function LoginPage() {
               </div>
 
               {error && (
-                <div style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                <div role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
                   {error}
                 </div>
               )}
@@ -234,7 +234,7 @@ export default function LoginPage() {
               </div>
 
               {error && (
-                <div style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                <div role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
                   {error}
                 </div>
               )}

--- a/apps/patient-portal/app/messages/page.tsx
+++ b/apps/patient-portal/app/messages/page.tsx
@@ -150,8 +150,9 @@ export default function PatientMessagesPage() {
           <h3 style={{ margin: "0 0 1rem", fontSize: "0.95rem" }}>New Message to Care Team</h3>
 
           <div style={{ marginBottom: "0.75rem" }}>
-            <label style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>To</label>
+            <label htmlFor="compose-recipient" style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>To</label>
             <select
+              id="compose-recipient"
               value={composeRecipient}
               onChange={(e) => setComposeRecipient(e.target.value)}
               style={{ ...inputStyle, cursor: "pointer" }}
@@ -166,8 +167,9 @@ export default function PatientMessagesPage() {
           </div>
 
           <div style={{ marginBottom: "0.75rem" }}>
-            <label style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>Subject</label>
+            <label htmlFor="compose-subject" style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>Subject</label>
             <input
+              id="compose-subject"
               type="text"
               value={composeSubject}
               onChange={(e) => setComposeSubject(e.target.value)}
@@ -177,8 +179,9 @@ export default function PatientMessagesPage() {
           </div>
 
           <div style={{ marginBottom: "0.75rem" }}>
-            <label style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>Message</label>
+            <label htmlFor="compose-body" style={{ display: "block", marginBottom: 4, fontSize: "0.8rem", color: "#999" }}>Message</label>
             <textarea
+              id="compose-body"
               value={composeBody}
               onChange={(e) => setComposeBody(e.target.value)}
               placeholder="Type your message..."
@@ -206,6 +209,22 @@ export default function PatientMessagesPage() {
       )}
 
       {/* Conversation list */}
+      {conversationsQuery.isError && (
+        <p role="alert" style={{ color: "#ef4444" }}>Failed to load conversations. Please try refreshing.</p>
+      )}
+
+      {sendMutation.isError && (
+        <div role="alert" style={{ backgroundColor: "#ef444420", border: "1px solid #ef4444", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#ef4444" }}>
+          Failed to send message. Please try again.
+        </div>
+      )}
+
+      {createConvoMutation.isError && (
+        <div role="alert" style={{ backgroundColor: "#ef444420", border: "1px solid #ef4444", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#ef4444" }}>
+          Failed to create conversation. Please try again.
+        </div>
+      )}
+
       {conversationsQuery.isLoading && <p style={{ color: "#999" }}>Loading conversations...</p>}
 
       {conversations.length === 0 && !conversationsQuery.isLoading && !showCompose && (
@@ -280,6 +299,7 @@ export default function PatientMessagesPage() {
                   onChange={(e) => setReplyText(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleSend()}
                   placeholder="Reply..."
+                  aria-label="Reply to conversation"
                   style={{ ...inputStyle, flex: 1 }}
                 />
                 <button

--- a/apps/patient-portal/app/notes/page.tsx
+++ b/apps/patient-portal/app/notes/page.tsx
@@ -61,7 +61,7 @@ export default function NotesPage() {
       )}
 
       {notesQuery.isLoading && <p style={{ color: "#999" }}>Loading notes...</p>}
-      {notesQuery.isError && <p style={{ color: "#ef4444" }}>Failed to load notes.</p>}
+      {notesQuery.isError && <p role="alert" style={{ color: "#ef4444" }}>Failed to load notes.</p>}
 
       {visibleNotes.length === 0 && !notesQuery.isLoading && (
         <p style={{ color: "#999" }}>No signed clinical notes available.</p>
@@ -107,6 +107,8 @@ export default function NotesPage() {
           >
             <button
               onClick={() => setExpandedId(isExpanded ? null : note.id)}
+              aria-expanded={isExpanded}
+              aria-label={`${NOTE_TYPE_LABELS[note.template_type] ?? note.template_type} — ${isExpanded ? "collapse" : "expand"}`}
               style={{
                 width: "100%",
                 padding: "1rem 1.25rem",

--- a/apps/patient-portal/app/page.tsx
+++ b/apps/patient-portal/app/page.tsx
@@ -54,11 +54,11 @@ function PatientDashboard() {
           <h2 style={{ fontSize: "1.25rem", margin: 0 }}>
             Welcome back, {user?.name ?? "Patient"}
           </h2>
-          <p style={{ margin: "0.25rem 0 0", color: "#999", fontSize: "0.8rem" }}>
+          <p aria-live="polite" style={{ margin: "0.25rem 0 0", color: "#999", fontSize: "0.8rem" }}>
             {healthQuery.data ? (
-              <span style={{ color: "#22c55e" }}>Connected to API</span>
+              <span style={{ color: "#22c55e" }}>&#x2713; Connected to API</span>
             ) : healthQuery.isError ? (
-              <span style={{ color: "#ef4444" }}>API offline</span>
+              <span role="alert" style={{ color: "#ef4444" }}>&#x2717; API offline</span>
             ) : (
               "Connecting..."
             )}
@@ -82,6 +82,7 @@ function PatientDashboard() {
 
       {isUnlinked && (
         <div
+          role="alert"
           style={{
             backgroundColor: "#7f1d1d",
             border: "1px solid #ef4444",
@@ -134,7 +135,11 @@ function PatientDashboard() {
         </Card>
 
         <Card title="Recent Vitals">
-          {vitalsQuery.isLoading ? (
+          {vitalsQuery.isError ? (
+            <p role="alert" style={{ margin: 0, color: "#ef4444", fontSize: "0.875rem" }}>
+              Failed to load vitals. Please try refreshing.
+            </p>
+          ) : vitalsQuery.isLoading ? (
             <p style={{ margin: 0, color: "#999", fontSize: "0.875rem" }}>Loading...</p>
           ) : vitals.length > 0 ? (
             <div style={{ fontSize: "0.875rem" }}>
@@ -162,7 +167,11 @@ function PatientDashboard() {
         </Card>
 
         <Card title="Active Medications">
-          {medsQuery.isLoading ? (
+          {medsQuery.isError ? (
+            <p role="alert" style={{ margin: 0, color: "#ef4444", fontSize: "0.875rem" }}>
+              Failed to load medications. Please try refreshing.
+            </p>
+          ) : medsQuery.isLoading ? (
             <p style={{ margin: 0, color: "#999", fontSize: "0.875rem" }}>Loading...</p>
           ) : activeMeds.length > 0 ? (
             <div style={{ fontSize: "0.875rem" }}>

--- a/apps/patient-portal/app/refill/page.tsx
+++ b/apps/patient-portal/app/refill/page.tsx
@@ -27,6 +27,7 @@ export default function RefillPage() {
 
   const [submittingMedId, setSubmittingMedId] = useState<string | null>(null);
   const [successMedId, setSuccessMedId] = useState<string | null>(null);
+  const [errorMedId, setErrorMedId] = useState<string | null>(null);
   const [note, setNote] = useState("");
 
   if (!user) {
@@ -62,6 +63,7 @@ export default function RefillPage() {
     if (!recipientId) return;
 
     setSubmittingMedId(med.id);
+    setErrorMedId(null);
 
     try {
       const convo = await createConvoMutation.mutateAsync({
@@ -87,6 +89,9 @@ export default function RefillPage() {
       setSuccessMedId(med.id);
       setNote("");
       setTimeout(() => setSuccessMedId(null), 3000);
+    } catch {
+      setErrorMedId(med.id);
+      setTimeout(() => setErrorMedId(null), 5000);
     } finally {
       setSubmittingMedId(null);
     }
@@ -117,7 +122,11 @@ export default function RefillPage() {
 
       {medsQuery.isLoading && <p style={{ color: "#999" }}>Loading medications...</p>}
 
-      {activeMeds.length === 0 && !medsQuery.isLoading && (
+      {medsQuery.isError && (
+        <p role="alert" style={{ color: "#ef4444" }}>Failed to load medications. Please try refreshing.</p>
+      )}
+
+      {activeMeds.length === 0 && !medsQuery.isLoading && !medsQuery.isError && (
         <p style={{ color: "#999" }}>No active medications found.</p>
       )}
 
@@ -141,8 +150,12 @@ export default function RefillPage() {
             </div>
 
             {successMedId === med.id ? (
-              <span style={{ color: "#22c55e", fontSize: "0.8rem", fontWeight: 600 }}>
-                Refill requested!
+              <span role="status" aria-live="polite" style={{ color: "#22c55e", fontSize: "0.8rem", fontWeight: 600 }}>
+                &#x2713; Refill requested!
+              </span>
+            ) : errorMedId === med.id ? (
+              <span role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", fontWeight: 600 }}>
+                &#x2717; Request failed. Try again.
               </span>
             ) : (
               <button
@@ -168,10 +181,11 @@ export default function RefillPage() {
 
       {activeMeds.length > 0 && (
         <div style={{ marginTop: "1rem" }}>
-          <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+          <label htmlFor="refill-note" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
             Optional note for your provider
           </label>
           <input
+            id="refill-note"
             type="text"
             value={note}
             onChange={(e) => setNote(e.target.value)}

--- a/apps/patient-portal/app/symptoms/page.tsx
+++ b/apps/patient-portal/app/symptoms/page.tsx
@@ -115,17 +115,24 @@ export default function SymptomsPage() {
       )}
 
       {submitted && (
-        <div style={{ backgroundColor: "#16a34a20", border: "1px solid #16a34a", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#16a34a" }}>
-          Observation recorded. Your care team will be notified if any patterns are detected.
+        <div role="status" aria-live="polite" style={{ backgroundColor: "#16a34a20", border: "1px solid #16a34a", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#16a34a" }}>
+          &#x2713; Observation recorded. Your care team will be notified if any patterns are detected.
+        </div>
+      )}
+
+      {createMutation.isError && (
+        <div role="alert" style={{ backgroundColor: "#ef444420", border: "1px solid #ef4444", borderRadius: 8, padding: "0.75rem", marginBottom: "1rem", color: "#ef4444" }}>
+          Failed to submit observation. Please try again.
         </div>
       )}
 
       <div style={{ backgroundColor: "#1a1a1a", border: "1px solid #2a2a2a", borderRadius: 8, padding: "1.25rem", marginBottom: "2rem" }}>
         <div style={{ marginBottom: "1rem" }}>
-          <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+          <label htmlFor="symptom-type" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
             What type of symptom?
           </label>
           <select
+            id="symptom-type"
             value={selectedType}
             onChange={(e) => setSelectedType(e.target.value as ObservationType)}
             style={{ ...inputStyle, cursor: "pointer" }}
@@ -138,10 +145,11 @@ export default function SymptomsPage() {
 
         {(selectedType === "pain" || selectedType === "skin") && (
           <div style={{ marginBottom: "1rem" }}>
-            <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+            <label htmlFor="body-location" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
               Where on your body?
             </label>
             <input
+              id="body-location"
               type="text"
               value={location}
               onChange={(e) => setLocation(e.target.value)}
@@ -152,15 +160,20 @@ export default function SymptomsPage() {
         )}
 
         <div style={{ marginBottom: "1rem" }}>
-          <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+          <label htmlFor="severity-scale" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
             How severe? ({severityScale}/10)
           </label>
           <input
+            id="severity-scale"
             type="range"
             min={1}
             max={10}
             value={severityScale}
             onChange={(e) => setSeverityScale(Number(e.target.value))}
+            aria-valuemin={1}
+            aria-valuemax={10}
+            aria-valuenow={severityScale}
+            aria-label={`Severity scale: ${severityScale} out of 10`}
             style={{ width: "100%" }}
           />
           <div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.75rem", color: "#666" }}>
@@ -178,6 +191,7 @@ export default function SymptomsPage() {
               <button
                 key={opt.value}
                 onClick={() => setSeverityAssessment(opt.value)}
+                aria-pressed={severityAssessment === opt.value}
                 style={{
                   flex: 1,
                   padding: "0.5rem",
@@ -196,10 +210,11 @@ export default function SymptomsPage() {
         </div>
 
         <div style={{ marginBottom: "1rem" }}>
-          <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+          <label htmlFor="symptom-duration" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
             How long has this been going on?
           </label>
           <input
+            id="symptom-duration"
             type="text"
             value={duration}
             onChange={(e) => setDuration(e.target.value)}
@@ -209,10 +224,11 @@ export default function SymptomsPage() {
         </div>
 
         <div style={{ marginBottom: "1rem" }}>
-          <label style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
+          <label htmlFor="symptom-description" style={{ display: "block", marginBottom: 4, fontSize: "0.85rem", color: "#999" }}>
             Describe what you&apos;re experiencing
           </label>
           <textarea
+            id="symptom-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Tell us in your own words what's going on..."


### PR DESCRIPTION
## Summary
- Add `role="alert"` to all error message elements across patient portal pages so screen readers announce failures immediately
- Surface previously silent errors in the medication refill request flow (was `try/finally` with no catch) and message send/create mutations
- Add missing query error states on dashboard, health summary, messages, and refill pages that previously showed perpetual "Loading..." on failure
- Add `htmlFor`/`id` pairing on form labels in symptoms, messages, and refill pages for screen reader association
- Add `aria-pressed` on severity toggle buttons, `aria-expanded` on clinical notes accordions, `aria-label` on severity slider and reply input, and `aria-live="polite"` on dynamic status regions

## Test plan
- [ ] Verify screen reader (VoiceOver/NVDA) announces error messages when queries fail
- [ ] Confirm refill request failure now shows "Request failed. Try again." instead of silently swallowing
- [ ] Confirm message send/create errors surface visible feedback
- [ ] Verify all form labels are properly associated with inputs (click label focuses input)
- [ ] Check severity buttons announce pressed state to screen readers
- [ ] Verify notes expand/collapse buttons announce expanded state

Closes #312