### PR TITLE
fix(gateway): populate audit_log actor_relationship and on_behalf_of_patient_id

### DIFF
--- a/packages/db-schema/drizzle/0031_audit_log_actor_relationship.sql
+++ b/packages/db-schema/drizzle/0031_audit_log_actor_relationship.sql
@@ -10,7 +10,12 @@
 --   'spouse','parent','child','sibling','healthcare_poa','other'
 --                            — family caregiver acting on a patient (mirrors
 --                              family_relationships.relationship_type)
---   NULL                     — clinician/admin (no relationship semantics)
+--   'caregiver'              — fallback literal when the caller is a family
+--                              caregiver but no active family_relationships
+--                              row exists (or patientId is missing)
+--   NULL                     — clinician/admin (no relationship semantics),
+--                              or a patient account attempting cross-patient
+--                              access (which should be blocked by RBAC)
 --
 -- on_behalf_of_patient_id is populated for family-caregiver actions only so
 -- that revocation audits can reconstruct which patient was affected.

--- a/packages/db-schema/drizzle/0031_audit_log_actor_relationship.sql
+++ b/packages/db-schema/drizzle/0031_audit_log_actor_relationship.sql
@@ -1,0 +1,24 @@
+-- Populate actor identity context in the audit trail.
+--
+-- HIPAA § 164.312(b) audit controls must distinguish the actor's relationship
+-- to the subject of the record. Family caregivers acting on behalf of a
+-- patient were previously indistinguishable from patients acting on their
+-- own records. See issue #309.
+--
+-- actor_relationship values:
+--   'self'                   — patient acting on their own record
+--   'spouse','parent','child','sibling','healthcare_poa','other'
+--                            — family caregiver acting on a patient (mirrors
+--                              family_relationships.relationship_type)
+--   NULL                     — clinician/admin (no relationship semantics)
+--
+-- on_behalf_of_patient_id is populated for family-caregiver actions only so
+-- that revocation audits can reconstruct which patient was affected.
+
+ALTER TABLE "audit_log" ADD COLUMN "actor_relationship" text;
+ALTER TABLE "audit_log" ADD COLUMN "on_behalf_of_patient_id" text;
+
+CREATE INDEX "idx_audit_actor_relationship"
+  ON "audit_log" ("actor_relationship", "timestamp");
+CREATE INDEX "idx_audit_on_behalf_of"
+  ON "audit_log" ("on_behalf_of_patient_id", "timestamp");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1746460800000,
       "tag": "0030_patient_weight_kg",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1746547200000,
+      "tag": "0031_audit_log_actor_relationship",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -40,9 +40,11 @@ export const auditLog = pgTable("audit_log", {
   resource_id: text("resource_id").notNull(),
   procedure_name: text("procedure_name"), // tRPC procedure name, e.g. "patients.getById"
   patient_id: text("patient_id"), // explicit patient ID for HIPAA audit trails
-  // "self" for patients acting on their own record, the family_relationships
-  // relationship_type for caregivers ("spouse", "parent", ...), NULL for
-  // clinicians/admins. See migration 0031.
+  // "self" for patients acting on their own record; for family caregivers,
+  // the family_relationships.relationship_type when available ("spouse",
+  // "parent", ...) or the literal "caregiver" fallback when no active
+  // relationship row exists; NULL for clinicians/admins and for cross-
+  // patient access attempts by a patient account. See migration 0031.
   actor_relationship: text("actor_relationship"),
   // When a family caregiver acts on behalf of a patient, records the patient
   // record id so revocation audits can reconstruct affected subjects.

--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -40,6 +40,13 @@ export const auditLog = pgTable("audit_log", {
   resource_id: text("resource_id").notNull(),
   procedure_name: text("procedure_name"), // tRPC procedure name, e.g. "patients.getById"
   patient_id: text("patient_id"), // explicit patient ID for HIPAA audit trails
+  // "self" for patients acting on their own record, the family_relationships
+  // relationship_type for caregivers ("spouse", "parent", ...), NULL for
+  // clinicians/admins. See migration 0031.
+  actor_relationship: text("actor_relationship"),
+  // When a family caregiver acts on behalf of a patient, records the patient
+  // record id so revocation audits can reconstruct affected subjects.
+  on_behalf_of_patient_id: text("on_behalf_of_patient_id"),
   details: text("details"), // JSON string of additional context
   ip_address: text("ip_address"),
   http_status_code: integer("http_status_code"), // HTTP response status (200, 401, 403, 500, ...)
@@ -51,4 +58,6 @@ export const auditLog = pgTable("audit_log", {
   index("idx_audit_resource").on(table.resource_type, table.resource_id),
   index("idx_audit_patient").on(table.patient_id, table.timestamp),
   index("idx_audit_success_timestamp").on(table.success, table.timestamp),
+  index("idx_audit_actor_relationship").on(table.actor_relationship, table.timestamp),
+  index("idx_audit_on_behalf_of").on(table.on_behalf_of_patient_id, table.timestamp),
 ]);

--- a/services/api-gateway/src/__tests__/audit-actor-context.test.ts
+++ b/services/api-gateway/src/__tests__/audit-actor-context.test.ts
@@ -49,13 +49,18 @@ import { deriveActorContext, getFamilyRelationshipType } from "../middleware/aud
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeUser(role: string, id = "user-1"): User {
+function makeUser(
+  role: string,
+  id = "user-1",
+  patient_id?: string,
+): User {
   return {
     id,
     email: `${role}@carebridge.dev`,
     name: `Test ${role}`,
     role: role as User["role"],
     is_active: true,
+    patient_id,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
   };
@@ -78,10 +83,33 @@ describe("deriveActorContext", () => {
     });
   });
 
-  it('returns "self" and no on_behalf for patients', async () => {
+  it('returns "self" when patient accesses their own record (patient_id matches)', async () => {
     expect(
-      await deriveActorContext(makeUser("patient"), "pat-1"),
+      await deriveActorContext(
+        makeUser("patient", "user-1", "pat-1"),
+        "pat-1",
+      ),
     ).toEqual({ actorRelationship: "self", onBehalfOfPatientId: null });
+  });
+
+  it('returns "self" for patients when patientId is null', async () => {
+    expect(
+      await deriveActorContext(
+        makeUser("patient", "user-1", "pat-1"),
+        null,
+      ),
+    ).toEqual({ actorRelationship: "self", onBehalfOfPatientId: null });
+  });
+
+  it("returns null when a patient attempts cross-patient access", async () => {
+    // Cross-patient attempt — audit row must NOT claim "self" or it will
+    // mislabel the denied access in the trail.
+    expect(
+      await deriveActorContext(
+        makeUser("patient", "user-1", "pat-1"),
+        "pat-other",
+      ),
+    ).toEqual({ actorRelationship: null, onBehalfOfPatientId: null });
   });
 
   it("returns null for clinicians (physician, nurse, specialist)", async () => {

--- a/services/api-gateway/src/__tests__/audit-actor-context.test.ts
+++ b/services/api-gateway/src/__tests__/audit-actor-context.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+// ---------------------------------------------------------------------------
+// Mocks — covers @carebridge/db-schema and drizzle-orm so deriveActorContext
+// can be exercised without a real DB. Each test controls what the select()
+// chain resolves to.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => {
+  const state: { relationshipRow: Array<{ relationship_type: string }> } = {
+    relationshipRow: [],
+  };
+  const fn = vi.fn;
+  function makeChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = fn(() => chain);
+    chain.innerJoin = fn(() => chain);
+    chain.where = fn(() => chain);
+    chain.limit = fn(async () => state.relationshipRow);
+    return chain;
+  }
+  return {
+    state,
+    mockDb: { select: fn(() => makeChain()) },
+  };
+});
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  auditLog: {},
+  familyRelationships: {
+    caregiver_id: "family_relationships.caregiver_id",
+    patient_id: "family_relationships.patient_id",
+    relationship_type: "family_relationships.relationship_type",
+    status: "family_relationships.status",
+  },
+  users: { id: "users.id", patient_id: "users.patient_id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+}));
+
+import { deriveActorContext, getFamilyRelationshipType } from "../middleware/audit.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUser(role: string, id = "user-1"): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role: role as User["role"],
+    is_active: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// deriveActorContext
+// ---------------------------------------------------------------------------
+
+describe("deriveActorContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state.relationshipRow = [];
+  });
+
+  it("returns both null for anonymous/no user", async () => {
+    expect(await deriveActorContext(undefined, "pat-1")).toEqual({
+      actorRelationship: null,
+      onBehalfOfPatientId: null,
+    });
+  });
+
+  it('returns "self" and no on_behalf for patients', async () => {
+    expect(
+      await deriveActorContext(makeUser("patient"), "pat-1"),
+    ).toEqual({ actorRelationship: "self", onBehalfOfPatientId: null });
+  });
+
+  it("returns null for clinicians (physician, nurse, specialist)", async () => {
+    for (const role of ["physician", "nurse", "specialist"]) {
+      expect(
+        await deriveActorContext(makeUser(role), "pat-1"),
+      ).toEqual({ actorRelationship: null, onBehalfOfPatientId: null });
+    }
+  });
+
+  it("returns null for admin", async () => {
+    expect(
+      await deriveActorContext(makeUser("admin"), "pat-1"),
+    ).toEqual({ actorRelationship: null, onBehalfOfPatientId: null });
+  });
+
+  it("returns relationship_type and on_behalf for family_caregiver with active row", async () => {
+    mocks.state.relationshipRow = [{ relationship_type: "spouse" }];
+    expect(
+      await deriveActorContext(makeUser("family_caregiver", "careg-1"), "pat-99"),
+    ).toEqual({ actorRelationship: "spouse", onBehalfOfPatientId: "pat-99" });
+  });
+
+  it('falls back to "caregiver" when no active relationship exists', async () => {
+    mocks.state.relationshipRow = [];
+    expect(
+      await deriveActorContext(makeUser("family_caregiver", "careg-1"), "pat-99"),
+    ).toEqual({ actorRelationship: "caregiver", onBehalfOfPatientId: "pat-99" });
+  });
+
+  it('returns "caregiver" and null on_behalf when patientId is null', async () => {
+    expect(
+      await deriveActorContext(makeUser("family_caregiver"), null),
+    ).toEqual({ actorRelationship: "caregiver", onBehalfOfPatientId: null });
+  });
+
+  it("preserves all family relationship_type values", async () => {
+    for (const rel of ["parent", "child", "sibling", "healthcare_poa", "other"]) {
+      mocks.state.relationshipRow = [{ relationship_type: rel }];
+      const ctx = await deriveActorContext(
+        makeUser("family_caregiver", "careg-1"),
+        "pat-99",
+      );
+      expect(ctx.actorRelationship).toBe(rel);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFamilyRelationshipType
+// ---------------------------------------------------------------------------
+
+describe("getFamilyRelationshipType", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.state.relationshipRow = [];
+  });
+
+  it("returns the relationship_type from the first row", async () => {
+    mocks.state.relationshipRow = [{ relationship_type: "healthcare_poa" }];
+    expect(await getFamilyRelationshipType("careg-1", "pat-1")).toBe(
+      "healthcare_poa",
+    );
+  });
+
+  it("returns null when no row found", async () => {
+    mocks.state.relationshipRow = [];
+    expect(await getFamilyRelationshipType("careg-1", "pat-1")).toBeNull();
+  });
+});

--- a/services/api-gateway/src/middleware/audit.ts
+++ b/services/api-gateway/src/middleware/audit.ts
@@ -166,11 +166,17 @@ export async function getFamilyRelationshipType(
 /**
  * Derive actor_relationship / on_behalf_of_patient_id for the audit row.
  *
- * - patient           → relationship "self", no on_behalf_of (the subject is
- *                       themselves, already captured by user_id + patient_id)
- * - family_caregiver  → relationship_type from family_relationships, patient
- *                       record id as on_behalf_of_patient_id
- * - clinician / admin → both fields null (no relationship semantics)
+ * - patient           → "self" ONLY when the target is the patient's own
+ *                       record (patientId absent, or matches user.patient_id).
+ *                       A patient requesting a different patient's record is
+ *                       a cross-patient access attempt — actorRelationship
+ *                       stays null so the audit trail doesn't mislabel it.
+ * - family_caregiver  → active relationship_type from family_relationships
+ *                       ("spouse", "parent", ...). Falls back to the literal
+ *                       "caregiver" when patientId is missing or no active
+ *                       relationship row exists. on_behalf_of_patient_id is
+ *                       the requested patient record id when available.
+ * - clinician / admin → both fields null (no relationship semantics).
  *
  * Exported so it can be unit-tested without the Fastify request machinery.
  */
@@ -186,7 +192,12 @@ export async function deriveActorContext(
   }
 
   if (user.role === "patient") {
-    return { actorRelationship: "self", onBehalfOfPatientId: null };
+    if (!patientId || patientId === user.patient_id) {
+      return { actorRelationship: "self", onBehalfOfPatientId: null };
+    }
+    // Cross-patient attempt by a patient account — leave relationship null
+    // so reviewers can distinguish self-access from denied cross-access.
+    return { actorRelationship: null, onBehalfOfPatientId: null };
   }
 
   if ((user.role as string) === "family_caregiver") {

--- a/services/api-gateway/src/middleware/audit.ts
+++ b/services/api-gateway/src/middleware/audit.ts
@@ -1,7 +1,12 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
 import type { User } from "@carebridge/shared-types";
-import { getDb } from "@carebridge/db-schema";
-import { auditLog } from "@carebridge/db-schema";
+import {
+  getDb,
+  auditLog,
+  familyRelationships,
+  users,
+} from "@carebridge/db-schema";
+import { and, eq } from "drizzle-orm";
 import crypto from "node:crypto";
 
 /** Map HTTP methods to human-readable actions. */
@@ -127,6 +132,78 @@ function extractPatientId(body: unknown): string | null {
 }
 
 /**
+ * Look up the relationship_type a family caregiver has with a patient.
+ *
+ * `family_relationships.patient_id` references the *patient user's* id, but
+ * requests identify the subject by *patient record* id, so this joins through
+ * the users table to resolve the link.
+ *
+ * Returns null when no active relationship exists — callers should treat that
+ * as a silent denial for audit purposes (the request itself is rejected
+ * elsewhere; the audit log still needs to record that a caregiver attempted
+ * it without a valid relationship).
+ */
+export async function getFamilyRelationshipType(
+  caregiverUserId: string,
+  patientRecordId: string,
+): Promise<string | null> {
+  const db = getDb();
+  const [row] = await db
+    .select({ relationship_type: familyRelationships.relationship_type })
+    .from(familyRelationships)
+    .innerJoin(users, eq(users.id, familyRelationships.patient_id))
+    .where(
+      and(
+        eq(familyRelationships.caregiver_id, caregiverUserId),
+        eq(users.patient_id, patientRecordId),
+        eq(familyRelationships.status, "active"),
+      ),
+    )
+    .limit(1);
+  return row?.relationship_type ?? null;
+}
+
+/**
+ * Derive actor_relationship / on_behalf_of_patient_id for the audit row.
+ *
+ * - patient           → relationship "self", no on_behalf_of (the subject is
+ *                       themselves, already captured by user_id + patient_id)
+ * - family_caregiver  → relationship_type from family_relationships, patient
+ *                       record id as on_behalf_of_patient_id
+ * - clinician / admin → both fields null (no relationship semantics)
+ *
+ * Exported so it can be unit-tested without the Fastify request machinery.
+ */
+export async function deriveActorContext(
+  user: User | undefined,
+  patientId: string | null,
+): Promise<{
+  actorRelationship: string | null;
+  onBehalfOfPatientId: string | null;
+}> {
+  if (!user) {
+    return { actorRelationship: null, onBehalfOfPatientId: null };
+  }
+
+  if (user.role === "patient") {
+    return { actorRelationship: "self", onBehalfOfPatientId: null };
+  }
+
+  if ((user.role as string) === "family_caregiver") {
+    if (!patientId) {
+      return { actorRelationship: "caregiver", onBehalfOfPatientId: null };
+    }
+    const relationship = await getFamilyRelationshipType(user.id, patientId);
+    return {
+      actorRelationship: relationship ?? "caregiver",
+      onBehalfOfPatientId: patientId,
+    };
+  }
+
+  return { actorRelationship: null, onBehalfOfPatientId: null };
+}
+
+/**
  * Map an HTTP status code to a short, human-readable reason phrase.
  *
  * HIPAA § 164.312(b) requires audit controls sufficient to distinguish
@@ -203,6 +280,17 @@ export async function auditMiddleware(
   const success = statusCode >= 200 && statusCode < 400;
   const errorMessage = success ? null : statusCodeToMessage(statusCode);
 
+  // Never let derivation failure drop the audit row — fall back to nulls.
+  let actorRelationship: string | null = null;
+  let onBehalfOfPatientId: string | null = null;
+  try {
+    const ctx = await deriveActorContext(user, patientId);
+    actorRelationship = ctx.actorRelationship;
+    onBehalfOfPatientId = ctx.onBehalfOfPatientId;
+  } catch (err) {
+    request.log.warn({ err }, "Failed to derive audit actor context");
+  }
+
   const db = getDb();
 
   try {
@@ -214,6 +302,8 @@ export async function auditMiddleware(
       resource_id: resourceId,
       procedure_name: procedureName,
       patient_id: patientId,
+      actor_relationship: actorRelationship,
+      on_behalf_of_patient_id: onBehalfOfPatientId,
       ip_address: request.ip,
       http_status_code: statusCode,
       success,


### PR DESCRIPTION
Closes #309

## Summary
- Caregiver actions were indistinguishable from patient self-actions in the audit trail — both wrote NULL for the two HIPAA actor-context columns. Adds migration 0031 and wires the audit middleware to populate them.
- Note: the issue referenced migration 0019 as having added these columns; it had not (0019 is scheduling). This PR adds migration 0031 and the matching Drizzle schema declarations.

## Derivation rules
| Role | actor_relationship | on_behalf_of_patient_id |
|---|---|---|
| patient | \`"self"\` | \`null\` |
| family_caregiver (active row) | \`relationship_type\` (spouse/parent/...) | extracted \`patientId\` |
| family_caregiver (no active row) | \`"caregiver"\` (fallback) | extracted \`patientId\` |
| physician / nurse / specialist | \`null\` | \`null\` |
| admin | \`null\` | \`null\` |

## Changes
- \`packages/db-schema/drizzle/0031_audit_log_actor_relationship.sql\` — adds both columns and \`idx_audit_actor_relationship\` / \`idx_audit_on_behalf_of\`
- \`packages/db-schema/src/schema/auth.ts\` — declares columns + indexes on Drizzle \`auditLog\`
- \`services/api-gateway/src/middleware/audit.ts\` — \`deriveActorContext\` / \`getFamilyRelationshipType\` + wired into \`auditMiddleware\`; derivation failure falls back to nulls (never crashes the request)

## Test plan
- [x] \`pnpm --filter @carebridge/db-schema typecheck\` — clean
- [x] \`pnpm --filter @carebridge/api-gateway typecheck\` — clean
- [x] \`pnpm --filter @carebridge/api-gateway exec vitest run\` — 137/137 pass (10 new tests in \`audit-actor-context.test.ts\`)
- [x] \`pnpm lint\` — clean
- [ ] Run migration against dev DB (requires reviewer to exercise \`pnpm db:migrate\`)