### PR TITLE
fix(ai): split CHEMO-FEVER rule for confirmed febrile neutropenia

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -8,7 +8,7 @@ import {
   type PatientContext,
 } from "../rules/cross-specialty.js";
 
-describe("CHEMO-FEVER-001 — ANC-aware behavior", () => {
+describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   const baseCtx = (overrides: Partial<PatientContext> = {}): PatientContext => ({
     active_diagnoses: ["Breast cancer"],
     active_diagnosis_codes: ["C50.9"],
@@ -18,30 +18,80 @@ describe("CHEMO-FEVER-001 — ANC-aware behavior", () => {
     ...overrides,
   });
 
-  it("fires CRITICAL when ANC < 1500 (febrile neutropenia)", () => {
+  it("fires CHEMO-NEUTRO-FEVER-001 (critical) when ANC < 1500 — and suppresses the warning rule", () => {
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800 }] });
+    const flags = checkCrossSpecialtyPatterns(ctx);
+
+    const critical = flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001");
+    expect(critical).toBeDefined();
+    expect(critical!.severity).toBe("critical");
+
+    // CHEMO-FEVER-001 must NOT fire once febrile neutropenia is confirmed —
+    // the critical rule owns that case; the warning rule only prompts a CBC.
+    expect(flags.find((f) => f.rule_id === "CHEMO-FEVER-001")).toBeUndefined();
+  });
+
+  it("adds a severe-neutropenia addendum when ANC < 500", () => {
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 200 }] });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
+    );
+    expect(flag!.suggested_action).toMatch(/Severe neutropenia \(ANC < 500\)/);
+    expect(flag!.suggested_action).toMatch(/reverse isolation/);
+  });
+
+  it("omits the severe-neutropenia addendum when 500 <= ANC < 1500", () => {
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 1200 }] });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
+    );
+    expect(flag!.suggested_action).not.toMatch(/Severe neutropenia/);
+  });
+
+  it("fires CHEMO-FEVER-001 (warning) when ANC is unknown", () => {
+    const ctx = baseCtx({ recent_labs: [] });
+    const flags = checkCrossSpecialtyPatterns(ctx);
+
+    const warning = flags.find((f) => f.rule_id === "CHEMO-FEVER-001");
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe("warning");
+
+    // Critical rule must NOT fire without confirmed ANC data.
+    expect(
+      flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001"),
+    ).toBeUndefined();
+  });
+
+  it("fires neither rule when ANC is normal (>= 1500)", () => {
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 3200 }] });
+    const flags = checkCrossSpecialtyPatterns(ctx);
+
+    expect(flags.find((f) => f.rule_id === "CHEMO-FEVER-001")).toBeUndefined();
+    expect(
+      flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001"),
+    ).toBeUndefined();
+  });
+
+  it("CHEMO-NEUTRO-FEVER-001 notifies emergency as well as oncology/infectious_disease", () => {
     const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800 }] });
     const flag = checkCrossSpecialtyPatterns(ctx).find(
-      (f) => f.rule_id === "CHEMO-FEVER-001",
+      (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
-    expect(flag).toBeDefined();
-    expect(flag!.severity).toBe("critical");
+    expect(flag!.notify_specialties).toEqual(
+      expect.arrayContaining(["oncology", "infectious_disease", "emergency"]),
+    );
   });
 
-  it("fires only WARNING when ANC is unknown (no recent labs)", () => {
-    const ctx = baseCtx({ recent_labs: [] });
-    const flag = checkCrossSpecialtyPatterns(ctx).find(
-      (f) => f.rule_id === "CHEMO-FEVER-001",
-    );
-    expect(flag).toBeDefined();
-    expect(flag!.severity).toBe("warning");
-  });
-
-  it("does NOT fire when ANC is normal (>= 1500)", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 3200 }] });
-    const flag = checkCrossSpecialtyPatterns(ctx).find(
-      (f) => f.rule_id === "CHEMO-FEVER-001",
-    );
-    expect(flag).toBeUndefined();
+  it("does not fire either rule when patient is not on chemo", () => {
+    const ctx = baseCtx({
+      active_medications: ["Lisinopril"],
+      recent_labs: [{ name: "ANC", value: 800 }],
+    });
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    expect(flags.find((f) => f.rule_id === "CHEMO-FEVER-001")).toBeUndefined();
+    expect(
+      flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001"),
+    ).toBeUndefined();
   });
 });
 

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -36,6 +36,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
+    expect(flag).toBeDefined();
     expect(flag!.suggested_action).toMatch(/Severe neutropenia \(ANC < 500\)/);
     expect(flag!.suggested_action).toMatch(/reverse isolation/);
   });
@@ -45,6 +46,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
+    expect(flag).toBeDefined();
     expect(flag!.suggested_action).not.toMatch(/Severe neutropenia/);
   });
 
@@ -77,6 +79,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
+    expect(flag).toBeDefined();
     expect(flag!.notify_specialties).toEqual(
       expect.arrayContaining(["oncology", "infectious_disease", "emergency"]),
     );

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -53,6 +53,16 @@ const CATEGORY_D_TERATOGEN_PATTERN =
 const ANTICOAGULANT_PATTERN =
   /warfarin|coumadin|heparin|enoxaparin|lovenox|rivaroxaban|xarelto|apixaban|eliquis|dabigatran|pradaxa|edoxaban|savaysa|fondaparinux|arixtra/i;
 
+/**
+ * Chemotherapy agent name pattern. Shared by CHEMO-FEVER-001 and
+ * CHEMO-NEUTRO-FEVER-001 so both rules classify the same set of regimens.
+ */
+const CHEMO_MED_PATTERN =
+  /chemo|capecitabine|xeloda|cisplatin|carboplatin|doxorubicin|cyclophosphamide|paclitaxel|docetaxel|methotrexate|5-fu|fluorouracil/i;
+
+/** Fever-symptom pattern shared across CHEMO-* rules. */
+const FEVER_SYMPTOM_PATTERN = /fever|febrile|temperature|chills/i;
+
 /** ICD-10 pattern for active VTE / DVT / PE diagnoses. */
 const VTE_ICD10_PATTERN = /^(I26|I80|I82)\./;
 
@@ -252,37 +262,77 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
   },
   {
     id: "CHEMO-FEVER-001",
-    name: "Chemotherapy patient with fever (ANC-aware)",
+    name: "Chemotherapy patient with fever (ANC unknown)",
     check: (ctx: PatientContext) => {
       const onChemo = ctx.active_medications.some((m) =>
-        /chemo|capecitabine|xeloda|cisplatin|carboplatin|doxorubicin|cyclophosphamide|paclitaxel|docetaxel|methotrexate|5-fu|fluorouracil/i.test(m),
+        CHEMO_MED_PATTERN.test(m),
       );
       const hasFever = ctx.new_symptoms.some((s) =>
-        /fever|febrile|temperature|chills/i.test(s),
+        FEVER_SYMPTOM_PATTERN.test(s),
       );
       if (!onChemo || !hasFever) return false;
       const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
-      // If we have a recent ANC and it's normal, suppress the flag —
-      // avoids the false-confidence alert that the previous version produced.
-      if (anc !== undefined && anc >= 1500) return false;
+      // ANC >= 1500 → normal neutrophil count, suppress (avoid alert fatigue).
+      // ANC <  1500 → confirmed febrile neutropenia, owned by CHEMO-NEUTRO-FEVER-001.
+      // ANC unknown  → fire this warning to prompt an urgent CBC.
+      if (anc !== undefined) return false;
       return true;
-    },
-    buildSeverity: (ctx: PatientContext) => {
-      const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
-      // ANC < 1500 → confirmed febrile neutropenia → critical.
-      // ANC unknown → warning so clinicians review without alert fatigue.
-      return anc !== undefined && anc < 1500 ? "critical" : "warning";
     },
     severity: "warning" as const,
     category: "cross-specialty" as const,
     summary:
-      "Chemotherapy patient presenting with fever — evaluate for febrile neutropenia and infection",
+      "Chemotherapy patient presenting with fever — obtain CBC urgently to rule out febrile neutropenia",
     rationale:
-      "Obtain CBC with differential urgently. If ANC < 1500, treat as febrile neutropenia per protocol. " +
-      "Consider broad-spectrum antibiotics while awaiting results.",
+      "Recent ANC is unknown. In a chemotherapy patient, any fever must be treated as potential " +
+      "febrile neutropenia until a current ANC confirms otherwise — delayed antibiotics in true " +
+      "febrile neutropenia double 30-day mortality.",
     suggested_action:
-      "Obtain CBC with differential urgently. If ANC < 1500, treat as febrile neutropenia per protocol. Consider broad-spectrum antibiotics while awaiting results.",
+      "Obtain CBC with differential STAT. If ANC < 1500, escalate to febrile-neutropenia protocol " +
+      "and start broad-spectrum antibiotics within 60 minutes of fever onset.",
     notify_specialties: ["oncology", "infectious_disease"],
+  },
+  {
+    id: "CHEMO-NEUTRO-FEVER-001",
+    name: "Confirmed febrile neutropenia (chemo + fever + ANC < 1500)",
+    check: (ctx: PatientContext) => {
+      const onChemo = ctx.active_medications.some((m) =>
+        CHEMO_MED_PATTERN.test(m),
+      );
+      const hasFever = ctx.new_symptoms.some((s) =>
+        FEVER_SYMPTOM_PATTERN.test(s),
+      );
+      if (!onChemo || !hasFever) return false;
+      const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
+      // Only fire when ANC is known AND below the febrile-neutropenia threshold.
+      return anc !== undefined && anc < 1500;
+    },
+    buildSuggestedAction: (ctx: PatientContext) => {
+      const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
+      const base =
+        "ED-level emergency: confirmed febrile neutropenia. Start broad-spectrum IV antibiotics " +
+        "(e.g. cefepime or piperacillin-tazobactam) within 60 minutes of fever onset. Blood and " +
+        "urine cultures before antibiotics if no delay. Admit for inpatient management.";
+      // Severe neutropenia (ANC < 500) carries the highest sepsis/mortality risk.
+      if (anc !== undefined && anc < 500) {
+        return (
+          base +
+          " Severe neutropenia (ANC < 500): add anti-pseudomonal coverage and consider G-CSF; " +
+          "reverse isolation recommended."
+        );
+      }
+      return base;
+    },
+    severity: "critical" as const,
+    category: "cross-specialty" as const,
+    summary:
+      "Febrile neutropenia confirmed — ED-level emergency, antibiotics within 60 minutes",
+    rationale:
+      "Chemotherapy + fever + ANC < 1500 meets the IDSA definition of febrile neutropenia. " +
+      "Infection-related mortality rises sharply for every hour antibiotics are delayed; this is " +
+      "one of the few oncology emergencies where time-to-antibiotic is a direct mortality driver.",
+    suggested_action:
+      "Start broad-spectrum IV antibiotics within 60 minutes of fever onset. Cultures before antibiotics if no delay. Admit.",
+    notify_specialties: ["oncology", "infectious_disease", "emergency"],
   },
   {
     id: "RENAL-NSAID-001",

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -313,11 +313,16 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
         "(e.g. cefepime or piperacillin-tazobactam) within 60 minutes of fever onset. Blood and " +
         "urine cultures before antibiotics if no delay. Admit for inpatient management.";
       // Severe neutropenia (ANC < 500) carries the highest sepsis/mortality risk.
+      // The base regimen already provides anti-pseudomonal coverage; severe
+      // neutropenia warrants additional layers rather than redundant coverage.
       if (anc !== undefined && anc < 500) {
         return (
           base +
-          " Severe neutropenia (ANC < 500): add anti-pseudomonal coverage and consider G-CSF; " +
-          "reverse isolation recommended."
+          " Severe neutropenia (ANC < 500): confirm the empiric regimen provides " +
+          "anti-pseudomonal coverage; add empiric anti-MRSA (e.g. vancomycin) if " +
+          "catheter infection, skin/soft tissue involvement, pneumonia, or " +
+          "hemodynamic instability suspected. Consider G-CSF and recommend " +
+          "reverse isolation."
         );
       }
       return base;


### PR DESCRIPTION
Closes #264

## Summary
- Splits the ANC-aware CHEMO-FEVER-001 rule so that confirmed febrile neutropenia (chemo + fever + ANC < 1500) emits distinct rationale and suggested-action text under a new rule id **CHEMO-NEUTRO-FEVER-001**, with critical severity.
- The original CHEMO-FEVER-001 rule keeps the "ANC unknown — obtain CBC" warning path. The two rules are now mutually exclusive on the ANC branch.

## Behavior matrix
| ANC | Before | After (CHEMO-FEVER-001) | After (CHEMO-NEUTRO-FEVER-001) |
|---|---|---|---|
| unknown | warning (generic text) | warning, "obtain CBC STAT" | — |
| < 1500  | critical (generic text) | suppressed | critical, ED-level antibiotics-in-60-min |
| < 500   | critical (generic text) | suppressed | critical, adds reverse-isolation + anti-pseudomonal + G-CSF |
| >= 1500 | suppressed | suppressed | suppressed |
| no chemo or no fever | does not fire | does not fire | does not fire |

Severity escalation (< 500) lives in \`buildSuggestedAction\`; no change to the rule-runner surface.

\`CHEMO-NEUTRO-FEVER-001\` also adds \`"emergency"\` to \`notify_specialties\` so the ED is paged alongside oncology and infectious_disease.

## Files
- \`services/ai-oversight/src/rules/cross-specialty.ts\` — new rule, shared \`CHEMO_MED_PATTERN\` and \`FEVER_SYMPTOM_PATTERN\`
- \`services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts\` — 7 new cases (mutual exclusion, ANC < 500 addendum, unknown-ANC warning, no-chemo suppression, notify_specialties)

## Test plan
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 260/260 pass
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` — clean
- [x] \`pnpm lint\` — clean