### PR TITLE
fix(ai): structured log on LLM flag truncation + recalibrate suspicious threshold

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { validateLLMResponse } from "../llm-validator.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  validateLLMResponse,
+  MAX_FLAGS,
+  SUSPICIOUS_FLAG_THRESHOLD,
+} from "../llm-validator.js";
 
 function makeFlag(overrides: Record<string, unknown> = {}) {
   return {
@@ -157,8 +161,11 @@ describe("validateLLMResponse", () => {
     }
   });
 
-  it("warns on suspicious flag count (>= 15)", () => {
-    const flags = Array.from({ length: 16 }, () => makeFlag());
+  it("warns on suspicious flag count at the threshold boundary", () => {
+    // Exactly at threshold should fire (boundary is inclusive).
+    const flags = Array.from({ length: SUSPICIOUS_FLAG_THRESHOLD }, () =>
+      makeFlag(),
+    );
     const input = JSON.stringify(flags);
     const result = validateLLMResponse(input);
 
@@ -170,11 +177,104 @@ describe("validateLLMResponse", () => {
     }
   });
 
+  it("does not warn on suspicious flag count just below threshold", () => {
+    const flags = Array.from({ length: SUSPICIOUS_FLAG_THRESHOLD - 1 }, () =>
+      makeFlag(),
+    );
+    const input = JSON.stringify(flags);
+    const result = validateLLMResponse(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(
+        result.warnings.some((w) => w.includes("Suspiciously high")),
+      ).toBe(false);
+    }
+  });
+
   it("returns ok: false when response is not an array", () => {
     const result = validateLLMResponse(JSON.stringify({ flag: "value" }));
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("must be a JSON array");
     }
+  });
+});
+
+describe("validateLLMResponse — configuration constants", () => {
+  it("exposes MAX_FLAGS = 50", () => {
+    expect(MAX_FLAGS).toBe(50);
+  });
+
+  // Regression guard: SUSPICIOUS_FLAG_THRESHOLD was recalibrated after
+  // MAX_FLAGS was raised from 20 -> 50 (issue #511). At MAX_FLAGS=20 the
+  // original threshold of 15 sat at 75% of cap ("near-cap" semantics);
+  // after the raise to 50 we preserve that ratio at floor(50 * 0.75) = 37.
+  it("exposes SUSPICIOUS_FLAG_THRESHOLD = 37 (~75% of MAX_FLAGS)", () => {
+    expect(SUSPICIOUS_FLAG_THRESHOLD).toBe(37);
+    expect(SUSPICIOUS_FLAG_THRESHOLD).toBe(Math.floor(MAX_FLAGS * 0.75));
+  });
+});
+
+describe("validateLLMResponse — truncation observability", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("emits a structured console.warn when flags exceed MAX_FLAGS", () => {
+    const criticals = Array.from({ length: 2 }, () =>
+      makeFlag({ severity: "critical" }),
+    );
+    const warnings = Array.from({ length: 3 }, () =>
+      makeFlag({ severity: "warning" }),
+    );
+    const infos = Array.from({ length: 60 }, () =>
+      makeFlag({ severity: "info" }),
+    );
+    const input = JSON.stringify([...criticals, ...warnings, ...infos]);
+
+    const result = validateLLMResponse(input);
+
+    expect(result.ok).toBe(true);
+    // Find the structured truncation log (object arg, not a raw string).
+    const structuredCall = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event === "llm_findings_truncated",
+    );
+    expect(structuredCall).toBeDefined();
+    expect(structuredCall![0]).toMatchObject({
+      event: "llm_findings_truncated",
+      received: 65,
+      kept: 50,
+      dropped: 15,
+      droppedBySeverity: {
+        critical: 0,
+        warning: 0,
+        info: 15,
+      },
+      maxFlags: MAX_FLAGS,
+    });
+  });
+
+  it("does not emit a truncation log when flags are at or below MAX_FLAGS", () => {
+    const flags = Array.from({ length: MAX_FLAGS }, () => makeFlag());
+    const result = validateLLMResponse(JSON.stringify(flags));
+
+    expect(result.ok).toBe(true);
+    const structuredCall = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event === "llm_findings_truncated",
+    );
+    expect(structuredCall).toBeUndefined();
   });
 });

--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -17,8 +17,27 @@ const VALID_CATEGORIES = [
   "documentation-discrepancy",
 ] as const;
 
-const MAX_FLAGS = 50;
-const SUSPICIOUS_FLAG_THRESHOLD = 15;
+export const MAX_FLAGS = 50;
+
+/**
+ * Threshold at which a single LLM review's flag count is considered
+ * "suspiciously high" and a warning is appended to the validation result.
+ *
+ * Originally 15 when MAX_FLAGS was 20 (see PR #493 history) — i.e. 75% of
+ * cap, which reads as "the LLM is approaching the hard ceiling; something
+ * may be off (prompt regression, prompt-injection probe, runaway model)."
+ *
+ * When MAX_FLAGS was raised 20 -> 50, this constant was left at 15, which
+ * meant the warning fired at 30% of capacity. At that level a multi-system
+ * oncology patient routinely trips the warning, drowning real signal in
+ * noise (see issue #511).
+ *
+ * We re-peg the threshold to the original "near-cap" semantics at ~75%
+ * of MAX_FLAGS. floor(50 * 0.75) = 37. Derived from MAX_FLAGS so future
+ * cap changes automatically preserve the ratio; the suspicious-count
+ * test asserts the numeric value to catch accidental drift.
+ */
+export const SUSPICIOUS_FLAG_THRESHOLD = Math.floor(MAX_FLAGS * 0.75);
 
 /** Ordering used when a response overflows MAX_FLAGS: critical survive first. */
 const SEVERITY_RANK: Record<(typeof VALID_SEVERITIES)[number], number> = {
@@ -227,6 +246,20 @@ export function validateLLMResponse(raw: string): ValidationResult {
         `(dropped: critical=${droppedBySeverity.critical}, ` +
         `warning=${droppedBySeverity.warning}, info=${droppedBySeverity.info})`,
     );
+    // Structured emission so log aggregators (Datadog, Loki, CloudWatch
+    // Insights) can alert on truncation counts over time. Issue #510:
+    // string-formatted alerts from the ai-oversight worker aren't reliably
+    // parseable as a counter source. Consumers that wrap a metrics emitter
+    // can still read `truncation` from the return value; this log is the
+    // low-lift stopgap until a service-wide structured logger lands.
+    console.warn({
+      event: "llm_findings_truncated",
+      received: all.length,
+      kept: capped.length,
+      dropped: dropped.length,
+      droppedBySeverity,
+      maxFlags: MAX_FLAGS,
+    });
   }
 
   return { ok: true, flags: capped, warnings, ...(truncation ? { truncation } : {}) };


### PR DESCRIPTION
Closes #510
Closes #511

## Summary
Two `from-review` follow-ups from PR #493 landing in the same file
(`packages/phi-sanitizer/src/llm-validator.ts`).

### #510 — structured log for LLM flag truncation
When the validator drops findings to stay under `MAX_FLAGS`, emit a
structured `console.warn({...})` alongside the existing string warning
and `TruncationInfo` return field, so log aggregators (Datadog, Loki,
CloudWatch Insights) can alert on truncation counts over time without
parsing free-form text.

Log shape:

```js
console.warn({
  event: "llm_findings_truncated",
  received,        // total flags from LLM
  kept,            // how many survived the cap
  dropped,         // how many were truncated
  droppedBySeverity: { critical, warning, info },
  maxFlags,        // the active cap
})
```

No patient/job identifiers are attached here — the validator doesn't have
them. Callers (`review-service.ts`) still emit the `console.error` alert
that includes `jobId`/redacted patient context; this counter log is
additive and purely about truncation-rate observability.

### #511 — recalibrate `SUSPICIOUS_FLAG_THRESHOLD` after MAX_FLAGS 20->50
PR #493 raised `MAX_FLAGS` from 20 to 50 but left
`SUSPICIOUS_FLAG_THRESHOLD = 15` untouched. That used to sit at 75% of
the cap; it now sits at 30%, so a normal multi-system oncology patient
trips the warning.

**New value:** `SUSPICIOUS_FLAG_THRESHOLD = Math.floor(MAX_FLAGS * 0.75) = 37`.

**Rationale:**
- Preserves the original "near-cap" signal-to-noise calibration from
  the 20-flag regime (15/20 = 0.75).
- Derived from `MAX_FLAGS` so a future cap change auto-scales.
- A single LLM call producing 37+ flags for one review is a legitimate
  prompt-regression / injection-probe / runaway-model signal regardless
  of cap; anything below that is plausible multi-system complexity.
- A numeric regression test asserts the exact `37` to catch drift in
  case someone tweaks the ratio without intent.

The reasoning is also captured in a doc comment above the constant.

## Test plan
- [x] `pnpm --filter @carebridge/phi-sanitizer test` — 83 passed, 3 new
      tests (threshold regression, boundary-just-below, structured-log
      emission shape) + existing 15
- [x] `pnpm typecheck` — 34/34 green
- [x] `pnpm lint` — no new warnings
- [x] Existing truncation tests still pass (structured log spy confirms
      emission shape for critical/warning/info-mix payloads)
- [ ] Manual verification in staging that Datadog parses the JSON log
      as a counter source (post-merge)