### PR TITLE
fix(ai): ONCO-VTE-NEURO-001 ignores resolved or stale DVTs

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -189,6 +189,191 @@ describe("ONCO-VTE-NEURO-001 — Cancer + VTE + neurological symptom", () => {
     expect(flag).toBeDefined();
     expect(flag!.suggested_action).toContain("NOT on anticoagulation");
   });
+
+  // --- Recency gate (issue #215) ---
+  //
+  // When structured diagnosis detail is provided, the rule must treat stale /
+  // resolved DVTs as non-qualifying. Without this gate, cancer patients with
+  // a years-old resolved DVT still listed in their chart trigger unnecessary
+  // CT head / CT angiography with IV contrast whenever they present with any
+  // common neurological complaint (e.g. tension headache).
+
+  it("does NOT fire when the VTE is resolved years ago (status=resolved)", () => {
+    const today = new Date();
+    const sixYearsAgo = new Date(today);
+    sixYearsAgo.setFullYear(today.getFullYear() - 6);
+    const fiveYearsAgo = new Date(today);
+    fiveYearsAgo.setFullYear(today.getFullYear() - 5);
+
+    const ctx: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "Deep vein thrombosis"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: [],
+      new_symptoms: ["tension headache"],
+      care_team_specialties: ["oncology"],
+      active_diagnoses_detail: [
+        {
+          description: "Pancreatic cancer",
+          icd10_code: "C25.9",
+          status: "active",
+          onset_date: null,
+          resolved_date: null,
+        },
+        {
+          description: "Deep vein thrombosis",
+          icd10_code: "I82.401",
+          status: "resolved",
+          onset_date: sixYearsAgo.toISOString(),
+          resolved_date: fiveYearsAgo.toISOString(),
+        },
+      ],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const flag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire when VTE onset is >6 months ago and patient is off anticoagulation", () => {
+    const today = new Date();
+    const twoYearsAgo = new Date(today);
+    twoYearsAgo.setFullYear(today.getFullYear() - 2);
+
+    const ctx: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "History of DVT"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: [], // off anticoagulation
+      new_symptoms: ["headache"],
+      care_team_specialties: ["oncology"],
+      active_diagnoses_detail: [
+        {
+          description: "Pancreatic cancer",
+          icd10_code: "C25.9",
+          status: "active",
+          onset_date: null,
+          resolved_date: null,
+        },
+        {
+          description: "History of DVT",
+          icd10_code: "I82.401",
+          status: "active", // still listed as active in the problem list
+          onset_date: twoYearsAgo.toISOString(),
+          resolved_date: null,
+        },
+      ],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const flag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("fires when VTE onset is recent (<6 months) even without anticoagulation", () => {
+    const today = new Date();
+    const threeMonthsAgo = new Date(today);
+    threeMonthsAgo.setMonth(today.getMonth() - 3);
+
+    const ctx: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "Deep vein thrombosis"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: [],
+      new_symptoms: ["new onset severe headache"],
+      care_team_specialties: ["oncology"],
+      active_diagnoses_detail: [
+        {
+          description: "Pancreatic cancer",
+          icd10_code: "C25.9",
+          status: "active",
+          onset_date: null,
+          resolved_date: null,
+        },
+        {
+          description: "Deep vein thrombosis",
+          icd10_code: "I82.401",
+          status: "active",
+          onset_date: threeMonthsAgo.toISOString(),
+          resolved_date: null,
+        },
+      ],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const flag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it("fires when VTE onset is old but patient is on active anticoagulation (proxy for active disease)", () => {
+    const today = new Date();
+    const twoYearsAgo = new Date(today);
+    twoYearsAgo.setFullYear(today.getFullYear() - 2);
+
+    const ctx: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "Chronic DVT"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: ["Apixaban 5mg BID"], // still anticoagulated
+      new_symptoms: ["new headache"],
+      care_team_specialties: ["oncology", "hematology"],
+      active_diagnoses_detail: [
+        {
+          description: "Pancreatic cancer",
+          icd10_code: "C25.9",
+          status: "active",
+          onset_date: null,
+          resolved_date: null,
+        },
+        {
+          description: "Chronic DVT",
+          icd10_code: "I82.401",
+          status: "active",
+          onset_date: twoYearsAgo.toISOString(),
+          resolved_date: null,
+        },
+      ],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const flag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("does NOT fire when VTE has a resolved_date in the past even if status string is 'active'", () => {
+    // EHR data is messy: some problem lists leave status='active' even after
+    // the diagnosis is resolved. A non-null resolved_date wins.
+    const today = new Date();
+    const oneYearAgo = new Date(today);
+    oneYearAgo.setFullYear(today.getFullYear() - 1);
+    const eighteenMonthsAgo = new Date(today);
+    eighteenMonthsAgo.setMonth(today.getMonth() - 18);
+
+    const ctx: PatientContext = {
+      active_diagnoses: ["Pancreatic cancer", "Deep vein thrombosis"],
+      active_diagnosis_codes: ["C25.9", "I82.401"],
+      active_medications: [],
+      new_symptoms: ["headache"],
+      care_team_specialties: ["oncology"],
+      active_diagnoses_detail: [
+        {
+          description: "Pancreatic cancer",
+          icd10_code: "C25.9",
+          status: "active",
+          onset_date: null,
+          resolved_date: null,
+        },
+        {
+          description: "Deep vein thrombosis",
+          icd10_code: "I82.401",
+          status: "active",
+          onset_date: eighteenMonthsAgo.toISOString(),
+          resolved_date: oneYearAgo.toISOString(),
+        },
+      ],
+    };
+
+    const flags = checkCrossSpecialtyPatterns(ctx);
+    const flag = flags.find((f) => f.rule_id === "ONCO-VTE-NEURO-001");
+    expect(flag).toBeUndefined();
+  });
 });
 
 describe("ONCO-ANTICOAG-HELD-001 — Anticoagulant held/discontinued with active VTE", () => {

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -17,10 +17,34 @@ export interface PatientAllergy {
   reaction?: string | null;
 }
 
+/**
+ * Structured diagnosis record used by rules that need to reason about the
+ * recency or resolution status of a specific condition (e.g. the
+ * ONCO-VTE-NEURO-001 recency gate — see issue #215). When present, the rule
+ * layer uses this in preference to the flat `active_diagnoses` string list.
+ */
+export interface PatientDiagnosis {
+  description: string;
+  icd10_code: string | null;
+  /** Problem-list status string: active, resolved, chronic, etc. */
+  status: string | null;
+  /** ISO 8601 date of onset; null if unknown. */
+  onset_date: string | null;
+  /** ISO 8601 date of resolution; null if still active. */
+  resolved_date: string | null;
+}
+
 export interface PatientContext {
   active_diagnoses: string[];
   /** ICD-10 codes for active diagnoses (parallel to active_diagnoses). */
   active_diagnosis_codes: string[];
+  /**
+   * Optional structured diagnosis list. Populated by
+   * `buildPatientContextForRules`. Carries recency metadata
+   * (onset_date / resolved_date / status) so individual rules can apply
+   * recency gates without round-tripping to the database.
+   */
+  active_diagnoses_detail?: PatientDiagnosis[];
   active_medications: string[];
   /** RxNorm codes for active medications (parallel to active_medications). */
   active_medication_rxnorm_codes?: (string | null)[];
@@ -65,6 +89,68 @@ const FEVER_SYMPTOM_PATTERN = /fever|febrile|temperature|chills/i;
 
 /** ICD-10 pattern for active VTE / DVT / PE diagnoses. */
 const VTE_ICD10_PATTERN = /^(I26|I80|I82)\./;
+
+/** Text pattern matching VTE / DVT / PE descriptions. */
+const VTE_DESCRIPTION_PATTERN =
+  /dvt|deep vein thrombosis|pulmonary embolism|vte|venous thromboembolism|thrombosis|clot/i;
+
+/**
+ * Recency window (months) for treating a VTE diagnosis as "clinically active"
+ * for stroke-risk stratification in the absence of ongoing anticoagulation.
+ *
+ * Rationale: most cancer-associated VTEs are treated for 3–6 months per CHEST
+ * and ASCO guidance; beyond 6 months without active anticoagulation the acute
+ * pro-thrombotic contribution of that specific clot has largely resolved.
+ * Patients with persistent VTE risk should either remain on anticoagulation
+ * (handled by the anticoag branch below) or have a newer VTE episode.
+ */
+const VTE_RECENCY_WINDOW_MONTHS = 6;
+
+/**
+ * Is this diagnosis record a clinically active VTE for ONCO-VTE-NEURO-001?
+ *
+ * Returns true only when:
+ *   1. The diagnosis actually matches VTE (by ICD-10 or description); AND
+ *   2. It is NOT explicitly resolved (status !== "resolved" and no
+ *      resolved_date in the past); AND
+ *   3. Either the onset is within the recency window OR the patient is on
+ *      active anticoagulation (used as a proxy for active treatment of this
+ *      VTE at the caller site).
+ *
+ * Unknown onset dates are treated permissively when on anticoagulation but
+ * require an onset date to trigger on recency alone, to avoid firing on stale
+ * EHR problem-list entries that have no date at all.
+ */
+function isActiveVTEDiagnosis(
+  dx: PatientDiagnosis,
+  onAnticoag: boolean,
+  now: Date = new Date(),
+): boolean {
+  const matchesVTE =
+    (dx.icd10_code !== null && VTE_ICD10_PATTERN.test(dx.icd10_code)) ||
+    VTE_DESCRIPTION_PATTERN.test(dx.description);
+  if (!matchesVTE) return false;
+
+  // Hard exclude: resolved diagnoses. A resolved DVT never qualifies, even if
+  // the EHR problem list mistakenly left status="active".
+  if (dx.status && /^resolved$/i.test(dx.status)) return false;
+  if (dx.resolved_date) {
+    const resolved = new Date(dx.resolved_date);
+    if (!Number.isNaN(resolved.getTime()) && resolved <= now) return false;
+  }
+
+  // Active anticoagulation is an accepted proxy for ongoing VTE treatment,
+  // which keeps the stroke-risk stratification relevant regardless of age.
+  if (onAnticoag) return true;
+
+  // No anticoagulation → require a fresh onset date within the recency window.
+  if (!dx.onset_date) return false;
+  const onset = new Date(dx.onset_date);
+  if (Number.isNaN(onset.getTime())) return false;
+  const cutoff = new Date(now);
+  cutoff.setMonth(cutoff.getMonth() - VTE_RECENCY_WINDOW_MONTHS);
+  return onset >= cutoff;
+}
 
 /**
  * ANTICOAG-BLEED severity stratification patterns.
@@ -139,13 +225,32 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       const hasCancer = ctx.active_diagnoses.some((d) =>
         /cancer|malignant|carcinoma|lymphoma|leukemia|tumor|neoplasm/i.test(d),
       );
-      const hasVTE = ctx.active_diagnoses.some((d) =>
-        /dvt|deep vein thrombosis|pulmonary embolism|vte|thrombosis|clot/i.test(d),
-      );
       const hasNeuroSymptom = ctx.new_symptoms.some((s) =>
         /headache|vision change|weakness|numbness|confusion|speech difficulty|dizziness|syncope/i.test(s),
       );
-      return hasCancer && hasVTE && hasNeuroSymptom;
+      if (!hasCancer || !hasNeuroSymptom) return false;
+
+      // Recency gate (issue #215): a years-old resolved DVT must not trigger
+      // urgent neuroimaging. When structured diagnosis detail is available,
+      // require the VTE to be either recently onset (within
+      // VTE_RECENCY_WINDOW_MONTHS) or covered by active anticoagulation
+      // (proxy for ongoing VTE treatment). Fall back to the legacy
+      // description-based match only when no structured detail is provided,
+      // preserving behavior for callers that have not yet been upgraded.
+      const onAnticoag = ctx.active_medications.some((m) =>
+        ANTICOAGULANT_PATTERN.test(m),
+      );
+
+      if (ctx.active_diagnoses_detail && ctx.active_diagnoses_detail.length > 0) {
+        return ctx.active_diagnoses_detail.some((dx) =>
+          isActiveVTEDiagnosis(dx, onAnticoag),
+        );
+      }
+
+      const hasVTE = ctx.active_diagnoses.some((d) =>
+        VTE_DESCRIPTION_PATTERN.test(d),
+      );
+      return hasVTE;
     },
     severity: "critical" as const,
     category: "cross-specialty" as const,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -573,6 +573,17 @@ export async function buildPatientContextForRules(
   return {
     active_diagnoses: activeDx.map((d) => d.description),
     active_diagnosis_codes: activeDx.map((d) => d.icd10_code ?? ""),
+    // Structured diagnosis detail with recency metadata (issue #215).
+    // Enables rules like ONCO-VTE-NEURO-001 to suppress stale/resolved VTE
+    // false positives without losing the flat `active_diagnoses` shape that
+    // other rules rely on.
+    active_diagnoses_detail: activeDx.map((d) => ({
+      description: d.description,
+      icd10_code: d.icd10_code ?? null,
+      status: d.status ?? null,
+      onset_date: d.onset_date ?? null,
+      resolved_date: d.resolved_date ?? null,
+    })),
     active_medications: activeMedsList.map((m) => m.name),
     active_medication_rxnorm_codes: activeMedsList.map((m) => m.rxnorm_code),
     new_symptoms: newSymptoms,


### PR DESCRIPTION
Closes #215

## Problem
`ONCO-VTE-NEURO-001` (cancer + VTE + new neuro symptom → urgent CT head / CTA) matched any diagnosis containing "dvt" / "thrombosis" regardless of whether the VTE was active, years-old, or resolved. A 65-year-old oncology patient with a 2018 DVT (resolved, off anticoagulation since 2019) presenting with a tension headache got an IV-contrast CT head / CTA workup — contrast nephropathy risk with zero clinical benefit. At scale this drives a lot of unnecessary neuroimaging.

## Fix — recency gate on the VTE diagnosis
New helper `isActiveVTEDiagnosis` in `services/ai-oversight/src/rules/cross-specialty.ts`. A VTE diagnosis qualifies the rule only when:

1. It matches VTE by ICD-10 (`I26` / `I80` / `I82.*`) or description, **and**
2. It is **not** explicitly resolved — `status === "resolved"` OR any past-dated `resolved_date` disqualifies it (EHR problem lists often leave `status="active"` on resolved problems, so `resolved_date` wins), **and**
3. **Either** onset is within the last **6 months** (`VTE_RECENCY_WINDOW_MONTHS`) **or** the patient is on active anticoagulation (proxy for ongoing VTE treatment).

### Why 6 months
Cancer-associated VTE is typically anticoagulated for 3–6 months per CHEST and ASCO guidance. Beyond 6 months without ongoing anticoagulation the acute pro-thrombotic contribution of that specific clot has largely resolved; patients with persistent risk either remain on anticoagulants (caught by the anticoag branch) or have a newer VTE episode (caught by the onset branch).

## Shape change
- `PatientContext` gains an optional `active_diagnoses_detail?: PatientDiagnosis[]` carrying `{description, icd10_code, status, onset_date, resolved_date}` per diagnosis. The rule uses this when present and falls back to the legacy flat-list behavior when it's absent, so no existing caller or test breaks.
- `buildPatientContextForRules` now populates `active_diagnoses_detail` from the `diagnoses` table, so production callers get the recency gate automatically.

## Test coverage (TDD)
Added 5 new cases to `cross-specialty-rules.test.ts` (all started red, now green):
- Resolved DVT from 5 years ago → no flag
- `status=active` but onset >6 months ago, off anticoag → no flag
- Recent onset (<6 months), no anticoag → fires (critical)
- Old onset, patient on apixaban → fires (anticoag proxy keeps it active)
- Mixed signal: `status=active` but a past `resolved_date` → no flag (resolved_date wins over stale status)

All 69 tests in `cross-specialty-rules.test.ts` pass; all 307 tests in `@carebridge/ai-oversight` pass. `pnpm typecheck` and `pnpm lint` clean at repo root.