### PR TITLE
feat(ai): persist full rule-evaluation output for audit

### DIFF
--- a/packages/db-schema/drizzle/0032_review_jobs_rules_output.sql
+++ b/packages/db-schema/drizzle/0032_review_jobs_rules_output.sql
@@ -1,0 +1,14 @@
+-- Migration: Persist full rule-evaluation output on review_jobs.
+--
+-- Previously review_jobs only stored rules_fired as an array of rule IDs.
+-- For forensic / regulatory audit (HIPAA §164.308(a)(1)(ii)(D), §164.312(b))
+-- that is not enough: when a decision is challenged we need the severity,
+-- category, matched-drug context, rationale, and notify_specialties that
+-- each rule produced — not just the rule's static ID.
+--
+-- rules_output is a jsonb array of RuleFlag entries (see packages/shared-
+-- types for the canonical shape). Nullable default '[]' keeps pre-existing
+-- rows valid; new writes always populate.
+
+ALTER TABLE review_jobs
+  ADD COLUMN IF NOT EXISTS rules_output jsonb NOT NULL DEFAULT '[]';

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -69,6 +69,12 @@ export const reviewJobs = pgTable("review_jobs", {
   context_hash: text("context_hash"),
   rules_evaluated: jsonb("rules_evaluated").$type<string[]>().default([]),
   rules_fired: jsonb("rules_fired").$type<string[]>().default([]),
+  // Full rule-evaluation output: for each fired rule we persist the exact
+  // RuleFlag (severity, category, summary, rationale, suggested_action,
+  // notify_specialties, rule_id) so regulatory and forensic audits can
+  // reconstruct the decision without replaying the rule engine against
+  // (possibly-mutated) patient state. See migration 0032.
+  rules_output: jsonb("rules_output").$type<Array<Record<string, unknown>>>().default([]),
   llm_request_tokens: integer("llm_request_tokens"),
   llm_response_tokens: integer("llm_response_tokens"),
   redacted_prompt: text("redacted_prompt"),

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -386,6 +386,10 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         status: jobStatus,
         rules_evaluated: rulesEvaluated,
         rules_fired: rulesFired,
+        // Full rule output (severity, category, rationale, notify_specialties,
+        // rule_id per match) — required for forensic/regulatory audit.
+        // See #241 and migration 0032.
+        rules_output: allRuleFlags as unknown as Array<Record<string, unknown>>,
         flags_generated: flagIds,
         processing_time_ms: processingTime,
         ...(llmFailed ? { error: llmErrorMessage } : {}),


### PR DESCRIPTION
## Summary
- Migration **0032** adds \`review_jobs.rules_output jsonb DEFAULT '[]'\`.
- Drizzle schema exposes it as an array of \`RuleFlag\`-shaped records.
- \`review-service\` populates it with \`allRuleFlags\` in the same update that closes out the \`review_jobs\` row.

## Why
\`rules_fired\` stored only rule IDs. For regulatory review / adverse-event investigation / liability defense we need to reproduce the exact rule output — severity, category, rationale, matched-drug context, notify_specialties — at decision time without replaying the rule engine against (possibly-mutated) patient state. HIPAA §164.308(a)(1)(ii)(D) / §164.312(b) expects that.

## Test plan
- [x] \`pnpm --filter @carebridge/db-schema build\` — clean
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 278/278 passing
- [ ] Manual: apply migration 0032 to dev DB, confirm column exists with default '[]'

Closes #241