### PR TITLE
test(gateway): add RBAC tests for family-access tRPC router (#310 partial)

### DIFF
--- a/services/api-gateway/src/__tests__/family-access.test.ts
+++ b/services/api-gateway/src/__tests__/family-access.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Gateway-layer RBAC tests for the family-access tRPC router.
+ *
+ * The service layer ("@carebridge/auth/family-invite-flow") is covered by
+ * ~35 cases in services/auth. These tests verify the router's role gate
+ * and that it forwards inputs correctly to the service layer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const ROLE_IDS: Record<string, string> = {
+  nurse: "33333333-3333-4333-8333-333333333333",
+  physician: "44444444-4444-4444-8444-444444444444",
+  specialist: "55555555-5555-4555-8555-555555555555",
+  admin: "66666666-6666-4666-8666-666666666666",
+  patient: PATIENT_ID,
+  family_caregiver: "77777777-7777-4777-8777-777777777777",
+};
+
+const mocks = vi.hoisted(() => ({
+  createFamilyInvite: vi.fn(async () => ({ id: "invite-1", token: "tok-1" })),
+  acceptFamilyInvite: vi.fn(async () => ({
+    id: "rel-1",
+    status: "active" as const,
+  })),
+  revokeFamilyAccess: vi.fn(async () => undefined),
+  cancelFamilyInvite: vi.fn(async () => undefined),
+  listFamilyRelationships: vi.fn(async () => []),
+  listFamilyInvites: vi.fn(async () => []),
+}));
+
+vi.mock("@carebridge/auth/family-invite-flow", () => ({
+  createFamilyInvite: mocks.createFamilyInvite,
+  acceptFamilyInvite: mocks.acceptFamilyInvite,
+  revokeFamilyAccess: mocks.revokeFamilyAccess,
+  cancelFamilyInvite: mocks.cancelFamilyInvite,
+  listFamilyRelationships: mocks.listFamilyRelationships,
+  listFamilyInvites: mocks.listFamilyInvites,
+}));
+
+import { familyAccessRbacRouter } from "../routers/family-access.js";
+import type { Context } from "../context.js";
+
+function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function callerFor(user: User | null) {
+  const ctx: Context = {
+    db: {} as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+  return familyAccessRbacRouter.createCaller(ctx);
+}
+
+const inviteInput = {
+  invitee_email: "caregiver@example.com",
+  relationship_type: "spouse" as const,
+};
+
+describe("familyAccessRbacRouter — createInvite RBAC", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows a patient to create an invite", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(caller.createInvite(inviteInput)).resolves.toBeDefined();
+    expect(mocks.createFamilyInvite).toHaveBeenCalledWith(
+      PATIENT_ID,
+      "caregiver@example.com",
+      "spouse",
+    );
+  });
+
+  it("denies a physician (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("physician"));
+    await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
+  });
+
+  it("denies a nurse (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("nurse"));
+    await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
+  });
+
+  it("denies an admin (FORBIDDEN) — only patients invite", async () => {
+    const caller = callerFor(makeUser("admin"));
+    await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("denies a family_caregiver (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("validates invitee_email shape", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.createInvite({
+        invitee_email: "not-an-email",
+        relationship_type: "spouse",
+      }),
+    ).rejects.toBeDefined();
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown relationship_type values", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.createInvite({
+        invitee_email: "caregiver@example.com",
+        relationship_type: "healthcare_poa" as never,
+      }),
+    ).rejects.toBeDefined();
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
+  });
+});
+
+describe("familyAccessRbacRouter — acceptInvite", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards the token and accepting user.id to the service", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await caller.acceptInvite({ invite_token: "tok-abc" });
+    expect(mocks.acceptFamilyInvite).toHaveBeenCalledWith(
+      "tok-abc",
+      ROLE_IDS.family_caregiver,
+    );
+  });
+
+  it("allows accept from any authenticated role (role check is on create)", async () => {
+    for (const role of ["patient", "physician", "nurse", "admin"] as const) {
+      const caller = callerFor(makeUser(role));
+      await expect(
+        caller.acceptInvite({ invite_token: "tok-abc" }),
+      ).resolves.toBeDefined();
+    }
+    expect(mocks.acceptFamilyInvite).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects empty token via input schema", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.acceptInvite({ invite_token: "" }),
+    ).rejects.toBeDefined();
+    expect(mocks.acceptFamilyInvite).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(
+      caller.acceptInvite({ invite_token: "tok-abc" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});
+
+describe("familyAccessRbacRouter — revokeAccess", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards relationship_id, user.id, user.role to the service", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver });
+    expect(mocks.revokeFamilyAccess).toHaveBeenCalledWith(
+      ROLE_IDS.family_caregiver,
+      PATIENT_ID,
+      "patient",
+    );
+  });
+
+  it("returns { revoked: true } on success", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver }),
+    ).resolves.toEqual({ revoked: true });
+  });
+
+  it("rejects non-UUID relationship_id", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.revokeAccess({ relationship_id: "not-a-uuid" }),
+    ).rejects.toBeDefined();
+    expect(mocks.revokeFamilyAccess).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(
+      caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});
+
+describe("familyAccessRbacRouter — cancelInvite", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards invite_id, user.id, user.role to the service", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await caller.cancelInvite({ invite_id: ROLE_IDS.family_caregiver });
+    expect(mocks.cancelFamilyInvite).toHaveBeenCalledWith(
+      ROLE_IDS.family_caregiver,
+      PATIENT_ID,
+      "patient",
+    );
+  });
+
+  it("returns { cancelled: true } on success", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.cancelInvite({ invite_id: ROLE_IDS.family_caregiver }),
+    ).resolves.toEqual({ cancelled: true });
+  });
+
+  it("rejects non-UUID invite_id", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(
+      caller.cancelInvite({ invite_id: "not-a-uuid" }),
+    ).rejects.toBeDefined();
+    expect(mocks.cancelFamilyInvite).not.toHaveBeenCalled();
+  });
+});
+
+describe("familyAccessRbacRouter — listRelationships RBAC", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows a patient to list their own relationships", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(caller.listRelationships()).resolves.toEqual([]);
+    expect(mocks.listFamilyRelationships).toHaveBeenCalledWith(PATIENT_ID);
+  });
+
+  it("allows an admin", async () => {
+    const caller = callerFor(makeUser("admin"));
+    await expect(caller.listRelationships()).resolves.toEqual([]);
+    expect(mocks.listFamilyRelationships).toHaveBeenCalledWith(ROLE_IDS.admin);
+  });
+
+  it("denies a physician (FORBIDDEN)", async () => {
+    const caller = callerFor(makeUser("physician"));
+    await expect(caller.listRelationships()).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.listFamilyRelationships).not.toHaveBeenCalled();
+  });
+
+  it("denies a family_caregiver (FORBIDDEN) — caregivers list via their own view", async () => {
+    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    await expect(caller.listRelationships()).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(caller.listRelationships()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});
+
+describe("familyAccessRbacRouter — listInvites RBAC", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows a patient", async () => {
+    const caller = callerFor(makeUser("patient"));
+    await expect(caller.listInvites()).resolves.toEqual([]);
+    expect(mocks.listFamilyInvites).toHaveBeenCalledWith(PATIENT_ID);
+  });
+
+  it("allows an admin", async () => {
+    const caller = callerFor(makeUser("admin"));
+    await expect(caller.listInvites()).resolves.toEqual([]);
+  });
+
+  it("denies nurse, specialist, physician, family_caregiver", async () => {
+    for (const role of [
+      "nurse",
+      "specialist",
+      "physician",
+      "family_caregiver",
+    ] as const) {
+      const caller = callerFor(makeUser(role as User["role"]));
+      await expect(caller.listInvites()).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+    }
+  });
+});

--- a/services/api-gateway/src/__tests__/family-access.test.ts
+++ b/services/api-gateway/src/__tests__/family-access.test.ts
@@ -19,6 +19,12 @@ const ROLE_IDS: Record<string, string> = {
   family_caregiver: "77777777-7777-4777-8777-777777777777",
 };
 
+// Record-id fixtures — semantically distinct from user ids. Used for the
+// revokeAccess / cancelInvite tests where the input is a relationship /
+// invite primary key, not a user id.
+const RELATIONSHIP_ID = "88888888-8888-4888-8888-888888888888";
+const INVITE_ID = "99999999-9999-4999-8999-999999999999";
+
 const mocks = vi.hoisted(() => ({
   createFamilyInvite: vi.fn(async () => ({ id: "invite-1", token: "tok-1" })),
   acceptFamilyInvite: vi.fn(async () => ({
@@ -43,12 +49,19 @@ vi.mock("@carebridge/auth/family-invite-flow", () => ({
 import { familyAccessRbacRouter } from "../routers/family-access.js";
 import type { Context } from "../context.js";
 
-function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
+/**
+ * Test-only role union. `User["role"]` from `@carebridge/shared-types` does
+ * not include "family_caregiver" yet; this alias keeps the `as User["role"]`
+ * cast localized to `makeUser` so future union-expansion is a single edit.
+ */
+type TestRole = User["role"] | "family_caregiver";
+
+function makeUser(role: TestRole, id = ROLE_IDS[role]!): User {
   return {
     id,
     email: `${role}@carebridge.dev`,
     name: `Test ${role}`,
-    role,
+    role: role as User["role"],
     is_active: true,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
@@ -104,13 +117,15 @@ describe("familyAccessRbacRouter — createInvite RBAC", () => {
     await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
   });
 
   it("denies a family_caregiver (FORBIDDEN)", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(caller.createInvite(inviteInput)).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
+    expect(mocks.createFamilyInvite).not.toHaveBeenCalled();
   });
 
   it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
@@ -147,7 +162,7 @@ describe("familyAccessRbacRouter — acceptInvite", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("forwards the token and accepting user.id to the service", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await caller.acceptInvite({ invite_token: "tok-abc" });
     expect(mocks.acceptFamilyInvite).toHaveBeenCalledWith(
       "tok-abc",
@@ -186,9 +201,9 @@ describe("familyAccessRbacRouter — revokeAccess", () => {
 
   it("forwards relationship_id, user.id, user.role to the service", async () => {
     const caller = callerFor(makeUser("patient"));
-    await caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver });
+    await caller.revokeAccess({ relationship_id: RELATIONSHIP_ID });
     expect(mocks.revokeFamilyAccess).toHaveBeenCalledWith(
-      ROLE_IDS.family_caregiver,
+      RELATIONSHIP_ID,
       PATIENT_ID,
       "patient",
     );
@@ -197,7 +212,7 @@ describe("familyAccessRbacRouter — revokeAccess", () => {
   it("returns { revoked: true } on success", async () => {
     const caller = callerFor(makeUser("patient"));
     await expect(
-      caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver }),
+      caller.revokeAccess({ relationship_id: RELATIONSHIP_ID }),
     ).resolves.toEqual({ revoked: true });
   });
 
@@ -212,7 +227,7 @@ describe("familyAccessRbacRouter — revokeAccess", () => {
   it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
     const caller = callerFor(null);
     await expect(
-      caller.revokeAccess({ relationship_id: ROLE_IDS.family_caregiver }),
+      caller.revokeAccess({ relationship_id: RELATIONSHIP_ID }),
     ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
   });
 });
@@ -222,9 +237,9 @@ describe("familyAccessRbacRouter — cancelInvite", () => {
 
   it("forwards invite_id, user.id, user.role to the service", async () => {
     const caller = callerFor(makeUser("patient"));
-    await caller.cancelInvite({ invite_id: ROLE_IDS.family_caregiver });
+    await caller.cancelInvite({ invite_id: INVITE_ID });
     expect(mocks.cancelFamilyInvite).toHaveBeenCalledWith(
-      ROLE_IDS.family_caregiver,
+      INVITE_ID,
       PATIENT_ID,
       "patient",
     );
@@ -233,7 +248,7 @@ describe("familyAccessRbacRouter — cancelInvite", () => {
   it("returns { cancelled: true } on success", async () => {
     const caller = callerFor(makeUser("patient"));
     await expect(
-      caller.cancelInvite({ invite_id: ROLE_IDS.family_caregiver }),
+      caller.cancelInvite({ invite_id: INVITE_ID }),
     ).resolves.toEqual({ cancelled: true });
   });
 
@@ -242,6 +257,14 @@ describe("familyAccessRbacRouter — cancelInvite", () => {
     await expect(
       caller.cancelInvite({ invite_id: "not-a-uuid" }),
     ).rejects.toBeDefined();
+    expect(mocks.cancelFamilyInvite).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(
+      caller.cancelInvite({ invite_id: INVITE_ID }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     expect(mocks.cancelFamilyInvite).not.toHaveBeenCalled();
   });
 });
@@ -270,7 +293,7 @@ describe("familyAccessRbacRouter — listRelationships RBAC", () => {
   });
 
   it("denies a family_caregiver (FORBIDDEN) — caregivers list via their own view", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(caller.listRelationships()).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
@@ -293,9 +316,10 @@ describe("familyAccessRbacRouter — listInvites RBAC", () => {
     expect(mocks.listFamilyInvites).toHaveBeenCalledWith(PATIENT_ID);
   });
 
-  it("allows an admin", async () => {
+  it("allows an admin and forwards ctx.user.id to the service", async () => {
     const caller = callerFor(makeUser("admin"));
     await expect(caller.listInvites()).resolves.toEqual([]);
+    expect(mocks.listFamilyInvites).toHaveBeenCalledWith(ROLE_IDS.admin);
   });
 
   it("denies nurse, specialist, physician, family_caregiver", async () => {
@@ -305,10 +329,18 @@ describe("familyAccessRbacRouter — listInvites RBAC", () => {
       "physician",
       "family_caregiver",
     ] as const) {
-      const caller = callerFor(makeUser(role as User["role"]));
+      const caller = callerFor(makeUser(role));
       await expect(caller.listInvites()).rejects.toMatchObject({
         code: "FORBIDDEN",
       });
     }
+  });
+
+  it("rejects unauthenticated caller (UNAUTHORIZED)", async () => {
+    const caller = callerFor(null);
+    await expect(caller.listInvites()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(mocks.listFamilyInvites).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Partially addresses #310

## Summary
- Adds 27 tests for the gateway-layer family-access router, which had zero coverage
- Scoped to the gateway role gate because the service layer (\`services/auth/\`) already has 720 lines of tests
- Does not claim to close #310 — other sub-items remain open (noted below)

## Coverage added (27 tests)
| Procedure | Cases |
|---|---|
| \`createInvite\` | patient allowed; physician/nurse/admin/caregiver denied; bad email + unknown relationship_type rejected; UNAUTHORIZED when anonymous; args forwarded |
| \`acceptInvite\` | all roles allowed; empty token rejected; UNAUTHORIZED when anonymous; args forwarded |
| \`revokeAccess\` | non-UUID rejected; \`{ revoked: true }\` on success; args forwarded |
| \`cancelInvite\` | non-UUID rejected; \`{ cancelled: true }\` on success; args forwarded |
| \`listRelationships\` | patient + admin allowed; clinician + caregiver denied |
| \`listInvites\` | patient + admin allowed; all other roles denied |

## Explicitly out of scope (from #310's list)
- \`packages/validators/src/__tests__/family-access.test.ts\` — no family schemas exist in \`@carebridge/validators\` yet; the router uses inline zod
- Adding family_caregiver cases to \`services/api-gateway/src/middleware/rbac.test.ts\` — middleware has no family_caregiver branch; that logic lives in \`enforcePatientAccess\` in patient-records.ts
- Checkins scope enforcement tests — separate router, separate work
- Portal E2E — separate work stream

## Test plan
- [x] \`pnpm --filter @carebridge/api-gateway exec vitest run src/__tests__/family-access.test.ts\` — 27/27 pass
- [x] \`pnpm --filter @carebridge/api-gateway typecheck\` — clean
- [x] \`pnpm lint\` — clean