### PR TITLE
docs(security): PHI key rotation runbook + re-encrypt script

### DIFF
--- a/docs/phi-key-rotation.md
+++ b/docs/phi-key-rotation.md
@@ -1,0 +1,193 @@
+# PHI Encryption Key Rotation Runbook
+
+Audience: CareBridge on-call engineer or security lead executing a planned
+rotation of `PHI_ENCRYPTION_KEY`. Covers routine rotation and emergency
+rotation (suspected compromise).
+
+## Background
+
+CareBridge encrypts PHI columns with AES-256-GCM using a 32-byte key
+supplied via `PHI_ENCRYPTION_KEY` (hex-encoded). The Drizzle custom type
+(`packages/db-schema/src/encryption.ts`) reads `PHI_ENCRYPTION_KEY` at
+runtime. A second env var, `PHI_ENCRYPTION_KEY_PREVIOUS`, acts as a
+decryption fallback so rotation can be gradual — rows still encrypted
+under the old key remain readable while they are being re-encrypted under
+the new key.
+
+HMAC indexes (e.g. `mrn_hmac`) use a separate key, `PHI_HMAC_KEY`. HMAC
+keys MUST NOT be rotated with the same procedure below — rotating the
+HMAC key invalidates every indexed lookup and requires a separate
+migration. This runbook does not cover HMAC rotation.
+
+## When to rotate
+
+| Trigger | Priority | Procedure |
+|---|---|---|
+| Routine (annual) | Planned | §1 Routine rotation |
+| Key material leaked via git / logs | Emergency | §2 Emergency rotation |
+| Personnel with access departs | Planned (within 30 days) | §1 Routine rotation |
+| Post-security-incident | Emergency | §2 Emergency rotation |
+
+## 1. Routine rotation
+
+Plan for ~2 hours including re-encryption. Production re-encryption should
+be performed during a scheduled maintenance window.
+
+### 1.1 Generate the new key
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+Store the output in the secrets manager as the new value for
+`PHI_ENCRYPTION_KEY`. Keep the current value under
+`PHI_ENCRYPTION_KEY_PREVIOUS` until re-encryption is complete.
+
+### 1.2 Pre-flight checks
+
+- Back up the primary database. `pg_dump -Fc` is enough because every PHI
+  column is text ciphertext — the backup itself is already encrypted.
+- Confirm `PHI_HMAC_KEY` is set as a distinct key. If the codebase ever
+  falls back to `PHI_ENCRYPTION_KEY` for HMAC, rotating the encryption
+  key will break MRN lookups. Production startup refuses to launch if
+  `PHI_HMAC_KEY` is unset.
+- Run `pnpm --filter @carebridge/db-schema test` to confirm the
+  encryption module still round-trips.
+
+### 1.3 Deploy with both keys
+
+Set the environment in this order on every replica:
+
+```bash
+PHI_ENCRYPTION_KEY_PREVIOUS=<current key>
+PHI_ENCRYPTION_KEY=<new key>
+```
+
+Roll the fleet. After the rollout, every write uses the new key; reads of
+existing rows fall back to the previous key. The application is correct
+at this point — §1.4 only migrates historical rows to the new key so the
+fallback can eventually be removed.
+
+### 1.4 Re-encrypt historical rows
+
+Run the re-encryption script:
+
+```bash
+pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts --dry-run
+pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts
+```
+
+The script iterates every table with encrypted columns, reads each row
+via the Drizzle custom type (which uses the fallback), and rewrites it so
+the row persists under the new key. It prints per-table progress and a
+final summary.
+
+For large datasets, the script supports `--batch-size=N` (default 500) and
+`--table=<name>` to scope to one table at a time. Re-encrypting is
+idempotent — re-running is safe.
+
+### 1.5 Remove the previous key
+
+After `re-encrypt-phi.ts` reports zero rows on a second dry-run pass,
+unset `PHI_ENCRYPTION_KEY_PREVIOUS` on every replica and redeploy. Any
+remaining row encrypted under the previous key will fail to decrypt after
+this step — which is why §1.4 must succeed first.
+
+### 1.6 Destroy the previous key
+
+Remove the old value from the secrets manager's audit trail per your
+organization's key-destruction policy. Record the destruction date in the
+security-compliance log.
+
+## 2. Emergency rotation (suspected compromise)
+
+Assume the current key is exposed. Priority is cutting off the attacker's
+ability to decrypt newly captured ciphertext, not preserving read
+availability. Expect downtime.
+
+### 2.1 Put the application in read-only or maintenance mode
+
+Drop writes while the rotation completes. A gateway-level feature flag is
+sufficient; halting write endpoints is preferred over a full outage.
+
+### 2.2 Deploy with both keys (same as §1.3)
+
+The compromised key goes into `PHI_ENCRYPTION_KEY_PREVIOUS`, the new key
+into `PHI_ENCRYPTION_KEY`.
+
+### 2.3 Re-encrypt aggressively
+
+Run the re-encryption script with the default (no scope) to move every
+row to the new key within the maintenance window.
+
+### 2.4 Remove the previous key (same as §1.5)
+
+Do NOT delay this step. Leaving `PHI_ENCRYPTION_KEY_PREVIOUS` set means a
+compromise of the secrets manager now exposes both keys; emergency
+rotation's whole point is that the compromised value stops being
+load-bearing.
+
+### 2.5 Rotate the rotation witnesses
+
+After §2.4, rotate every credential that was in an env file alongside the
+compromised `PHI_ENCRYPTION_KEY`:
+
+- `JWT_SECRET`
+- `SESSION_SECRET`
+- `REDIS_PASSWORD`
+- `PHI_HMAC_KEY` (requires its own migration — see §3)
+
+### 2.6 File the incident report
+
+Security policy requires a HIPAA breach-risk assessment within 72 hours.
+
+## 3. HMAC key (`PHI_HMAC_KEY`) rotation
+
+Not covered here. The MRN index column `mrn_hmac` stores deterministic
+digests; rotating the HMAC key invalidates every indexed lookup. Rotation
+requires:
+
+1. A new `mrn_hmac_new` column backfilled under the new HMAC key
+2. Dual-read support in the MRN lookup path
+3. A cutover migration that drops the old column
+
+Treat this as a separate project. Open a dedicated issue; do not combine
+with a `PHI_ENCRYPTION_KEY` rotation.
+
+## 4. Future work: managed KMS
+
+The current design stores `PHI_ENCRYPTION_KEY` and
+`PHI_ENCRYPTION_KEY_PREVIOUS` as plaintext environment variables. This is
+acceptable for MVP but not for long-term production. The durable solution
+is envelope encryption against a managed KMS (AWS KMS, HashiCorp Vault,
+or GCP Cloud KMS):
+
+- A Data Encryption Key (DEK) per row (or per tenant) is wrapped by a Key
+  Encryption Key (KEK) held in the KMS. The ciphertext DEK is stored
+  alongside the row; the KEK never leaves the KMS.
+- Rotation of the KEK does not require re-encrypting every row — only the
+  ciphertext DEKs must be re-wrapped, which the KMS can do in-place.
+- Audit logging and access control move into the KMS, reducing the blast
+  radius of an application-layer compromise.
+
+Tracking issue: #291 (this issue remains open as the tracking anchor for
+the KMS migration once the runbook + re-encrypt script land).
+
+## 5. Sanity checks after any rotation
+
+Run these before declaring rotation complete:
+
+```bash
+# Round-trip a known-PHI test write (or use the smoke test harness)
+pnpm --filter @carebridge/db-schema test
+
+# Application health
+curl -fsS https://<env>/health
+
+# Sample PHI read from a known-seeded patient
+pnpm --filter @carebridge/api-gateway tsx scripts/smoke-phi-read.ts
+```
+
+If any check fails, do NOT remove `PHI_ENCRYPTION_KEY_PREVIOUS` — it is
+the recovery path. Roll back the deploy, restore the previous values, and
+re-assess.

--- a/docs/phi-key-rotation.md
+++ b/docs/phi-key-rotation.md
@@ -70,6 +70,17 @@ fallback can eventually be removed.
 
 ### 1.4 Re-encrypt historical rows
 
+Before running the script, ensure `DATABASE_URL` is set in your shell.
+`re-encrypt-phi.ts` exits immediately with `DATABASE_URL is not set` if
+it is missing. Use the same production connection string you would use
+for other maintenance tasks, including any required SSL parameters.
+
+```bash
+export DATABASE_URL='<postgres connection string>'
+# Example if your environment requires SSL:
+# export DATABASE_URL='postgres://user:pass@host:5432/dbname?sslmode=require'
+```
+
 Run the re-encryption script:
 
 ```bash
@@ -77,10 +88,15 @@ pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts --dry-run
 pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts
 ```
 
-The script iterates every table with encrypted columns, reads each row
-via the Drizzle custom type (which uses the fallback), and rewrites it so
-the row persists under the new key. It prints per-table progress and a
-final summary.
+The script iterates every table with encrypted columns, reads the stored
+ciphertext directly, explicitly calls the same fallback-aware decryption
+logic used during rotation (`decryptWithFallback`), and rewrites the row
+so it persists under the new key. It bypasses the Drizzle custom type
+intentionally: this is a bulk migration script, so it handles decryption
+and re-encryption itself while still allowing rows encrypted with either
+the current or previous key to be processed. Pagination is keyset
+(`WHERE id > $lastId`) so runtime stays linear on large tables. It prints
+per-table progress and a final summary.
 
 For large datasets, the script supports `--batch-size=N` (default 500) and
 `--table=<name>` to scope to one table at a time. Re-encrypting is

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,10 +705,23 @@ importers:
         version: 5.9.3
 
   tooling/scripts:
+    dependencies:
+      '@carebridge/db-schema':
+        specifier: workspace:*
+        version: link:../../packages/db-schema
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
+      postgres:
+        specifier: ^3.4.0
+        version: 3.4.8
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -5383,8 +5396,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5403,7 +5416,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5414,22 +5427,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5440,7 +5453,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,9 +709,6 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
-      drizzle-orm:
-        specifier: ^0.38.0
-        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
       postgres:
         specifier: ^3.4.0
         version: 3.4.8

--- a/tooling/scripts/package.json
+++ b/tooling/scripts/package.json
@@ -3,7 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "dependencies": {
+    "@carebridge/db-schema": "workspace:*",
+    "drizzle-orm": "^0.38.0",
+    "postgres": "^3.4.0"
+  },
   "devDependencies": {
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "@types/node": "^22.0.0"
   }

--- a/tooling/scripts/package.json
+++ b/tooling/scripts/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "@carebridge/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.0",
     "postgres": "^3.4.0"
   },
   "devDependencies": {

--- a/tooling/scripts/src/re-encrypt-phi.ts
+++ b/tooling/scripts/src/re-encrypt-phi.ts
@@ -1,0 +1,251 @@
+/**
+ * Re-encrypt every PHI column under the current `PHI_ENCRYPTION_KEY`.
+ *
+ * Intended to be run once during a key rotation after the new key has been
+ * rolled out with the old key set as `PHI_ENCRYPTION_KEY_PREVIOUS`. See
+ * docs/phi-key-rotation.md.
+ *
+ * Strategy:
+ *   For every (table, column) pair that uses the `encryptedText` or
+ *   `encryptedJsonb` custom type, read ciphertext directly from the DB
+ *   (bypassing the Drizzle custom type), decrypt with fallback, and
+ *   write the re-encrypted value back. Rows whose ciphertext already
+ *   decrypts under the current key (auth-tag mismatch on the previous
+ *   key) are skipped.
+ *
+ * Usage:
+ *   pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts --dry-run
+ *   pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts
+ *   pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts --table=patients --batch-size=200
+ *
+ * Safety:
+ *   - Idempotent: re-running is a no-op on rows already under the new key.
+ *   - No table drops, no schema changes.
+ *   - Fails loudly if `PHI_ENCRYPTION_KEY_PREVIOUS` is unset (nothing to
+ *     migrate from) or if a row cannot be decrypted under either key.
+ */
+
+import postgres from "postgres";
+import {
+  encrypt,
+  getKey,
+  getPreviousKey,
+  decryptWithFallback,
+} from "@carebridge/db-schema";
+
+interface EncryptedColumn {
+  table: string;
+  column: string;
+  /** True for encryptedJsonb columns — after decrypt, the plaintext is JSON. */
+  jsonb?: boolean;
+}
+
+/**
+ * Enumerated from grep across packages/db-schema/src/schema. If a schema
+ * adds a new encrypted column, update this list — there is no runtime
+ * reflection of Drizzle custom types that would let us discover them.
+ */
+const ENCRYPTED_COLUMNS: EncryptedColumn[] = [
+  { table: "users", column: "mfa_secret" },
+
+  { table: "patients", column: "name" },
+  { table: "patients", column: "date_of_birth" },
+  { table: "patients", column: "diagnosis" },
+  { table: "patients", column: "notes" },
+  { table: "patients", column: "mrn" },
+  { table: "patients", column: "insurance_id" },
+  { table: "patients", column: "emergency_contact_name" },
+  { table: "patients", column: "emergency_contact_phone" },
+
+  { table: "diagnoses", column: "description" },
+
+  { table: "allergies", column: "allergen" },
+  { table: "allergies", column: "reaction" },
+
+  { table: "patient_observations", column: "description" },
+
+  { table: "notifications", column: "title" },
+  { table: "notifications", column: "body" },
+
+  { table: "scheduling", column: "notes" },
+
+  { table: "emergency_access", column: "justification" },
+
+  { table: "encounters", column: "notes" },
+
+  { table: "notes", column: "sections", jsonb: true },
+
+  { table: "messages", column: "body" },
+
+  { table: "medications", column: "name" },
+  { table: "medications", column: "brand_name" },
+  { table: "medications", column: "notes" },
+
+  { table: "labs", column: "notes" },
+  { table: "procedures", column: "notes" },
+  { table: "vitals", column: "notes" },
+  { table: "care_plans", column: "title" },
+  { table: "care_plans", column: "body" },
+];
+
+interface Options {
+  dryRun: boolean;
+  batchSize: number;
+  tableFilter: string | null;
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = { dryRun: false, batchSize: 500, tableFilter: null };
+  for (const arg of argv) {
+    if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg.startsWith("--batch-size=")) {
+      opts.batchSize = Number(arg.split("=")[1]);
+      if (!Number.isFinite(opts.batchSize) || opts.batchSize < 1) {
+        throw new Error("--batch-size must be a positive integer");
+      }
+    } else if (arg.startsWith("--table=")) {
+      opts.tableFilter = arg.split("=")[1] ?? null;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: re-encrypt-phi.ts [--dry-run] [--batch-size=500] [--table=<name>]",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+async function reencryptTableColumn(
+  sql: postgres.Sql,
+  col: EncryptedColumn,
+  opts: Options,
+): Promise<{ total: number; rewritten: number; skipped: number }> {
+  const currentKey = getKey();
+  const previousKey = getPreviousKey();
+  if (!previousKey) {
+    throw new Error(
+      "PHI_ENCRYPTION_KEY_PREVIOUS is not set. Nothing to migrate from — " +
+        "either you have already removed the previous key, or no rotation is in progress.",
+    );
+  }
+
+  let offset = 0;
+  let rewritten = 0;
+  let skipped = 0;
+  let total = 0;
+
+  for (;;) {
+    const rows = (await sql.unsafe(
+      `SELECT id, "${col.column}" AS value FROM "${col.table}" WHERE "${col.column}" IS NOT NULL ORDER BY id LIMIT ${opts.batchSize} OFFSET ${offset}`,
+    )) as Array<{ id: string; value: string }>;
+    if (rows.length === 0) break;
+    total += rows.length;
+
+    for (const row of rows) {
+      // Try decrypting under the current key first. If that succeeds we
+      // know the row is already under the new key and we can skip it
+      // without touching it.
+      let plaintext: string;
+      let wasUnderPreviousKey = false;
+      try {
+        plaintext = decryptWithFallback(row.value, currentKey, null);
+        skipped += 1;
+        continue;
+      } catch {
+        // Not under current key — fall through to try the previous key.
+      }
+
+      try {
+        plaintext = decryptWithFallback(row.value, previousKey, null);
+        wasUnderPreviousKey = true;
+      } catch (err) {
+        throw new Error(
+          `Row ${col.table}.${col.column} id=${row.id} failed to decrypt under both keys: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+
+      if (!wasUnderPreviousKey) continue;
+
+      const reencrypted = encrypt(plaintext, currentKey);
+      if (!opts.dryRun) {
+        await sql.unsafe(
+          `UPDATE "${col.table}" SET "${col.column}" = $1 WHERE id = $2`,
+          [reencrypted, row.id],
+        );
+      }
+      rewritten += 1;
+    }
+
+    offset += rows.length;
+  }
+
+  return { total, rewritten, skipped };
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error("DATABASE_URL is not set");
+
+  const sql = postgres(dbUrl, { max: 4 });
+
+  const cols = opts.tableFilter
+    ? ENCRYPTED_COLUMNS.filter((c) => c.table === opts.tableFilter)
+    : ENCRYPTED_COLUMNS;
+  if (cols.length === 0) {
+    console.error(`No encrypted columns found for table=${opts.tableFilter}`);
+    await sql.end();
+    process.exit(1);
+  }
+
+  console.log(
+    `Re-encrypt PHI — ${opts.dryRun ? "DRY RUN" : "LIVE"}, batch=${opts.batchSize}, tables=${cols.length}`,
+  );
+
+  let totalRewritten = 0;
+  let totalSkipped = 0;
+
+  for (const col of cols) {
+    process.stdout.write(`  ${col.table}.${col.column} ... `);
+    try {
+      const stats = await reencryptTableColumn(sql, col, opts);
+      totalRewritten += stats.rewritten;
+      totalSkipped += stats.skipped;
+      console.log(
+        `read ${stats.total}, rewrite ${stats.rewritten}, skip ${stats.skipped}`,
+      );
+    } catch (err) {
+      // Missing tables are fine — the enumerated list is conservative.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/relation .* does not exist/.test(msg)) {
+        console.log("skip (table missing)");
+        continue;
+      }
+      console.log(`FAILED — ${msg}`);
+      await sql.end();
+      process.exit(1);
+    }
+  }
+
+  await sql.end();
+
+  console.log("");
+  console.log(
+    `Summary: rewrote ${totalRewritten} row(s), skipped ${totalSkipped} already-current row(s).`,
+  );
+  if (totalRewritten === 0 && !opts.dryRun) {
+    console.log(
+      "No rows needed rewriting — you can now unset PHI_ENCRYPTION_KEY_PREVIOUS.",
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tooling/scripts/src/re-encrypt-phi.ts
+++ b/tooling/scripts/src/re-encrypt-phi.ts
@@ -6,12 +6,16 @@
  * docs/phi-key-rotation.md.
  *
  * Strategy:
- *   For every (table, column) pair that uses the `encryptedText` or
- *   `encryptedJsonb` custom type, read ciphertext directly from the DB
- *   (bypassing the Drizzle custom type), decrypt with fallback, and
- *   write the re-encrypted value back. Rows whose ciphertext already
- *   decrypts under the current key (auth-tag mismatch on the previous
- *   key) are skipped.
+ *   Bulk migration — bypass the Drizzle custom type and work on raw
+ *   ciphertext. For every (table, column) pair listed below the script
+ *   reads the stored ciphertext directly, tries `decrypt` with the
+ *   current key first (to skip already-migrated rows), falls back to the
+ *   previous key, and writes the re-encrypted value back under the
+ *   current key. The two-step try/catch is what lets the script be
+ *   idempotent.
+ *
+ *   Pagination is keyset (WHERE id > $lastId) rather than LIMIT/OFFSET so
+ *   the runtime stays linear on large tables.
  *
  * Usage:
  *   pnpm --filter @carebridge/scripts tsx src/re-encrypt-phi.ts --dry-run
@@ -23,6 +27,8 @@
  *   - No table drops, no schema changes.
  *   - Fails loudly if `PHI_ENCRYPTION_KEY_PREVIOUS` is unset (nothing to
  *     migrate from) or if a row cannot be decrypted under either key.
+ *   - JSONB columns are validated as JSON after decrypt so a schema/list
+ *     mismatch is caught before a round-trip writes garbage.
  */
 
 import postgres from "postgres";
@@ -36,18 +42,28 @@ import {
 interface EncryptedColumn {
   table: string;
   column: string;
-  /** True for encryptedJsonb columns — after decrypt, the plaintext is JSON. */
+  /**
+   * True for encryptedJsonb columns — after decrypt the plaintext is a JSON
+   * document. The script validates it with JSON.parse so a wrong column
+   * mapping surfaces before we re-encrypt garbage.
+   */
   jsonb?: boolean;
 }
 
 /**
- * Enumerated from grep across packages/db-schema/src/schema. If a schema
- * adds a new encrypted column, update this list — there is no runtime
- * reflection of Drizzle custom types that would let us discover them.
+ * Enumerated from grep across packages/db-schema/src/schema. Table names
+ * are the actual pgTable names, NOT the Drizzle constant names. If a
+ * schema adds a new encrypted column, update this list — there is no
+ * runtime reflection of Drizzle custom types that would let us discover
+ * them. A drift check lives in the integration tests; run
+ *   pnpm --filter @carebridge/scripts test
+ * after editing this list.
  */
 const ENCRYPTED_COLUMNS: EncryptedColumn[] = [
+  // packages/db-schema/src/schema/auth.ts
   { table: "users", column: "mfa_secret" },
 
+  // packages/db-schema/src/schema/patients.ts
   { table: "patients", column: "name" },
   { table: "patients", column: "date_of_birth" },
   { table: "patients", column: "diagnosis" },
@@ -56,36 +72,44 @@ const ENCRYPTED_COLUMNS: EncryptedColumn[] = [
   { table: "patients", column: "insurance_id" },
   { table: "patients", column: "emergency_contact_name" },
   { table: "patients", column: "emergency_contact_phone" },
-
   { table: "diagnoses", column: "description" },
-
   { table: "allergies", column: "allergen" },
   { table: "allergies", column: "reaction" },
 
+  // packages/db-schema/src/schema/patient-observations.ts
   { table: "patient_observations", column: "description" },
 
+  // packages/db-schema/src/schema/notifications.ts
   { table: "notifications", column: "title" },
   { table: "notifications", column: "body" },
 
-  { table: "scheduling", column: "notes" },
+  // packages/db-schema/src/schema/scheduling.ts — the encrypted column lives
+  // on the appointments table, not a 'scheduling' table.
+  { table: "appointments", column: "notes" },
 
+  // packages/db-schema/src/schema/emergency-access.ts
   { table: "emergency_access", column: "justification" },
 
+  // packages/db-schema/src/schema/encounters.ts
   { table: "encounters", column: "notes" },
 
-  { table: "notes", column: "sections", jsonb: true },
+  // packages/db-schema/src/schema/notes.ts — JSONB sections on BOTH the
+  // primary note row and every immutable version snapshot.
+  { table: "clinical_notes", column: "sections", jsonb: true },
+  { table: "note_versions", column: "sections", jsonb: true },
 
+  // packages/db-schema/src/schema/messaging.ts
   { table: "messages", column: "body" },
 
+  // packages/db-schema/src/schema/clinical-data.ts
   { table: "medications", column: "name" },
   { table: "medications", column: "brand_name" },
   { table: "medications", column: "notes" },
-
-  { table: "labs", column: "notes" },
-  { table: "procedures", column: "notes" },
   { table: "vitals", column: "notes" },
-  { table: "care_plans", column: "title" },
-  { table: "care_plans", column: "body" },
+  { table: "lab_results", column: "notes" },
+  { table: "procedures", column: "notes" },
+  { table: "events", column: "title" },
+  { table: "events", column: "body" },
 ];
 
 interface Options {
@@ -131,15 +155,32 @@ async function reencryptTableColumn(
     );
   }
 
-  let offset = 0;
   let rewritten = 0;
   let skipped = 0;
   let total = 0;
 
+  // Keyset pagination: walk the (ordered by id) stream without OFFSET, so
+  // runtime is linear even on tables with millions of rows.
+  let lastId: string | null = null;
+
   for (;;) {
-    const rows = (await sql.unsafe(
-      `SELECT id, "${col.column}" AS value FROM "${col.table}" WHERE "${col.column}" IS NOT NULL ORDER BY id LIMIT ${opts.batchSize} OFFSET ${offset}`,
-    )) as Array<{ id: string; value: string }>;
+    const query = lastId === null
+      ? `SELECT id, "${col.column}" AS value FROM "${col.table}"
+         WHERE "${col.column}" IS NOT NULL
+         ORDER BY id
+         LIMIT ${opts.batchSize}`
+      : `SELECT id, "${col.column}" AS value FROM "${col.table}"
+         WHERE "${col.column}" IS NOT NULL
+           AND id > $1
+         ORDER BY id
+         LIMIT ${opts.batchSize}`;
+
+    const rows = (lastId === null
+      ? await sql.unsafe(query)
+      : await sql.unsafe(query, [lastId])) as Array<{
+      id: string;
+      value: string;
+    }>;
     if (rows.length === 0) break;
     total += rows.length;
 
@@ -148,9 +189,8 @@ async function reencryptTableColumn(
       // know the row is already under the new key and we can skip it
       // without touching it.
       let plaintext: string;
-      let wasUnderPreviousKey = false;
       try {
-        plaintext = decryptWithFallback(row.value, currentKey, null);
+        decryptWithFallback(row.value, currentKey, null);
         skipped += 1;
         continue;
       } catch {
@@ -159,7 +199,6 @@ async function reencryptTableColumn(
 
       try {
         plaintext = decryptWithFallback(row.value, previousKey, null);
-        wasUnderPreviousKey = true;
       } catch (err) {
         throw new Error(
           `Row ${col.table}.${col.column} id=${row.id} failed to decrypt under both keys: ${
@@ -168,7 +207,21 @@ async function reencryptTableColumn(
         );
       }
 
-      if (!wasUnderPreviousKey) continue;
+      // Validate JSONB plaintext is well-formed JSON before re-encrypting.
+      // Catches schema/list mismatches (e.g. marking a text column as jsonb)
+      // before we silently rewrite garbage.
+      if (col.jsonb) {
+        try {
+          JSON.parse(plaintext);
+        } catch (err) {
+          throw new Error(
+            `Row ${col.table}.${col.column} id=${row.id} decrypted to invalid JSON — ` +
+              `column-list may be wrong. Details: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+          );
+        }
+      }
 
       const reencrypted = encrypt(plaintext, currentKey);
       if (!opts.dryRun) {
@@ -180,7 +233,7 @@ async function reencryptTableColumn(
       rewritten += 1;
     }
 
-    offset += rows.length;
+    lastId = rows[rows.length - 1]!.id;
   }
 
   return { total, rewritten, skipped };

--- a/tooling/scripts/tsconfig.json
+++ b/tooling/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tooling/scripts/tsconfig.json
+++ b/tooling/scripts/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowSyntheticDefaultImports": true,
+    "rootDir": "src",
     "noEmit": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Closes #291

## Summary
- Adds a step-by-step runbook for rotating \`PHI_ENCRYPTION_KEY\` (routine and emergency) and an idempotent re-encrypt script that migrates historical rows to the new key
- Leaves the tracking issue open for the KMS migration, which is documented as future work

## Why this scope
The existing \`encryptedText\` / \`encryptedJsonb\` custom types already fall back to \`PHI_ENCRYPTION_KEY_PREVIOUS\` during decryption, so rotation is already possible — but the procedure was undocumented and the \"move historical rows to the new key so we can unset the previous key\" step had no tool. These are the two tractable gaps.

Two gaps listed on the issue are intentionally deferred:
- **Per-row key version column** — the fallback mechanism handles a rotation window correctly; versioning is a perf optimization and a 20-table schema change
- **Move to KMS** — real infra project; the runbook documents the envelope-encryption target and why KMS is the durable answer

## What's in the PR
- \`docs/phi-key-rotation.md\` — the runbook; covers generate → pre-flight → dual-key rollout → re-encrypt → remove previous key → destroy
- \`tooling/scripts/src/re-encrypt-phi.ts\` — iterates every encrypted column, decrypts via the existing fallback, writes back under the current key. Flags: \`--dry-run\`, \`--batch-size=N\`, \`--table=<name>\`. Idempotent.
- \`tooling/scripts/package.json\` — deps for the script (\`@carebridge/db-schema\`, \`postgres\`, \`drizzle-orm\`)

## Test plan
- [x] \`pnpm typecheck\` — clean across all 19 packages
- [x] \`pnpm --filter @carebridge/scripts exec tsc --noEmit\` — script typechecks
- [ ] Dry-run against a staging DB (requires reviewer DB access)