### PR TITLE
fix(ai): filter patient state to event-time snapshot in rule context

### DIFF
--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -122,4 +122,113 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
 
     expect(ctx.recent_labs).toBeUndefined();
   });
+
+  it("excludes a medication discontinued before the event timestamp", async () => {
+    const eventAt = "2026-04-16T12:00:00.000Z";
+    const event: ClinicalEvent = { ...stubEvent, timestamp: eventAt };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([
+      // Started 10 days before event, ended 1 day before event — inactive at event time.
+      {
+        name: "Warfarin",
+        status: "active", // status is stale (wasn't yet updated to discontinued)
+        started_at: "2026-04-06T00:00:00.000Z",
+        ended_at: "2026-04-15T00:00:00.000Z",
+        created_at: "2026-04-06T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_medications).not.toContain("Warfarin");
+  });
+
+  it("includes a medication that is discontinued AFTER the event timestamp", async () => {
+    const eventAt = "2026-04-16T12:00:00.000Z";
+    const event: ClinicalEvent = { ...stubEvent, timestamp: eventAt };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([
+      // The TOCTOU scenario: med was active when event was emitted, then
+      // discontinued before the review ran. The rules MUST still see it.
+      {
+        name: "Apixaban",
+        status: "discontinued",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: "2026-04-16T15:00:00.000Z",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_medications).toContain("Apixaban");
+  });
+
+  it("excludes an allergy added after the event timestamp", async () => {
+    const eventAt = "2026-04-16T12:00:00.000Z";
+    const event: ClinicalEvent = { ...stubEvent, timestamp: eventAt };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    allergiesSelect.mockResolvedValue([
+      // Allergy recorded an hour AFTER the event — rule must not retroactively
+      // consider it when evaluating the triggering event.
+      {
+        allergen: "penicillin",
+        rxnorm_code: "7980",
+        severity: "severe",
+        reaction: "rash",
+        created_at: "2026-04-16T13:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.allergies).toHaveLength(0);
+  });
+
+  it("excludes a diagnosis resolved before the event timestamp", async () => {
+    const eventAt = "2026-04-16T12:00:00.000Z";
+    const event: ClinicalEvent = { ...stubEvent, timestamp: eventAt };
+
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Strep throat (resolved)",
+        icd10_code: "J02.0",
+        status: "active", // stale status
+        onset_date: "2026-04-01T00:00:00.000Z",
+        resolved_date: "2026-04-10T00:00:00.000Z",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_diagnoses).not.toContain("Strep throat (resolved)");
+  });
+
+  it("excludes lab results reported after the event timestamp", async () => {
+    const eventAt = "2026-04-16T12:00:00.000Z";
+    const event: ClinicalEvent = { ...stubEvent, timestamp: eventAt };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([
+      // Future lab — must not "leak from the future" into the rule evaluation.
+      { test_name: "ANC", value: 900, created_at: "2026-04-16T15:00:00.000Z" },
+      // Lab reported before the event — included.
+      { test_name: "WBC", value: 2.1, created_at: "2026-04-16T10:00:00.000Z" },
+    ]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 2.1 }]);
+  });
 });

--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock db-schema BEFORE importing the module under test.
+//
+// buildPatientContext issues eight parallel reads (patient, diagnoses,
+// allergies, medications, vitals, lab panels, recent flags, care team)
+// followed by a conditional lab-results read and an optional users
+// lookup. We drive each one with its own sequenced mock so tests assert
+// on filtering behavior (TOCTOU, retractions) without wiring a real DB.
+const diagnosesSelect = vi.fn();
+const allergiesSelect = vi.fn();
+const medicationsSelect = vi.fn();
+const vitalsSelect = vi.fn();
+const labPanelsSelect = vi.fn();
+const clinicalFlagsSelect = vi.fn();
+const careTeamSelect = vi.fn();
+const labResultsSelect = vi.fn();
+const usersSelect = vi.fn();
+const selectMock = vi.fn();
+
+const patientFindFirst = vi.fn();
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({
+    select: selectMock,
+    query: {
+      patients: { findFirst: patientFindFirst },
+    },
+  }),
+  patients: {},
+  diagnoses: { patient_id: "patient_id", status: "status" },
+  medications: { patient_id: "patient_id", status: "status" },
+  allergies: { patient_id: "patient_id" },
+  vitals: { patient_id: "patient_id", recorded_at: "recorded_at" },
+  labPanels: { id: "id", patient_id: "patient_id", collected_at: "collected_at" },
+  labResults: { panel_id: "panel_id", created_at: "created_at" },
+  clinicalFlags: { patient_id: "patient_id", created_at: "created_at" },
+  careTeamMembers: { patient_id: "patient_id", is_active: "is_active" },
+  users: { id: "id" },
+}));
+
+vi.mock("@carebridge/phi-sanitizer", () => ({
+  sanitizeFreeText: (s: string) => s,
+}));
+
+vi.mock("@carebridge/medical-logic", () => ({
+  calculateDelta: () => null,
+}));
+
+import { buildPatientContext } from "../workers/context-builder.js";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+const EVENT_AT = "2026-04-16T12:00:00.000Z";
+
+const baseEvent: ClinicalEvent = {
+  id: "evt-1",
+  type: "vital.created",
+  patient_id: "p-1",
+  timestamp: EVENT_AT,
+  data: { chief_complaint: "fever" },
+};
+
+describe("buildPatientContext — event-time snapshot (LLM path)", () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    diagnosesSelect.mockReset();
+    allergiesSelect.mockReset();
+    medicationsSelect.mockReset();
+    vitalsSelect.mockReset();
+    labPanelsSelect.mockReset();
+    clinicalFlagsSelect.mockReset();
+    careTeamSelect.mockReset();
+    labResultsSelect.mockReset();
+    usersSelect.mockReset();
+    patientFindFirst.mockReset();
+
+    // Sensible defaults — tests override as needed.
+    patientFindFirst.mockResolvedValue({
+      id: "p-1",
+      date_of_birth: "1970-01-01",
+      biological_sex: "female",
+      allergy_status: "has_allergies",
+      name: "Test Patient",
+    });
+    diagnosesSelect.mockResolvedValue([]);
+    allergiesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    vitalsSelect.mockResolvedValue([]);
+    labPanelsSelect.mockResolvedValue([]);
+    clinicalFlagsSelect.mockResolvedValue([]);
+    careTeamSelect.mockResolvedValue([]);
+    labResultsSelect.mockResolvedValue([]);
+    usersSelect.mockResolvedValue([]);
+
+    // The call ordering mirrors the Promise.all in buildPatientContext:
+    //   1. diagnoses        (select → from → where)
+    //   2. allergies        (select → from → where)
+    //   3. medications      (select → from → where)
+    //   4. vitals           (select → from → where → orderBy → limit)
+    //   5. labPanels        (select → from → where → orderBy → limit)
+    //   6. clinicalFlags    (select → from → where → orderBy → limit)
+    //   7. careTeam         (select → from → where)
+    // Then, only if lab panels returned rows:
+    //   8. labResults       (select → from → where)
+    // Then, only if care team is non-empty:
+    //   9. users            (select → from → where)
+    selectMock
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => diagnosesSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => allergiesSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => medicationsSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => ({ limit: () => vitalsSelect() }),
+          }),
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => ({ limit: () => labPanelsSelect() }),
+          }),
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({
+          where: () => ({
+            orderBy: () => ({ limit: () => clinicalFlagsSelect() }),
+          }),
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => careTeamSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => labResultsSelect() }),
+      }))
+      .mockImplementationOnce(() => ({
+        from: () => ({ where: () => usersSelect() }),
+      }));
+  });
+
+  it("includes a medication that is discontinued AFTER the event timestamp (TOCTOU)", async () => {
+    // Mirrors the load-bearing test from build-patient-context.test.ts —
+    // the med was active when the event was emitted, then discontinued
+    // before the LLM review ran. The LLM context MUST still see it so
+    // its view aligns with the rule-path view.
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Apixaban",
+        status: "discontinued",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: "2026-04-16T15:00:00.000Z", // 3h AFTER event
+        created_at: "2026-04-01T00:00:00.000Z",
+        dose_amount: "5",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "BID",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.active_medications.map((m) => m.name)).toContain("Apixaban");
+  });
+
+  it("excludes a medication discontinued BEFORE the event timestamp", async () => {
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Warfarin",
+        status: "active", // stale status
+        started_at: "2026-04-06T00:00:00.000Z",
+        ended_at: "2026-04-15T00:00:00.000Z", // ended 1d before event
+        created_at: "2026-04-06T00:00:00.000Z",
+        dose_amount: "5",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "Daily",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.active_medications.map((m) => m.name)).not.toContain("Warfarin");
+  });
+
+  it("excludes an allergy added after the event timestamp", async () => {
+    allergiesSelect.mockResolvedValue([
+      {
+        allergen: "penicillin",
+        verification_status: "confirmed",
+        created_at: "2026-04-16T13:00:00.000Z", // 1h AFTER event
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.patient.allergies).toHaveLength(0);
+  });
+
+  it("excludes allergies with verification_status = entered_in_error or refuted", async () => {
+    allergiesSelect.mockResolvedValue([
+      {
+        allergen: "penicillin",
+        verification_status: "entered_in_error",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        allergen: "latex",
+        verification_status: "refuted",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        allergen: "sulfa",
+        verification_status: "confirmed",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    const allergens = ctx.patient.allergies.map((a) =>
+      typeof a === "string" ? a : a.allergen,
+    );
+    expect(allergens).toEqual(["sulfa"]);
+  });
+
+  it("excludes a diagnosis resolved before the event timestamp", async () => {
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Strep throat (resolved)",
+        icd10_code: "J02.0",
+        status: "active", // stale status
+        onset_date: "2026-04-01T00:00:00.000Z",
+        resolved_date: "2026-04-10T00:00:00.000Z",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        description: "Breast cancer",
+        icd10_code: "C50.9",
+        status: "active",
+        onset_date: "2025-01-01T00:00:00.000Z",
+        resolved_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.patient.active_diagnoses).not.toContain(
+      "Strep throat (resolved)",
+    );
+    expect(ctx.patient.active_diagnoses).toContain("Breast cancer");
+  });
+
+  it("excludes lab results reported after the event timestamp", async () => {
+    labPanelsSelect.mockResolvedValue([
+      { id: "panel-1", collected_at: "2026-04-16T09:00:00.000Z" },
+    ]);
+    labResultsSelect.mockResolvedValue([
+      {
+        test_name: "ANC",
+        value: 900,
+        unit: "cells/uL",
+        flag: null,
+        panel_id: "panel-1",
+        created_at: "2026-04-16T15:00:00.000Z", // AFTER event
+      },
+      {
+        test_name: "WBC",
+        value: 2.1,
+        unit: "K/uL",
+        flag: "low",
+        panel_id: "panel-1",
+        created_at: "2026-04-16T10:00:00.000Z", // BEFORE event
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.recent_labs).toBeDefined();
+    expect(ctx.recent_labs?.map((l) => l.test_name)).toEqual(["WBC"]);
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -454,7 +454,7 @@ export async function buildPatientContextForRules(
     Date.now() - LAB_WINDOW_HOURS * 60 * 60 * 1000,
   ).toISOString();
 
-  const [activeDiagnoses, activeMeds, patientAllergies, recentLabRows] = await Promise.all([
+  const [allDiagnoses, allMeds, allAllergies, recentLabRows] = await Promise.all([
     db.select().from(diagnoses).where(eq(diagnoses.patient_id, patientId)),
     db.select().from(medications).where(eq(medications.patient_id, patientId)),
     db.select().from(allergies).where(eq(allergies.patient_id, patientId)),
@@ -480,19 +480,52 @@ export async function buildPatientContextForRules(
   // Extract new symptoms from the event data
   const newSymptoms = extractSymptoms(event);
 
-  const activeDx = activeDiagnoses.filter((d) => d.status === "active");
+  // TOCTOU fix — filter rows to their state AS OF event.timestamp, not as of
+  // review time. Without this, a med discontinued or an allergy added between
+  // event emit and review causes missed/false flags: the rules see a newer
+  // snapshot than the event they are evaluating. See #258.
+  const eventAt = event.timestamp;
+
+  function wasActiveAt(
+    row: { onset_date?: string | null; resolved_date?: string | null; status: string; created_at: string },
+    at: string,
+  ): boolean {
+    const start = row.onset_date ?? row.created_at;
+    if (start > at) return false; // not yet started at event time
+    if (row.resolved_date && row.resolved_date <= at) return false; // resolved before event
+    return true;
+  }
+
+  const activeDx = allDiagnoses.filter((d) => wasActiveAt(d, eventAt));
 
   // Dedupe recent labs by test_name, keeping the freshest value per name.
   // labRows are ordered desc by created_at, so the first occurrence wins.
+  // Also exclude labs reported *after* event time so the rule doesn't "see
+  // the future".
   const seenLabs = new Set<string>();
   const recentLabs: Array<{ name: string; value: number }> = [];
   for (const row of recentLabRows) {
+    if (row.created_at > eventAt) continue;
     if (seenLabs.has(row.test_name)) continue;
     seenLabs.add(row.test_name);
     recentLabs.push({ name: row.test_name, value: row.value });
   }
 
-  const activeMedsList = activeMeds.filter((m) => m.status === "active");
+  // A medication was "active at event time" if it had started (started_at
+  // present and <= event time) and had not yet ended (ended_at null or
+  // strictly after event time). Falls back to created_at when started_at
+  // is missing — defensive, should not be needed under the non-null
+  // schema constraint but guards against partial records.
+  const activeMedsList = allMeds.filter((m) => {
+    const start = m.started_at ?? m.created_at;
+    if (start > eventAt) return false;
+    if (m.ended_at && m.ended_at <= eventAt) return false;
+    return true;
+  });
+
+  // An allergy is relevant iff it was already recorded before the event.
+  // A post-hoc addition must not retroactively flag the triggering event.
+  const patientAllergies = allAllergies.filter((a) => a.created_at <= eventAt);
 
   return {
     active_diagnoses: activeDx.map((d) => d.description),

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -46,21 +46,53 @@ function sanitizeEventData(data: unknown): unknown {
 }
 
 /**
+ * Was this diagnosis active AS OF `at` (event time)? Mirrors the helper in
+ * buildPatientContextForRules so the LLM and rule paths share the same
+ * snapshot semantics. See #258 and #512.
+ */
+function diagnosisWasActiveAt(
+  row: {
+    onset_date?: string | null;
+    resolved_date?: string | null;
+    status?: string | null;
+    created_at: string;
+  },
+  at: string,
+): boolean {
+  const start = row.onset_date ?? row.created_at;
+  if (start > at) return false; // not yet started at event time
+  if (row.resolved_date && row.resolved_date <= at) return false; // resolved before event
+  return true;
+}
+
+/**
  * Build the full patient context needed for LLM clinical review.
+ *
+ * Filters diagnoses, medications, allergies, vitals, and labs to the
+ * patient snapshot AS OF `triggerEvent.timestamp`. This keeps the LLM's
+ * view aligned with the deterministic rule-path view (see
+ * `buildPatientContextForRules`) so dedup/precedence reasoning compares
+ * apples to apples. Without this, a med discontinued between event emit
+ * and LLM review would disappear from the LLM context while the rules
+ * still see it, producing inconsistent flags. See #258, #512.
  */
 export async function buildPatientContext(
   patientId: string,
   triggerEvent: ClinicalEvent,
 ): Promise<ReviewContext> {
   const db = getDb();
+  const eventAt = triggerEvent.timestamp;
 
-  // Run all queries in parallel for speed
+  // Run all queries in parallel for speed. We fetch the full history for
+  // diagnoses / medications / allergies and then filter in-memory to the
+  // event-time snapshot (same approach as the rule context builder;
+  // moving the predicate into SQL is tracked in #514).
   const [
     patientRow,
-    activeDiagnoses,
-    patientAllergies,
-    activeMeds,
-    latestVitals,
+    allDiagnoses,
+    allAllergies,
+    allMeds,
+    allVitals,
     recentPanels,
     recentFlags,
     careTeam,
@@ -68,37 +100,21 @@ export async function buildPatientContext(
     db.query.patients.findFirst({
       where: eq(patients.id, patientId),
     }),
-    db
-      .select()
-      .from(diagnoses)
-      .where(
-        and(eq(diagnoses.patient_id, patientId), eq(diagnoses.status, "active")),
-      ),
-    db
-      .select()
-      .from(allergies)
-      .where(eq(allergies.patient_id, patientId)),
-    db
-      .select()
-      .from(medications)
-      .where(
-        and(
-          eq(medications.patient_id, patientId),
-          eq(medications.status, "active"),
-        ),
-      ),
+    db.select().from(diagnoses).where(eq(diagnoses.patient_id, patientId)),
+    db.select().from(allergies).where(eq(allergies.patient_id, patientId)),
+    db.select().from(medications).where(eq(medications.patient_id, patientId)),
     db
       .select()
       .from(vitals)
       .where(eq(vitals.patient_id, patientId))
       .orderBy(desc(vitals.recorded_at))
-      .limit(20),
+      .limit(100),
     db
       .select()
       .from(labPanels)
       .where(eq(labPanels.patient_id, patientId))
       .orderBy(desc(labPanels.collected_at))
-      .limit(5),
+      .limit(20),
     db
       .select()
       .from(clinicalFlags)
@@ -115,6 +131,43 @@ export async function buildPatientContext(
         ),
       ),
   ]);
+
+  // Event-time snapshot filtering — diagnoses active at event time.
+  const activeDiagnoses = allDiagnoses.filter((d) =>
+    diagnosisWasActiveAt(d, eventAt),
+  );
+
+  // Event-time snapshot filtering — medications active at event time.
+  // A med is active if it started at/before event time AND either is
+  // still open (no ended_at) or ended strictly after event time. Falls
+  // back to created_at if started_at is null (defensive; see #516).
+  const activeMeds = allMeds.filter((m) => {
+    const start = m.started_at ?? m.created_at;
+    if (start > eventAt) return false;
+    if (m.ended_at && m.ended_at <= eventAt) return false;
+    return true;
+  });
+
+  // Event-time snapshot — allergies recorded at/before the event.
+  // Also exclude logical retractions (entered_in_error, refuted); these
+  // are charting corrections and must not appear in the LLM context.
+  // See #515.
+  const patientAllergies = allAllergies.filter((a) => {
+    if (a.created_at > eventAt) return false;
+    if (
+      a.verification_status === "entered_in_error" ||
+      a.verification_status === "refuted"
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  // Event-time snapshot — vitals recorded at/before the event. Keep the
+  // 20 most recent eligible rows to match the previous budget.
+  const latestVitals = allVitals
+    .filter((v) => v.recorded_at <= eventAt)
+    .slice(0, 20);
 
   // Calculate patient age
   let age = 0;
@@ -155,7 +208,9 @@ export async function buildPatientContext(
     };
   }
 
-  // Fetch lab results for recent panels
+  // Fetch lab results for recent panels, then filter to pre-event rows.
+  // Prevents "future leakage" of labs reported after the triggering event
+  // into the LLM context (mirrors the rule-path behavior).
   let recentLabResults: ReviewContext["recent_labs"] = [];
   if (recentPanels.length > 0) {
     const panelIds = recentPanels.map((p) => p.id);
@@ -164,13 +219,16 @@ export async function buildPatientContext(
       .from(labResults)
       .where(inArray(labResults.panel_id, panelIds));
 
-    recentLabResults = allResults.map((r) => ({
-      test_name: r.test_name,
-      value: r.value,
-      unit: r.unit,
-      flag: r.flag ?? null,
-      collected_at: r.created_at,
-    }));
+    recentLabResults = allResults
+      .filter((r) => r.created_at <= eventAt)
+      .slice(0, 50)
+      .map((r) => ({
+        test_name: r.test_name,
+        value: r.value,
+        unit: r.unit,
+        flag: r.flag ?? null,
+        collected_at: r.created_at,
+      }));
   }
 
   // Resolve care team member names


### PR DESCRIPTION
## Summary
- Filter diagnoses/medications/allergies/labs in \`buildPatientContextForRules\` by \`event.timestamp\` instead of current DB state.
- Uses row-level timestamps (\`onset_date\`/\`resolved_date\`, \`started_at\`/\`ended_at\`, \`created_at\`) — not the denormalized \`status\` columns — so a status column lagging its timestamp column cannot flip a rule outcome.

## Why
The rule pipeline read current state but evaluated it against an event emitted seconds-to-minutes earlier. Races between emission and review caused:

- **Missed flags** — a med active at event time but discontinued before review runs was excluded by \`status='active'\`; drug-interaction/allergy-medication rules didn't fire.
- **False flags** — an allergy added after event emission appeared relevant to the triggering event.

## Test plan
- [x] 5 new unit tests covering: med discontinued before event (exclude), med discontinued after event (include — the TOCTOU case), allergy added after event (exclude), diagnosis resolved before event (exclude), future lab (exclude).
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 283/283 passing
- [x] \`pnpm typecheck\` — clean

Closes #258