### PR TITLE
fix(notifications): strip PHI from push-delivery notification body

### DIFF
--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -244,4 +244,97 @@ describe("dispatch-worker", () => {
     expect(insertedRecords).toHaveLength(2);
     expect(mockPublishNotification).toHaveBeenCalledTimes(2);
   });
+
+  // ── PHI lock-screen safety (issue #289) ────────────────────────────
+  //
+  // These tests lock in the two-tier split: the Redis pub/sub payload
+  // (what any future APNs/FCM integration hands to the OS for lock-screen
+  // render) must never contain PHI, while the persisted notification row
+  // must still carry the full summary for the authenticated portal fetch.
+
+  describe("PHI lock-screen safety", () => {
+    const phiEvent = (): NotificationEvent =>
+      makeEvent({
+        severity: "critical",
+        category: "critical-value",
+        summary: "Potassium = 7.2 mmol/L for MRN 123456, BP 145/95",
+      });
+
+    it("published body contains no numeric values", async () => {
+      mockSelectResult.push({ user_id: "user-neuro" });
+      mockSelectResult2.push({
+        id: "user-neuro",
+        specialty: "Neurology",
+        role: "physician",
+      });
+
+      const event = phiEvent();
+      await processorFn({ data: event, id: "job-phi-1" });
+
+      expect(mockPublishNotification).toHaveBeenCalledTimes(1);
+      const [, payload] = mockPublishNotification.mock.calls[0];
+      expect(payload.body).not.toMatch(/\d/);
+    });
+
+    it("published body does not contain the raw event.summary text", async () => {
+      mockSelectResult.push({ user_id: "user-neuro" });
+      mockSelectResult2.push({
+        id: "user-neuro",
+        specialty: "Neurology",
+        role: "physician",
+      });
+
+      const event = phiEvent();
+      await processorFn({ data: event, id: "job-phi-2" });
+
+      const [, payload] = mockPublishNotification.mock.calls[0];
+      expect(payload.body).not.toContain(event.summary);
+      // And individual PHI tokens from the summary must not leak.
+      expect(payload.body).not.toContain("Potassium");
+      expect(payload.body).not.toContain("MRN");
+      expect(payload.body).not.toContain("7.2");
+      expect(payload.body).not.toContain("145/95");
+    });
+
+    it("persisted record.summary_safe equals the buildSafeSummary output", async () => {
+      mockSelectResult.push({ user_id: "user-neuro" });
+      mockSelectResult2.push({
+        id: "user-neuro",
+        specialty: "Neurology",
+        role: "physician",
+      });
+
+      const event = phiEvent();
+      await processorFn({ data: event, id: "job-phi-3" });
+
+      // Reproduce buildSafeSummary locally (mirror of the private helper):
+      // a category-only template, PHI-free by construction.
+      const expectedSafe =
+        `Clinical flag — ${event.category.replace(/-/g, " ")}. ` +
+        `Open the portal to view details.`;
+
+      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      expect(insertedRecords).toHaveLength(1);
+      expect(insertedRecords[0].summary_safe).toBe(expectedSafe);
+
+      // Cross-check: the same value is what we publish.
+      const [, payload] = mockPublishNotification.mock.calls[0];
+      expect(payload.body).toBe(expectedSafe);
+    });
+
+    it("persisted record.body still equals event.summary (full, for authenticated fetch)", async () => {
+      mockSelectResult.push({ user_id: "user-neuro" });
+      mockSelectResult2.push({
+        id: "user-neuro",
+        specialty: "Neurology",
+        role: "physician",
+      });
+
+      const event = phiEvent();
+      await processorFn({ data: event, id: "job-phi-4" });
+
+      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      expect(insertedRecords[0].body).toBe(event.summary);
+    });
+  });
 });

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -103,10 +103,37 @@ async function findNotificationRecipients(
 
 /**
  * Build a notification title based on flag severity and category.
+ *
+ * HIPAA lock-screen safety: the title MUST NOT contain patient identifiers
+ * or clinical numeric values. This function produces a generic
+ * "CRITICAL: Clinical flag — critical value" form with no PHI. Upstream
+ * push-notification integrations (APNs, FCM) should render only this
+ * title on device lock screens; clinical detail is behind the
+ * authenticated portal fetch keyed off related_flag_id.
  */
 function buildNotificationTitle(event: NotificationEvent): string {
   const severityLabel = event.severity === "critical" ? "CRITICAL" : event.severity === "warning" ? "Warning" : "Info";
   return `${severityLabel}: Clinical flag — ${event.category.replace(/-/g, " ")}`;
+}
+
+/**
+ * Produce a lock-screen-safe rendering of the flag summary for push-layer
+ * delivery. The persisted notification row keeps the full summary for
+ * authenticated render inside the portal; the *push* payload must not
+ * include patient name or numeric values (BP 145/95, K+ 7.2 mmol/L) that
+ * could surface on a locked device.
+ *
+ * We strip:
+ *  - every number (integers, decimals, ratios) → "…"
+ *  - common clinical identifiers (MRN-like strings)
+ *
+ * Output is a generic cue like "Clinical flag — critical value" that
+ * signals urgency without disclosing PHI.
+ */
+function buildSafeSummary(event: NotificationEvent): string {
+  // Trust nothing from the event.summary — always fall back to category.
+  return `Clinical flag — ${event.category.replace(/-/g, " ")}. ` +
+    `Open the portal to view details.`;
 }
 
 /**
@@ -227,13 +254,22 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   // Publish to Redis pub/sub for real-time SSE delivery.
   // Best-effort: failures are logged but do not cause job retry
   // (which would duplicate the already-inserted notification rows).
+  //
+  // Lock-screen safety — the published payload is what any future
+  // push-notification integration (APNs/FCM) will hand to the OS. It
+  // MUST NOT contain patient identifiers or clinical numeric values. We
+  // replace `body` with a generic cue generated from category alone;
+  // the authenticated clinician-portal fetch keyed off related_flag_id
+  // is responsible for rendering full clinical detail once the device
+  // is unlocked. The DB `body` (full summary) remains for that fetch.
+  const safeSummary = buildSafeSummary(event);
   for (const record of immediateRecords) {
     try {
       await publishNotification(record.user_id, {
         id: record.id,
         type: record.type,
         title: record.title,
-        body: record.body,
+        body: safeSummary,
         link: record.link,
         related_flag_id: record.related_flag_id,
         is_urgent: record.is_urgent,
@@ -282,11 +318,15 @@ async function processDelayedNotification(event: NotificationEvent & { _targeted
   await db.insert(notifications).values(record);
 
   try {
+    // Same lock-screen safety as the immediate path — strip PHI from the
+    // pushed body; full detail remains in the persisted notification row
+    // for post-unlock fetch.
+    const safeSummary = buildSafeSummary(event);
     await publishNotification(record.user_id, {
       id: record.id,
       type: record.type,
       title: record.title,
-      body: record.body,
+      body: safeSummary,
       link: record.link,
       related_flag_id: record.related_flag_id,
       is_urgent: record.is_urgent,

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -118,17 +118,17 @@ function buildNotificationTitle(event: NotificationEvent): string {
 
 /**
  * Produce a lock-screen-safe rendering of the flag summary for push-layer
- * delivery. The persisted notification row keeps the full summary for
- * authenticated render inside the portal; the *push* payload must not
- * include patient name or numeric values (BP 145/95, K+ 7.2 mmol/L) that
- * could surface on a locked device.
+ * delivery. Returns a template string built from `event.category` alone;
+ * `event.summary` is intentionally discarded (it may contain PHI such as
+ * patient identifiers or clinical numeric values like "BP 145/95" or
+ * "K+ 7.2 mmol/L" that must not surface on a locked device).
  *
- * We strip:
- *  - every number (integers, decimals, ratios) → "…"
- *  - common clinical identifiers (MRN-like strings)
- *
- * Output is a generic cue like "Clinical flag — critical value" that
- * signals urgency without disclosing PHI.
+ * The full summary is still persisted on `notifications.body` (encrypted
+ * at rest) for authenticated portal render once the device is unlocked;
+ * the value returned here is what a future APNs/FCM push integration
+ * will hand to the OS, and it is also persisted on
+ * `notifications.summary_safe` so later fetches can surface the safe
+ * variant without re-deriving it.
  */
 function buildSafeSummary(event: NotificationEvent): string {
   // Trust nothing from the event.summary — always fall back to category.
@@ -183,6 +183,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   const link = buildFlagLink(event);
   const now = new Date().toISOString();
   const urgent = isUrgentFlag(event.severity);
+  const safeSummary = buildSafeSummary(event);
 
   let immediateCount = 0;
   let delayedCount = 0;
@@ -194,6 +195,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
     type: "ai-flag";
     title: string;
     body: string;
+    summary_safe: string;
     link: string;
     related_flag_id: string;
     is_urgent: boolean;
@@ -237,6 +239,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
       type: "ai-flag" as const,
       title,
       body: event.summary,
+      summary_safe: safeSummary,
       link,
       related_flag_id: event.flag_id,
       is_urgent: urgent,
@@ -258,18 +261,18 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   // Lock-screen safety — the published payload is what any future
   // push-notification integration (APNs/FCM) will hand to the OS. It
   // MUST NOT contain patient identifiers or clinical numeric values. We
-  // replace `body` with a generic cue generated from category alone;
-  // the authenticated clinician-portal fetch keyed off related_flag_id
-  // is responsible for rendering full clinical detail once the device
-  // is unlocked. The DB `body` (full summary) remains for that fetch.
-  const safeSummary = buildSafeSummary(event);
+  // replace `body` with the persisted `summary_safe` column (a generic
+  // cue generated from category alone); the authenticated
+  // clinician-portal fetch keyed off related_flag_id is responsible for
+  // rendering full clinical detail once the device is unlocked. The DB
+  // `body` (full summary) remains for that fetch.
   for (const record of immediateRecords) {
     try {
       await publishNotification(record.user_id, {
         id: record.id,
         type: record.type,
         title: record.title,
-        body: safeSummary,
+        body: record.summary_safe,
         link: record.link,
         related_flag_id: record.related_flag_id,
         is_urgent: record.is_urgent,
@@ -302,12 +305,14 @@ async function processDelayedNotification(event: NotificationEvent & { _targeted
   const link = buildFlagLink(event);
   const now = new Date().toISOString();
 
+  const safeSummary = buildSafeSummary(event);
   const record = {
     id: crypto.randomUUID(),
     user_id: userId,
     type: "ai-flag" as const,
     title,
     body: event.summary,
+    summary_safe: safeSummary,
     link,
     related_flag_id: event.flag_id,
     is_urgent: isUrgentFlag(event.severity),
@@ -318,15 +323,13 @@ async function processDelayedNotification(event: NotificationEvent & { _targeted
   await db.insert(notifications).values(record);
 
   try {
-    // Same lock-screen safety as the immediate path — strip PHI from the
-    // pushed body; full detail remains in the persisted notification row
-    // for post-unlock fetch.
-    const safeSummary = buildSafeSummary(event);
+    // Same lock-screen safety as the immediate path — publish the
+    // PHI-free summary_safe rather than the persisted (encrypted) body.
     await publishNotification(record.user_id, {
       id: record.id,
       type: record.type,
       title: record.title,
-      body: safeSummary,
+      body: record.summary_safe,
       link: record.link,
       related_flag_id: record.related_flag_id,
       is_urgent: record.is_urgent,


### PR DESCRIPTION
## Summary
Two-tier notification delivery to prevent HIPAA-disclosive lock-screen previews:

- **Persisted row** (\`notifications.body\`): full flag summary, rendered only inside the authenticated portal.
- **Pushed payload** (\`publishNotification(body)\`): generic category-only cue from \`buildSafeSummary\` — no numeric values, no patient identifiers.

Title stays as the already-safe severity + category form. Full clinical detail is keyed off \`related_flag_id\` for post-unlock fetch.

## Why
Flag summaries like \"Potassium = 7.2 mmol/L\" and \"Critically high heart_rate: 145 bpm\" were flowing straight into the SSE publish payload — and into any future APNs/FCM push integration. Locked-device preview of that text is a HIPAA disclosure.

## Test plan
- [x] \`pnpm --filter @carebridge/notifications test\` — 43/43 passing
- [x] \`pnpm typecheck\` — clean
- [ ] Manual: trigger critical flag, confirm SSE payload \`body\` is generic cue, confirm portal still shows full summary

Closes #289