### PR TITLE
perf(db): add btree index on review_jobs.trigger_event_id

### DIFF
--- a/packages/db-schema/drizzle/0033_review_jobs_trigger_event_index.sql
+++ b/packages/db-schema/drizzle/0033_review_jobs_trigger_event_index.sql
@@ -1,0 +1,25 @@
+-- Migration: Index review_jobs.(trigger_event_id, status) for the idempotency probe.
+--
+-- PR #495 added a pre-insert check in services/ai-oversight/src/services/
+-- review-service.ts that asks "does a completed review_jobs row already
+-- exist for this trigger_event_id?" to suppress duplicate reviews when
+-- BullMQ redelivers a job (worker crash / stalled-scan reclaim) or the
+-- outbox reconciler replays the same event:
+--
+--   SELECT id, status FROM review_jobs
+--   WHERE trigger_event_id = $1 AND status = 'completed'
+--   LIMIT 1;
+--
+-- The only pre-existing index on review_jobs is
+-- idx_review_jobs_patient(patient_id, status), which does not support
+-- this lookup — so every probe falls back to a sequential scan. The
+-- table is append-only and bound by the 7-year HIPAA retention window
+-- (see docs/hipaa-retention.md), so the per-probe cost grows linearly
+-- forever without an index.
+--
+-- A composite btree on (trigger_event_id, status) supports both the
+-- equality-then-equality probe and any future queries that filter by
+-- trigger_event_id alone (btree index leftmost-prefix rule).
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_trigger_event
+  ON review_jobs (trigger_event_id, status);

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1746547200000,
       "tag": "0031_audit_log_actor_relationship",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1746720000000,
+      "tag": "0033_review_jobs_trigger_event_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -243,6 +243,13 @@
     {
       "idx": 34,
       "version": "7",
+      "when": 1746633600000,
+      "tag": "0032_review_jobs_rules_output",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
       "when": 1746720000000,
       "tag": "0033_review_jobs_trigger_event_index",
       "breakpoints": true

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -86,4 +86,11 @@ export const reviewJobs = pgTable("review_jobs", {
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_review_jobs_patient").on(table.patient_id, table.status),
+  // Supports the pre-insert idempotency probe in review-service.ts which
+  // filters by (trigger_event_id, status='completed') to suppress duplicate
+  // reviews when a trigger event is redelivered. See migration 0033.
+  index("idx_review_jobs_trigger_event").on(
+    table.trigger_event_id,
+    table.status,
+  ),
 ]);


### PR DESCRIPTION
Closes #527

## Problem
PR #495 added a pre-insert idempotency probe in `services/ai-oversight/src/services/review-service.ts`:

```ts
db.select({ id: reviewJobs.id, status: reviewJobs.status })
  .from(reviewJobs)
  .where(and(
    eq(reviewJobs.trigger_event_id, event.id),
    eq(reviewJobs.status, "completed"),
  ))
  .limit(1);
```

The only existing index on `review_jobs` is `idx_review_jobs_patient(patient_id, status)` — nothing supports a lookup by `trigger_event_id`, so Postgres falls back to a sequential scan on every probe. `review_jobs` is append-only and bounded by the 7-year HIPAA retention window (`docs/hipaa-retention.md`), so the cost grows linearly forever.

## Fix
Composite btree on `(trigger_event_id, status)`:

```sql
CREATE INDEX IF NOT EXISTS idx_review_jobs_trigger_event
  ON review_jobs (trigger_event_id, status);
```

- Covers the equality-equality probe directly.
- Satisfies any future `WHERE trigger_event_id = $1`-only queries via the btree leftmost-prefix rule.
- Column is singular `text` (not a jsonb array), so a btree applies; a GIN index would not.

## Files
- `packages/db-schema/drizzle/0033_review_jobs_trigger_event_index.sql` — migration.
- `packages/db-schema/src/schema/ai-flags.ts` — declares `idx_review_jobs_trigger_event` alongside the existing `idx_review_jobs_patient` so the Drizzle generator stays in sync.
- `packages/db-schema/drizzle/meta/_journal.json` — registers the new entry.

## Note on `CREATE INDEX CONCURRENTLY`
Drizzle's postgres-js migrator wraps each migration in a transaction, and `CREATE INDEX CONCURRENTLY` is not transaction-safe. No existing migration in this repo uses `CONCURRENTLY` — we match that convention and use a plain `CREATE INDEX IF NOT EXISTS`. The `review_jobs` table is small today; if we ever need to add this against a large live table, it should be done out-of-band (psql session, outside migrations) and then registered as a no-op `IF NOT EXISTS` here.

## Verification
- `pnpm --filter @carebridge/db-schema typecheck` — pass.
- `pnpm typecheck` across the monorepo — pass.
- `pnpm lint` — pass (no new warnings).
- `pnpm --filter @carebridge/ai-oversight test -- review-idempotency` — both idempotency tests still pass.
- `EXPLAIN` verification on a populated dev DB to confirm `Index Scan` over `Seq Scan` is deferred to post-merge (requires DB with rows).