### PR TITLE
fix(ai): explicit BullMQ lock tuning + trigger_event_id review idempotency

### DIFF
--- a/services/ai-oversight/src/__tests__/review-idempotency.test.ts
+++ b/services/ai-oversight/src/__tests__/review-idempotency.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+// ─── Mocks ───────────────────────────────────────────────────────
+//
+// This test covers the narrow contract that processReviewJob SKIPS the
+// full review pipeline when a `completed` review_jobs row already exists
+// for the trigger_event_id. We mock the first select().from().where().limit()
+// to return a prior-completed row; if the idempotency check works, the
+// pipeline returns early without touching flag-service, LLM, or context.
+
+const insertValues = vi.fn().mockResolvedValue(undefined);
+const insertMock = vi.fn().mockReturnValue({ values: insertValues });
+
+const updateSetWhere = vi.fn().mockResolvedValue(undefined);
+const updateSet = vi.fn().mockReturnValue({ where: updateSetWhere });
+const updateMock = vi.fn().mockReturnValue({ set: updateSet });
+
+// Idempotency-first select chain: select().from().where().limit()
+const limitMock = vi.fn();
+const selectWhere = vi.fn().mockReturnValue({ limit: limitMock });
+const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+const selectMock = vi.fn().mockImplementation(() => ({ from: selectFrom }));
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({
+    insert: insertMock,
+    update: updateMock,
+    select: selectMock,
+    query: { patients: { findFirst: vi.fn() } },
+  }),
+  reviewJobs: { id: "id", trigger_event_id: "trigger_event_id", status: "status" },
+  diagnoses: {},
+  medications: {},
+  patients: {},
+  allergies: {},
+  messages: {},
+  patientObservations: {},
+  labPanels: {},
+  labResults: {},
+  clinicalFlags: {},
+  encounters: {},
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  desc: vi.fn(),
+  gte: vi.fn(),
+  sql: vi.fn(),
+}));
+
+const { mockCreateFlag } = vi.hoisted(() => ({
+  mockCreateFlag: vi.fn(),
+}));
+vi.mock("../services/flag-service.js", () => ({
+  createFlag: mockCreateFlag,
+}));
+
+vi.mock("../services/claude-client.js", () => ({
+  reviewPatientRecord: vi.fn(),
+}));
+
+vi.mock("../workers/context-builder.js", () => ({
+  buildPatientContext: vi.fn(),
+}));
+
+vi.mock("../rules/critical-values.js", () => ({
+  checkCriticalValues: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../rules/cross-specialty.js", () => ({
+  checkCrossSpecialtyPatterns: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../rules/drug-interactions.js", () => ({
+  checkDrugInteractions: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../rules/allergy-medication.js", () => ({
+  checkAllergyMedication: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../rules/message-screening.js", () => ({
+  screenPatientMessage: vi.fn().mockReturnValue([]),
+}));
+vi.mock("../rules/observation-screening.js", () => ({
+  screenPatientObservation: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@carebridge/ai-prompts", () => ({
+  CLINICAL_REVIEW_SYSTEM_PROMPT: "system",
+  PROMPT_VERSION: "1.0.0-test",
+  buildReviewPrompt: vi.fn(),
+  enforceTokenBudget: vi.fn(),
+}));
+
+vi.mock("@carebridge/phi-sanitizer", () => ({
+  redactClinicalText: vi.fn(),
+  redactPatientId: vi.fn().mockReturnValue("[patient]"),
+  validateLLMResponse: vi.fn(),
+}));
+
+import { processReviewJob } from "../services/review-service.js";
+
+function makeEvent(overrides: Partial<ClinicalEvent> = {}): ClinicalEvent {
+  return {
+    id: "evt-idem-1",
+    type: "vital.created",
+    patient_id: "pat-1",
+    timestamp: "2026-04-16T12:00:00.000Z",
+    data: {},
+    ...overrides,
+  };
+}
+
+describe("processReviewJob — idempotency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertMock.mockReturnValue({ values: insertValues });
+    updateMock.mockReturnValue({ set: updateSet });
+    updateSet.mockReturnValue({ where: updateSetWhere });
+    selectMock.mockImplementation(() => ({ from: selectFrom }));
+    selectFrom.mockReturnValue({ where: selectWhere });
+    selectWhere.mockReturnValue({ limit: limitMock });
+  });
+
+  it("skips processing when a completed review_jobs row already exists for the event", async () => {
+    // First select.limit() call is the idempotency probe — return a prior
+    // completed row. No other mocks need priming because the function
+    // returns before touching anything else.
+    limitMock.mockResolvedValueOnce([
+      { id: "prior-job-id", status: "completed" },
+    ]);
+
+    await processReviewJob(makeEvent());
+
+    // No insert, no flag creation, no update.
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(mockCreateFlag).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with processing when no prior completed review exists", async () => {
+    // Idempotency probe returns [] — no prior run. All downstream selects
+    // (patient context builder, encounters, etc.) also get [] to keep the
+    // pipeline unblocked through to the insert.
+    limitMock.mockResolvedValue([]);
+
+    // The downstream pipeline still needs usable mocks — at minimum the
+    // insert into review_jobs must be reached. Everything after that is
+    // short-circuited by the empty rule results mocked above.
+    const event = makeEvent({ id: "evt-new" });
+
+    // We expect this NOT to return early; the job row insert is proof.
+    try {
+      await processReviewJob(event);
+    } catch {
+      // The rest of the pipeline is stubbed lightly — exceptions from
+      // context-builder etc. are acceptable; we only care that we got past
+      // the idempotency guard.
+    }
+
+    expect(insertMock).toHaveBeenCalled();
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -57,6 +57,31 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
   const jobId = crypto.randomUUID();
   const startTime = Date.now();
 
+  // Idempotency: if a completed review already exists for this trigger event,
+  // skip. BullMQ can re-deliver a job when a worker crashes mid-processing
+  // (lock expires → stalled-scan reclaims the job) or the same event is
+  // replayed via the outbox reconciler. Without this check each redelivery
+  // writes an extra review_jobs row and — for rules whose dedup cannot cover
+  // the replay window — potentially duplicate flags.
+  const existingCompleted = await db
+    .select({ id: reviewJobs.id, status: reviewJobs.status })
+    .from(reviewJobs)
+    .where(
+      and(
+        eq(reviewJobs.trigger_event_id, event.id),
+        eq(reviewJobs.status, "completed"),
+      ),
+    )
+    .limit(1);
+
+  if (existingCompleted.length > 0) {
+    console.log(
+      `[review-service] Skipping duplicate review for event ${event.id} ` +
+        `(prior completed job ${existingCompleted[0]!.id})`,
+    );
+    return;
+  }
+
   // Step 1: Create a review_jobs record
   await db.insert(reviewJobs).values({
     id: jobId,

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -18,6 +18,24 @@ const DLQ_NAME = "clinical-events-failed";
 
 const connection = getRedisConnection();
 
+/**
+ * Worker lock tuning.
+ *
+ * A clinical review can take up to ~90s end-to-end (DB context fetch +
+ * Claude call + flag writes). BullMQ's default 30s lockDuration would let
+ * a slow-but-healthy job be reclaimed by another worker and double-processed
+ * mid-flight. Raise to 2 minutes so only a genuinely-crashed worker loses
+ * its lock, then let `maxStalledCount` surface the crash as a retry rather
+ * than a silent duplicate.
+ *
+ * With stalledInterval=30s + maxStalledCount=1, a truly stuck job takes at
+ * most ~60s to be noticed after its lock expires — balancing fast recovery
+ * against wrongly reclaiming a long-running but healthy job.
+ */
+const WORKER_LOCK_DURATION_MS = 120_000; // 2 minutes
+const WORKER_STALLED_INTERVAL_MS = 30_000; // scan for stalled jobs every 30s
+const WORKER_MAX_STALLED_COUNT = 1;
+
 const dlq = new Queue(DLQ_NAME, {
   connection,
   defaultJobOptions: {
@@ -66,6 +84,11 @@ export function startReviewWorker(): Worker {
         max: 10,
         duration: 60_000, // Max 10 jobs per minute to respect API rate limits
       },
+      // Crash-recovery tuning — see constants above. Explicit values so a
+      // BullMQ default change can't silently shift our recovery window.
+      lockDuration: WORKER_LOCK_DURATION_MS,
+      stalledInterval: WORKER_STALLED_INTERVAL_MS,
+      maxStalledCount: WORKER_MAX_STALLED_COUNT,
     },
   );
 


### PR DESCRIPTION
## Summary
- \`review-worker\`: set \`lockDuration=120s\`, \`stalledInterval=30s\`, \`maxStalledCount=1\` explicitly so a slow (30–90s) healthy review can't be reclaimed by another worker mid-flight.
- \`review-service\`: add a pre-insert idempotency probe — if a \`review_jobs\` row with this \`trigger_event_id\` and \`status='completed'\` already exists, skip. Pairs with #261's flag-level idempotency for partial completions.

## Why
BullMQ's default 30s lockDuration is shorter than the p99 review duration. A slow healthy job could be reclaimed and double-processed; a crashed job was redelivered without any app-level guard against re-executing the full pipeline, leading to duplicate \`review_jobs\` rows and noisy audit data.

## Test plan
- [x] New test file \`review-idempotency.test.ts\` — 2 tests: skips when prior completed row, proceeds when none
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 280/280 passing
- [x] \`pnpm typecheck\` — clean

Closes #257