### PR TITLE
fix(clinical): baseline-aware trend computation

### DIFF
--- a/packages/medical-logic/src/__tests__/trend-utils.test.ts
+++ b/packages/medical-logic/src/__tests__/trend-utils.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   calculateDelta,
+  calculateDeltaFromBaseline,
   classifyTrend,
   detectAKI,
   getGoodDirection,
   getTrendColor,
   getTrendInfo,
+  getTrendInfoFromBaseline,
   isOutOfRange,
   getRangeFlag,
   formatDelta,
@@ -94,6 +96,69 @@ describe("getTrendColor", () => {
 
   it("returns 'neutral' for stable direction regardless of change", () => {
     expect(getTrendColor(10, "stable")).toBe("neutral");
+  });
+});
+
+// ─── calculateDeltaFromBaseline ─────────────────────────────────
+
+describe("calculateDeltaFromBaseline", () => {
+  it("returns null for empty input", () => {
+    expect(calculateDeltaFromBaseline([])).toBeNull();
+  });
+
+  it("uses an explicit baseline and reports change against it", () => {
+    const delta = calculateDeltaFromBaseline([1.2], 0.7);
+    expect(delta).not.toBeNull();
+    expect(delta!.current).toBe(1.2);
+    expect(delta!.previous).toBe(0.7);
+    expect(delta!.change).toBeCloseTo(0.5, 5);
+    expect(delta!.pctChange).toBeCloseTo(71.428, 2);
+  });
+
+  it("falls back to the first value when baseline is omitted", () => {
+    // 0.7 → 0.8 → 0.9 → 1.1 → 1.2 — last-two-point delta = +0.1 (+9%),
+    // baseline-aware delta = +0.5 (+71%).
+    const delta = calculateDeltaFromBaseline([0.7, 0.8, 0.9, 1.1, 1.2]);
+    expect(delta).not.toBeNull();
+    expect(delta!.previous).toBe(0.7);
+    expect(delta!.change).toBeCloseTo(0.5, 5);
+    expect(delta!.pctChange).toBeCloseTo(71.428, 2);
+  });
+
+  it("returns null for a single-value series when baseline is omitted", () => {
+    expect(calculateDeltaFromBaseline([1.2])).toBeNull();
+  });
+
+  it("handles a zero baseline without dividing by zero", () => {
+    const delta = calculateDeltaFromBaseline([5], 0);
+    expect(delta!.pctChange).toBe(0); // falls back to 0 rather than Infinity
+  });
+});
+
+// ─── getTrendInfoFromBaseline ───────────────────────────────────
+
+describe("getTrendInfoFromBaseline", () => {
+  it("surfaces a creatinine rise against baseline instead of last-two-point noise", () => {
+    // Compared against last point (1.1 → 1.2) the slope looks tiny; compared
+    // against baseline 0.7 it's a clear clinically-meaningful rise.
+    const info = getTrendInfoFromBaseline(
+      [0.7, 0.8, 0.9, 1.1, 1.2],
+      getGoodDirection("Creatinine"),
+      0.7,
+    );
+    expect(info.arrow).toBe("↑");
+    expect(info.color).toBe("negative");
+    expect(info.delta?.change).toBeCloseTo(0.5, 5);
+  });
+
+  it("still returns neutral when there is no change from baseline", () => {
+    const info = getTrendInfoFromBaseline(
+      [0.8, 0.8, 0.8],
+      getGoodDirection("Creatinine"),
+      0.8,
+    );
+    expect(info.arrow).toBe("→");
+    expect(info.color).toBe("neutral");
   });
 });
 

--- a/packages/medical-logic/src/trend-utils.ts
+++ b/packages/medical-logic/src/trend-utils.ts
@@ -87,6 +87,34 @@ export function calculateDelta(values: number[]): Delta | null {
   return { current, previous, change, pctChange };
 }
 
+/**
+ * Compute a delta against an explicit baseline rather than the immediately
+ * preceding point.
+ *
+ * Clinical rationale: for labs like creatinine, BUN, and liver enzymes a
+ * slow drift of 0.7 → 0.8 → 0.9 → 1.1 → 1.2 is a ~70% rise that KDIGO
+ * would classify as stage-1 AKI — but `calculateDelta` reports the
+ * last-two-point change of +0.1 (+9%), which reads as "slightly rising"
+ * or even "stable" under a naive threshold. Computing against baseline
+ * preserves the actual trajectory.
+ *
+ * When `baseline` is omitted, the first value in `values` is used as the
+ * baseline so callers that only know the series still get the correct
+ * "change-from-baseline" semantics.
+ */
+export function calculateDeltaFromBaseline(
+  values: number[],
+  baseline?: number,
+): Delta | null {
+  if (values.length === 0) return null;
+  const current = values[values.length - 1]!;
+  const base = baseline ?? values[0]!;
+  if (values.length < 2 && baseline === undefined) return null;
+  const change = current - base;
+  const pctChange = base !== 0 ? (change / base) * 100 : 0;
+  return { current, previous: base, change, pctChange };
+}
+
 export function getTrendColor(
   change: number,
   goodDirection: GoodDirection,
@@ -111,6 +139,28 @@ export function getTrendInfo(
   isOutOfRange?: boolean
 ): TrendInfo {
   const delta = calculateDelta(values);
+  if (!delta) {
+    return { delta: null, color: "neutral", arrow: "→", hex: TREND_COLORS.neutral };
+  }
+  const color = getTrendColor(delta.change, goodDirection, isOutOfRange);
+  const arrow = Math.abs(delta.change) < 0.01 ? "→" : delta.change > 0 ? "↑" : "↓";
+  return { delta, color, arrow, hex: TREND_COLORS[color] };
+}
+
+/**
+ * Baseline-aware variant of `getTrendInfo`. Use this whenever a per-patient
+ * baseline exists (prior-admission creatinine, known-good BP, etc.) — the
+ * color/arrow will reflect movement from that stable value instead of from
+ * the last noisy reading. For ambiguous cases pass `baseline = undefined`
+ * and the first value in the series acts as the baseline.
+ */
+export function getTrendInfoFromBaseline(
+  values: number[],
+  goodDirection: GoodDirection,
+  baseline?: number,
+  isOutOfRange?: boolean,
+): TrendInfo {
+  const delta = calculateDeltaFromBaseline(values, baseline);
   if (!delta) {
     return { delta: null, color: "neutral", arrow: "→", hex: TREND_COLORS.neutral };
   }


### PR DESCRIPTION
## Summary
- Add \`calculateDeltaFromBaseline(values, baseline?)\` — compares current value against an explicit baseline (or \`values[0]\` when omitted).
- Add \`getTrendInfoFromBaseline(values, goodDirection, baseline?, isOutOfRange?)\` — same \`TrendInfo\` shape as \`getTrendInfo\`, so UI can swap in.
- Guard against divide-by-zero on \`pctChange\` when baseline is 0.

## Why
A slow creatinine drift of 0.7 → 0.8 → 0.9 → 1.1 → 1.2 reports as \"+0.1 (+9%) slightly rising\" under \`calculateDelta\` — nearly stable — when it is actually a ~70% rise from baseline and KDIGO stage-1 AKI territory. Baseline-aware delta preserves the true trajectory.

## Test plan
- [x] 6 new unit tests — explicit baseline, fallback-to-values[0], zero-baseline, neutral-at-baseline
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 146/146 passing
- [x] \`pnpm typecheck\` — clean

Closes #249