### PR TITLE
fix(portal): per-vital staleness tiers with age-at-a-glance rendering

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -79,6 +79,67 @@ function StaleDataBanner({
   );
 }
 
+/**
+ * Compute a human-readable "N units ago" string for a clinical-data timestamp.
+ * Fixed clinical thresholds (not locale-based) so the age string is
+ * diagnostic at a glance: hours for <24h, days beyond that.
+ */
+function formatAge(recordedAtIso: string): string {
+  const ageMs = Date.now() - new Date(recordedAtIso).getTime();
+  if (ageMs < 60_000) return "just now";
+  const mins = Math.round(ageMs / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(ageMs / 3_600_000);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(ageMs / 86_400_000);
+  return `${days}d ago`;
+}
+
+/**
+ * Classify a recorded-at timestamp into a staleness tier.
+ *
+ * Thresholds mirror the clinical expectation for acute-care inpatient
+ * monitoring: vitals taken more than 4h ago are due for re-check, and
+ * vitals older than 24h should not be read as "current" at all.
+ *
+ *  - "current":  <= 4h — no visual treatment
+ *  - "overdue":  4h < age <= 24h — amber tint, "recheck due"
+ *  - "stale":    > 24h — gray, "stale" label, reader should not trust
+ */
+type StalenessTier = "current" | "overdue" | "stale";
+
+function classifyStaleness(recordedAtIso: string): StalenessTier {
+  const ageMs = Date.now() - new Date(recordedAtIso).getTime();
+  if (ageMs > 24 * 60 * 60 * 1000) return "stale";
+  if (ageMs > 4 * 60 * 60 * 1000) return "overdue";
+  return "current";
+}
+
+function stalenessStyles(tier: StalenessTier): {
+  color?: string;
+  background?: string;
+  border?: string;
+  note?: string;
+} {
+  switch (tier) {
+    case "overdue":
+      return {
+        background: "var(--color-warning-bg, #fff8e1)",
+        border: "1px solid var(--color-warning-border, #f0b429)",
+        note: "recheck due",
+      };
+    case "stale":
+      return {
+        background: "var(--color-muted-bg, #f4f4f5)",
+        color: "var(--text-muted)",
+        border: "1px solid var(--color-muted-border, #d4d4d8)",
+        note: "stale",
+      };
+    default:
+      return {};
+  }
+}
+
 function OverviewTab({ patientId }: { patientId: string }) {
   const patientQuery = trpc.patients.getById.useQuery({ id: patientId });
   const diagnosesQuery = trpc.patients.diagnoses.getByPatient.useQuery({ patientId });
@@ -221,20 +282,42 @@ function VitalsTab({ patientId }: { patientId: string }) {
         />
       ) : null}
       <div className="detail-grid">
-        {latest.map((vital, i) => (
-          <div key={i} className="stat-card">
-            <span className="stat-label">{vital.type}</span>
-            <span
-              className="stat-value"
-              style={{ fontSize: 24, color: "var(--text-primary)" }}
+        {latest.map((vital, i) => {
+          const tier = classifyStaleness(vital.recorded_at);
+          const s = stalenessStyles(tier);
+          return (
+            <div
+              key={i}
+              className="stat-card"
+              style={{
+                background: s.background,
+                border: s.border,
+                color: s.color,
+              }}
             >
-              {vital.value_primary} {vital.unit}
-            </span>
-            <span className="stat-detail">
-              {new Date(vital.recorded_at).toLocaleString()}
-            </span>
-          </div>
-        ))}
+              <span className="stat-label">{vital.type}</span>
+              <span
+                className="stat-value"
+                style={{
+                  fontSize: 24,
+                  color: s.color ?? "var(--text-primary)",
+                }}
+              >
+                {vital.value_primary} {vital.unit}
+              </span>
+              <span className="stat-detail">
+                {formatAge(vital.recorded_at)}
+                {s.note ? ` — ${s.note}` : ""}
+              </span>
+              <span
+                className="stat-detail"
+                style={{ fontSize: 11, opacity: 0.7 }}
+              >
+                {new Date(vital.recorded_at).toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
       </div>
       <VitalsTrendChart
         vitals={history.map((v) => ({


### PR DESCRIPTION
## Summary
- Classify each latest vital card into \`current\` (≤4h), \`overdue\` (4h–24h), or \`stale\` (>24h).
- Overdue cards get an amber tint + \"recheck due\" note; stale cards go gray with a \"stale\" note.
- Every card now shows a relative-age line (\"3h ago\", \"2d ago\") plus the absolute timestamp.

## Why
A vital from 3 days ago rendered identically to one from 30 minutes ago — clinicians could not tell a current assessment from stale data. The 4h/24h thresholds mirror acute-care inpatient vital-sign expectations.

## Relation to #256
Composes with #256's top-of-tab banner (fires when freshest reading > 7d): banner flags the dataset as aged overall; these per-card tiers show which specific readings are still trustworthy. Small merge conflict expected if both land — straightforward to resolve.

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` — clean
- [ ] Manual: load chart with 1h-old, 6h-old, and 36h-old vitals → see three distinct visual tiers
- [ ] Manual: accessibility — colors paired with text notes, not color-only signal

Closes #246