### PR TITLE
fix(infra): extend clinical-events retry budget to ~4 minutes

### DIFF
--- a/packages/redis-config/src/index.ts
+++ b/packages/redis-config/src/index.ts
@@ -1,2 +1,2 @@
-export { getRedisConnection } from "./redis.js";
+export { getRedisConnection, CLINICAL_EVENTS_JOB_OPTIONS } from "./redis.js";
 export type { RedisConnectionOptions } from "./redis.js";

--- a/packages/redis-config/src/redis.test.ts
+++ b/packages/redis-config/src/redis.test.ts
@@ -79,6 +79,15 @@ describe("getRedisConnection", () => {
 });
 
 describe("CLINICAL_EVENTS_JOB_OPTIONS", () => {
+  it("pins attempts=8 and base delay=2000 ms", () => {
+    // Pin the exact invariants the retry-budget calculation depends on;
+    // the ≥4-min floor below is a derived consequence. Changing either
+    // value without touching these assertions is a silent behavior
+    // change the floor assertion would miss.
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.attempts).toBe(8);
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.backoff.delay).toBe(2000);
+  });
+
   it("provides at least 4 minutes of cumulative retry tolerance", () => {
     // 8 attempts with exponential backoff base 2000 ms:
     // 0 + 2 + 4 + 8 + 16 + 32 + 64 + 128 = 254 s ~= 4.2 min

--- a/packages/redis-config/src/redis.test.ts
+++ b/packages/redis-config/src/redis.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { getRedisConnection } from "./redis.js";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "./redis.js";
 
 describe("getRedisConnection", () => {
   const originalEnv = { ...process.env };
@@ -72,5 +75,26 @@ describe("getRedisConnection", () => {
       password: "p@ss",
       tls: {},
     });
+  });
+});
+
+describe("CLINICAL_EVENTS_JOB_OPTIONS", () => {
+  it("provides at least 4 minutes of cumulative retry tolerance", () => {
+    // 8 attempts with exponential backoff base 2000 ms:
+    // 0 + 2 + 4 + 8 + 16 + 32 + 64 + 128 = 254 s ~= 4.2 min
+    const base = CLINICAL_EVENTS_JOB_OPTIONS.backoff.delay;
+    const attempts = CLINICAL_EVENTS_JOB_OPTIONS.attempts;
+    let totalMs = 0;
+    for (let i = 1; i < attempts; i++) totalMs += base * 2 ** (i - 1);
+    expect(totalMs).toBeGreaterThanOrEqual(240_000);
+  });
+
+  it("uses exponential backoff", () => {
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.backoff.type).toBe("exponential");
+  });
+
+  it("keeps history bounded", () => {
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnComplete).toEqual({ count: 1000 });
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnFail).toEqual({ count: 10000 });
   });
 });

--- a/packages/redis-config/src/redis.ts
+++ b/packages/redis-config/src/redis.ts
@@ -21,3 +21,24 @@ export function getRedisConnection(): RedisConnectionOptions {
     ...(process.env.REDIS_TLS === "true" ? { tls: {} } : {}),
   };
 }
+
+/**
+ * BullMQ defaultJobOptions shared across every "clinical-events" publisher.
+ *
+ * Healthcare-critical: a Redis blip longer than the retry budget means the
+ * event lands in the DLQ and the downstream AI oversight review may never
+ * run. With 8 attempts and 2 s exponential backoff, the cumulative retry
+ * window is ~4 minutes (2+4+8+16+32+64+128 s), which tolerates the 90 s
+ * outage surfaced in issue #267 with generous margin.
+ *
+ * Exposing this as a shared constant keeps the six producers (api-gateway,
+ * clinical-data, clinical-notes, patient-records, messaging, and the
+ * clinical events emitted from within services/messaging) in lockstep so
+ * future bumps can't drift.
+ */
+export const CLINICAL_EVENTS_JOB_OPTIONS = {
+  attempts: 8,
+  backoff: { type: "exponential" as const, delay: 2000 },
+  removeOnComplete: { count: 1000 },
+  removeOnFail: { count: 10000 },
+};

--- a/packages/redis-config/src/redis.ts
+++ b/packages/redis-config/src/redis.ts
@@ -31,10 +31,9 @@ export function getRedisConnection(): RedisConnectionOptions {
  * window is ~4 minutes (2+4+8+16+32+64+128 s), which tolerates the 90 s
  * outage surfaced in issue #267 with generous margin.
  *
- * Exposing this as a shared constant keeps the six producers (api-gateway,
- * clinical-data, clinical-notes, patient-records, messaging, and the
- * clinical events emitted from within services/messaging) in lockstep so
- * future bumps can't drift.
+ * Exposing this as a shared constant keeps the clinical-events publishers
+ * (api-gateway, clinical-data, clinical-notes, patient-records, and
+ * messaging) in lockstep so future bumps can't drift.
  */
 export const CLINICAL_EVENTS_JOB_OPTIONS = {
   attempts: 8,

--- a/services/api-gateway/src/routers/messaging.ts
+++ b/services/api-gateway/src/routers/messaging.ts
@@ -16,7 +16,10 @@ import {
 } from "@carebridge/db-schema";
 import { eq, and, desc, inArray } from "drizzle-orm";
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
 
@@ -34,12 +37,7 @@ const protectedProcedure = t.procedure.use(isAuthenticated);
 const connection = getRedisConnection();
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 10000 },
-  },
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
 /** Verify the authenticated user is a participant in the conversation. */

--- a/services/clinical-data/src/__tests__/events.test.ts
+++ b/services/clinical-data/src/__tests__/events.test.ts
@@ -9,6 +9,12 @@ vi.mock("bullmq", () => ({
 
 vi.mock("@carebridge/redis-config", () => ({
   getRedisConnection: () => ({}),
+  CLINICAL_EVENTS_JOB_OPTIONS: {
+    attempts: 8,
+    backoff: { type: "exponential" as const, delay: 2000 },
+    removeOnComplete: { count: 1000 },
+    removeOnFail: { count: 10000 },
+  },
 }));
 
 // ── Mock DB ─────────────────────────────────────────────────────

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -1,5 +1,8 @@
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
 import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
@@ -9,12 +12,7 @@ const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 10000 },
-  },
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -1,5 +1,8 @@
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
 import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
 import type { ClinicalEvent } from "@carebridge/shared-types";
 
@@ -9,12 +12,7 @@ const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 10000 },
-  },
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {

--- a/services/messaging/src/router.ts
+++ b/services/messaging/src/router.ts
@@ -16,7 +16,10 @@ import {
 } from "@carebridge/db-schema";
 import { eq, and, desc, inArray } from "drizzle-orm";
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
 import crypto from "node:crypto";
 
 const t = initTRPC.create();
@@ -25,12 +28,7 @@ const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 10000 },
-  },
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
 export const messagingRouter = t.router({

--- a/services/patient-records/src/router.ts
+++ b/services/patient-records/src/router.ts
@@ -12,19 +12,17 @@ import {
 } from "@carebridge/validators";
 import { eq, desc } from "drizzle-orm";
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
 import crypto from "node:crypto";
 
 const connection = getRedisConnection();
 
 const clinicalEventsQueue = new Queue("clinical-events", {
   connection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
-    removeOnFail: { count: 10000 },
-  },
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
 const t = initTRPC.create();


### PR DESCRIPTION
Closes #267

## Summary
- Bumps the clinical-events BullMQ retry budget from ~62 s (5 attempts) to ~254 s (8 attempts), same 2 s exponential backoff
- Centralizes the config in \`@carebridge/redis-config\` as \`CLINICAL_EVENTS_JOB_OPTIONS\` so the five publishers can't drift

## Why
A 90 s Redis blip or worker restart exceeds the old budget and silently drops clinical events to the DLQ. For an AI-oversight-gated pipeline, lost events mean the safety review never runs.

| | attempts | cumulative retry | tolerates |
|---|---|---|---|
| before | 5 | 2+4+8+16+32 = 62 s | ~45 s outage |
| after  | 8 | 2+4+8+16+32+64+128 = 254 s | ~3 min outage |

## Files touched
- \`packages/redis-config/src/redis.ts\` — add \`CLINICAL_EVENTS_JOB_OPTIONS\` constant (+ export)
- \`packages/redis-config/src/redis.test.ts\` — 3 new tests asserting the 4-min floor, exponential type, and bounded history
- \`services/{clinical-data,clinical-notes,patient-records,messaging}/src/...\` — replace inline options with the shared constant
- \`services/api-gateway/src/routers/messaging.ts\` — same

Other queues (notifications, escalation, auth cleanup, DLQs) intentionally untouched — different reliability profiles.

## Test plan
- [x] \`pnpm --filter @carebridge/redis-config test\` — 10/10 pass
- [x] \`pnpm typecheck\` — clean across all 19 packages
- [x] \`pnpm lint\` — clean