### PR TITLE
fix(gateway): filter patient list for family_caregiver role (#307)

### DIFF
--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -16,6 +16,8 @@ import {
   allergies,
   careTeamMembers,
   careTeamAssignments,
+  familyRelationships,
+  users,
 } from "@carebridge/db-schema";
 import { createPatientSchema, updatePatientSchema } from "@carebridge/validators";
 import {
@@ -32,7 +34,7 @@ import {
   createAllergySchema,
   updateAllergySchema,
 } from "@carebridge/validators";
-import { eq, and, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
 import { assertCareTeamAccess } from "../middleware/rbac.js";
@@ -135,6 +137,10 @@ export const patientRecordsRbacRouter = t.router({
     }),
 
   // HIPAA minimum-necessary: filter patient list by role.
+  //   - patient: only their own record
+  //   - admin: full list
+  //   - family_caregiver: only patients linked via an active family_relationships row
+  //   - clinician (nurse/physician/specialist): only patients with an active care-team assignment
   list: protectedProcedure.query(async ({ ctx }) => {
     const db = getDb();
 
@@ -152,6 +158,39 @@ export const patientRecordsRbacRouter = t.router({
     // Admins see all patients.
     if (ctx.user.role === "admin") {
       return db.select().from(patients);
+    }
+
+    // Family caregivers: only patients linked via an active family_relationships row.
+    if ((ctx.user.role as string) === "family_caregiver") {
+      const activeRelationships = await db
+        .select({ patient_user_id: familyRelationships.patient_id })
+        .from(familyRelationships)
+        .where(
+          and(
+            eq(familyRelationships.caregiver_id, ctx.user.id),
+            eq(familyRelationships.status, "active"),
+          ),
+        );
+      if (activeRelationships.length === 0) {
+        return [];
+      }
+      const patientUserIds = activeRelationships.map((r) => r.patient_user_id);
+      const linkedUsers = await db
+        .select({ patient_id: users.patient_id })
+        .from(users)
+        .where(
+          and(
+            inArray(users.id, patientUserIds),
+            isNotNull(users.patient_id),
+          ),
+        );
+      const patientRecordIds = linkedUsers
+        .map((u) => u.patient_id)
+        .filter((id): id is string => Boolean(id));
+      if (patientRecordIds.length === 0) {
+        return [];
+      }
+      return db.select().from(patients).where(inArray(patients.id, patientRecordIds));
     }
 
     // Clinicians (physician, specialist, nurse): only patients with an


### PR DESCRIPTION
## Summary

Fixes issue #307 (HIGH severity HIPAA information disclosure).

The `patients.list` tRPC procedure only rejected `role === "patient"` and let every other role — including `family_caregiver` — read the full patients table. A family caregiver logging into the patient portal could enumerate every patient name and MRN in the system, and the UI's `data?.[0]` fallback could surface the wrong patient's data.

PR #454 (care-team scoping) addresses admin / patient / clinician roles but leaves family_caregiver falling through to the unfiltered `db.select().from(patients)` path. This PR closes that gap.

## Changes

- **Schema**: add `family_relationships` and `family_invites` tables (migration `0025_family_access.sql`) matching the shape planned in #466 so this fix does not block on that PR landing.
- **Router**: `patients.list` now resolves `family_caregiver` callers to only the patients they have an active `family_relationships` row for:
  ```
  family_relationships.caregiver_id = ctx.user.id AND status = 'active'
    -> users.id = family_relationships.patient_id
    -> patients.id = users.patient_id
  ```
  Returns `[]` when the caregiver has no active relationships or when linked patient users lack a `patient_id`. Admin / nurse / physician / specialist paths are unchanged; `patient` continues to get FORBIDDEN.
- **Tests**: 8 new tests in `patient-records-list-rbac.test.ts` covering:
  - empty-relationships short-circuit
  - scoped results for multiple active relationships
  - empty when linked users lack a patient_id
  - no unscoped `patients` select ever leaks through for a caregiver
  - admin / clinician full list, patient FORBIDDEN, unauthenticated UNAUTHORIZED

## HIPAA Reference

45 CFR 164.502(b) — Minimum Necessary. Family caregivers receive access only to the patient records they were explicitly granted.

## Coordination with open PRs

- **#454** (care-team scoping): touches the same `list` procedure. This PR keeps the clinician path unchanged so #454 can rebase cleanly — its care-team join slots into the `return db.select().from(patients)` tail branch without conflicting with the new `family_caregiver` branch.
- **#466** (family-access ownership): uses the same table names/columns. If #466 lands first the duplicate schema file / migration should be dropped from this branch during rebase; the router changes here remain independent.

## Test plan

- [x] `pnpm --filter @carebridge/api-gateway test -- patient-records-list-rbac` — 8 passed
- [x] Full api-gateway suite — 109 passed (one pre-existing failure in `ai-oversight-rbac.test.ts` unrelated to this change; `@carebridge/ai-oversight` isn't built)
- [x] Typecheck clean for the new code in `patient-records.ts` (remaining errors are pre-existing module-resolution warnings)

Closes #307