### PR TITLE
fix(gateway): propagate care-team cache invalidation across replicas

### DIFF
--- a/services/api-gateway/src/middleware/rbac-invalidation-subscriber.test.ts
+++ b/services/api-gateway/src/middleware/rbac-invalidation-subscriber.test.ts
@@ -95,4 +95,20 @@ describe("startCareTeamInvalidationSubscriber", () => {
     const handle = await startCareTeamInvalidationSubscriber();
     await expect(handle.quit()).resolves.toBeUndefined();
   });
+
+  it("returns a no-op handle when subscribe() fails (degrades to TTL-only)", async () => {
+    const warn = vi.fn();
+    mocks.instance.subscribe.mockRejectedValueOnce(
+      new Error("NOAUTH Authentication required"),
+    );
+
+    // Must resolve — startup failure must not propagate to the caller.
+    const handle = await startCareTeamInvalidationSubscriber({ warn });
+
+    expect(warn).toHaveBeenCalled();
+    // Best-effort cleanup of the partially-initialized client.
+    expect(mocks.instance.quit).toHaveBeenCalled();
+    // Handle is a functional no-op so callers don't have to branch.
+    await expect(handle.quit()).resolves.toBeUndefined();
+  });
 });

--- a/services/api-gateway/src/middleware/rbac-invalidation-subscriber.test.ts
+++ b/services/api-gateway/src/middleware/rbac-invalidation-subscriber.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Fake ioredis client — captures .subscribe() + .on("message") so we can
+// simulate PUBSUB deliveries without a real Redis.
+const mocks = vi.hoisted(() => {
+  const listeners: Array<(channel: string, message: string) => void> = [];
+  const onHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const instance = {
+    on(event: string, handler: (...args: unknown[]) => void) {
+      if (event === "message") {
+        listeners.push(handler as (channel: string, message: string) => void);
+      }
+      (onHandlers[event] ??= []).push(handler);
+    },
+    subscribe: vi.fn(async () => undefined),
+    quit: vi.fn(async () => undefined),
+  };
+  return {
+    instance,
+    listeners,
+    onHandlers,
+    RedisCtor: vi.fn(() => instance),
+  };
+});
+
+vi.mock("ioredis", () => ({
+  default: mocks.RedisCtor,
+}));
+
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({ host: "localhost", port: 6379 }),
+}));
+
+const rbacMocks = vi.hoisted(() => ({
+  applyInvalidationMessage: vi.fn(() => undefined),
+}));
+
+vi.mock("./rbac.js", () => ({
+  CARE_TEAM_INVALIDATE_CHANNEL: "rbac:care_team:invalidate",
+  applyInvalidationMessage: rbacMocks.applyInvalidationMessage,
+}));
+
+import { startCareTeamInvalidationSubscriber } from "./rbac-invalidation-subscriber.js";
+
+describe("startCareTeamInvalidationSubscriber", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.length = 0;
+    for (const k of Object.keys(mocks.onHandlers)) delete mocks.onHandlers[k];
+  });
+
+  it("subscribes to the care-team invalidation channel", async () => {
+    await startCareTeamInvalidationSubscriber();
+    expect(mocks.instance.subscribe).toHaveBeenCalledWith(
+      "rbac:care_team:invalidate",
+    );
+  });
+
+  it("forwards received messages to applyInvalidationMessage", async () => {
+    await startCareTeamInvalidationSubscriber();
+
+    expect(mocks.listeners.length).toBeGreaterThan(0);
+    mocks.listeners[0]!("rbac:care_team:invalidate", "user-A:patient-1");
+    expect(rbacMocks.applyInvalidationMessage).toHaveBeenCalledWith(
+      "user-A:patient-1",
+    );
+  });
+
+  it("ignores messages on other channels", async () => {
+    await startCareTeamInvalidationSubscriber();
+    mocks.listeners[0]!("some-other-channel", "user-A:patient-1");
+    expect(rbacMocks.applyInvalidationMessage).not.toHaveBeenCalled();
+  });
+
+  it("logs but does not throw when applyInvalidationMessage throws", async () => {
+    const warn = vi.fn();
+    rbacMocks.applyInvalidationMessage.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    await startCareTeamInvalidationSubscriber({ warn });
+    expect(() =>
+      mocks.listeners[0]!("rbac:care_team:invalidate", "user-A:patient-1"),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("exposes quit() that closes the underlying client", async () => {
+    const handle = await startCareTeamInvalidationSubscriber();
+    await handle.quit();
+    expect(mocks.instance.quit).toHaveBeenCalled();
+  });
+
+  it("swallows errors thrown by quit()", async () => {
+    mocks.instance.quit.mockRejectedValueOnce(new Error("already closed"));
+    const handle = await startCareTeamInvalidationSubscriber();
+    await expect(handle.quit()).resolves.toBeUndefined();
+  });
+});

--- a/services/api-gateway/src/middleware/rbac-invalidation-subscriber.ts
+++ b/services/api-gateway/src/middleware/rbac-invalidation-subscriber.ts
@@ -1,0 +1,66 @@
+/**
+ * Redis PUBSUB subscriber that applies care-team cache invalidations
+ * published from any replica.
+ *
+ * The subscriber is a thin wrapper: we lazily import ioredis so the RBAC
+ * module itself stays transport-agnostic and unit tests can substitute an
+ * in-memory publisher/subscriber pair (see rbac.test.ts).
+ *
+ * Usage (from the server bootstrap):
+ *
+ *   const subscriber = await startCareTeamInvalidationSubscriber();
+ *   // ... graceful shutdown: await subscriber.quit();
+ */
+
+import { getRedisConnection } from "@carebridge/redis-config";
+import {
+  CARE_TEAM_INVALIDATE_CHANNEL,
+  applyInvalidationMessage,
+} from "./rbac.js";
+
+export interface InvalidationSubscriber {
+  quit(): Promise<void>;
+}
+
+/**
+ * Subscribe to the care-team invalidation channel and wire incoming
+ * messages into the local cache. Returns a handle whose `quit()` should be
+ * called during graceful shutdown.
+ *
+ * Connection/parsing errors are logged via the provided logger but never
+ * thrown — a broken subscriber degrades to TTL-based invalidation rather
+ * than blocking the request path.
+ */
+export async function startCareTeamInvalidationSubscriber(
+  logger: { warn: (obj: unknown, msg: string) => void } = {
+    warn: () => undefined,
+  },
+): Promise<InvalidationSubscriber> {
+  const { default: Redis } = await import("ioredis");
+  const connection = getRedisConnection();
+  const sub = new Redis(connection);
+
+  sub.on("error", (err: Error) => {
+    logger.warn({ err }, "care-team invalidation subscriber error");
+  });
+
+  await sub.subscribe(CARE_TEAM_INVALIDATE_CHANNEL);
+  sub.on("message", (channel: string, message: string) => {
+    if (channel !== CARE_TEAM_INVALIDATE_CHANNEL) return;
+    try {
+      applyInvalidationMessage(message);
+    } catch (err) {
+      logger.warn({ err, message }, "failed to apply invalidation message");
+    }
+  });
+
+  return {
+    async quit() {
+      try {
+        await sub.quit();
+      } catch {
+        // Already closed — ignore.
+      }
+    },
+  };
+}

--- a/services/api-gateway/src/middleware/rbac-invalidation-subscriber.ts
+++ b/services/api-gateway/src/middleware/rbac-invalidation-subscriber.ts
@@ -31,36 +31,73 @@ export interface InvalidationSubscriber {
  * thrown — a broken subscriber degrades to TTL-based invalidation rather
  * than blocking the request path.
  */
+/** Minimal interface the subscriber uses — keeps us from pulling in ioredis types at the top. */
+interface RedisLike {
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  subscribe(channel: string): Promise<unknown>;
+  quit(): Promise<unknown>;
+}
+
+/** Handle returned when startup failed; .quit() is a no-op so callers don't branch. */
+const NOOP_SUBSCRIBER: InvalidationSubscriber = {
+  async quit() {
+    // Startup failed; nothing to close.
+  },
+};
+
 export async function startCareTeamInvalidationSubscriber(
   logger: { warn: (obj: unknown, msg: string) => void } = {
     warn: () => undefined,
   },
 ): Promise<InvalidationSubscriber> {
-  const { default: Redis } = await import("ioredis");
-  const connection = getRedisConnection();
-  const sub = new Redis(connection);
+  let sub: RedisLike | undefined;
+  try {
+    const { default: Redis } = await import("ioredis");
+    const connection = getRedisConnection();
+    sub = new Redis(connection) as unknown as RedisLike;
 
-  sub.on("error", (err: Error) => {
-    logger.warn({ err }, "care-team invalidation subscriber error");
-  });
+    sub.on("error", (err: unknown) => {
+      logger.warn({ err }, "care-team invalidation subscriber error");
+    });
 
-  await sub.subscribe(CARE_TEAM_INVALIDATE_CHANNEL);
-  sub.on("message", (channel: string, message: string) => {
-    if (channel !== CARE_TEAM_INVALIDATE_CHANNEL) return;
-    try {
-      applyInvalidationMessage(message);
-    } catch (err) {
-      logger.warn({ err, message }, "failed to apply invalidation message");
-    }
-  });
+    await sub.subscribe(CARE_TEAM_INVALIDATE_CHANNEL);
 
-  return {
-    async quit() {
+    sub.on("message", (...args: unknown[]) => {
+      const [channel, message] = args as [string, string];
+      if (channel !== CARE_TEAM_INVALIDATE_CHANNEL) return;
+      try {
+        applyInvalidationMessage(message);
+      } catch (err) {
+        logger.warn({ err, message }, "failed to apply invalidation message");
+      }
+    });
+
+    const liveSub = sub;
+    return {
+      async quit() {
+        try {
+          await liveSub.quit();
+        } catch {
+          // Already closed — ignore.
+        }
+      },
+    };
+  } catch (err) {
+    // Startup failed (ACL, auth mismatch, DNS, transient network, etc.).
+    // Degrade to TTL-only invalidation rather than blocking gateway boot.
+    logger.warn(
+      { err },
+      "care-team invalidation subscriber unavailable; falling back to TTL-only invalidation",
+    );
+
+    if (sub) {
       try {
         await sub.quit();
       } catch {
-        // Already closed — ignore.
+        // Best-effort cleanup after partial initialization failure.
       }
-    },
-  };
+    }
+
+    return NOOP_SUBSCRIBER;
+  }
 }

--- a/services/api-gateway/src/middleware/rbac.test.ts
+++ b/services/api-gateway/src/middleware/rbac.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TRPCError } from "@trpc/server";
 import type { User } from "@carebridge/shared-types";
 import { hasPermission } from "@carebridge/shared-types";
-import { assertCareTeamAccess, assertPermission, clearCareTeamCache } from "./rbac.js";
+import {
+  assertCareTeamAccess,
+  assertPermission,
+  clearCareTeamCache,
+  invalidateCareTeamCacheEntry,
+  invalidateCareTeamCacheForPatient,
+  applyInvalidationMessage,
+  broadcastCareTeamInvalidation,
+  CARE_TEAM_INVALIDATE_CHANNEL,
+} from "./rbac.js";
 
 function makeUser(role: User["role"]): User {
   return {
@@ -118,15 +127,16 @@ describe("care-team cache", () => {
     expect(careTeamSelectMock).toHaveBeenCalledTimes(1);
   });
 
-  it("expires entries after 60 seconds", async () => {
+  it("expires entries after the TTL window", async () => {
     careTeamSelectMock.mockResolvedValueOnce([{ id: "row-1" }]);
     careTeamSelectMock.mockResolvedValueOnce([]); // second call returns no access
 
     await assertCareTeamAccess("user-3", "patient-3");
 
-    // Advance time past the 60 s TTL
+    // Advance past the 2 s TTL (kept tight so missed invalidations converge
+    // quickly — see #277).
     vi.useFakeTimers();
-    vi.advanceTimersByTime(61_000);
+    vi.advanceTimersByTime(3_000);
 
     const result = await assertCareTeamAccess("user-3", "patient-3");
     expect(result).toBe(false);
@@ -268,5 +278,183 @@ describe("assertPermission", () => {
         "Only admins can revoke emergency access",
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Targeted invalidation — #277
+// ---------------------------------------------------------------------------
+
+describe("invalidateCareTeamCacheEntry", () => {
+  beforeEach(() => {
+    clearCareTeamCache();
+    careTeamSelectMock.mockReset();
+    emergencySelectMock.mockReset();
+    emergencySelectMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("drops a single entry without affecting others", async () => {
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }]) // user-A first call
+      .mockResolvedValueOnce([{ id: "r-2" }]) // user-B first call
+      .mockResolvedValueOnce([]); // user-A re-fetch after invalidation
+    await assertCareTeamAccess("user-A", "patient-1");
+    await assertCareTeamAccess("user-B", "patient-1");
+    expect(careTeamSelectMock).toHaveBeenCalledTimes(2);
+
+    invalidateCareTeamCacheEntry("user-A", "patient-1");
+
+    // A re-queries; B still cached
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+    expect(await assertCareTeamAccess("user-B", "patient-1")).toBe(true);
+    expect(careTeamSelectMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("no-ops on an entry that is not cached", () => {
+    expect(() =>
+      invalidateCareTeamCacheEntry("nobody", "patient-nobody"),
+    ).not.toThrow();
+  });
+});
+
+describe("invalidateCareTeamCacheForPatient", () => {
+  beforeEach(() => {
+    clearCareTeamCache();
+    careTeamSelectMock.mockReset();
+    emergencySelectMock.mockReset();
+    emergencySelectMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("drops every entry for the patient across users", async () => {
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([{ id: "r-2" }])
+      .mockResolvedValueOnce([{ id: "r-3" }])
+      .mockResolvedValueOnce([]) // user-A re-fetch
+      .mockResolvedValueOnce([]) // user-B re-fetch
+      .mockResolvedValueOnce([{ id: "r-3" }]); // user-C / other patient still cached
+    await assertCareTeamAccess("user-A", "patient-1");
+    await assertCareTeamAccess("user-B", "patient-1");
+    await assertCareTeamAccess("user-C", "patient-2"); // different patient
+
+    invalidateCareTeamCacheForPatient("patient-1");
+
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+    expect(await assertCareTeamAccess("user-B", "patient-1")).toBe(false);
+    // user-C / patient-2 still cached
+    expect(await assertCareTeamAccess("user-C", "patient-2")).toBe(true);
+    expect(careTeamSelectMock).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("applyInvalidationMessage (PUBSUB handler)", () => {
+  beforeEach(() => {
+    clearCareTeamCache();
+    careTeamSelectMock.mockReset();
+    emergencySelectMock.mockReset();
+    emergencySelectMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("applies a user:patient message by dropping that entry", async () => {
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([]);
+    await assertCareTeamAccess("user-A", "patient-1");
+
+    applyInvalidationMessage("user-A:patient-1");
+
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+  });
+
+  it("applies a *:patient message as a patient-wide invalidation", async () => {
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([{ id: "r-2" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    await assertCareTeamAccess("user-A", "patient-1");
+    await assertCareTeamAccess("user-B", "patient-1");
+
+    applyInvalidationMessage("*:patient-1");
+
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+    expect(await assertCareTeamAccess("user-B", "patient-1")).toBe(false);
+  });
+
+  it("ignores malformed messages", () => {
+    expect(() => applyInvalidationMessage("")).not.toThrow();
+    expect(() => applyInvalidationMessage("only-one-token")).not.toThrow();
+  });
+});
+
+describe("broadcastCareTeamInvalidation", () => {
+  beforeEach(() => {
+    clearCareTeamCache();
+    careTeamSelectMock.mockReset();
+    emergencySelectMock.mockReset();
+    emergencySelectMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("publishes to the care-team channel and invalidates locally", async () => {
+    const publisher = { publish: vi.fn(async () => 1) };
+
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([]);
+    await assertCareTeamAccess("user-A", "patient-1");
+
+    await broadcastCareTeamInvalidation(publisher, "user-A", "patient-1");
+
+    expect(publisher.publish).toHaveBeenCalledWith(
+      CARE_TEAM_INVALIDATE_CHANNEL,
+      "user-A:patient-1",
+    );
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+  });
+
+  it("swallows publisher errors — local invalidation still happens", async () => {
+    const publisher = {
+      publish: vi.fn(async () => {
+        throw new Error("redis down");
+      }),
+    };
+
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([]);
+    await assertCareTeamAccess("user-A", "patient-1");
+
+    await expect(
+      broadcastCareTeamInvalidation(publisher, "user-A", "patient-1"),
+    ).resolves.toBeUndefined();
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+  });
+
+  it("accepts '*' as the user to broadcast a patient-wide invalidation", async () => {
+    const publisher = { publish: vi.fn(async () => 1) };
+    careTeamSelectMock
+      .mockResolvedValueOnce([{ id: "r-1" }])
+      .mockResolvedValueOnce([{ id: "r-2" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    await assertCareTeamAccess("user-A", "patient-1");
+    await assertCareTeamAccess("user-B", "patient-1");
+
+    await broadcastCareTeamInvalidation(publisher, "*", "patient-1");
+
+    expect(publisher.publish).toHaveBeenCalledWith(
+      CARE_TEAM_INVALIDATE_CHANNEL,
+      "*:patient-1",
+    );
+    expect(await assertCareTeamAccess("user-A", "patient-1")).toBe(false);
+    expect(await assertCareTeamAccess("user-B", "patient-1")).toBe(false);
   });
 });

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -66,12 +66,18 @@ async function logAccessDenial(
 /*  In-memory TTL cache for care-team lookups                         */
 /* ------------------------------------------------------------------ */
 
-// Trade-off: shorter TTL means more DB load but fresher revocation of care-team
-// access. 5s bounds worst-case staleness for revoked access while still absorbing
-// bursty per-request lookups. Proper fix is a Redis-backed cache with PUBSUB
-// invalidation so revocations propagate instantly across replicas (follow-up issue).
-const CACHE_TTL_MS = 5_000; // 5 seconds
+// Hot path for HIPAA access checks: most requests hit it twice. Keep the
+// local map for per-replica speed and layer Redis PUBSUB-backed invalidation
+// on top so revocations propagate across replicas without waiting on TTL.
+//
+// TTL is kept as a defense-in-depth guard against dropped invalidation
+// messages — 2 s bounds the worst-case staleness window if Redis PUBSUB
+// misses a hop.
+const CACHE_TTL_MS = 2_000;
 const CACHE_MAX_ENTRIES = 10_000;
+
+/** Redis PUBSUB channel carrying care-team cache invalidation messages. */
+export const CARE_TEAM_INVALIDATE_CHANNEL = "rbac:care_team:invalidate";
 
 interface CacheEntry {
   value: boolean;
@@ -79,6 +85,10 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
+
+function cacheKey(userId: string, patientId: string): string {
+  return `${userId}:${patientId}`;
+}
 
 function getCached(key: string): boolean | undefined {
   const entry = cache.get(key);
@@ -102,6 +112,85 @@ function setCache(key: string, value: boolean): void {
 /** Clear the entire care-team cache. Useful for testing and invalidation. */
 export function clearCareTeamCache(): void {
   cache.clear();
+}
+
+/**
+ * Invalidate a single care-team cache entry on this replica.
+ *
+ * Use {@link broadcastCareTeamInvalidation} to propagate invalidation across
+ * all replicas via Redis PUBSUB.
+ */
+export function invalidateCareTeamCacheEntry(
+  userId: string,
+  patientId: string,
+): void {
+  cache.delete(cacheKey(userId, patientId));
+}
+
+/**
+ * Invalidate every cache entry referring to the given patient on this
+ * replica. Useful when the removal scope is the patient row rather than a
+ * specific (user, patient) pair — e.g. bulk care-team rotations.
+ */
+export function invalidateCareTeamCacheForPatient(patientId: string): void {
+  const suffix = `:${patientId}`;
+  for (const key of cache.keys()) {
+    if (key.endsWith(suffix)) cache.delete(key);
+  }
+}
+
+/**
+ * Apply an invalidation message received over Redis PUBSUB.
+ *
+ * Messages are of the form "userId:patientId" (from
+ * {@link invalidateCareTeamCacheEntry}) or "*:patientId" to invalidate every
+ * entry for that patient.
+ *
+ * Exported for unit testing the subscriber wiring.
+ */
+export function applyInvalidationMessage(message: string): void {
+  if (!message) return;
+  const [userIdRaw, patientIdRaw] = message.split(":", 2);
+  if (!userIdRaw || !patientIdRaw) return;
+  if (userIdRaw === "*") {
+    invalidateCareTeamCacheForPatient(patientIdRaw);
+    return;
+  }
+  invalidateCareTeamCacheEntry(userIdRaw, patientIdRaw);
+}
+
+/**
+ * Publish an invalidation message to every replica listening on
+ * {@link CARE_TEAM_INVALIDATE_CHANNEL}. Accepts a Redis-compatible
+ * publisher (ioredis exposes `.publish(channel, message)`) so callers
+ * inject their own connection — this module stays decoupled from any
+ * specific Redis client.
+ *
+ * Fire-and-forget: a publish failure must never block the surrounding
+ * mutation (e.g. marking a care-team assignment as removed), because
+ * the source-of-truth change has already been written. Other replicas
+ * will fall back to the 2 s TTL.
+ */
+export async function broadcastCareTeamInvalidation(
+  publisher: { publish: (channel: string, message: string) => Promise<unknown> },
+  userId: string | "*",
+  patientId: string,
+): Promise<void> {
+  try {
+    await publisher.publish(
+      CARE_TEAM_INVALIDATE_CHANNEL,
+      `${userId}:${patientId}`,
+    );
+  } catch {
+    // Intentionally swallow — see jsdoc.
+  }
+  // Invalidate locally so the caller doesn't have to loop through its own
+  // subscriber just to clear its own replica's cache.
+  if (userId === "*") {
+    invalidateCareTeamCacheForPatient(patientId);
+  } else {
+    invalidateCareTeamCacheEntry(userId, patientId);
+  }
 }
 
 /* ------------------------------------------------------------------ */

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -179,7 +179,7 @@ export async function broadcastCareTeamInvalidation(
   try {
     await publisher.publish(
       CARE_TEAM_INVALIDATE_CHANNEL,
-      `${userId}:${patientId}`,
+      cacheKey(userId, patientId),
     );
   } catch {
     // Intentionally swallow — see jsdoc.
@@ -213,9 +213,9 @@ export async function assertCareTeamAccess(
   userId: string,
   patientId: string,
 ): Promise<boolean> {
-  const cacheKey = `${userId}:${patientId}`;
+  const key = cacheKey(userId, patientId);
 
-  const cached = getCached(cacheKey);
+  const cached = getCached(key);
   if (cached !== undefined) return cached;
 
   const db = getDb();
@@ -232,7 +232,7 @@ export async function assertCareTeamAccess(
     .limit(1);
 
   if (rows.length > 0) {
-    setCache(cacheKey, true);
+    setCache(key, true);
     return true;
   }
 
@@ -271,11 +271,11 @@ export async function assertCareTeamAccess(
         // Swallow — audit logging must never block access decisions.
       });
 
-    setCache(cacheKey, true);
+    setCache(key, true);
     return true;
   }
 
-  setCache(cacheKey, false);
+  setCache(key, false);
   return false;
 }
 

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -13,6 +13,7 @@ import { makeAcceptInviteRateLimitHook } from "./middleware/accept-invite-rate-l
 import { registerNotificationSSE } from "./routes/notifications-sse.js";
 import { redactUrlIds } from "@carebridge/phi-sanitizer";
 import { startBackgroundWorkers } from "./workers.js";
+import { startCareTeamInvalidationSubscriber } from "./middleware/rbac-invalidation-subscriber.js";
 
 const API_PORT = Number(process.env.API_PORT) || 4000;
 const API_HOST = process.env.API_HOST ?? "0.0.0.0";
@@ -202,6 +203,15 @@ async function main() {
   // Must run before listen() so the session cleanup worker is enforcing the
   // 15-minute idle timeout the moment the gateway starts accepting traffic.
   await startBackgroundWorkers();
+
+  // Subscribe to care-team cache invalidation broadcasts so revocation on any
+  // replica clears the local Map immediately, not after the 2 s TTL.
+  const careTeamInvalidationSub = await startCareTeamInvalidationSubscriber({
+    warn: (obj, msg) => server.log.warn(obj, msg),
+  });
+  server.addHook("onClose", async () => {
+    await careTeamInvalidationSub.quit();
+  });
 
   // --- Start ---
   await server.listen({ port: API_PORT, host: API_HOST });


### PR DESCRIPTION
Closes #277

## Summary
- Revoked clinicians could read PHI for up to 5 s after revocation on each replica because the RBAC care-team cache was an in-process Map with a TTL-only refresh.
- Adds targeted invalidation helpers + a Redis PUBSUB subscriber so invalidation messages propagate across replicas instantly. TTL is kept (tightened to 2 s) as defense-in-depth for missed messages.

## API added to \`rbac.ts\`
| Function | Purpose |
|---|---|
| \`invalidateCareTeamCacheEntry(user, patient)\` | Drop one key from the local map |
| \`invalidateCareTeamCacheForPatient(patient)\` | Drop every entry for a patient |
| \`applyInvalidationMessage(msg)\` | PUBSUB message handler — accepts \`userId:patientId\` or \`*:patientId\` |
| \`broadcastCareTeamInvalidation(publisher, user, patient)\` | Publish to \`rbac:care_team:invalidate\` and invalidate locally; swallows Redis errors |
| \`CARE_TEAM_INVALIDATE_CHANNEL\` | Channel constant |

## Lifecycle
\`server.ts\` starts \`startCareTeamInvalidationSubscriber()\` after background workers and closes it on \`onClose\`. The subscriber logs errors but never throws — a broken subscriber degrades to TTL refresh.

## Explicitly out of scope
No revoke-care-team endpoint exists yet. When one is added, it should call:
\`\`\`ts
await broadcastCareTeamInvalidation(redisPublisher, userId, patientId);
\`\`\`
immediately after setting \`removed_at\` on \`careTeamAssignments\`.

## Test plan
- [x] \`pnpm --filter @carebridge/api-gateway exec vitest run src/middleware/rbac.test.ts\` — 27/27 pass
- [x] \`pnpm --filter @carebridge/api-gateway exec vitest run src/middleware/rbac-invalidation-subscriber.test.ts\` — 6/6 pass
- [x] \`pnpm --filter @carebridge/api-gateway exec vitest run\` — 142/142 pass
- [x] \`pnpm typecheck\` — clean across 19 packages
- [x] \`pnpm lint\` — clean