### PR TITLE
fix(ai): severity-priority + alert on LLM flag truncation

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
@@ -63,15 +63,79 @@ describe("validateLLMResponse", () => {
     }
   });
 
-  it("caps flags at 20", () => {
-    const flags = Array.from({ length: 25 }, () => makeFlag());
+  it("caps flags at the configured MAX and records truncation detail", () => {
+    // 60 info-severity flags — above the 50 MAX_FLAGS cap.
+    const flags = Array.from({ length: 60 }, () =>
+      makeFlag({ severity: "info" }),
+    );
     const input = JSON.stringify(flags);
     const result = validateLLMResponse(input);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.flags).toHaveLength(20);
+      expect(result.flags).toHaveLength(50);
       expect(result.warnings.some((w) => w.includes("truncated"))).toBe(true);
+      expect(result.truncation).toBeDefined();
+      expect(result.truncation?.receivedCount).toBe(60);
+      expect(result.truncation?.keptCount).toBe(50);
+      expect(result.truncation?.droppedCount).toBe(10);
+      expect(result.truncation?.droppedBySeverity).toEqual({
+        critical: 0,
+        warning: 0,
+        info: 10,
+      });
+    }
+  });
+
+  it("preserves all critical flags under truncation", () => {
+    // 3 critical + 60 info (total 63, cap 50). Critical must all survive;
+    // info is dropped first.
+    const criticals = Array.from({ length: 3 }, (_, i) =>
+      makeFlag({ severity: "critical", summary: `crit-${i}` }),
+    );
+    const infos = Array.from({ length: 60 }, (_, i) =>
+      makeFlag({ severity: "info", summary: `info-${i}` }),
+    );
+    // Input order: infos first, then criticals. After severity sort, criticals come first.
+    const input = JSON.stringify([...infos, ...criticals]);
+    const result = validateLLMResponse(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.flags).toHaveLength(50);
+      const kept = result.flags.filter((f) => f.severity === "critical");
+      expect(kept).toHaveLength(3);
+      expect(result.truncation?.droppedBySeverity.critical).toBe(0);
+      expect(result.truncation?.droppedBySeverity.info).toBe(13);
+    }
+  });
+
+  it("drops warning before critical when both would overflow", () => {
+    const criticals = Array.from({ length: 40 }, () =>
+      makeFlag({ severity: "critical" }),
+    );
+    const warnings = Array.from({ length: 20 }, () =>
+      makeFlag({ severity: "warning" }),
+    );
+    const input = JSON.stringify([...warnings, ...criticals]); // 60 total
+    const result = validateLLMResponse(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.flags.filter((f) => f.severity === "critical")).toHaveLength(40);
+      expect(result.flags.filter((f) => f.severity === "warning")).toHaveLength(10);
+      expect(result.truncation?.droppedBySeverity.critical).toBe(0);
+      expect(result.truncation?.droppedBySeverity.warning).toBe(10);
+    }
+  });
+
+  it("does not set truncation when at or below the cap", () => {
+    const flags = Array.from({ length: 45 }, () => makeFlag());
+    const result = validateLLMResponse(JSON.stringify(flags));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.truncation).toBeUndefined();
+      expect(result.flags).toHaveLength(45);
     }
   });
 

--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -17,8 +17,15 @@ const VALID_CATEGORIES = [
   "documentation-discrepancy",
 ] as const;
 
-const MAX_FLAGS = 20;
+const MAX_FLAGS = 50;
 const SUSPICIOUS_FLAG_THRESHOLD = 15;
+
+/** Ordering used when a response overflows MAX_FLAGS: critical survive first. */
+const SEVERITY_RANK: Record<(typeof VALID_SEVERITIES)[number], number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
 
 export interface LLMFlag {
   severity: (typeof VALID_SEVERITIES)[number];
@@ -29,10 +36,25 @@ export interface LLMFlag {
   notify_specialties: string[];
 }
 
+/**
+ * Structured record of an over-cap truncation. Present only when the LLM
+ * returned more flags than MAX_FLAGS. Callers are expected to emit an
+ * ALERT-level log when this is set so ops can tell when clinical signal
+ * is being dropped rather than being quietly surfaced as a warning string.
+ */
+export interface TruncationInfo {
+  receivedCount: number;
+  keptCount: number;
+  droppedCount: number;
+  droppedBySeverity: Record<(typeof VALID_SEVERITIES)[number], number>;
+}
+
 export interface ValidationSuccess {
   ok: true;
   flags: LLMFlag[];
   warnings: string[];
+  /** Set only when findings were dropped to stay under MAX_FLAGS. */
+  truncation?: TruncationInfo;
 }
 
 export interface ValidationFailure {
@@ -175,13 +197,37 @@ export function validateLLMResponse(raw: string): ValidationResult {
     );
   }
 
+  // Sort by severity before capping so critical findings survive a truncation.
+  // Array.prototype.sort is stable in Node ≥ 12, so ordering within a severity
+  // bucket matches the LLM's original output (preserves rank/tie-break intent).
+  const all = [...(parsed as LLMFlag[])].sort(
+    (a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity],
+  );
+
   // Cap at MAX_FLAGS
-  const capped = parsed.slice(0, MAX_FLAGS) as LLMFlag[];
-  if (parsed.length > MAX_FLAGS) {
+  const capped = all.slice(0, MAX_FLAGS);
+  let truncation: TruncationInfo | undefined;
+  if (all.length > MAX_FLAGS) {
+    const dropped = all.slice(MAX_FLAGS);
+    const droppedBySeverity: Record<
+      (typeof VALID_SEVERITIES)[number],
+      number
+    > = { critical: 0, warning: 0, info: 0 };
+    for (const f of dropped) {
+      droppedBySeverity[f.severity]++;
+    }
+    truncation = {
+      receivedCount: all.length,
+      keptCount: capped.length,
+      droppedCount: dropped.length,
+      droppedBySeverity,
+    };
     warnings.push(
-      `Flag count ${parsed.length} exceeds maximum ${MAX_FLAGS}, truncated`,
+      `Flag count ${all.length} exceeds maximum ${MAX_FLAGS}, truncated ` +
+        `(dropped: critical=${droppedBySeverity.critical}, ` +
+        `warning=${droppedBySeverity.warning}, info=${droppedBySeverity.info})`,
     );
   }
 
-  return { ok: true, flags: capped, warnings };
+  return { ok: true, flags: capped, warnings, ...(truncation ? { truncation } : {}) };
 }

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -276,6 +276,20 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         );
       }
 
+      // Truncation is an alert-level event: the LLM produced more clinical
+      // signal than we kept. Emit as console.error so ops dashboards surface
+      // it distinct from generic warnings.
+      if (validationResult.truncation) {
+        const t = validationResult.truncation;
+        console.error(
+          `[review-service] ALERT: LLM findings truncated for job ${jobId} ` +
+            `(patient: ${redactPatientId(event.patient_id)}, event: ${event.type}/${event.id}): ` +
+            `received=${t.receivedCount}, kept=${t.keptCount}, dropped=${t.droppedCount} ` +
+            `[critical=${t.droppedBySeverity.critical}, ` +
+            `warning=${t.droppedBySeverity.warning}, info=${t.droppedBySeverity.info}]`,
+        );
+      }
+
       llmFindings = validationResult.flags.map((f) => ({
         severity: f.severity,
         category: f.category,


### PR DESCRIPTION
## Summary
- Raise \`MAX_FLAGS\` 20 → 50.
- Sort findings by severity (critical > warning > info) before capping, so criticals never get dropped while info survives.
- Add structured \`TruncationInfo\` on the validation result (receivedCount, keptCount, droppedCount, droppedBySeverity); \`review-service\` logs \`console.error\` at ALERT level when it's set.

## Why
Previously overflow was silently sliced in arbitrary response order with only a warning string. Any critical finding beyond the 20th was dropped and the clinician never saw it.

## Test plan
- [x] New tests: cap at 50 w/ dropped-by-severity breakdown; all criticals survive truncation; warnings drop before criticals; no truncation under the cap
- [x] \`pnpm --filter @carebridge/phi-sanitizer test\` — 13/13 passing
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 278/278 passing
- [x] \`pnpm typecheck\` — clean

Closes #260