### PR TITLE
fix(portal): distinguish allergy error, loading, and unknown states in overview tab

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -11,6 +11,10 @@ import {
   type FlagActionModalFlag,
 } from "@/components/flag-action-modal";
 import { VitalsTrendChart } from "@/components/vitals-trend-chart";
+import {
+  deriveAllergyDisplayState,
+  type AllergyStatus,
+} from "@/lib/allergy-display";
 
 const tabs = [
   { key: "overview", label: "Overview" },
@@ -146,13 +150,24 @@ function OverviewTab({ patientId }: { patientId: string }) {
   const allergiesQuery = trpc.patients.allergies.getByPatient.useQuery({ patientId });
   const careTeamQuery = trpc.patients.careTeam.getByPatient.useQuery({ patientId });
 
+  const [showAllergyError, setShowAllergyError] = useState(false);
+
   const patient = patientQuery.data;
   const diagnoses = diagnosesQuery.data ?? [];
-  const allergies = allergiesQuery.data ?? [];
   const careTeam = careTeamQuery.data ?? [];
 
   if (patientQuery.isLoading) return <LoadingState label="overview" />;
   if (patientQuery.isError || !patient) return <ErrorState label="overview" />;
+
+  // Issue #218: allergies must never silently fall back to "NKDA" on fetch
+  // failure. deriveAllergyDisplayState() distinguishes loading / error /
+  // the three empty variants (nkda, unknown, has_allergies) from a
+  // populated list, using the same allergy_status semantics as
+  // formatAllergies() in @carebridge/ai-prompts.
+  const allergyState = deriveAllergyDisplayState(
+    allergiesQuery,
+    (patient.allergy_status as AllergyStatus | null | undefined) ?? null,
+  );
 
   return (
     <div className="detail-grid">
@@ -193,10 +208,53 @@ function OverviewTab({ patientId }: { patientId: string }) {
 
       <div className="detail-card">
         <div className="detail-card-title">Allergies</div>
-        {allergiesQuery.isLoading ? (
-          <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>
-        ) : allergies.length > 0 ? (
-          allergies.map((allergy, i) => (
+        {allergyState.kind === "loading" ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
+            Loading...
+          </div>
+        ) : allergyState.kind === "error" ? (
+          // Clinical-safety critical (issue #218): on fetch failure we
+          // explicitly surface that allergy data is UNAVAILABLE. We do
+          // NOT render "NKDA" — a silent fallback could lead to
+          // prescribing a contraindicated drug.
+          <div role="alert" style={{ fontSize: 13 }}>
+            <div style={{ color: "var(--critical)", fontWeight: 600 }}>
+              {"\u26A0"} Allergy data unavailable — refresh before
+              prescribing.
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowAllergyError((v) => !v)}
+              style={{
+                marginTop: 6,
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                color: "var(--text-muted)",
+                fontSize: 12,
+                textDecoration: "underline",
+                cursor: "pointer",
+              }}
+              aria-expanded={showAllergyError}
+            >
+              {showAllergyError ? "Hide details" : "Show details"}
+            </button>
+            {showAllergyError ? (
+              <div
+                style={{
+                  marginTop: 6,
+                  color: "var(--text-muted)",
+                  fontFamily: "monospace",
+                  fontSize: 12,
+                  wordBreak: "break-word",
+                }}
+              >
+                {allergyState.message}
+              </div>
+            ) : null}
+          </div>
+        ) : allergyState.kind === "populated" ? (
+          allergyState.allergies.map((allergy, i) => (
             <div
               key={i}
               className="list-item"
@@ -206,8 +264,29 @@ function OverviewTab({ patientId }: { patientId: string }) {
               {allergy.reaction ? ` (${allergy.reaction})` : ""}
             </div>
           ))
+        ) : allergyState.kind === "nkda" ? (
+          <div style={{ color: "var(--success)", fontSize: 13 }}>
+            NKDA (confirmed)
+          </div>
+        ) : allergyState.kind === "has_allergies_undocumented" ? (
+          // Status affirms allergies exist but none are on file — a
+          // documentation gap. Distinct from "unknown" because somebody
+          // has flagged the patient as allergic.
+          <div
+            role="status"
+            style={{ color: "var(--warning)", fontSize: 13 }}
+          >
+            Has allergies — none documented (data gap)
+          </div>
         ) : (
-          <div style={{ color: "var(--success)", fontSize: 13 }}>NKDA</div>
+          // allergyState.kind === "unknown" — never assessed. Must NOT
+          // be conflated with NKDA.
+          <div
+            role="status"
+            style={{ color: "var(--warning)", fontSize: 13 }}
+          >
+            Allergy status unknown — not assessed
+          </div>
         )}
       </div>
 
@@ -508,6 +587,7 @@ function MedicationsTab({ patientId }: { patientId: string }) {
   if (medsQuery.isError) return <ErrorState label="medications" />;
 
   const active = medications.filter((m) => m.status === "active");
+  const held = medications.filter((m) => m.status === "held");
   const discontinued = medications.filter((m) => m.status === "discontinued");
 
   if (medications.length === 0) {
@@ -546,6 +626,45 @@ function MedicationsTab({ patientId }: { patientId: string }) {
                   <td style={{ color: "var(--text-secondary)" }}>{med.frequency}</td>
                   <td>
                     <span className="badge badge-success">Active</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {held.length > 0 && (
+        <div className="table-container">
+          <div className="table-header">
+            <span className="table-title">Held</span>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Medication</th>
+                <th>Dose</th>
+                <th>Route</th>
+                <th>Frequency</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {held.map((med) => (
+                <tr key={med.id}>
+                  <td style={{ fontWeight: 500 }}>{med.name}</td>
+                  <td style={{ color: "var(--text-secondary)" }}>
+                    {med.dose_amount} {med.dose_unit}
+                  </td>
+                  <td style={{ color: "var(--text-secondary)" }}>{med.route}</td>
+                  <td style={{ color: "var(--text-secondary)" }}>{med.frequency}</td>
+                  <td>
+                    <span
+                      className="badge badge-warning"
+                      title="Temporarily paused — intent to resume"
+                    >
+                      Held
+                    </span>
                   </td>
                 </tr>
               ))}

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -587,7 +587,6 @@ function MedicationsTab({ patientId }: { patientId: string }) {
   if (medsQuery.isError) return <ErrorState label="medications" />;
 
   const active = medications.filter((m) => m.status === "active");
-  const held = medications.filter((m) => m.status === "held");
   const discontinued = medications.filter((m) => m.status === "discontinued");
 
   if (medications.length === 0) {
@@ -626,45 +625,6 @@ function MedicationsTab({ patientId }: { patientId: string }) {
                   <td style={{ color: "var(--text-secondary)" }}>{med.frequency}</td>
                   <td>
                     <span className="badge badge-success">Active</span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {held.length > 0 && (
-        <div className="table-container">
-          <div className="table-header">
-            <span className="table-title">Held</span>
-          </div>
-          <table>
-            <thead>
-              <tr>
-                <th>Medication</th>
-                <th>Dose</th>
-                <th>Route</th>
-                <th>Frequency</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {held.map((med) => (
-                <tr key={med.id}>
-                  <td style={{ fontWeight: 500 }}>{med.name}</td>
-                  <td style={{ color: "var(--text-secondary)" }}>
-                    {med.dose_amount} {med.dose_unit}
-                  </td>
-                  <td style={{ color: "var(--text-secondary)" }}>{med.route}</td>
-                  <td style={{ color: "var(--text-secondary)" }}>{med.frequency}</td>
-                  <td>
-                    <span
-                      className="badge badge-warning"
-                      title="Temporarily paused — intent to resume"
-                    >
-                      Held
-                    </span>
                   </td>
                 </tr>
               ))}

--- a/apps/clinician-portal/src/__tests__/allergy-display.test.ts
+++ b/apps/clinician-portal/src/__tests__/allergy-display.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveAllergyDisplayState,
+  type AllergyQueryLike,
+} from "../lib/allergy-display";
+
+type Allergy = { allergen: string; reaction?: string | null };
+
+function makeQuery(
+  overrides: Partial<AllergyQueryLike<Allergy[]>>,
+): AllergyQueryLike<Allergy[]> {
+  return {
+    isLoading: false,
+    isError: false,
+    data: undefined,
+    error: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Issue #218: the overview tab rendered "NKDA" whenever the allergies
+ * query returned no data, including the `isError` path. This file nails
+ * down the contract that the render-state helper MUST produce an error
+ * kind (not NKDA) on fetch failure, and distinguishes the three empty
+ * variants from each other.
+ */
+describe("deriveAllergyDisplayState", () => {
+  it("returns error (NOT nkda) when the query failed", () => {
+    const state = deriveAllergyDisplayState(
+      makeQuery({ isError: true, error: { message: "network" } }),
+      "nkda",
+    );
+    expect(state.kind).toBe("error");
+    if (state.kind === "error") {
+      expect(state.message).toBe("network");
+    }
+  });
+
+  it("error kind wins even if stale data is present", () => {
+    // If a previous fetch succeeded and was cached, the tRPC hook can have
+    // isError === true AND data !== undefined. The error must still take
+    // precedence so the clinician is not shown a stale allergy list that
+    // they mistake for the current picture.
+    const state = deriveAllergyDisplayState(
+      makeQuery({
+        isError: true,
+        data: [{ allergen: "penicillin" }],
+        error: { message: "boom" },
+      }),
+      "has_allergies",
+    );
+    expect(state.kind).toBe("error");
+  });
+
+  it("returns loading while the query is in flight", () => {
+    const state = deriveAllergyDisplayState(
+      makeQuery({ isLoading: true }),
+      "nkda",
+    );
+    expect(state.kind).toBe("loading");
+  });
+
+  it("returns populated when the query resolves with allergies", () => {
+    const data: Allergy[] = [
+      { allergen: "penicillin", reaction: "anaphylaxis" },
+      { allergen: "peanuts", reaction: null },
+    ];
+    const state = deriveAllergyDisplayState(makeQuery({ data }), "has_allergies");
+    expect(state.kind).toBe("populated");
+    if (state.kind === "populated") {
+      expect(state.allergies).toEqual(data);
+    }
+  });
+
+  it("returns nkda when data is empty and allergy_status is 'nkda'", () => {
+    const state = deriveAllergyDisplayState(makeQuery({ data: [] }), "nkda");
+    expect(state.kind).toBe("nkda");
+  });
+
+  it("returns unknown when data is empty and allergy_status is 'unknown'", () => {
+    const state = deriveAllergyDisplayState(makeQuery({ data: [] }), "unknown");
+    expect(state.kind).toBe("unknown");
+  });
+
+  it("returns has_allergies_undocumented when flagged but list is empty", () => {
+    const state = deriveAllergyDisplayState(
+      makeQuery({ data: [] }),
+      "has_allergies",
+    );
+    expect(state.kind).toBe("has_allergies_undocumented");
+  });
+
+  it("defaults to 'unknown' (never 'nkda') when allergy_status is absent", () => {
+    // The historical bug: missing allergy_status + empty data rendered
+    // "NKDA". The safer default is "unknown" — force the clinician to
+    // acknowledge the gap.
+    const state = deriveAllergyDisplayState(makeQuery({ data: [] }), null);
+    expect(state.kind).toBe("unknown");
+  });
+
+  it("defaults to 'unknown' when allergy_status is undefined", () => {
+    const state = deriveAllergyDisplayState(makeQuery({ data: [] }), undefined);
+    expect(state.kind).toBe("unknown");
+  });
+
+  it("error with no message surfaces a fallback string", () => {
+    const state = deriveAllergyDisplayState(
+      makeQuery({ isError: true, error: null }),
+      "nkda",
+    );
+    expect(state.kind).toBe("error");
+    if (state.kind === "error") {
+      expect(state.message).toBe("Unknown error");
+    }
+  });
+});

--- a/apps/clinician-portal/src/lib/allergy-display.ts
+++ b/apps/clinician-portal/src/lib/allergy-display.ts
@@ -1,0 +1,92 @@
+/**
+ * Allergy display decision logic for the patient overview tab.
+ *
+ * Clinical safety: a failed allergies fetch must NEVER render as "NKDA".
+ * Historically the overview tab defaulted `allergies` to `[]` when the query
+ * was `isError`, then rendered "NKDA" on empty — silently misrepresenting
+ * documented allergies (e.g., penicillin) as "no known drug allergies" and
+ * inviting a contraindicated prescription.
+ *
+ * This module encodes the five distinct states the UI must render:
+ *   - loading
+ *   - error (query failed — show unavailable indicator, NOT NKDA)
+ *   - populated (allergies present — render the list)
+ *   - empty + allergy_status === "nkda"         — confirmed NKDA
+ *   - empty + allergy_status === "unknown"      — never assessed
+ *   - empty + allergy_status === "has_allergies"— documented gap
+ *
+ * The semantics mirror `formatAllergies()` in
+ * `packages/ai-prompts/src/clinical-review.ts` so the clinician UI and the
+ * LLM reviewer agree on what an empty list means.
+ */
+
+export type AllergyStatus = "nkda" | "unknown" | "has_allergies";
+
+export type AllergyDisplayState =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | {
+      kind: "populated";
+      allergies: ReadonlyArray<{ allergen: string; reaction?: string | null }>;
+    }
+  | { kind: "nkda" }
+  | { kind: "unknown" }
+  | { kind: "has_allergies_undocumented" };
+
+export interface AllergyQueryLike<T> {
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly data: T | undefined;
+  readonly error?: { message?: string } | null;
+}
+
+/**
+ * Derive the render state for the allergies card.
+ *
+ * Order of checks is load-bearing:
+ *   1. isError wins over everything — a failed fetch must never be confused
+ *      with "no allergies". If the query errored we surface an unavailable
+ *      indicator regardless of stale `data`.
+ *   2. isLoading before empty checks — an in-flight query would otherwise
+ *      flash "NKDA" on mount while data streams in.
+ *   3. Populated list is unambiguous.
+ *   4. Empty list + allergy_status drives the three empty variants. Default
+ *      to "unknown" when allergy_status is absent — the safer assumption
+ *      than "nkda".
+ */
+export function deriveAllergyDisplayState<
+  T extends ReadonlyArray<{ allergen: string; reaction?: string | null }>,
+>(
+  query: AllergyQueryLike<T>,
+  allergyStatus: AllergyStatus | null | undefined,
+): AllergyDisplayState {
+  if (query.isError) {
+    return {
+      kind: "error",
+      message: query.error?.message ?? "Unknown error",
+    };
+  }
+
+  if (query.isLoading) {
+    return { kind: "loading" };
+  }
+
+  const allergies = query.data ?? [];
+  if (allergies.length > 0) {
+    return { kind: "populated", allergies };
+  }
+
+  // Empty list — the meaning depends on allergy_status. Absent status is
+  // treated as "unknown" (never assessed), not NKDA. Defaulting to NKDA on
+  // missing status is the original bug this module exists to prevent.
+  const status: AllergyStatus = allergyStatus ?? "unknown";
+  switch (status) {
+    case "nkda":
+      return { kind: "nkda" };
+    case "has_allergies":
+      return { kind: "has_allergies_undocumented" };
+    case "unknown":
+    default:
+      return { kind: "unknown" };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #218.

The patient overview tab rendered "NKDA" whenever the allergies tRPC query returned an empty list, including the `isError` path. A network error or backend outage therefore silently misrepresented documented drug allergies as "no known drug allergies" — a clinical-safety hazard that could lead to prescribing a contraindicated drug (e.g., amoxicillin to a penicillin-allergic patient).

## Change

Introduces a pure `deriveAllergyDisplayState()` helper in `apps/clinician-portal/src/lib/allergy-display.ts` that resolves the query + `patient.allergy_status` into six explicit render kinds. Order of checks is load-bearing: `isError` wins over cached data, and `isLoading` wins over the empty-list branch so "NKDA" never flashes on mount.

## Rendered states

- **loading** — spinner/placeholder ("Loading...").
- **error** — critical-colored advisory "`⚠` Allergy data unavailable — refresh before prescribing" with raw error tucked behind a "Show details" toggle. Never "NKDA".
- **populated** — existing list rendering (`allergen (reaction)`).
- **empty + `allergy_status === "nkda"`** — "NKDA (confirmed)" in success color.
- **empty + `allergy_status === "unknown"`** — "Allergy status unknown — not assessed" in warning color. Distinct from NKDA.
- **empty + `allergy_status === "has_allergies"`** — "Has allergies — none documented (data gap)" in warning color.

Absent `allergy_status` defaults to `unknown` (the safer assumption), not NKDA.

## Semantics alignment

The empty-list semantics mirror `formatAllergies()` in `packages/ai-prompts/src/clinical-review.ts` (lines 103-124), so the clinician UI and the LLM reviewer agree on what `allergies: []` means — neither should treat an empty list as NKDA unless `allergy_status === "nkda"`.

## Test plan

- [x] 10 new unit tests in `apps/clinician-portal/src/__tests__/allergy-display.test.ts` covering: error precedence over stale data, loading, populated, all three empty variants, missing/undefined `allergy_status` defaulting to "unknown", and error-message fallback.
- [x] `pnpm --filter @carebridge/clinician-portal test` — 12/12 passing.
- [x] `tsc --noEmit` clean.
- [x] `pnpm lint` — no new warnings.
- [ ] Manual: open a patient chart, kill the allergies endpoint, confirm the overview shows the red unavailable advisory (not NKDA).
- [ ] Manual: patient with `allergy_status = 'unknown'` and empty allergy list renders the amber "not assessed" state.