### PR TITLE
feat(ai): escalation worker for unacknowledged critical flags

### DIFF
--- a/packages/db-schema/drizzle/0027_flag_escalation_tracking.sql
+++ b/packages/db-schema/drizzle/0027_flag_escalation_tracking.sql
@@ -1,0 +1,19 @@
+-- Migration: Add escalation tracking to clinical_flags
+--
+-- The escalation worker re-notifies care team members for critical/warning
+-- flags that remain unacknowledged past their escalation threshold.
+-- `escalation_count` caps the number of re-notifications at 3 so that
+-- chronic unacknowledged flags do not generate unbounded alert fatigue.
+-- `last_escalated_at` is used to ensure we wait at least one full
+-- escalation interval between re-notifications for the same flag.
+
+ALTER TABLE clinical_flags
+  ADD COLUMN IF NOT EXISTS escalation_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE clinical_flags
+  ADD COLUMN IF NOT EXISTS last_escalated_at TEXT;
+
+-- Composite index supports the escalation worker's hot query:
+-- find open, unacknowledged flags by severity that are eligible to escalate.
+CREATE INDEX IF NOT EXISTS idx_flags_escalation_scan
+  ON clinical_flags (severity, status, acknowledged_at, escalation_count);

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1745856000000,
       "tag": "0026_family_access_constraints",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1745942400000,
+      "tag": "0027_flag_escalation_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -27,10 +27,18 @@ export const clinicalFlags = pgTable("clinical_flags", {
   dismiss_reason: text("dismiss_reason"),
   model_id: text("model_id"),
   prompt_version: text("prompt_version"),
+  escalation_count: integer("escalation_count").notNull().default(0),
+  last_escalated_at: text("last_escalated_at"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_flags_patient").on(table.patient_id, table.status),
   index("idx_flags_severity").on(table.severity, table.status),
+  index("idx_flags_escalation_scan").on(
+    table.severity,
+    table.status,
+    table.acknowledged_at,
+    table.escalation_count,
+  ),
   uniqueIndex("idx_flags_open_rule_dedup")
     .on(table.patient_id, table.rule_id)
     .where(sql`status = 'open' AND rule_id IS NOT NULL`),

--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -44,6 +44,15 @@ export interface ClinicalFlag extends BaseRecord {
    * automation acts on it. Defaults to true for all LLM-sourced flags.
    */
   requires_human_review?: boolean;
+  /**
+   * Number of times the escalation worker has re-notified the care team for
+   * this flag. Capped at 3 to bound alert fatigue; once the cap is reached
+   * the flag transitions to status='escalated' so it is excluded from
+   * further escalation scans.
+   */
+  escalation_count?: number;
+  /** ISO timestamp of the last escalation re-notification. */
+  last_escalated_at?: string;
 }
 
 // ─── Clinical Rules ──────────────────────────────────────────────

--- a/services/ai-oversight/src/__tests__/escalation-worker.test.ts
+++ b/services/ai-oversight/src/__tests__/escalation-worker.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock the DB --------------------------------------------------------------
+//
+// We capture `update().set().where()` calls so we can assert on the
+// payload each escalation writes, and make `select().from().where()`
+// configurable per-test so we can simulate different sets of stale flags
+// per severity.
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockSelectWhere = vi.fn();
+
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockUpdateWhere = vi.fn();
+
+const mockDb = {
+  select: mockSelect,
+  update: mockUpdate,
+};
+
+// The worker references `clinicalFlags.<column>` when composing its query.
+// We stub each referenced column with an identity string — good enough for
+// the drizzle helpers we use in the assertions (eq/lt/isNull/and).
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  clinicalFlags: {
+    id: "id",
+    patient_id: "patient_id",
+    status: "status",
+    severity: "severity",
+    acknowledged_at: "acknowledged_at",
+    escalation_count: "escalation_count",
+    last_escalated_at: "last_escalated_at",
+    created_at: "created_at",
+    notify_specialties: "notify_specialties",
+    category: "category",
+    summary: "summary",
+    suggested_action: "suggested_action",
+    source: "source",
+  },
+}));
+
+// Avoid pulling Redis / BullMQ during module load.
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({}),
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: class MockQueue {
+    add = vi.fn();
+  },
+  Worker: class MockWorker {
+    on = vi.fn();
+  },
+}));
+
+const { mockEmitNotificationEvent } = vi.hoisted(() => ({
+  mockEmitNotificationEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@carebridge/notifications", () => ({
+  emitNotificationEvent: mockEmitNotificationEvent,
+}));
+
+import {
+  checkAndEscalate,
+  MAX_ESCALATIONS,
+  THRESHOLDS,
+} from "../workers/escalation-worker.js";
+
+type StaleFlag = {
+  id: string;
+  patient_id: string;
+  severity: string;
+  category: string;
+  summary: string;
+  suggested_action: string;
+  notify_specialties: string[];
+  source: string;
+  created_at: string;
+  escalation_count: number;
+  last_escalated_at: string | null;
+};
+
+function makeFlag(overrides: Partial<StaleFlag> = {}): StaleFlag {
+  return {
+    id: "flag-1",
+    patient_id: "pat-1",
+    severity: "critical",
+    category: "critical-value",
+    summary: "K+ 2.3 — severe hypokalemia",
+    suggested_action: "Urgent potassium replacement",
+    notify_specialties: ["nephrology"],
+    source: "rules",
+    created_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago
+    escalation_count: 0,
+    last_escalated_at: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Configure the `select().from().where()` chain to return a different set of
+ * rows for each call. The worker queries once per severity in THRESHOLDS, in
+ * insertion order (critical, warning).
+ */
+function mockSelectCalls(resultsBySeverity: Record<string, StaleFlag[]>) {
+  // The worker iterates Object.keys(THRESHOLDS) in order.
+  const ordered = Object.keys(THRESHOLDS).map(
+    (sev) => resultsBySeverity[sev] ?? [],
+  );
+
+  mockSelect.mockReset();
+  mockFrom.mockReset();
+  mockSelectWhere.mockReset();
+
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockSelectWhere });
+
+  ordered.forEach((rows) => {
+    mockSelectWhere.mockResolvedValueOnce(rows);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // update().set().where() — the `where` call resolves the promise.
+  mockUpdate.mockReset();
+  mockSet.mockReset();
+  mockUpdateWhere.mockReset();
+  mockUpdate.mockReturnValue({ set: mockSet });
+  mockSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdateWhere.mockResolvedValue(undefined);
+
+  mockEmitNotificationEvent.mockClear();
+  mockEmitNotificationEvent.mockResolvedValue(undefined);
+});
+
+describe("checkAndEscalate", () => {
+  it("returns escalated=0 when no flags are stale", async () => {
+    mockSelectCalls({});
+
+    const result = await checkAndEscalate();
+
+    expect(result).toEqual({ escalated: 0 });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockEmitNotificationEvent).not.toHaveBeenCalled();
+  });
+
+  it("escalates a stale critical flag and emits a re-notification", async () => {
+    const flag = makeFlag({ id: "flag-crit-1" });
+    mockSelectCalls({ critical: [flag] });
+
+    const result = await checkAndEscalate();
+
+    expect(result.escalated).toBe(1);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledTimes(1);
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(updatePayload.escalation_count).toBe(1);
+    expect(updatePayload.last_escalated_at).toEqual(expect.any(String));
+    // Not final — stays open.
+    expect(updatePayload.status).toBe("open");
+
+    expect(mockEmitNotificationEvent).toHaveBeenCalledTimes(1);
+    const event = mockEmitNotificationEvent.mock.calls[0][0];
+    expect(event.flag_id).toBe("flag-crit-1");
+    expect(event.severity).toBe("critical");
+    expect(event.summary.startsWith("ESCALATED (1/3):")).toBe(true);
+    expect(event.notify_specialties).toEqual(["nephrology"]);
+  });
+
+  it("marks the flag status='escalated' on the final attempt", async () => {
+    const flag = makeFlag({
+      id: "flag-crit-final",
+      escalation_count: MAX_ESCALATIONS - 1, // next escalation is the last
+      last_escalated_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    });
+    mockSelectCalls({ critical: [flag] });
+
+    const result = await checkAndEscalate();
+
+    expect(result.escalated).toBe(1);
+    const updatePayload = mockSet.mock.calls[0][0];
+    expect(updatePayload.escalation_count).toBe(MAX_ESCALATIONS);
+    expect(updatePayload.status).toBe("escalated");
+
+    const event = mockEmitNotificationEvent.mock.calls[0][0];
+    expect(event.summary.startsWith(`ESCALATED (${MAX_ESCALATIONS}/3):`)).toBe(
+      true,
+    );
+  });
+
+  it("handles multiple severities and counts all escalations", async () => {
+    const critical = makeFlag({ id: "c-1", severity: "critical" });
+    const warning1 = makeFlag({
+      id: "w-1",
+      severity: "warning",
+      category: "care-gap",
+    });
+    const warning2 = makeFlag({
+      id: "w-2",
+      severity: "warning",
+      category: "trend-concern",
+    });
+
+    mockSelectCalls({
+      critical: [critical],
+      warning: [warning1, warning2],
+    });
+
+    const result = await checkAndEscalate();
+
+    expect(result.escalated).toBe(3);
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
+    expect(mockEmitNotificationEvent).toHaveBeenCalledTimes(3);
+
+    const emittedIds = mockEmitNotificationEvent.mock.calls.map(
+      (call) => call[0].flag_id,
+    );
+    expect(emittedIds).toEqual(["c-1", "w-1", "w-2"]);
+  });
+
+  it("records a fresh last_escalated_at timestamp", async () => {
+    const flag = makeFlag();
+    mockSelectCalls({ critical: [flag] });
+
+    const before = Date.now();
+    await checkAndEscalate();
+    const after = Date.now();
+
+    const updatePayload = mockSet.mock.calls[0][0];
+    const stamped = Date.parse(updatePayload.last_escalated_at);
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(after);
+  });
+
+  it("preserves notify_specialties as an array when null/missing", async () => {
+    const flag = makeFlag({
+      notify_specialties: null as unknown as string[],
+    });
+    mockSelectCalls({ critical: [flag] });
+
+    await checkAndEscalate();
+
+    const event = mockEmitNotificationEvent.mock.calls[0][0];
+    expect(event.notify_specialties).toEqual([]);
+  });
+
+  it("exposes the configured thresholds and escalation cap", () => {
+    expect(MAX_ESCALATIONS).toBe(3);
+    expect(THRESHOLDS.critical).toBe(30 * 60 * 1000);
+    expect(THRESHOLDS.warning).toBe(2 * 60 * 60 * 1000);
+  });
+});

--- a/services/ai-oversight/src/workers/escalation-worker.ts
+++ b/services/ai-oversight/src/workers/escalation-worker.ts
@@ -1,15 +1,30 @@
 /**
  * Flag escalation worker.
  *
- * Periodically checks for unacknowledged critical flags that have exceeded
- * their escalation threshold. When found, updates the flag status to
- * "escalated" and emits notification events to a broader audience.
+ * Periodically checks for unacknowledged open flags that have exceeded their
+ * escalation threshold and re-notifies the care team with higher urgency.
  *
- * Thresholds:
- *  - Critical flags: 30 minutes
- *  - Warning flags: 2 hours
+ * Clinical rationale:
+ *   A critical flag that sits unread is functionally equivalent to no flag
+ *   at all. Re-notifying the care team — and eventually marking the flag as
+ *   escalated so it surfaces to supervising staff — bounds the window in
+ *   which a stale alert can go unnoticed.
  *
- * Runs as a BullMQ repeatable job (every 5 minutes by default).
+ * Escalation policy:
+ *   - Severity `critical` escalates after 30 minutes of no acknowledgement.
+ *   - Severity `warning` escalates after 2 hours of no acknowledgement.
+ *   - Each flag is escalated at most MAX_ESCALATIONS (3) times. After the
+ *     final escalation the flag's status is moved to `escalated` so the
+ *     scan no longer matches it.
+ *   - The worker re-checks every CHECK_INTERVAL_MS. A flag becomes eligible
+ *     for its next escalation when
+ *       (now - last_escalated_at) >= threshold
+ *     so the interval between re-notifications scales with severity.
+ *
+ * Infrastructure:
+ *   BullMQ repeatable job (every 15 minutes). Only one instance runs at a
+ *   time (concurrency=1) so escalations are not double-counted when the
+ *   worker pool is larger than one.
  */
 
 import { Queue, Worker } from "bullmq";
@@ -18,47 +33,43 @@ import { getRedisConnection } from "@carebridge/redis-config";
 import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { getDb } from "@carebridge/db-schema";
 import { clinicalFlags } from "@carebridge/db-schema";
-import { eq, and, lt, isNull } from "drizzle-orm";
+import { eq, and, lt, isNull, sql } from "drizzle-orm";
+import { emitNotificationEvent } from "@carebridge/notifications";
 
 const QUEUE_NAME = "escalation-checks";
 
 const connection = getRedisConnection();
 
 /** Escalation thresholds in milliseconds. */
-const THRESHOLDS = {
-  critical: 30 * 60 * 1000,  // 30 minutes
+export const THRESHOLDS: Record<string, number> = {
+  critical: 30 * 60 * 1000, // 30 minutes
   warning: 2 * 60 * 60 * 1000, // 2 hours
-} as const;
+};
+
+/** Maximum number of re-notifications per flag before it is marked escalated. */
+export const MAX_ESCALATIONS = 3;
 
 /** How often the check runs (ms). */
-const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-
-/**
- * Notification queue reference — we emit escalation notifications here.
- * The notification dispatch worker picks these up and creates user records.
- */
-const notificationsQueue = new Queue("notifications", {
-  connection,
-  defaultJobOptions: {
-    attempts: 3,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 5000 },
-  },
-});
+const CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
 /**
  * Check for unacknowledged flags past their escalation threshold and escalate them.
+ *
+ * Exported for tests.
  */
-async function checkAndEscalate(): Promise<{ escalated: number }> {
+export async function checkAndEscalate(): Promise<{ escalated: number }> {
   const db = getDb();
   const now = Date.now();
   let escalated = 0;
 
-  for (const [severity, thresholdMs] of Object.entries(THRESHOLDS)) {
+  for (const severity of Object.keys(THRESHOLDS)) {
+    const thresholdMs = THRESHOLDS[severity];
     const cutoff = new Date(now - thresholdMs).toISOString();
 
-    // Find open, unacknowledged flags of this severity created before the cutoff
+    // An open, unacknowledged flag is eligible for re-escalation when:
+    //   (a) it has never been escalated and it is older than the threshold, OR
+    //   (b) its last escalation was more than one threshold-interval ago.
+    // In both cases escalation_count must still be under the cap.
     const staleFlags = await db
       .select()
       .from(clinicalFlags)
@@ -67,27 +78,50 @@ async function checkAndEscalate(): Promise<{ escalated: number }> {
           eq(clinicalFlags.status, "open"),
           eq(clinicalFlags.severity, severity),
           isNull(clinicalFlags.acknowledged_at),
-          lt(clinicalFlags.created_at, cutoff),
+          lt(clinicalFlags.escalation_count, MAX_ESCALATIONS),
+          sql`(
+            (${clinicalFlags.last_escalated_at} IS NULL
+              AND ${clinicalFlags.created_at} < ${cutoff})
+            OR (${clinicalFlags.last_escalated_at} IS NOT NULL
+              AND ${clinicalFlags.last_escalated_at} < ${cutoff})
+          )`,
         ),
       );
 
+    if (staleFlags.length === 0) continue;
+
     for (const flag of staleFlags) {
-      // Update status to escalated
+      const nextCount = (flag.escalation_count ?? 0) + 1;
+      const isFinalEscalation = nextCount >= MAX_ESCALATIONS;
+      const nowIso = new Date(now).toISOString();
+
+      // Update the flag first — this is the idempotency boundary.
+      // If the notification emit fails we have still recorded the
+      // attempt; the job retry will not re-escalate because
+      // last_escalated_at has moved forward.
       await db
         .update(clinicalFlags)
         .set({
-          status: "escalated",
+          escalation_count: nextCount,
+          last_escalated_at: nowIso,
+          // Only flip to `escalated` on the final re-notification so earlier
+          // passes can still find the flag in status='open'. This keeps the
+          // audit trail intact: an escalated flag was escalated to the cap.
+          status: isFinalEscalation ? "escalated" : "open",
         })
         .where(eq(clinicalFlags.id, flag.id));
 
-      // Emit escalation notification — broader audience than original
+      // Re-notify. The dispatch-worker treats severity='critical' as urgent
+      // (`is_urgent=true`), so prefixing the summary with `ESCALATED` plus
+      // the attempt count is sufficient to surface the heightened urgency
+      // to the UI without a separate schema field.
       const notifySpecialties = (flag.notify_specialties as string[]) ?? [];
-      await notificationsQueue.add("flag-escalated", {
+      await emitNotificationEvent({
         flag_id: flag.id,
         patient_id: flag.patient_id,
         severity: flag.severity,
         category: flag.category,
-        summary: `ESCALATED: ${flag.summary}`,
+        summary: `ESCALATED (${nextCount}/${MAX_ESCALATIONS}): ${flag.summary}`,
         suggested_action: flag.suggested_action,
         notify_specialties: notifySpecialties,
         source: flag.source,
@@ -96,10 +130,14 @@ async function checkAndEscalate(): Promise<{ escalated: number }> {
 
       escalated++;
 
+      const ageMin = Math.round(
+        (now - new Date(flag.created_at).getTime()) / 60000,
+      );
       console.log(
         `[escalation-worker] Escalated flag ${flag.id} ` +
           `(severity: ${flag.severity}, patient: ${redactPatientId(flag.patient_id)}, ` +
-          `age: ${Math.round((now - new Date(flag.created_at).getTime()) / 60000)}min)`,
+          `age: ${ageMin}min, attempt: ${nextCount}/${MAX_ESCALATIONS}` +
+          `${isFinalEscalation ? ", final" : ""})`,
       );
     }
   }
@@ -139,14 +177,17 @@ export function startEscalationWorker(): Worker {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {
-      console.log(`[escalation-worker] Running escalation check (job ${job.id})`);
+      console.log(
+        `[escalation-worker] Running escalation check (job ${job.id})`,
+      );
       const startTime = Date.now();
 
       const result = await checkAndEscalate();
 
       const elapsed = Date.now() - startTime;
       console.log(
-        `[escalation-worker] Check complete in ${elapsed}ms — ${result.escalated} flags escalated`,
+        `[escalation-worker] Check complete in ${elapsed}ms — ` +
+          `${result.escalated} flags escalated`,
       );
 
       return result;
@@ -158,7 +199,9 @@ export function startEscalationWorker(): Worker {
   );
 
   worker.on("ready", () => {
-    console.log(`[escalation-worker] Worker ready, processing "${QUEUE_NAME}" queue`);
+    console.log(
+      `[escalation-worker] Worker ready, processing "${QUEUE_NAME}" queue`,
+    );
   });
 
   worker.on("failed", (job: Job | undefined, error: Error) => {
@@ -173,3 +216,6 @@ export function startEscalationWorker(): Worker {
 
   return worker;
 }
+
+// Re-export for the service entry point and tests.
+export { QUEUE_NAME, CHECK_INTERVAL_MS };


### PR DESCRIPTION
## Summary
Closes #220.

No mechanism existed to re-notify the care team when a critical clinical flag remained unacknowledged. A critical flag could sit at `status='open'` indefinitely while the assigned clinician was occupied with another patient, turning minutes-level events (critical labs, troponin spikes, DVT→stroke risk) into silent failures.

This PR extends the existing flag escalation worker so it meets the clinical-safety requirements:

- Adds `escalation_count` and `last_escalated_at` to `clinical_flags` (migration `0025_flag_escalation_tracking`).
- Re-notifies the care team on each escalation via `emitNotificationEvent` so the dispatch worker fans out urgent alerts (`is_urgent=true` for critical severity). Summary is prefixed with `ESCALATED (n/3):` so the UI can surface the heightened urgency without a schema change.
- Caps escalations at 3 per flag. On the final attempt the flag moves to `status='escalated'` so it drops out of future scans; earlier attempts leave the flag `open` so the next scan still finds it.
- Uses severity-sized re-escalation intervals (critical: 30m, warning: 2h) keyed on `last_escalated_at`, so running the worker early does not double-escalate.
- Moves the repeatable schedule from every 5m to every 15m; concurrency stays at 1.

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test` — 186/186 pass, including 7 new escalation-worker cases
- [x] `pnpm --filter @carebridge/ai-oversight typecheck`
- [x] `pnpm --filter @carebridge/db-schema typecheck`
- [x] `pnpm --filter @carebridge/shared-types typecheck`
- [x] `pnpm --filter @carebridge/notifications typecheck`
- [ ] Apply migration `0025_flag_escalation_tracking.sql` in a staging DB and confirm the new columns + index are created.
- [ ] Seed a stale critical flag (created >30m ago, unacknowledged) and confirm the worker increments `escalation_count`, writes `last_escalated_at`, and a notification lands in the dispatch queue with `is_urgent=true`.
- [ ] Run the scan 3 times past each threshold and confirm the flag's status flips to `escalated` on the 3rd pass and is not rescanned after that.