### PR TITLE
fix(notifications): whitelist notification categories for lock-screen safety

### DIFF
--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -308,10 +308,11 @@ describe("dispatch-worker", () => {
       await processorFn({ data: event, id: "job-phi-3" });
 
       // Reproduce buildSafeSummary locally (mirror of the private helper):
-      // a category-only template, PHI-free by construction.
+      // a category-only template, PHI-free by construction. The category
+      // is rendered through the whitelist label (`critical-value` →
+      // "Critical value") rather than a raw dash→space transform.
       const expectedSafe =
-        `Clinical flag — ${event.category.replace(/-/g, " ")}. ` +
-        `Open the portal to view details.`;
+        "Clinical flag — Critical value. Open the portal to view details.";
 
       const insertedRecords = mockInsertValues.mock.calls[0][0];
       expect(insertedRecords).toHaveLength(1);
@@ -335,6 +336,129 @@ describe("dispatch-worker", () => {
 
       const insertedRecords = mockInsertValues.mock.calls[0][0];
       expect(insertedRecords[0].body).toBe(event.summary);
+    });
+  });
+
+  // Category whitelist (issue #551).
+  // `NotificationEvent.category` is typed as `string`, so a future rule
+  // author or LLM could pass something like `"psychiatric-symptoms"` that
+  // would otherwise render verbatim on a device lock screen. These tests
+  // lock in the whitelist + generic fallback + observability behaviour.
+  describe("category whitelist", () => {
+    const primeRecipients = (): void => {
+      mockSelectResult.push({ user_id: "user-neuro" });
+      mockSelectResult2.push({
+        id: "user-neuro",
+        specialty: "Neurology",
+        role: "physician",
+      });
+    };
+
+    const knownCategoryCases: Array<[string, string]> = [
+      ["cross-specialty", "Cross-specialty concern"],
+      ["drug-interaction", "Drug interaction"],
+      ["medication-safety", "Medication safety"],
+      ["care-gap", "Care gap"],
+      ["critical-value", "Critical value"],
+      ["trend-concern", "Trend concern"],
+      ["documentation-discrepancy", "Documentation discrepancy"],
+      ["patient-reported", "Patient-reported concern"],
+    ];
+
+    for (const [category, label] of knownCategoryCases) {
+      it(`renders whitelisted category "${category}" as "${label}"`, async () => {
+        primeRecipients();
+
+        const warnSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => undefined);
+
+        const event = makeEvent({ severity: "warning", category });
+        await processorFn({ data: event, id: `job-cat-${category}` });
+
+        const insertedRecords = mockInsertValues.mock.calls[0][0];
+        expect(insertedRecords[0].title).toBe(
+          `Warning: Clinical flag — ${label}`,
+        );
+        expect(insertedRecords[0].summary_safe).toBe(
+          `Clinical flag — ${label}. Open the portal to view details.`,
+        );
+        // Known categories must not trigger the unknown-category warning.
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+      });
+    }
+
+    it("falls back to 'Clinical alert' for unknown categories", async () => {
+      primeRecipients();
+
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const event = makeEvent({
+        severity: "critical",
+        // Unknown, PHI-adjacent category that MUST NOT surface verbatim.
+        category: "hiv-status-change",
+      });
+      await processorFn({ data: event, id: "job-cat-unknown" });
+
+      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      const title = insertedRecords[0].title as string;
+      const safeSummary = insertedRecords[0].summary_safe as string;
+
+      expect(title).toBe("CRITICAL: Clinical flag — Clinical alert");
+      expect(safeSummary).toBe(
+        "Clinical flag — Clinical alert. Open the portal to view details.",
+      );
+      // The raw, unknown category must not leak into either field.
+      expect(title).not.toContain("hiv");
+      expect(title).not.toContain("status");
+      expect(safeSummary).not.toContain("hiv");
+
+      // Observability: unknown categories are logged with structured context
+      // so the operator can triage and either admit them to the whitelist
+      // or fix the upstream rule/LLM output.
+      expect(warnSpy).toHaveBeenCalled();
+      const warnCall = warnSpy.mock.calls.find((call) =>
+        String(call[0]).includes("Unknown notification category"),
+      );
+      expect(warnCall).toBeDefined();
+      const context = warnCall![1] as { category: string; fallback: string };
+      expect(context.category).toBe("hiv-status-change");
+      expect(context.fallback).toBe("Clinical alert");
+
+      warnSpy.mockRestore();
+    });
+
+    it("published lock-screen payload uses fallback label and carries no PHI for unknown categories", async () => {
+      primeRecipients();
+
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+
+      const event = makeEvent({
+        severity: "warning",
+        category: "psychiatric-symptoms-self-harm",
+        summary: "Patient MRN 987654 reports ideation; BP 145/95",
+      });
+      await processorFn({ data: event, id: "job-cat-unknown-phi" });
+
+      expect(mockPublishNotification).toHaveBeenCalledTimes(1);
+      const [, payload] = mockPublishNotification.mock.calls[0];
+      expect(payload.title).toBe("Warning: Clinical flag — Clinical alert");
+      expect(payload.body).toBe(
+        "Clinical flag — Clinical alert. Open the portal to view details.",
+      );
+      // Neither the raw summary nor the suspicious category should leak.
+      expect(payload.title).not.toContain("psychiatric");
+      expect(payload.body).not.toContain("psychiatric");
+      expect(payload.body).not.toContain("MRN");
+      expect(payload.body).not.toMatch(/\d/);
+
+      warnSpy.mockRestore();
     });
   });
 });

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -26,6 +26,56 @@ import { filterRecipientsBySpecialty } from "./specialty-filter.js";
 import type { CandidateRecipient } from "./specialty-filter.js";
 import { getUserPreferences, evaluateDelivery } from "./preferences.js";
 
+/**
+ * Whitelist of clinical flag categories that are safe to surface on a
+ * device lock screen. This mirrors the `FlagCategory` union in
+ * `@carebridge/shared-types/ai-flags` — kept as a local constant (rather
+ * than deriving it from the type) so that new rule/LLM categories cannot
+ * reach the lock screen without a reviewer also extending this map.
+ *
+ * HIPAA lock-screen safety (issue #551): `NotificationEvent.category` is
+ * typed as `string` (set by rule authors and LLM output) so a
+ * free-form value like `psychiatric-symptoms-self-harm` could otherwise
+ * surface verbatim in a push-notification title. Every value admitted
+ * here is a generic, PHI-free clinical taxonomy bucket; anything outside
+ * this set falls back to `UNKNOWN_CATEGORY_LABEL` and is logged.
+ */
+const CATEGORY_LABELS = {
+  "cross-specialty": "Cross-specialty concern",
+  "drug-interaction": "Drug interaction",
+  "medication-safety": "Medication safety",
+  "care-gap": "Care gap",
+  "critical-value": "Critical value",
+  "trend-concern": "Trend concern",
+  "documentation-discrepancy": "Documentation discrepancy",
+  "patient-reported": "Patient-reported concern",
+} as const satisfies Record<string, string>;
+
+type SafeCategory = keyof typeof CATEGORY_LABELS;
+
+const UNKNOWN_CATEGORY_LABEL = "Clinical alert";
+
+function isSafeCategory(category: string): category is SafeCategory {
+  return Object.prototype.hasOwnProperty.call(CATEGORY_LABELS, category);
+}
+
+/**
+ * Resolve a category string to a lock-screen-safe human-readable label.
+ * Unknown categories are replaced with a generic label and logged as a
+ * structured warning so the operator can detect new rule/LLM taxonomies
+ * that need review before being admitted to the whitelist.
+ */
+function resolveCategoryLabel(category: string): string {
+  if (isSafeCategory(category)) {
+    return CATEGORY_LABELS[category];
+  }
+  console.warn(
+    "[dispatch-worker] Unknown notification category — falling back to generic label",
+    { category, fallback: UNKNOWN_CATEGORY_LABEL },
+  );
+  return UNKNOWN_CATEGORY_LABEL;
+}
+
 const QUEUE_NAME = "notifications";
 const DLQ_NAME = "notifications-failed";
 
@@ -106,22 +156,28 @@ async function findNotificationRecipients(
  *
  * HIPAA lock-screen safety: the title MUST NOT contain patient identifiers
  * or clinical numeric values. This function produces a generic
- * "CRITICAL: Clinical flag — critical value" form with no PHI. Upstream
+ * "CRITICAL: Clinical flag — Critical value" form with no PHI. Upstream
  * push-notification integrations (APNs, FCM) should render only this
  * title on device lock screens; clinical detail is behind the
  * authenticated portal fetch keyed off related_flag_id.
+ *
+ * The category portion is resolved via `resolveCategoryLabel`, which
+ * enforces a whitelist and falls back to "Clinical alert" for any
+ * unexpected value (see `CATEGORY_LABELS`).
  */
 function buildNotificationTitle(event: NotificationEvent): string {
   const severityLabel = event.severity === "critical" ? "CRITICAL" : event.severity === "warning" ? "Warning" : "Info";
-  return `${severityLabel}: Clinical flag — ${event.category.replace(/-/g, " ")}`;
+  const categoryLabel = resolveCategoryLabel(event.category);
+  return `${severityLabel}: Clinical flag — ${categoryLabel}`;
 }
 
 /**
  * Produce a lock-screen-safe rendering of the flag summary for push-layer
- * delivery. Returns a template string built from `event.category` alone;
- * `event.summary` is intentionally discarded (it may contain PHI such as
- * patient identifiers or clinical numeric values like "BP 145/95" or
- * "K+ 7.2 mmol/L" that must not surface on a locked device).
+ * delivery. Returns a template string built from the whitelisted category
+ * label alone; `event.summary` is intentionally discarded (it may contain
+ * PHI such as patient identifiers or clinical numeric values like
+ * "BP 145/95" or "K+ 7.2 mmol/L" that must not surface on a locked
+ * device).
  *
  * The full summary is still persisted on `notifications.body` (encrypted
  * at rest) for authenticated portal render once the device is unlocked;
@@ -131,9 +187,10 @@ function buildNotificationTitle(event: NotificationEvent): string {
  * variant without re-deriving it.
  */
 function buildSafeSummary(event: NotificationEvent): string {
-  // Trust nothing from the event.summary — always fall back to category.
-  return `Clinical flag — ${event.category.replace(/-/g, " ")}. ` +
-    `Open the portal to view details.`;
+  // Trust nothing from the event.summary — always fall back to the
+  // whitelisted category label (which itself guards against unknown values).
+  const categoryLabel = resolveCategoryLabel(event.category);
+  return `Clinical flag — ${categoryLabel}. Open the portal to view details.`;
 }
 
 /**


### PR DESCRIPTION
Closes #551

## Why
`NotificationEvent.category` is typed as free-form `string`, so a
future rule author or LLM response could set it to a PHI-adjacent
value like `psychiatric-symptoms-self-harm` or `hiv-status-change`
that would render verbatim in a push-notification title surfaced on a
device lock screen. The existing dash-to-space transform in
`buildNotificationTitle` / `buildSafeSummary` offered no guard.

## What changed
- New `CATEGORY_LABELS` whitelist in `services/notifications/src/workers/dispatch-worker.ts`
  mapping every canonical `FlagCategory` value to a human-readable
  label:
    - `cross-specialty` -> Cross-specialty concern
    - `drug-interaction` -> Drug interaction
    - `medication-safety` -> Medication safety
    - `care-gap` -> Care gap
    - `critical-value` -> Critical value
    - `trend-concern` -> Trend concern
    - `documentation-discrepancy` -> Documentation discrepancy
    - `patient-reported` -> Patient-reported concern
- `buildNotificationTitle` and `buildSafeSummary` now route the
  category through `resolveCategoryLabel` instead of the raw
  dash-to-space transform.
- Unknown categories fall back to the generic label `"Clinical alert"`
  and emit a structured `console.warn` with `{ category, fallback }`
  context so operators can triage and either admit the new taxonomy to
  the whitelist or fix the upstream producer.
- Lock-screen PHI invariant is preserved: the full `event.summary` is
  still persisted on `notifications.body` (encrypted at rest) and only
  the category-derived `summary_safe` is handed to the push layer.

## Tests
- 8 parameterised cases assert each whitelisted category renders to
  its expected label and does not trigger the warn log.
- 1 case asserts an unknown category (`hiv-status-change`) falls back
  to `"Clinical alert"`, never leaks tokens from the raw category, and
  emits a structured warn with the expected context fields.
- 1 case re-runs the same unknown-category event with a PHI-laden
  `summary` and asserts the published lock-screen payload carries no
  digits, no `psychiatric`, and no `MRN`.
- Existing PHI lock-screen-safety tests (issue #289) updated to the
  new label capitalisation; all 57 notifications tests pass.

## Test plan
- [x] `pnpm --filter @carebridge/notifications test` -> 57 passed
- [x] `pnpm typecheck`
- [x] `pnpm lint`