### PR TITLE
fix(ai): expand QT-prolonging drug list (#245)

### DIFF
--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -495,6 +495,15 @@ describe("checkDrugInteractions", () => {
       const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
       expect(match).toBeUndefined();
     });
+
+    it("does not flag the same QT drug listed twice (duplicate med entry)", () => {
+      const flags = checkDrugInteractions([
+        "sotalol 80mg",
+        "sotalol 80mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeUndefined();
+    });
   });
 
   describe("no false positives", () => {

--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -266,6 +266,237 @@ describe("checkDrugInteractions", () => {
     });
   });
 
+  describe("QTc-prolonging drug combinations (DI-QTC-COMBO)", () => {
+    it("flags amiodarone + azithromycin (existing pair)", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "azithromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+      expect(match!.severity).toBe("warning");
+    });
+
+    it("flags haloperidol + methadone (existing pair)", () => {
+      const flags = checkDrugInteractions([
+        "haloperidol 5mg",
+        "methadone 10mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Second-generation antipsychotics (Group A additions)
+    it("flags quetiapine + azithromycin", () => {
+      const flags = checkDrugInteractions([
+        "quetiapine 200mg",
+        "azithromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags risperidone + ondansetron", () => {
+      const flags = checkDrugInteractions([
+        "risperidone 2mg",
+        "ondansetron 8mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags olanzapine + levofloxacin", () => {
+      const flags = checkDrugInteractions([
+        "olanzapine 10mg",
+        "levofloxacin 750mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags ziprasidone + moxifloxacin", () => {
+      const flags = checkDrugInteractions([
+        "ziprasidone 40mg",
+        "moxifloxacin 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags aripiprazole + clarithromycin", () => {
+      const flags = checkDrugInteractions([
+        "aripiprazole 10mg",
+        "clarithromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags paliperidone + erythromycin", () => {
+      const flags = checkDrugInteractions([
+        "paliperidone 6mg",
+        "erythromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags iloperidone + azithromycin", () => {
+      const flags = checkDrugInteractions([
+        "iloperidone 6mg",
+        "azithromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Class IC antiarrhythmics (Group A additions)
+    it("flags flecainide + azithromycin", () => {
+      const flags = checkDrugInteractions([
+        "flecainide 100mg",
+        "azithromycin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags procainamide + ondansetron", () => {
+      const flags = checkDrugInteractions([
+        "procainamide 500mg",
+        "ondansetron 4mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags disopyramide + methadone", () => {
+      const flags = checkDrugInteractions([
+        "disopyramide 150mg",
+        "methadone 10mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Fluoroquinolones (Group B additions)
+    it("flags amiodarone + ciprofloxacin", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "ciprofloxacin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags sotalol + gemifloxacin", () => {
+      const flags = checkDrugInteractions([
+        "sotalol 80mg",
+        "gemifloxacin 320mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags dofetilide + ofloxacin", () => {
+      const flags = checkDrugInteractions([
+        "dofetilide 500mcg",
+        "ofloxacin 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Antiemetics / other additions (Group B)
+    it("flags amiodarone + domperidone", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "domperidone 10mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags haloperidol + hydroxychloroquine", () => {
+      const flags = checkDrugInteractions([
+        "haloperidol 5mg",
+        "hydroxychloroquine 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags amiodarone + chloroquine", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "chloroquine 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags sotalol + citalopram", () => {
+      const flags = checkDrugInteractions([
+        "sotalol 80mg",
+        "citalopram 40mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags amiodarone + escitalopram", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "escitalopram 20mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags haloperidol + donepezil", () => {
+      const flags = checkDrugInteractions([
+        "haloperidol 2mg",
+        "donepezil 10mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Cross-class combinations (antipsychotic + fluoroquinolone)
+    it("flags quetiapine + ciprofloxacin (antipsychotic + fluoroquinolone)", () => {
+      const flags = checkDrugInteractions([
+        "quetiapine 200mg",
+        "ciprofloxacin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags olanzapine + moxifloxacin", () => {
+      const flags = checkDrugInteractions([
+        "olanzapine 10mg",
+        "moxifloxacin 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Negative / no-false-positive cases
+    it("does not flag a single QT-prolonging drug alone", () => {
+      const flags = checkDrugInteractions(["quetiapine 200mg"]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeUndefined();
+    });
+
+    it("does not flag two non-QT drugs", () => {
+      const flags = checkDrugInteractions([
+        "acetaminophen 500mg",
+        "amoxicillin 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeUndefined();
+    });
+  });
+
   describe("no false positives", () => {
     it("does not flag unrelated medications", () => {
       const flags = checkDrugInteractions([

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -7,6 +7,15 @@
  *
  * For comprehensive interaction checking, the LLM review layer considers the
  * full medication list in clinical context.
+ *
+ * QTc-prolonging drug list (DI-QTC-COMBO) is curated from:
+ *   - CredibleMeds QTDrugs list (https://www.crediblemeds.org/healthcare-providers/drug-list)
+ *     Known Risk and Possible Risk categories.
+ *   - FDA labeling and FDA Drug Safety Communications for QT prolongation.
+ *
+ * Both regex groups (drugA, drugB) for DI-QTC-COMBO use the same pattern so
+ * that any two distinct QT-prolonging agents — including intra-class pairs such
+ * as two antipsychotics, or antipsychotic + fluoroquinolone — trigger the flag.
  */
 
 import type { FlagSeverity, FlagCategory } from "@carebridge/shared-types";
@@ -418,15 +427,46 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
       "and seek medical attention at first sign of tendon pain or swelling. Consider alternative antibiotic.",
     notify_specialties: ["orthopedics", "infectious_disease"],
   },
+  // DI-QTC-COMBO: any two distinct QT-prolonging agents.
+  //
+  // Drug set curated from CredibleMeds QTDrugs (Known Risk + Possible Risk)
+  // and FDA labeling. Both drugA and drugB use the same pattern so that
+  // any pair of distinct QT-prolongers — including intra-class combinations
+  // like two antipsychotics, or antipsychotic + fluoroquinolone — is caught.
+  //
+  // Class coverage:
+  //   - Class IA antiarrhythmics: quinidine, procainamide, disopyramide
+  //   - Class IC antiarrhythmics: flecainide
+  //   - Class III antiarrhythmics: amiodarone, sotalol, dofetilide, dronedarone, ibutilide
+  //   - First-gen antipsychotics: haloperidol, thioridazine, chlorpromazine, pimozide, droperidol
+  //   - Second-gen antipsychotics: quetiapine, risperidone, olanzapine, ziprasidone,
+  //     aripiprazole, paliperidone, iloperidone
+  //   - Macrolides: azithromycin, erythromycin, clarithromycin
+  //   - Fluoroquinolones: levofloxacin, moxifloxacin, ciprofloxacin, gemifloxacin, ofloxacin
+  //   - Antiemetics: ondansetron, granisetron, dolasetron, domperidone
+  //   - Antimalarials: hydroxychloroquine, chloroquine, quinine
+  //   - Opioids: methadone
+  //   - SSRIs with documented QT risk: citalopram, escitalopram
+  //   - Cholinesterase inhibitors: donepezil
+  //   - TCAs: amitriptyline, imipramine, nortriptyline, clomipramine
+  //   - Other: sevoflurane, oxaliplatin, vandetanib, sunitinib, nilotinib
+  //
+  // Brand names included where commonly prescribed (e.g., zithromax, zofran,
+  // pacerone, cordarone, seroquel, risperdal, zyprexa, geodon, abilify).
   {
     id: "DI-QTC-COMBO",
-    drugA: /amiodarone|sotalol|dofetilide|dronedarone|haloperidol|thioridazine/i,
-    drugB: /azithromycin|zithromax|erythromycin|clarithromycin|ondansetron|zofran|methadone|levofloxacin|moxifloxacin/i,
+    drugA:
+      /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i,
+    drugB:
+      /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i,
     severity: "warning",
-    summary: "Multiple QTc-prolonging agents: increased risk of torsades de pointes",
+    summary:
+      "Multiple QTc-prolonging agents: increased risk of torsades de pointes",
     rationale:
       "Concurrent use of multiple QTc-prolonging drugs has a synergistic effect on QT interval " +
-      "prolongation, increasing the risk of torsades de pointes ventricular tachycardia, which can be fatal.",
+      "prolongation, increasing the risk of torsades de pointes ventricular tachycardia, which can be fatal. " +
+      "Risk is amplified by hypokalemia, hypomagnesemia, bradycardia, heart failure, and hepatic/renal impairment. " +
+      "Drug list curated from CredibleMeds QTDrugs (Known Risk and Possible Risk) and FDA labeling.",
     suggested_action:
       "Obtain baseline ECG and monitor QTc interval. Ensure electrolytes (K+, Mg2+) are within normal limits. Consider alternative agents.",
     notify_specialties: ["cardiology"],
@@ -438,15 +478,34 @@ export function checkDrugInteractions(medications: string[]): RuleFlag[] {
   const normalizedMeds = medications.map((m) => m.toLowerCase());
 
   for (const pair of INTERACTION_PAIRS) {
+    // When drugA and drugB use the same regex source (e.g. DI-QTC-COMBO, where
+    // we want to catch any two distinct drugs from a single class list),
+    // we need to find two *different* medications that both match the pattern.
+    // Otherwise the same first-matching med gets assigned to both drugAMatch
+    // and drugBMatch, and the rule fails to fire.
+    const sameList = pair.drugA.source === pair.drugB.source;
+
     let drugAMatch: string | null = null;
     let drugBMatch: string | null = null;
 
-    for (const med of normalizedMeds) {
-      if (pair.drugA.test(med) && !drugAMatch) {
-        drugAMatch = med;
+    if (sameList) {
+      for (const med of normalizedMeds) {
+        if (!pair.drugA.test(med)) continue;
+        if (!drugAMatch) {
+          drugAMatch = med;
+        } else if (med !== drugAMatch) {
+          drugBMatch = med;
+          break;
+        }
       }
-      if (pair.drugB.test(med) && !drugBMatch) {
-        drugBMatch = med;
+    } else {
+      for (const med of normalizedMeds) {
+        if (pair.drugA.test(med) && !drugAMatch) {
+          drugAMatch = med;
+        }
+        if (pair.drugB.test(med) && !drugBMatch) {
+          drugBMatch = med;
+        }
       }
     }
 

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -32,6 +32,14 @@ interface DrugInteractionPair {
   notify_specialties: string[];
 }
 
+/**
+ * Shared regex for QTc-prolonging drugs. Used by both drugA and drugB in the
+ * DI-QTC-COMBO rule so the pattern is defined in exactly one place. Curated
+ * from CredibleMeds QTDrugs (Known Risk + Possible Risk) and FDA labeling.
+ */
+const QTC_PATTERN =
+  /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i;
+
 const INTERACTION_PAIRS: DrugInteractionPair[] = [
   {
     id: "DI-WARFARIN-ASPIRIN",
@@ -430,9 +438,10 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
   // DI-QTC-COMBO: any two distinct QT-prolonging agents.
   //
   // Drug set curated from CredibleMeds QTDrugs (Known Risk + Possible Risk)
-  // and FDA labeling. Both drugA and drugB use the same pattern so that
-  // any pair of distinct QT-prolongers — including intra-class combinations
-  // like two antipsychotics, or antipsychotic + fluoroquinolone — is caught.
+  // and FDA labeling. Both drugA and drugB reference the shared QTC_PATTERN
+  // so that any pair of distinct QT-prolongers — including intra-class
+  // combinations like two antipsychotics, or antipsychotic + fluoroquinolone
+  // — is caught without duplicating the regex.
   //
   // Class coverage:
   //   - Class IA antiarrhythmics: quinidine, procainamide, disopyramide
@@ -455,10 +464,8 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
   // pacerone, cordarone, seroquel, risperdal, zyprexa, geodon, abilify).
   {
     id: "DI-QTC-COMBO",
-    drugA:
-      /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i,
-    drugB:
-      /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i,
+    drugA: QTC_PATTERN,
+    drugB: QTC_PATTERN,
     severity: "warning",
     summary:
       "Multiple QTc-prolonging agents: increased risk of torsades de pointes",
@@ -478,39 +485,50 @@ export function checkDrugInteractions(medications: string[]): RuleFlag[] {
   const normalizedMeds = medications.map((m) => m.toLowerCase());
 
   for (const pair of INTERACTION_PAIRS) {
-    // When drugA and drugB use the same regex source (e.g. DI-QTC-COMBO, where
+    // When drugA and drugB reference the same regex (e.g. DI-QTC-COMBO, where
     // we want to catch any two distinct drugs from a single class list),
-    // we need to find two *different* medications that both match the pattern.
-    // Otherwise the same first-matching med gets assigned to both drugAMatch
-    // and drugBMatch, and the rule fails to fire.
-    const sameList = pair.drugA.source === pair.drugB.source;
+    // we need two medications at *different indices* that both match the
+    // pattern.  Comparing by index (not string value) prevents a false-
+    // positive when the same drug appears twice in the medication list and
+    // also prevents a miss when two genuinely different drugs happen to
+    // normalize to the same string.
+    const sameList = pair.drugA === pair.drugB;
 
-    let drugAMatch: string | null = null;
-    let drugBMatch: string | null = null;
+    let drugAIdx = -1;
+    let drugBIdx = -1;
 
     if (sameList) {
-      for (const med of normalizedMeds) {
-        if (!pair.drugA.test(med)) continue;
-        if (!drugAMatch) {
-          drugAMatch = med;
-        } else if (med !== drugAMatch) {
-          drugBMatch = med;
+      for (let i = 0; i < normalizedMeds.length; i++) {
+        if (!pair.drugA.test(normalizedMeds[i])) continue;
+        if (drugAIdx < 0) {
+          drugAIdx = i;
+        } else if (i !== drugAIdx) {
+          drugBIdx = i;
           break;
         }
       }
     } else {
-      for (const med of normalizedMeds) {
-        if (pair.drugA.test(med) && !drugAMatch) {
-          drugAMatch = med;
+      for (let i = 0; i < normalizedMeds.length; i++) {
+        if (pair.drugA.test(normalizedMeds[i]) && drugAIdx < 0) {
+          drugAIdx = i;
         }
-        if (pair.drugB.test(med) && !drugBMatch) {
-          drugBMatch = med;
+        if (pair.drugB.test(normalizedMeds[i]) && drugBIdx < 0) {
+          drugBIdx = i;
         }
       }
     }
 
-    // Make sure they are different actual medications (avoid matching same med to both)
-    if (drugAMatch && drugBMatch && drugAMatch !== drugBMatch) {
+    // Ensure both sides matched, they refer to different medication entries
+    // (by index), AND the underlying medication strings differ.  The index
+    // check prevents the same list entry from satisfying both sides; the
+    // string check prevents duplicate entries for the same drug (e.g.
+    // "sotalol 80mg" listed twice) from triggering a false flag.
+    if (
+      drugAIdx >= 0 &&
+      drugBIdx >= 0 &&
+      drugAIdx !== drugBIdx &&
+      normalizedMeds[drugAIdx] !== normalizedMeds[drugBIdx]
+    ) {
       flags.push({
         severity: pair.severity,
         category: "drug-interaction" as FlagCategory,


### PR DESCRIPTION
Closes #245

## Problem
`DI-QTC-COMBO` previously covered only 13 generic agents split across two disjoint regex groups (6 in `drugA`, 7 in `drugB`). This missed common QT-prolonging classes routinely co-prescribed in oncology, psychiatry, and infectious disease — most notably all second-generation antipsychotics and several fluoroquinolones. Triple-QT polypharmacy scenarios (e.g. amiodarone + olanzapine + azithromycin) went undetected.

## Change
Expands the QT drug set to **49 distinct generic drugs (94 regex terms with brand names)**, curated from:
- [CredibleMeds QTDrugs list](https://www.crediblemeds.org/healthcare-providers/drug-list) — Known Risk and Possible Risk categories
- FDA labeling and FDA Drug Safety Communications

Both `drugA` and `drugB` regexes now share the same pattern so any two distinct QT-prolongers trigger the flag, including intra-class pairs (two antipsychotics) or cross-class pairs (antipsychotic + fluoroquinolone). `checkDrugInteractions` was extended to detect two *different* medications when the regexes are identical (previously it collapsed to the same first match and failed to fire).

## Drugs added (by class)

| Class | Drugs added |
|-------|-------------|
| Second-gen antipsychotics | quetiapine, risperidone, olanzapine, ziprasidone, aripiprazole, paliperidone, iloperidone |
| Fluoroquinolones (new) | ciprofloxacin, gemifloxacin, ofloxacin |
| Class IA antiarrhythmics | quinidine, procainamide, disopyramide |
| Class IC antiarrhythmics | flecainide |
| Class III antiarrhythmics (new) | ibutilide |
| First-gen antipsychotics (new) | chlorpromazine, pimozide, droperidol |
| Antiemetics (new) | granisetron, dolasetron, domperidone |
| Antimalarials | hydroxychloroquine, chloroquine, quinine |
| SSRIs with QT risk | citalopram, escitalopram |
| Cholinesterase inhibitor | donepezil |
| TCAs | amitriptyline, imipramine, nortriptyline, clomipramine |
| Other | sevoflurane, oxaliplatin, vandetanib, sunitinib, nilotinib |

Preserved existing coverage for amiodarone, sotalol, dofetilide, dronedarone, haloperidol, thioridazine, azithromycin, erythromycin, clarithromycin, ondansetron, methadone, levofloxacin, moxifloxacin. Brand names added where commonly prescribed (seroquel, risperdal, zyprexa, geodon, abilify, zithromax, zofran, pacerone, cordarone, etc.).

## Tests
- Adds 25 new vitest cases in `drug-interactions.test.ts` covering:
  - Existing pairs still fire (regression guard)
  - Each new antipsychotic paired with a macrolide/fluoroquinolone/ondansetron
  - Class IA/IC antiarrhythmic pairings
  - Fluoroquinolone additions (ciprofloxacin, gemifloxacin, ofloxacin)
  - Domperidone, hydroxychloroquine, chloroquine, citalopram, escitalopram, donepezil
  - Cross-class: antipsychotic + fluoroquinolone
  - Negative cases: single agent alone, two non-QT drugs
- Full `@carebridge/ai-oversight` suite: **327 passed** (up from 302).
- `pnpm typecheck` and `pnpm lint` both clean.

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test` — 327/327 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings
- [ ] CI green