### PR TITLE
feat(ai): outbox reconciler drains failed_clinical_events backlog

### DIFF
--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -2,16 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mock DB chain ------------------------------------------------------------
 //
-// The reconciler uses three chains:
-//   select().from().where().limit()  — fetch pending rows
-//   update().set().where()             — mark a row processed / failed / retried
+// The reconciler uses two chains:
+//   select().from().where().for("update",{skipLocked}).limit()  — fetch + lock
+//   update().set().where()                                      — mark row state
 //
 // We stub each link; the leaf call is the one whose resolved value we can
-// configure per-test.
+// configure per-test. The `.for(...)` link exists so concurrent reconcilers
+// running on separate pods claim disjoint batches via Postgres
+// `FOR UPDATE SKIP LOCKED` and do not both re-emit the same row.
 
 const mockSelect = vi.fn();
 const mockFrom = vi.fn();
 const mockSelectWhere = vi.fn();
+const mockFor = vi.fn();
 const mockLimit = vi.fn();
 
 const mockUpdate = vi.fn();
@@ -100,11 +103,13 @@ function mockSelectRows(rows: PendingRow[]) {
   mockSelect.mockReset();
   mockFrom.mockReset();
   mockSelectWhere.mockReset();
+  mockFor.mockReset();
   mockLimit.mockReset();
 
   mockSelect.mockReturnValue({ from: mockFrom });
   mockFrom.mockReturnValue({ where: mockSelectWhere });
-  mockSelectWhere.mockReturnValue({ limit: mockLimit });
+  mockSelectWhere.mockReturnValue({ for: mockFor });
+  mockFor.mockReturnValue({ limit: mockLimit });
   mockLimit.mockResolvedValue(rows);
 }
 
@@ -146,6 +151,7 @@ describe("reconcileFailedEvents", () => {
     expect(mockQueueAdd).toHaveBeenCalledWith(
       "medication.created",
       row.event_payload,
+      { jobId: row.id },
     );
 
     expect(mockSet).toHaveBeenCalledTimes(1);
@@ -210,5 +216,111 @@ describe("reconcileFailedEvents", () => {
     mockSelectRows([]);
     await reconcileFailedEvents();
     expect(mockLimit).toHaveBeenCalledWith(RECONCILE_BATCH_SIZE);
+  });
+
+  // ── Idempotency + concurrency guards --------------------------------------
+
+  it("passes jobId=row.id on queue.add so BullMQ dedupes the re-emit", async () => {
+    // Addresses the queue.add + UPDATE race: if the add succeeds but the
+    // status UPDATE fails, the row stays pending and the next tick will
+    // re-select it. BullMQ must refuse a duplicate job for the same id.
+    const row = makeRow({ id: "outbox-race-1" });
+    mockSelectRows([row]);
+
+    await reconcileFailedEvents();
+
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+    const [, , opts] = mockQueueAdd.mock.calls[0];
+    expect(opts).toEqual({ jobId: "outbox-race-1" });
+  });
+
+  it("on partial failure (add resolves, UPDATE rejects) a second tick re-adds with the same jobId", async () => {
+    // Partial-failure scenario from the review comment:
+    //   1) tick A: queue.add succeeds, success-path UPDATE throws.
+    //      The row does NOT get marked 'processed' — the code falls
+    //      into the catch block and routes the row to the retry path
+    //      (retry_count++, status stays 'pending'), so the row is
+    //      selectable on the next tick.
+    //   2) tick B: same row re-selected, queue.add called again.
+    //
+    // Invariant: both queue.add calls carry the same jobId (row.id)
+    // so BullMQ dedupes the duplicate enqueue on the receiving side.
+    // Without jobId dedup, review-service would produce a duplicate
+    // clinical flag that a clinician would see.
+    const row = makeRow({ id: "outbox-partial-1" });
+
+    // Tick A: first UPDATE (success-path) rejects -> catch fires; the
+    // catch's own UPDATE succeeds so reconcileFailedEvents returns
+    // normally with the row counted as retried.
+    mockSelectRows([row]);
+    mockUpdateWhere
+      .mockRejectedValueOnce(new Error("pool exhausted"))
+      .mockResolvedValueOnce(undefined);
+
+    const tickA = await reconcileFailedEvents();
+    expect(tickA.reconciled).toBe(0);
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
+    expect(mockQueueAdd.mock.calls[0][2]).toEqual({ jobId: "outbox-partial-1" });
+
+    // Tick B: row re-selected (still 'pending' after the retry update),
+    // UPDATE succeeds this time.
+    mockSelectRows([row]);
+    mockUpdateWhere.mockReset();
+    mockUpdateWhere.mockResolvedValue(undefined);
+
+    await reconcileFailedEvents();
+
+    // Two enqueue attempts total, both carrying the same jobId so the
+    // clinical-events queue dedupes on the receiving side.
+    expect(mockQueueAdd).toHaveBeenCalledTimes(2);
+    expect(mockQueueAdd.mock.calls[1][2]).toEqual({ jobId: "outbox-partial-1" });
+  });
+
+  it("uses FOR UPDATE SKIP LOCKED so concurrent reconcilers claim disjoint batches", async () => {
+    // Simulates two reconcilers ticking at once. Postgres lock semantics
+    // are enforced by the DB; here we assert the call shape — SKIP LOCKED
+    // is requested — and that the mock behavior (each caller gets their
+    // own set of rows) matches what the DB will do in prod.
+    const rowsForPodA = [makeRow({ id: "o-a1" }), makeRow({ id: "o-a2" })];
+    const rowsForPodB = [makeRow({ id: "o-b1" })];
+
+    // Reset + wire the chain so two successive .limit() calls return
+    // disjoint sets, mimicking two concurrent SKIP LOCKED claims.
+    mockSelect.mockReset();
+    mockFrom.mockReset();
+    mockSelectWhere.mockReset();
+    mockFor.mockReset();
+    mockLimit.mockReset();
+    mockSelect.mockReturnValue({ from: mockFrom });
+    mockFrom.mockReturnValue({ where: mockSelectWhere });
+    mockSelectWhere.mockReturnValue({ for: mockFor });
+    mockFor.mockReturnValue({ limit: mockLimit });
+    mockLimit
+      .mockResolvedValueOnce(rowsForPodA)
+      .mockResolvedValueOnce(rowsForPodB);
+
+    const [resultA, resultB] = await Promise.all([
+      reconcileFailedEvents(),
+      reconcileFailedEvents(),
+    ]);
+
+    // Both .for() invocations must request SKIP LOCKED so Postgres hands
+    // out disjoint row sets instead of blocking one caller on the other.
+    expect(mockFor).toHaveBeenCalledTimes(2);
+    for (const call of mockFor.mock.calls) {
+      expect(call[0]).toBe("update");
+      expect(call[1]).toEqual({ skipLocked: true });
+    }
+
+    // Disjoint claim: the union of enqueued ids equals the union of
+    // rows, with no duplicates across the two pods.
+    const enqueuedIds = mockQueueAdd.mock.calls.map(
+      (c) => (c[2] as { jobId: string }).jobId,
+    );
+    expect(new Set(enqueuedIds)).toEqual(
+      new Set(["o-a1", "o-a2", "o-b1"]),
+    );
+    expect(enqueuedIds.length).toBe(3); // no duplicates
+    expect(resultA.reconciled + resultB.reconciled).toBe(3);
   });
 });

--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock DB chain ------------------------------------------------------------
+//
+// The reconciler uses three chains:
+//   select().from().where().limit()  — fetch pending rows
+//   update().set().where()             — mark a row processed / failed / retried
+//
+// We stub each link; the leaf call is the one whose resolved value we can
+// configure per-test.
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockSelectWhere = vi.fn();
+const mockLimit = vi.fn();
+
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockUpdateWhere = vi.fn();
+
+const mockDb = {
+  select: mockSelect,
+  update: mockUpdate,
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  failedClinicalEvents: {
+    id: "id",
+    event_type: "event_type",
+    patient_id: "patient_id",
+    event_payload: "event_payload",
+    status: "status",
+    retry_count: "retry_count",
+    created_at: "created_at",
+    processed_at: "processed_at",
+    error_message: "error_message",
+  },
+}));
+
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({}),
+  CLINICAL_EVENTS_JOB_OPTIONS: {
+    attempts: 8,
+    backoff: { type: "exponential" as const, delay: 2000 },
+    removeOnComplete: { count: 1000 },
+    removeOnFail: { count: 10000 },
+  },
+}));
+
+const { mockQueueAdd } = vi.hoisted(() => ({
+  mockQueueAdd: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: class MockQueue {
+    add = mockQueueAdd;
+  },
+  Worker: class MockWorker {
+    on = vi.fn();
+  },
+}));
+
+import {
+  reconcileFailedEvents,
+  MAX_RECONCILE_RETRIES,
+  RECONCILE_BATCH_SIZE,
+} from "../workers/outbox-reconciler.js";
+
+type PendingRow = {
+  id: string;
+  event_type: string;
+  patient_id: string;
+  event_payload: unknown;
+  status: string;
+  retry_count: number;
+  created_at: string;
+};
+
+function makeRow(overrides: Partial<PendingRow> = {}): PendingRow {
+  return {
+    id: "outbox-1",
+    event_type: "medication.created",
+    patient_id: "pat-1",
+    event_payload: {
+      id: "evt-1",
+      type: "medication.created",
+      patient_id: "pat-1",
+      timestamp: "2026-04-16T00:00:00.000Z",
+      data: { resourceId: "med-1" },
+    },
+    status: "pending",
+    retry_count: 0,
+    created_at: "2026-04-16T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function mockSelectRows(rows: PendingRow[]) {
+  mockSelect.mockReset();
+  mockFrom.mockReset();
+  mockSelectWhere.mockReset();
+  mockLimit.mockReset();
+
+  mockSelect.mockReturnValue({ from: mockFrom });
+  mockFrom.mockReturnValue({ where: mockSelectWhere });
+  mockSelectWhere.mockReturnValue({ limit: mockLimit });
+  mockLimit.mockResolvedValue(rows);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockUpdate.mockReset();
+  mockSet.mockReset();
+  mockUpdateWhere.mockReset();
+  mockUpdate.mockReturnValue({ set: mockSet });
+  mockSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdateWhere.mockResolvedValue(undefined);
+
+  mockQueueAdd.mockReset();
+  mockQueueAdd.mockResolvedValue(undefined);
+});
+
+describe("reconcileFailedEvents", () => {
+  it("returns zero counts when no pending events", async () => {
+    mockSelectRows([]);
+
+    const result = await reconcileFailedEvents();
+
+    expect(result).toEqual({ reconciled: 0, retried: 0, failed: 0 });
+    expect(mockQueueAdd).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("re-emits pending events to the clinical-events queue and marks them processed", async () => {
+    const row = makeRow();
+    mockSelectRows([row]);
+
+    const result = await reconcileFailedEvents();
+
+    expect(result.reconciled).toBe(1);
+    expect(result.retried).toBe(0);
+    expect(result.failed).toBe(0);
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      "medication.created",
+      row.event_payload,
+    );
+
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    const payload = mockSet.mock.calls[0][0];
+    expect(payload.status).toBe("processed");
+    expect(payload.processed_at).toEqual(expect.any(String));
+  });
+
+  it("increments retry_count and keeps status='pending' when re-emit fails below the cap", async () => {
+    const row = makeRow({ retry_count: 1 });
+    mockSelectRows([row]);
+    mockQueueAdd.mockRejectedValueOnce(new Error("Redis still down"));
+
+    const result = await reconcileFailedEvents();
+
+    expect(result.reconciled).toBe(0);
+    expect(result.retried).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const payload = mockSet.mock.calls[0][0];
+    expect(payload.status).toBe("pending");
+    expect(payload.retry_count).toBe(2);
+    expect(payload.error_message).toContain("Redis still down");
+  });
+
+  it("marks row status='failed' once retry_count reaches MAX_RECONCILE_RETRIES", async () => {
+    const row = makeRow({ retry_count: MAX_RECONCILE_RETRIES - 1 });
+    mockSelectRows([row]);
+    mockQueueAdd.mockRejectedValueOnce(new Error("Redis persistently down"));
+
+    const result = await reconcileFailedEvents();
+
+    expect(result.failed).toBe(1);
+    expect(result.retried).toBe(0);
+
+    const payload = mockSet.mock.calls[0][0];
+    expect(payload.status).toBe("failed");
+    expect(payload.retry_count).toBe(MAX_RECONCILE_RETRIES);
+    expect(payload.processed_at).toEqual(expect.any(String));
+  });
+
+  it("processes multiple rows and tallies counts across outcomes", async () => {
+    const ok = makeRow({ id: "o-1" });
+    const retryable = makeRow({ id: "o-2", retry_count: 0 });
+    const terminal = makeRow({ id: "o-3", retry_count: MAX_RECONCILE_RETRIES - 1 });
+    mockSelectRows([ok, retryable, terminal]);
+
+    // ok: success on first add; retryable + terminal: rejected
+    mockQueueAdd
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockRejectedValueOnce(new Error("boom"));
+
+    const result = await reconcileFailedEvents();
+
+    expect(result).toEqual({ reconciled: 1, retried: 1, failed: 1 });
+    expect(mockQueueAdd).toHaveBeenCalledTimes(3);
+    expect(mockUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it("limits the batch size so a huge backlog doesn't starve the worker", async () => {
+    mockSelectRows([]);
+    await reconcileFailedEvents();
+    expect(mockLimit).toHaveBeenCalledWith(RECONCILE_BATCH_SIZE);
+  });
+});

--- a/services/ai-oversight/src/server.ts
+++ b/services/ai-oversight/src/server.ts
@@ -8,6 +8,10 @@
 import { createServer } from "node:http";
 import { startReviewWorker } from "./workers/review-worker.js";
 import { setupEscalationQueue, startEscalationWorker } from "./workers/escalation-worker.js";
+import {
+  setupOutboxReconcilerQueue,
+  startOutboxReconcilerWorker,
+} from "./workers/outbox-reconciler.js";
 import { formatPrometheus, getMetricsSnapshot } from "./services/shadow-metrics.js";
 
 const HEALTH_PORT = Number(process.env.HEALTH_PORT ?? 4001);
@@ -15,6 +19,8 @@ const HEALTH_PORT = Number(process.env.HEALTH_PORT ?? 4001);
 const worker = startReviewWorker();
 const escalationQueue = setupEscalationQueue();
 const escalationWorker = startEscalationWorker();
+const outboxReconcilerQueue = setupOutboxReconcilerQueue();
+const outboxReconcilerWorker = startOutboxReconcilerWorker();
 
 const REDIS_PING_TIMEOUT_MS = 2_000;
 
@@ -90,6 +96,8 @@ async function shutdown(signal: string) {
   await worker.close();
   await escalationWorker.close();
   await escalationQueue.close();
+  await outboxReconcilerWorker.close();
+  await outboxReconcilerQueue.close();
 
   console.log("[ai-oversight] Shutdown complete");
   process.exit(0);

--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -65,6 +65,22 @@ export interface ReconcileResult {
 
 /**
  * Drain one batch of pending outbox rows. Exported for tests.
+ *
+ * Multi-worker safety:
+ *   ai-oversight is horizontally scalable; N pods each tick independently.
+ *   The SELECT uses `FOR UPDATE SKIP LOCKED` so two reconcilers that tick
+ *   within the same window claim disjoint batches instead of both seeing
+ *   — and both re-emitting — the same `status='pending'` rows. The locks
+ *   are released when the surrounding statement completes, which for our
+ *   flow is effectively the end of this function.
+ *
+ * Idempotency:
+ *   `queue.add` is called with `jobId: row.id`. BullMQ dedupes by job id,
+ *   so even if the enqueue succeeds and the follow-up status UPDATE fails
+ *   (connection blip, pool exhaustion, SIGTERM between the two) the next
+ *   tick cannot produce a duplicate clinical-events job for the same
+ *   outbox row. This is belt-and-braces with review-service's
+ *   trigger_event_id idempotency (PR #492).
  */
 export async function reconcileFailedEvents(): Promise<ReconcileResult> {
   const db = getDb();
@@ -79,6 +95,7 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
         lt(failedClinicalEvents.retry_count, MAX_RECONCILE_RETRIES),
       ),
     )
+    .for("update", { skipLocked: true })
     .limit(RECONCILE_BATCH_SIZE);
 
   let reconciled = 0;
@@ -87,7 +104,10 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
 
   for (const row of pending) {
     try {
-      await queue.add(row.event_type, row.event_payload);
+      // jobId: row.id -> BullMQ dedupes by outbox row id. If the UPDATE
+      // below fails after this add resolves, the next tick's re-enqueue
+      // of the same row is a no-op on BullMQ's side.
+      await queue.add(row.event_type, row.event_payload, { jobId: row.id });
 
       await db
         .update(failedClinicalEvents)
@@ -138,14 +158,24 @@ export function setupOutboxReconcilerQueue(): Queue {
     },
   });
 
-  queue.add(
-    "reconcile",
-    {},
-    {
-      repeat: { every: RECONCILE_INTERVAL_MS },
-      jobId: "outbox-reconciler-repeatable",
-    },
-  );
+  // Fire-and-log — if Redis isn't ready at boot, surface the error so the
+  // deployment doesn't run silently with no reconciler scheduled. Mirrors
+  // the pattern we'd apply to setupEscalationQueue.
+  queue
+    .add(
+      "reconcile",
+      {},
+      {
+        repeat: { every: RECONCILE_INTERVAL_MS },
+        jobId: "outbox-reconciler-repeatable",
+      },
+    )
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[outbox-reconciler] failed to register repeatable job: ${message}`,
+      );
+    });
 
   return queue;
 }

--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -1,0 +1,197 @@
+/**
+ * Outbox reconciler for clinical-event emissions.
+ *
+ * When the primary BullMQ emit in `emitClinicalEvent` fails (Redis down,
+ * network blip, auth failure), the event is written to the `failed_clinical_events`
+ * outbox table so the oversight pipeline doesn't silently lose data — HIPAA
+ * audit + clinical-safety both require that every write reaches the review
+ * engine. The write-side is the *outbox*. This is the *drain*.
+ *
+ * Responsibilities:
+ *   1. Periodically scan the outbox for rows with status='pending'.
+ *   2. Re-enqueue the stored payload on the clinical-events BullMQ queue.
+ *   3. On success: mark the row status='processed' (processed_at stamped).
+ *   4. On failure below the retry cap: increment retry_count, keep pending.
+ *   5. On failure at the retry cap: mark status='failed' — this row is now
+ *      a candidate for operator-driven review; it will not be retried again.
+ *
+ * Failure-rate observability comes from the per-run return value:
+ * `{ reconciled, retried, failed }`. `startOutboxReconcilerWorker` logs
+ * this structured record on every tick so ops can alert on `failed > 0`
+ * or on elevated `retried` counts even without a metrics backend.
+ */
+
+import { Queue, Worker } from "bullmq";
+import type { Job } from "bullmq";
+import { and, eq, lt } from "drizzle-orm";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import { getDb, failedClinicalEvents } from "@carebridge/db-schema";
+
+const RECONCILER_QUEUE_NAME = "outbox-reconciler";
+const CLINICAL_EVENTS_QUEUE_NAME = "clinical-events";
+
+/** Rows with retry_count equal to this after a failure are parked as `failed`. */
+export const MAX_RECONCILE_RETRIES = 5;
+
+/** Cap per run so a huge backlog cannot starve the worker. */
+export const RECONCILE_BATCH_SIZE = 100;
+
+/** How often the reconciler runs. */
+const RECONCILE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+const connection = getRedisConnection();
+
+// Lazy init — tests mock the BullMQ Queue ctor, and production wants a
+// singleton so repeated ticks reuse the same client.
+let clinicalEventsQueue: Queue | null = null;
+function getClinicalEventsQueue(): Queue {
+  if (!clinicalEventsQueue) {
+    clinicalEventsQueue = new Queue(CLINICAL_EVENTS_QUEUE_NAME, {
+      connection,
+      defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+    });
+  }
+  return clinicalEventsQueue;
+}
+
+export interface ReconcileResult {
+  reconciled: number;
+  retried: number;
+  failed: number;
+}
+
+/**
+ * Drain one batch of pending outbox rows. Exported for tests.
+ */
+export async function reconcileFailedEvents(): Promise<ReconcileResult> {
+  const db = getDb();
+  const queue = getClinicalEventsQueue();
+
+  const pending = await db
+    .select()
+    .from(failedClinicalEvents)
+    .where(
+      and(
+        eq(failedClinicalEvents.status, "pending"),
+        lt(failedClinicalEvents.retry_count, MAX_RECONCILE_RETRIES),
+      ),
+    )
+    .limit(RECONCILE_BATCH_SIZE);
+
+  let reconciled = 0;
+  let retried = 0;
+  let failed = 0;
+
+  for (const row of pending) {
+    try {
+      await queue.add(row.event_type, row.event_payload);
+
+      await db
+        .update(failedClinicalEvents)
+        .set({
+          status: "processed",
+          processed_at: new Date().toISOString(),
+        })
+        .where(eq(failedClinicalEvents.id, row.id));
+
+      reconciled++;
+    } catch (err) {
+      const nextRetry = (row.retry_count ?? 0) + 1;
+      const isTerminal = nextRetry >= MAX_RECONCILE_RETRIES;
+      const errorMessage = err instanceof Error ? err.message : String(err);
+
+      await db
+        .update(failedClinicalEvents)
+        .set({
+          status: isTerminal ? "failed" : "pending",
+          retry_count: nextRetry,
+          error_message: errorMessage,
+          // Stamp processed_at on terminal failure so ops can see when we
+          // gave up. Kept null for retryable failures — we're not done yet.
+          processed_at: isTerminal ? new Date().toISOString() : null,
+        })
+        .where(eq(failedClinicalEvents.id, row.id));
+
+      if (isTerminal) {
+        failed++;
+      } else {
+        retried++;
+      }
+    }
+  }
+
+  return { reconciled, retried, failed };
+}
+
+/**
+ * Register the reconciler's repeatable job.
+ */
+export function setupOutboxReconcilerQueue(): Queue {
+  const queue = new Queue(RECONCILER_QUEUE_NAME, {
+    connection,
+    defaultJobOptions: {
+      removeOnComplete: { count: 100 },
+      removeOnFail: { count: 100 },
+    },
+  });
+
+  queue.add(
+    "reconcile",
+    {},
+    {
+      repeat: { every: RECONCILE_INTERVAL_MS },
+      jobId: "outbox-reconciler-repeatable",
+    },
+  );
+
+  return queue;
+}
+
+/**
+ * Start the reconciler worker.
+ */
+export function startOutboxReconcilerWorker(): Worker {
+  const worker = new Worker(
+    RECONCILER_QUEUE_NAME,
+    async (job: Job) => {
+      const startTime = Date.now();
+      const result = await reconcileFailedEvents();
+      const elapsed = Date.now() - startTime;
+
+      // Structured line — cheap to grep, easy to alert on `failed>0`.
+      console.log(
+        `[outbox-reconciler] job=${job.id} elapsed_ms=${elapsed} ` +
+          `reconciled=${result.reconciled} retried=${result.retried} failed=${result.failed}`,
+      );
+
+      return result;
+    },
+    {
+      connection,
+      concurrency: 1,
+    },
+  );
+
+  worker.on("ready", () => {
+    console.log(
+      `[outbox-reconciler] Worker ready, processing "${RECONCILER_QUEUE_NAME}" queue`,
+    );
+  });
+
+  worker.on("failed", (job: Job | undefined, error: Error) => {
+    console.error(
+      `[outbox-reconciler] Job ${job?.id} failed: ${error.message}`,
+    );
+  });
+
+  worker.on("error", (error: Error) => {
+    console.error(`[outbox-reconciler] Worker error: ${error.message}`);
+  });
+
+  return worker;
+}
+
+export { RECONCILER_QUEUE_NAME, RECONCILE_INTERVAL_MS };


### PR DESCRIPTION
## Summary
- Adds a BullMQ-repeatable reconciler in \`ai-oversight\` that drains the \`failed_clinical_events\` outbox every 5 minutes.
- Re-enqueues the original event payload to the \`clinical-events\` queue; marks rows \`processed\` on success, bumps \`retry_count\` and re-tries otherwise, flips \`status='failed'\` after 5 attempts.
- Each run returns/logs \`{ reconciled, retried, failed }\` so ops can alert on the failure rate without new metrics infra.

## Why
\`emitClinicalEvent\` already falls back to the outbox when BullMQ is unavailable, but nothing was draining it — any event written during a Redis blip was effectively lost from the AI oversight pipeline, defeating the clinical-safety + HIPAA audit guarantees.

## Test plan
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 284/284 passing (6 new for reconciler)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — clean (pre-existing clinician-portal warnings only)
- [ ] Manual: restart ai-oversight with pending rows, confirm structured log line emits

Closes #250