### PR TITLE
fix(ai): explicit drug-allergy check in LLM system prompt + guardrails

### DIFF
--- a/packages/ai-prompts/src/__tests__/clinical-review-prompt.test.ts
+++ b/packages/ai-prompts/src/__tests__/clinical-review-prompt.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  CLINICAL_REVIEW_SYSTEM_PROMPT,
+  PROMPT_VERSION,
+} from "../clinical-review.js";
+
+describe("CLINICAL_REVIEW_SYSTEM_PROMPT", () => {
+  it("explicitly instructs the LLM to check drug-allergy contraindications", () => {
+    // The prompt must tell the LLM to cross-check active_medications against
+    // the allergies list. Prior versions only passed allergies in context
+    // and hoped the model would catch conflicts — this issue's reason for
+    // existing (#255).
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toMatch(
+      /active medications that match or cross-react[\s\S]*allergies/i,
+    );
+  });
+
+  it("names common cross-reacting allergy classes", () => {
+    // Naming the common classes in-prompt gives the LLM concrete retrieval
+    // anchors; without them the instruction is too abstract to reliably act
+    // on.
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toContain("penicillin");
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toContain("sulfa");
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toContain("aspirin");
+  });
+
+  it("includes hallucination guardrails for uncertain interactions", () => {
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toMatch(
+      /if you are uncertain[\s\S]*do NOT flag/i,
+    );
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toMatch(
+      /standard medical references/i,
+    );
+  });
+
+  it("preserves the unknown-allergy-status handling", () => {
+    // When the patient has allergy_status = "unknown" the LLM must not
+    // treat an empty allergies array as NKDA.
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toMatch(
+      /allergy_status.*unknown/i,
+    );
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toContain("NKDA");
+  });
+
+  it("lists medication-safety as a permitted category", () => {
+    // The allergy-medication finding should use medication-safety. If the
+    // category isn't listed, the validator rejects the response.
+    expect(CLINICAL_REVIEW_SYSTEM_PROMPT).toContain("medication-safety");
+  });
+
+  it("bumps PROMPT_VERSION off 1.0.x when the prompt changes materially", () => {
+    // Guard against silently mutating the prompt without advancing the
+    // version string — audit trail of which prompt produced a given flag
+    // depends on PROMPT_VERSION uniquely identifying the prompt text.
+    expect(PROMPT_VERSION).not.toBe("1.0.0");
+  });
+});

--- a/packages/ai-prompts/src/clinical-review.ts
+++ b/packages/ai-prompts/src/clinical-review.ts
@@ -5,7 +5,7 @@
 
 import { PROMPT_SECTIONS } from "./prompt-sections.js";
 
-export const PROMPT_VERSION = "1.0.0";
+export const PROMPT_VERSION = "1.1.0";
 
 export const CLINICAL_REVIEW_SYSTEM_PROMPT = `You are a clinical decision support system reviewing a patient's medical record.
 Your role is to identify potential clinical concerns that might be missed when
@@ -15,7 +15,7 @@ You are NOT diagnosing. You are flagging patterns that warrant clinician review.
 
 For each concern you identify, respond with a JSON array. Each element must have:
 1. "severity": "critical" (needs immediate attention), "warning" (review within 24h), or "info" (consider at next visit)
-2. "category": one of "cross-specialty", "drug-interaction", "care-gap", "critical-value", "trend-concern", "documentation-discrepancy"
+2. "category": one of "cross-specialty", "drug-interaction", "medication-safety", "care-gap", "critical-value", "trend-concern", "documentation-discrepancy", "patient-reported"
 3. "summary": a concise one-sentence finding
 4. "rationale": 2-4 sentences explaining the clinical reasoning
 5. "suggested_action": what the clinician should consider doing
@@ -24,10 +24,29 @@ For each concern you identify, respond with a JSON array. Each element must have
 Focus especially on:
 - Cross-specialty interactions (e.g., cancer + hematology + neurology)
 - Medication interactions in the context of the full problem list
+- Active medications that match or cross-react with the patient's documented
+  allergies (class effects count — penicillin allergy cross-reacts with
+  amoxicillin, ampicillin, piperacillin; sulfa allergy cross-reacts with
+  sulfonamide antibiotics; aspirin allergy cross-reacts with other NSAIDs).
+  Use "medication-safety" as the category. Always check active_medications
+  against the allergies list on every review, not only when the triggering
+  event is medication-related.
 - Symptom patterns that span multiple provider notes
 - Missing preventive care given the patient's risk factors
 - Subtle trends in lab values that individually look fine but together suggest a pattern
 - New symptoms that, combined with existing diagnoses, indicate elevated risk
+
+IMPORTANT — hallucination guardrails:
+- Only flag drug interactions and allergy cross-reactions that are
+  documented in standard medical references (Lexicomp, Micromedex, FDA
+  labeling). Do not speculate about interactions not supported by the
+  clinical literature.
+- If you are uncertain about a specific interaction or cross-reaction, do
+  NOT flag it. A missed minor interaction is recoverable; a fabricated
+  interaction erodes clinician trust and is worse than no flag.
+- When allergy_status is "unknown", call this out as a documentation gap
+  rather than assuming either "NKDA" or "has allergies". Never treat
+  "allergies: []" as equivalent to NKDA unless allergy_status === "nkda".
 
 Do NOT flag things that are clearly already being managed (check recent notes and flags).
 If you find no concerns, return an empty array: []


### PR DESCRIPTION
## Summary
- Adds explicit allergy-cross-check instruction to \`CLINICAL_REVIEW_SYSTEM_PROMPT\` with concrete class-reaction examples (penicillin → amoxicillin, sulfa, aspirin → NSAIDs).
- Adds hallucination guardrails: require interactions to be in standard references (Lexicomp, Micromedex, FDA labeling), and drop uncertain flags rather than fabricate.
- Adds \`medication-safety\` to the permitted category list (was accepted by the validator but not advertised in-prompt).
- Bumps \`PROMPT_VERSION\` to \`1.1.0\` so the audit trail tracks the change.

## Why
Allergy data was passed in the prompt context but the model was never instructed to cross-check it against active medications. A penicillin-allergic patient on amoxicillin could slip through depending on model behavior — non-deterministic.

## Test plan
- [x] 6 new tests pin the prompt content (allergy instruction, class examples, guardrails, NKDA preservation, category list, version bump)
- [x] \`pnpm --filter @carebridge/ai-prompts test\` — 15/15 passing
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 278/278 passing
- [x] \`pnpm typecheck\` — clean

Closes #255