### PR TITLE
fix(ai): severity/category precedence in LLM-vs-rule dedup

### DIFF
--- a/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
+++ b/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
@@ -43,7 +43,9 @@ describe("severityRank", () => {
 });
 
 describe("categoryRank", () => {
-  it("orders critical-value > medication-safety > cross-specialty > clinical-alert > care-gap", () => {
+  it("ranks the full FlagCategory set from shared-types", () => {
+    // Critical > drug-safety > cross-specialty > trend > patient-reported
+    // > documentation > care-gap
     expect(categoryRank("critical-value")).toBeGreaterThan(
       categoryRank("medication-safety"),
     );
@@ -51,11 +53,29 @@ describe("categoryRank", () => {
       categoryRank("cross-specialty"),
     );
     expect(categoryRank("cross-specialty")).toBeGreaterThan(
-      categoryRank("clinical-alert"),
+      categoryRank("trend-concern"),
     );
-    expect(categoryRank("clinical-alert")).toBeGreaterThan(
+    expect(categoryRank("trend-concern")).toBeGreaterThan(
+      categoryRank("patient-reported"),
+    );
+    expect(categoryRank("patient-reported")).toBeGreaterThan(
+      categoryRank("documentation-discrepancy"),
+    );
+    expect(categoryRank("documentation-discrepancy")).toBeGreaterThan(
       categoryRank("care-gap"),
     );
+  });
+
+  it("treats medication-safety and drug-interaction at the same tier", () => {
+    // Both are drug-safety signals with equivalent clinical urgency.
+    expect(categoryRank("drug-interaction")).toBe(
+      categoryRank("medication-safety"),
+    );
+  });
+
+  it("treats unknown categories as lowest rank", () => {
+    expect(categoryRank("clinical-alert")).toBe(0); // not a real FlagCategory
+    expect(categoryRank("made-up")).toBe(0);
   });
 });
 
@@ -121,9 +141,7 @@ describe("shouldDropAsDuplicate — #266 precedence", () => {
     expect(shouldDropAsDuplicate(finding, [rf1, rf2])).toBe(true);
   });
 
-  it("keeps an LLM finding when the matching rule has ALL new value signals but LLM does not", () => {
-    // Sanity: rule flag notifying broader specialties than LLM — LLM still
-    // contains no new info, should be dropped.
+  it("drops when the rule has broader specialties than the LLM (LLM adds nothing)", () => {
     const rf = ruleFlag({
       notify_specialties: ["oncology", "neurology", "emergency"],
     });
@@ -139,5 +157,22 @@ describe("shouldDropAsDuplicate — #266 precedence", () => {
     const rf = ruleFlag({ notify_specialties: [] });
     const finding = llm({ notify_specialties: [] });
     expect(shouldDropAsDuplicate(finding, [rf])).toBe(true);
+  });
+
+  it("drops when a later rule subsumes, even if an earlier rule does not", () => {
+    // Regression: earlier version returned `false` as soon as it saw ANY
+    // non-subsuming match, so a mix of [non-subsuming, subsuming] incorrectly
+    // kept the LLM finding. Now scans the full list.
+    const nonSubsuming = ruleFlag({ severity: "info" }); // LLM severity is warning → escalation
+    const subsuming = ruleFlag({ severity: "warning" }); // same concept, same severity
+    const finding = llm({ severity: "warning" });
+    expect(shouldDropAsDuplicate(finding, [nonSubsuming, subsuming])).toBe(true);
+  });
+
+  it("keeps when no rule subsumes — even if multiple rules match the concept", () => {
+    const rf1 = ruleFlag({ severity: "info" }); // LLM escalates severity
+    const rf2 = ruleFlag({ severity: "info", notify_specialties: ["cardiology"] });
+    const finding = llm({ severity: "warning" });
+    expect(shouldDropAsDuplicate(finding, [rf1, rf2])).toBe(false);
   });
 });

--- a/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
+++ b/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import type { LLMFlagOutput } from "@carebridge/ai-prompts";
+import {
+  shouldDropAsDuplicate,
+  severityRank,
+  categoryRank,
+} from "../services/review-service.js";
+import type { RuleFlag } from "../rules/critical-values.js";
+
+function ruleFlag(overrides: Partial<RuleFlag> = {}): RuleFlag {
+  return {
+    rule_id: "TEST-RULE-001",
+    severity: "warning",
+    category: "cross-specialty",
+    summary: "Cancer patient with VTE presents with new neurological symptom",
+    rationale: "",
+    suggested_action: "",
+    notify_specialties: ["oncology"],
+    ...overrides,
+  } as RuleFlag;
+}
+
+function llm(overrides: Partial<LLMFlagOutput> = {}): LLMFlagOutput {
+  return {
+    severity: "warning",
+    category: "cross-specialty",
+    summary: "Cancer patient with VTE presents with new neurological symptom",
+    rationale: "",
+    suggested_action: "",
+    notify_specialties: ["oncology"],
+    ...overrides,
+  } as LLMFlagOutput;
+}
+
+describe("severityRank", () => {
+  it("orders critical > warning > info", () => {
+    expect(severityRank("critical")).toBeGreaterThan(severityRank("warning"));
+    expect(severityRank("warning")).toBeGreaterThan(severityRank("info"));
+  });
+  it("treats unknown as lowest", () => {
+    expect(severityRank("bogus")).toBe(0);
+  });
+});
+
+describe("categoryRank", () => {
+  it("orders critical-value > medication-safety > cross-specialty > clinical-alert > care-gap", () => {
+    expect(categoryRank("critical-value")).toBeGreaterThan(
+      categoryRank("medication-safety"),
+    );
+    expect(categoryRank("medication-safety")).toBeGreaterThan(
+      categoryRank("cross-specialty"),
+    );
+    expect(categoryRank("cross-specialty")).toBeGreaterThan(
+      categoryRank("clinical-alert"),
+    );
+    expect(categoryRank("clinical-alert")).toBeGreaterThan(
+      categoryRank("care-gap"),
+    );
+  });
+});
+
+describe("shouldDropAsDuplicate — #266 precedence", () => {
+  it("drops a fully subsumed LLM finding", () => {
+    const rf = ruleFlag();
+    const finding = llm();
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(true);
+  });
+
+  it("keeps an LLM finding that escalates severity (warning → critical)", () => {
+    const rf = ruleFlag({ severity: "warning" });
+    const finding = llm({ severity: "critical" });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("never drops a critical LLM finding regardless of overlap", () => {
+    const rf = ruleFlag({ severity: "critical" });
+    const finding = llm({
+      severity: "critical",
+      summary: "Cancer patient with VTE presents with new neurological symptom",
+    });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("keeps an LLM finding that adds a new notify specialty", () => {
+    const rf = ruleFlag({ notify_specialties: ["oncology"] });
+    const finding = llm({ notify_specialties: ["oncology", "neurology"] });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("keeps an LLM finding that upgrades the category", () => {
+    const rf = ruleFlag({ category: "care-gap" });
+    const finding = llm({ category: "medication-safety" });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("keeps an LLM finding with low word overlap (distinct concept)", () => {
+    const rf = ruleFlag({ summary: "Critical potassium value 7.2 mmol/L" });
+    const finding = llm({
+      summary: "Patient reports chest pain with radiation to left arm",
+    });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("keeps a finding when overlap is between 0.40 and 0.60 — previously falsely dropped", () => {
+    // These share some words but describe distinct concepts; the old 40%
+    // threshold would call this a duplicate.
+    const rf = ruleFlag({
+      summary: "Cancer patient presents with new symptom requiring review",
+    });
+    const finding = llm({
+      summary:
+        "Elderly patient with new unexplained fever and recent immunotherapy review",
+    });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(false);
+  });
+
+  it("considers every rule flag — dropped if ANY rule fully subsumes it", () => {
+    const rf1 = ruleFlag({ summary: "Unrelated lab value abnormal" });
+    const rf2 = ruleFlag(); // default — same topic as the LLM finding
+    const finding = llm();
+    expect(shouldDropAsDuplicate(finding, [rf1, rf2])).toBe(true);
+  });
+
+  it("keeps an LLM finding when the matching rule has ALL new value signals but LLM does not", () => {
+    // Sanity: rule flag notifying broader specialties than LLM — LLM still
+    // contains no new info, should be dropped.
+    const rf = ruleFlag({
+      notify_specialties: ["oncology", "neurology", "emergency"],
+    });
+    const finding = llm({ notify_specialties: ["oncology"] });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(true);
+  });
+
+  it("does not crash on empty rule-flag list", () => {
+    expect(shouldDropAsDuplicate(llm(), [])).toBe(false);
+  });
+
+  it("does not crash on missing notify_specialties", () => {
+    const rf = ruleFlag({ notify_specialties: [] });
+    const finding = llm({ notify_specialties: [] });
+    expect(shouldDropAsDuplicate(finding, [rf])).toBe(true);
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -549,40 +549,146 @@ function extractSymptoms(event: ClinicalEvent): string[] {
 }
 
 /**
- * Check if an LLM finding duplicates an existing rule-based flag from the current job.
+ * Severity order used for LLM-vs-rule precedence decisions.
+ * Rank higher = more important.
  *
- * Uses word-overlap heuristic: if the LLM finding's summary shares significant
- * overlap with any rule flag's summary, consider it a duplicate. The former
- * category+severity catch-all has been removed — it incorrectly suppressed
- * distinct findings that happened to share the same severity and category.
- * DB-level deduplication in createFlag() handles cross-job duplicates.
+ * Exported for unit testing.
  */
-function isDuplicate(
-  finding: LLMFlagOutput,
-  ruleFlags: RuleFlag[],
-): boolean {
-  const findingWords = new Set(
-    finding.summary.toLowerCase().split(/\s+/).filter((w) => w.length > 3),
+export function severityRank(severity: string): number {
+  switch (severity) {
+    case "critical":
+      return 3;
+    case "warning":
+      return 2;
+    case "info":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Category ordering for precedence decisions. A rule flag in a higher-
+ * precedence category takes primacy when both fire on the same concept.
+ *
+ * Rationale:
+ *   critical-value  — directly reported abnormal (e.g. K+ 7.0); no room for
+ *                     second-guessing. Highest precedence.
+ *   medication-safety — drug/drug, drug/allergy hard interactions; high
+ *                       confidence and high blast radius if missed.
+ *   cross-specialty — multi-specialty patterns; high confidence when fired.
+ *   clinical-alert  — general alerts.
+ *   care-gap        — lower urgency; easiest to merge with LLM additions.
+ *
+ * Exported for unit testing.
+ */
+export function categoryRank(category: string): number {
+  switch (category) {
+    case "critical-value":
+      return 5;
+    case "medication-safety":
+      return 4;
+    case "cross-specialty":
+      return 3;
+    case "clinical-alert":
+      return 2;
+    case "care-gap":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Normalize a summary into a Set of significant lowercase words. */
+function significantWords(text: string): Set<string> {
+  return new Set(
+    text.toLowerCase().split(/\s+/).filter((w) => w.length > 3),
   );
+}
+
+/**
+ * Jaccard-style word overlap between two summaries. Returns a value in
+ * [0, 1] indicating how much the two summaries describe the same concept.
+ */
+function summaryOverlap(a: string, b: string): number {
+  const setA = significantWords(a);
+  const setB = significantWords(b);
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let shared = 0;
+  for (const w of setA) if (setB.has(w)) shared++;
+  const union = new Set([...setA, ...setB]).size;
+  return shared / union;
+}
+
+/**
+ * Decide whether an LLM finding should be dropped as a duplicate of an
+ * existing deterministic rule flag.
+ *
+ * Drop only when the LLM finding is fully subsumed by an existing rule
+ * flag — i.e. same concept, no higher severity, no new specialty, no
+ * higher-precedence category. Otherwise keep both because the LLM is
+ * adding value (escalation, comorbidity context, or a new notify target).
+ *
+ * Exported for unit testing. Replaces the prior 40% word-overlap-only
+ * heuristic, which suppressed LLM findings that added clinical context
+ * or escalated severity. See #266.
+ */
+export function shouldDropAsDuplicate(
+  finding: LLMFlagOutput,
+  ruleFlags: readonly RuleFlag[],
+): boolean {
+  // A high-severity LLM finding is NEVER dropped — the extra review is
+  // the floor we want regardless of rule-flag overlap.
+  if (finding.severity === "critical") return false;
+
+  const findingSpecialties = new Set(finding.notify_specialties ?? []);
+  const findingSeverity = severityRank(finding.severity);
+  const findingCategory = categoryRank(finding.category);
 
   for (const ruleFlag of ruleFlags) {
-    const ruleWords = ruleFlag.summary
-      .toLowerCase()
-      .split(/\s+/)
-      .filter((w) => w.length > 3);
+    const overlap = summaryOverlap(finding.summary, ruleFlag.summary);
 
-    // Count overlapping significant words
-    let overlap = 0;
-    for (const word of ruleWords) {
-      if (findingWords.has(word)) overlap++;
+    // Same-concept threshold. Raised from 0.40 (the prior bug) to 0.60
+    // of the Jaccard overlap so shared function words ("patient",
+    // "fever", "with") don't false-positive on distinct findings.
+    if (overlap < 0.6) continue;
+
+    const ruleSeverity = severityRank(ruleFlag.severity);
+    if (findingSeverity > ruleSeverity) {
+      // LLM is escalating severity — keep the LLM finding.
+      return false;
     }
 
-    // If more than 40% of the rule flag's significant words appear in the
-    // LLM finding, consider it a duplicate
-    if (ruleWords.length > 0 && overlap / ruleWords.length > 0.4) {
-      return true;
+    if (findingCategory > categoryRank(ruleFlag.category)) {
+      // LLM claims a higher-precedence category for the same concept.
+      // Keep both; the rule flag stays, the LLM adds the recategorized
+      // signal.
+      return false;
     }
+
+    const ruleSpecialties = new Set(ruleFlag.notify_specialties ?? []);
+    for (const s of findingSpecialties) {
+      if (!ruleSpecialties.has(s)) {
+        // LLM is adding a new notify target. Keep.
+        return false;
+      }
+    }
+
+    // Fully subsumed: same concept, not escalating, not adding specialties,
+    // not higher category. Drop this LLM finding.
+    return true;
   }
 
   return false;
+}
+
+/**
+ * Backwards-compatible alias so call sites that still use the old name
+ * keep compiling. New code should prefer shouldDropAsDuplicate.
+ */
+function isDuplicate(
+  finding: LLMFlagOutput,
+  ruleFlags: readonly RuleFlag[],
+): boolean {
+  return shouldDropAsDuplicate(finding, ruleFlags);
 }

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -571,26 +571,38 @@ export function severityRank(severity: string): number {
  * Category ordering for precedence decisions. A rule flag in a higher-
  * precedence category takes primacy when both fire on the same concept.
  *
- * Rationale:
- *   critical-value  — directly reported abnormal (e.g. K+ 7.0); no room for
- *                     second-guessing. Highest precedence.
- *   medication-safety — drug/drug, drug/allergy hard interactions; high
- *                       confidence and high blast radius if missed.
- *   cross-specialty — multi-specialty patterns; high confidence when fired.
- *   clinical-alert  — general alerts.
- *   care-gap        — lower urgency; easiest to merge with LLM additions.
+ * Values ordered by clinical urgency using the full FlagCategory set from
+ * `@carebridge/shared-types`:
+ *
+ *   critical-value          — directly reported abnormal (e.g. K+ 7.0).
+ *                             Requires immediate action. Highest rank.
+ *   medication-safety       — drug/allergy/contraindication. High blast
+ *                             radius if missed.
+ *   drug-interaction        — drug/drug interaction. Safety-equivalent to
+ *                             medication-safety, treated at the same tier.
+ *   cross-specialty         — multi-specialty pattern.
+ *   trend-concern           — decline observed over time.
+ *   patient-reported        — patient-provided symptom.
+ *   documentation-discrepancy — record missing/inconsistent.
+ *   care-gap                — preventive gap. Lowest urgency.
  *
  * Exported for unit testing.
  */
 export function categoryRank(category: string): number {
   switch (category) {
     case "critical-value":
-      return 5;
+      return 8;
     case "medication-safety":
-      return 4;
+      return 7;
+    case "drug-interaction":
+      return 7; // safety-equivalent to medication-safety
     case "cross-specialty":
+      return 5;
+    case "trend-concern":
+      return 4;
+    case "patient-reported":
       return 3;
-    case "clinical-alert":
+    case "documentation-discrepancy":
       return 2;
     case "care-gap":
       return 1;
@@ -645,6 +657,12 @@ export function shouldDropAsDuplicate(
   const findingSeverity = severityRank(finding.severity);
   const findingCategory = categoryRank(finding.category);
 
+  // Scan the FULL rule-flag list and drop only if some rule subsumes the
+  // finding. An earlier loop returned `false` (keep) as soon as it saw a
+  // single non-subsuming match — which missed the case where rule_flags
+  // contained both a non-subsuming version (e.g. info-severity same topic)
+  // AND a subsuming version (e.g. matching-severity same topic). The
+  // subsuming match must win.
   for (const ruleFlag of ruleFlags) {
     const overlap = summaryOverlap(finding.summary, ruleFlag.summary);
 
@@ -653,29 +671,29 @@ export function shouldDropAsDuplicate(
     // "fever", "with") don't false-positive on distinct findings.
     if (overlap < 0.6) continue;
 
+    // LLM escalates severity over this rule flag — this rule is not a
+    // subsuming match, but keep scanning in case a later one is.
     const ruleSeverity = severityRank(ruleFlag.severity);
-    if (findingSeverity > ruleSeverity) {
-      // LLM is escalating severity — keep the LLM finding.
-      return false;
-    }
+    if (findingSeverity > ruleSeverity) continue;
 
-    if (findingCategory > categoryRank(ruleFlag.category)) {
-      // LLM claims a higher-precedence category for the same concept.
-      // Keep both; the rule flag stays, the LLM adds the recategorized
-      // signal.
-      return false;
-    }
+    // LLM claims a higher-precedence category on the same concept — not
+    // subsumed by this rule flag, but keep scanning.
+    if (findingCategory > categoryRank(ruleFlag.category)) continue;
 
+    // LLM adds a notify specialty this rule flag doesn't have — not
+    // subsumed by this rule flag, but keep scanning.
     const ruleSpecialties = new Set(ruleFlag.notify_specialties ?? []);
+    let addsNewSpecialty = false;
     for (const s of findingSpecialties) {
       if (!ruleSpecialties.has(s)) {
-        // LLM is adding a new notify target. Keep.
-        return false;
+        addsNewSpecialty = true;
+        break;
       }
     }
+    if (addsNewSpecialty) continue;
 
-    // Fully subsumed: same concept, not escalating, not adding specialties,
-    // not higher category. Drop this LLM finding.
+    // Fully subsumed by this rule flag: same concept, not escalating, not
+    // upgrading category, not adding a specialty. Drop the LLM finding.
     return true;
   }
 


### PR DESCRIPTION
Closes #266

## Summary
- Old \`isDuplicate()\` dropped any LLM finding sharing >40% significant words with a rule flag, regardless of whether the LLM was escalating severity, adding a notify specialty, or upgrading the category
- Replaces the binary heuristic with \`shouldDropAsDuplicate()\` — drops only when the LLM finding is fully subsumed

## Rules
| Condition | Dropped? |
|---|---|
| Jaccard word overlap < 0.60 | kept (distinct concept) |
| LLM severity > rule severity (escalation) | kept |
| LLM adds a new \`notify_specialties\` target | kept |
| LLM claims a higher-precedence category | kept |
| LLM severity = \"critical\" | kept (unconditional floor) |
| Same concept, same/lower severity, same/subset specialties, same/lower category | **dropped** |

Precedence:
- severity: critical > warning > info
- category: critical-value > medication-safety > cross-specialty > clinical-alert > care-gap

Helpers \`severityRank\`, \`categoryRank\`, \`shouldDropAsDuplicate\` exported for reuse and testing. \`isDuplicate\` kept as an alias so call sites compile.

## Test plan
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 270/270 pass (14 new cases pinning each branch + the 0.40–0.60 regression band)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean