### PR TITLE
fix(medical-logic): case/whitespace-tolerant lab unit validation

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -213,6 +213,60 @@ describe("validateLabResult", () => {
     expect(result.valid).toBe(true);
     expect(result.warnings.some((w) => w.includes("does not match expected"))).toBe(true);
   });
+
+  // Unit comparison tolerates case/whitespace variants. Real-world FHIR/HL7
+  // feeds frequently send "mg/dl" (UCUM canonical) or "MG/DL" (lab vendor
+  // shorthand); normalising both sides prevents false-reject errors on
+  // otherwise legitimate readings. See issue #538.
+  it("accepts glucose unit in upper case (MG/DL)", () => {
+    const result = validateLabResult("Glucose", 95, "MG/DL");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts glucose unit with trailing whitespace (mg/dL )", () => {
+    const result = validateLabResult("Glucose", 95, "mg/dL ");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts glucose unit with leading whitespace + lowercase ( mg/dl)", () => {
+    const result = validateLabResult("Glucose", 95, " mg/dl");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts glucose unit in canonical UCUM lowercase (mg/dl)", () => {
+    const result = validateLabResult("Glucose", 95, "mg/dl");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts glucose unit with internal whitespace (mg / dL)", () => {
+    const result = validateLabResult("Glucose", 95, "mg / dL");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("accepts potassium submitted as lowercase meq/L", () => {
+    const result = validateLabResult("Potassium", 4.1, "meq/L");
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("still rejects a genuinely wrong unit (dL alone)", () => {
+    const result = validateLabResult("Glucose", 95, "dL");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unit"))).toBe(true);
+  });
+
+  it("error message quotes the caller's original (non-normalized) unit", () => {
+    // Normalisation is only used for comparison; the operator's typed
+    // string should surface verbatim so they can see what they entered.
+    const result = validateLabResult("Glucose", 200, "mmol/L");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('"mmol/L"'))).toBe(true);
+  });
 });
 
 // ─── isCriticalVital ────────────────────────────────────────────

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -230,6 +230,24 @@ export function validateMedicationDose(
   return { valid: errors.length === 0, warnings, errors };
 }
 
+/**
+ * Normalise a lab unit string for allow-list comparison.
+ *
+ * Real-world FHIR/HL7 feeds send units with inconsistent casing and
+ * whitespace: `"mg/dL"`, `"mg/dl"`, `"MG/DL"`, `" mg/dL"`, `"mg / dL"`
+ * are all the same unit. Exact-string comparison would reject the
+ * legitimate reading the allow-list was designed to protect.
+ *
+ * The compare drops whitespace entirely (including internal whitespace
+ * around `/`) and lowercases. Slashes and digits are preserved so
+ * `"10*3/uL"` and `"K/uL"` remain distinguishable. Error messages quote
+ * the caller's original (non-normalised) string so clinicians see what
+ * they typed.
+ */
+function normalizeUnit(u: string): string {
+  return u.trim().toLowerCase().replace(/\s+/g, "");
+}
+
 export function validateLabResult(
   testName: string,
   value: number,
@@ -250,16 +268,20 @@ export function validateLabResult(
   // sentinel-event source (glucose ×18, creatinine ×88.4). Tests with an
   // explicit `allowed_units` list reject mismatches as errors; tests
   // without fall back to a warning when the caller's unit doesn't match
-  // the canonical reference unit.
+  // the canonical reference unit. The compare normalises case and
+  // whitespace on both sides so UCUM-canonical lowercase (`mg/dl`) and
+  // lab-vendor shorthand (`MG/DL`) both match the canonical `mg/dL`.
   if (unit !== undefined && unit !== null && unit !== "") {
     if (ref.allowed_units && ref.allowed_units.length > 0) {
-      if (!ref.allowed_units.includes(unit)) {
+      const normalizedInput = normalizeUnit(unit);
+      const normalizedAllowed = ref.allowed_units.map(normalizeUnit);
+      if (!normalizedAllowed.includes(normalizedInput)) {
         errors.push(
           `${testName} unit "${unit}" is not accepted — allowed: ` +
             ref.allowed_units.join(", "),
         );
       }
-    } else if (unit !== ref.unit) {
+    } else if (normalizeUnit(unit) !== normalizeUnit(ref.unit)) {
       warnings.push(
         `${testName} unit "${unit}" does not match expected "${ref.unit}" — verify unit is correct before interpretation`,
       );


### PR DESCRIPTION
Closes #538

## Summary
`validateLabResult` compared the caller's `unit` against `allowed_units` by exact string match, so `"mg/dl"`, `"MG/DL"`, `" mg/dL"`, and `"mg / dL"` all rejected as invalid even though they are the same unit. Real-world FHIR/HL7 feeds routinely send these variants — the allow-list added in #500 was producing the inverse of the sentinel event it was designed to prevent.

Fix: a small `normalizeUnit` helper is applied to both sides of the compare.

```ts
function normalizeUnit(u: string): string {
  return u.trim().toLowerCase().replace(/\s+/g, "");
}
```

Normalisation rules:
- `trim()` + collapse internal whitespace (so `"mg / dL"` collapses to `"mg/dL"` before lowercasing).
- `toLowerCase()` for compare only — error messages still quote the caller's original string verbatim so clinicians see what they typed.
- `/` and digits preserved, so `"10*3/uL"` and `"K/uL"` remain distinguishable.

Class-mismatch rejections (e.g. `mmol/L` against Glucose) still fire as errors — normalisation changes format only, not unit class.

## New accepted-variant tests
- `validateLabResult("Glucose", 95, "MG/DL")` accepted (upper case)
- `validateLabResult("Glucose", 95, "mg/dL ")` accepted (trailing space)
- `validateLabResult("Glucose", 95, " mg/dl")` accepted (leading space + lower)
- `validateLabResult("Glucose", 95, "mg/dl")` accepted (UCUM lowercase)
- `validateLabResult("Glucose", 95, "mg / dL")` accepted (internal whitespace)
- `validateLabResult("Potassium", 4.1, "meq/L")` accepted (lowercase UCUM equivalent)
- `validateLabResult("Glucose", 95, "dL")` still rejected (genuinely wrong unit)
- Error message quotes caller's original `"mmol/L"` verbatim on class-mismatch

## Test plan
- [x] `pnpm --filter @carebridge/medical-logic test` — 163 passed (8 new cases)
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (only unrelated pre-existing portal warnings)