### PR TITLE
fix(clinical): warn on implausible pulse pressure in BP validation

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -64,6 +64,32 @@ describe("validateVital", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("warns on narrow pulse pressure (shock / tamponade)", () => {
+    // 80/75 — PP=5, clinically suggests shock or artifact
+    const result = validateVital("blood_pressure", 80, 75);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(true);
+  });
+
+  it("warns on wide pulse pressure (aortic regurgitation)", () => {
+    // 140/20 — PP=120, suggests AR or measurement error
+    // Note: diastolic 20 is at the lower plausibility bound but valid.
+    const result = validateVital("blood_pressure", 140, 20);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("wide pulse pressure"))).toBe(true);
+  });
+
+  it("does not warn on typical pulse pressure", () => {
+    // 120/80 — PP=40, normal adult
+    const result = validateVital("blood_pressure", 120, 80);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("pulse pressure"))).toBe(false);
+  });
+
+  it("does not warn on pulse pressure when diastolic >= systolic (error already flagged)", () => {
+    // Invariant: PP warning should not fire when the diastolic >= systolic
+    // error is already flagged — no need to pile on.
+    const result = validateVital("blood_pressure", 120, 130);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("pulse pressure"))).toBe(false);
+  });
+
   it("returns valid for temperature in normal range", () => {
     const result = validateVital("temperature", 98.6);
     expect(result.valid).toBe(true);

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -180,6 +180,26 @@ export function validateVital(
     if (secondary < 20 || secondary > 200) {
       errors.push(`Diastolic ${secondary} is outside plausible range (20–200)`);
     }
+
+    // Pulse-pressure plausibility check. Normal adult pulse pressure is
+    // ~30-50 mmHg; a narrow (<20) PP usually indicates shock, tamponade,
+    // or an artifact, and a wide (>100) PP suggests aortic regurgitation
+    // or measurement error. Either extreme is physically implausible
+    // without clinical context that should be confirmed on the record.
+    if (secondary < primary) {
+      const pulsePressure = primary - secondary;
+      if (pulsePressure < 20) {
+        warnings.push(
+          `Narrow pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
+            `consider shock, cardiac tamponade, or measurement artifact`,
+        );
+      } else if (pulsePressure > 100) {
+        warnings.push(
+          `Wide pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
+            `consider aortic regurgitation or measurement error`,
+        );
+      }
+    }
   }
 
   return { valid: errors.length === 0, warnings, errors };


### PR DESCRIPTION
## Summary
- \`validateVital\` for \`blood_pressure\` now computes pulse pressure (systolic − diastolic) and warns on clinically implausible values:
  - **Narrow < 20 mmHg** — suggests shock, cardiac tamponade, or artifact
  - **Wide > 100 mmHg** — suggests aortic regurgitation or measurement error
- Only fires when secondary < primary, so the existing \"diastolic ≥ systolic\" error stays the primary signal for swapped/invalid readings.

## Why
Previously the validator accepted 80/75 (PP=5 — shock) or 140/20 (PP=120 — AR) without any warning because the diastolic was technically within the 20–200 range. Silent acceptance of physically implausible readings is a clinical-safety hazard.

## Test plan
- [x] 4 new unit tests: narrow PP warning, wide PP warning, normal PP no warning, no redundant warning on already-invalid BP
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 143/143 passing
- [x] \`pnpm typecheck\` — clean

Closes #247