### PR TITLE
fix(ai): dedup flags by trigger_event_id to prevent replay duplicates

### DIFF
--- a/services/ai-oversight/src/__tests__/flag-service.test.ts
+++ b/services/ai-oversight/src/__tests__/flag-service.test.ts
@@ -24,6 +24,7 @@ vi.mock("@carebridge/db-schema", () => ({
     category: "category",
     severity: "severity",
     created_at: "created_at",
+    trigger_event_ids: "trigger_event_ids",
   },
 }));
 
@@ -161,10 +162,11 @@ describe("createFlag", () => {
       ...baseFlag,
       created_at: "2026-01-01T00:00:00.000Z",
     };
-    // First call: dedup SELECT -> [] (no dup found at app level)
-    // Second call (after conflict): fetch winner -> [winnerFlag]
+    // Call sequence: (1) trigger_event_id idempotency check -> [],
+    // (2) app-level rule dedup -> [], (3) post-conflict fetch -> [winnerFlag]
     mockLimit
-      .mockResolvedValueOnce([])       // initial dedup check
+      .mockResolvedValueOnce([])           // idempotency pre-check
+      .mockResolvedValueOnce([])           // initial dedup check
       .mockResolvedValueOnce([winnerFlag]); // post-conflict fetch
 
     const result = await createFlag(baseFlag);
@@ -196,8 +198,10 @@ describe("createFlag", () => {
 
     // ON CONFLICT DO NOTHING returns empty
     mockReturning.mockResolvedValueOnce([]);
-    // First SELECT (app-level dedup) -> no match; second SELECT (post-conflict) -> winner
+    // (1) idempotency pre-check -> []; (2) app-level LLM dedup -> [];
+    // (3) post-conflict fetch -> [winnerFlag]
     mockLimit
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([winnerFlag]);
 
@@ -261,6 +265,47 @@ describe("createFlag", () => {
         notify_specialties: [],
       }),
     );
+  });
+
+  it("returns existing flag when a trigger_event_id matches, regardless of status", async () => {
+    // A prior flag — already resolved — was cited against evt-99. When an
+    // event replay arrives citing evt-99 again, createFlag must return the
+    // prior flag instead of inserting a duplicate. The open-status partial
+    // indexes would miss this because the prior flag is no longer open.
+    const replayedFlag = {
+      ...baseFlag,
+      trigger_event_ids: ["evt-99"],
+    };
+
+    const resolvedExistingFlag = {
+      id: "prior-resolved-flag",
+      ...replayedFlag,
+      status: "resolved",
+      trigger_event_ids: ["evt-99"],
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+
+    // First (and only) SELECT is the trigger-event-id idempotency check.
+    mockLimit.mockResolvedValueOnce([resolvedExistingFlag]);
+
+    const result = await createFlag(replayedFlag);
+
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockEmitNotificationEvent).not.toHaveBeenCalled();
+    expect(result.id).toBe("prior-resolved-flag");
+  });
+
+  it("does not short-circuit when trigger_event_ids is empty", async () => {
+    // Some callers may legitimately omit trigger_event_ids (e.g. manual
+    // flags). The idempotency check must not fire in that case — otherwise
+    // no flags could ever be created without an event id.
+    const manualFlag = { ...baseFlag, trigger_event_ids: [] };
+
+    const result = await createFlag(manualFlag);
+
+    // Insert proceeds via the rule-based dedup path.
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(result.id).toBeDefined();
   });
 
   it("does not emit a notification event when a duplicate flag is returned", async () => {

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -6,7 +6,7 @@
  * only moved through their lifecycle.
  */
 
-import { eq, and, gte, sql } from "drizzle-orm";
+import { eq, and, or, gte, sql } from "drizzle-orm";
 import { getDb } from "@carebridge/db-schema";
 import { clinicalFlags } from "@carebridge/db-schema";
 import type { ClinicalFlag, FlagStatus } from "@carebridge/shared-types";
@@ -34,6 +34,40 @@ export async function createFlag(
   flag: Omit<ClinicalFlag, "id" | "created_at">,
 ): Promise<ClinicalFlag> {
   const db = getDb();
+
+  // Idempotency check — replay safety.
+  //
+  // The existing (patient, rule_id) and (patient, category, severity) dedup
+  // only fires when the prior flag is still `status='open'`. If a previously
+  // resolved/acknowledged flag's trigger event is replayed (outbox reconciler,
+  // BullMQ retry, manual requeue), the partial-unique indexes won't match and
+  // a duplicate flag for the same clinical event is created.
+  //
+  // Guard against that here by refusing to create a flag when any *existing*
+  // flag (regardless of status) already records one of the incoming
+  // trigger_event_ids. jsonb `@>` checks containment per event id; OR across
+  // them so the check is correct even when a flag cites multiple events.
+  if (flag.trigger_event_ids && flag.trigger_event_ids.length > 0) {
+    const eventIdMatchers = flag.trigger_event_ids.map(
+      (id) =>
+        sql`${clinicalFlags.trigger_event_ids} @> ${JSON.stringify([id])}::jsonb`,
+    );
+
+    const byEventId = await db
+      .select()
+      .from(clinicalFlags)
+      .where(
+        and(
+          eq(clinicalFlags.patient_id, flag.patient_id),
+          or(...eventIdMatchers),
+        ),
+      )
+      .limit(1);
+
+    if (byEventId.length > 0) {
+      return byEventId[0] as unknown as ClinicalFlag;
+    }
+  }
 
   // Check for existing open duplicate before inserting
   if (flag.rule_id) {


### PR DESCRIPTION
## Summary
- Adds a replay-safety idempotency check at the top of \`createFlag\`: if any existing flag for the same patient (regardless of status) already records one of the incoming \`trigger_event_ids\`, return that flag.
- Uses Postgres jsonb \`@>\` containment per event id, OR'd across them, so the check is correct when a flag cites multiple events.

## Why
The existing \`(patient_id, rule_id)\` and \`(patient_id, category, severity)\` dedup only fires when the prior flag is still \`status='open'\`. When a previously resolved/acknowledged flag's trigger event is replayed (outbox reconciler, BullMQ retry, manual requeue), the partial-unique indexes don't match and a duplicate flag is created for the same clinical event — polluting the clinician inbox and the audit trail.

## Test plan
- [x] New test: flag returned when a trigger_event_id matches regardless of status
- [x] New test: idempotency skipped when trigger_event_ids is empty
- [x] Existing TOCTOU tests updated to account for the extra pre-check SELECT
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 280/280 passing
- [x] \`pnpm typecheck\` — clean

Closes #261