### PR TITLE
fix(ai): validate event.timestamp before using in context-builder filter

### DIFF
--- a/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
+++ b/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
+
+// Fixed reference time so tests are deterministic across timezones and CI
+// clock drift. 2026-04-16T12:00:00Z aligns with the event timestamp used in
+// the context-builder tests in this service.
+const NOW_MS = Date.UTC(2026, 3, 16, 12, 0, 0);
+const now = () => NOW_MS;
+
+describe("validateEventTimestamp", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns a valid ISO-8601 timestamp unchanged and logs nothing", () => {
+    const ts = "2026-04-16T11:59:00.000Z";
+    const result = validateEventTimestamp(ts, { now });
+    expect(result).toBe(ts);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to now when timestamp is undefined, and warns", () => {
+    const result = validateEventTimestamp(undefined, { now, eventId: "evt-1" });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("missing");
+    expect(warnSpy.mock.calls[0][0]).toContain("evt-1");
+  });
+
+  it("falls back to now when timestamp is an empty string, and warns", () => {
+    const result = validateEventTimestamp("", { now, eventId: "evt-2" });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("empty");
+    expect(warnSpy.mock.calls[0][0]).toContain("evt-2");
+  });
+
+  it("falls back to now when timestamp is whitespace-only", () => {
+    const result = validateEventTimestamp("   ", { now });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("empty");
+  });
+
+  it("falls back to now when timestamp is unparseable, and warns", () => {
+    const result = validateEventTimestamp("not-a-date", {
+      now,
+      eventId: "evt-3",
+    });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("unparseable");
+    expect(warnSpy.mock.calls[0][0]).toContain("evt-3");
+  });
+
+  it("falls back to now when timestamp is more than 1 minute in the future", () => {
+    // 5 minutes past `now` — outside the 1-minute clock-skew grace window.
+    const future = new Date(NOW_MS + 5 * 60 * 1000).toISOString();
+    const result = validateEventTimestamp(future, { now, eventId: "evt-4" });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("future");
+  });
+
+  it("accepts a timestamp within the 1-minute clock-skew grace window", () => {
+    // 30 seconds past `now` — inside the grace window.
+    const slightlyFuture = new Date(NOW_MS + 30 * 1000).toISOString();
+    const result = validateEventTimestamp(slightlyFuture, { now });
+    expect(result).toBe(slightlyFuture);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to now when timestamp is before year 2000 (epoch-leak guard)", () => {
+    const epoch = "1970-01-01T00:00:00.000Z";
+    const result = validateEventTimestamp(epoch, { now, eventId: "evt-5" });
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("too-old");
+  });
+
+  it("falls back when a non-string value leaks through the type boundary", () => {
+    // Simulates a queue payload that somehow deserialized a number instead of
+    // an ISO string. The type system would stop this, but events come off
+    // BullMQ as plain JSON — defensive check.
+    const result = validateEventTimestamp(
+      123 as unknown as string,
+      { now, eventId: "evt-6" },
+    );
+    expect(result).toBe(new Date(NOW_MS).toISOString());
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("not-a-string");
+  });
+
+  it("uses the caller label in the log prefix", () => {
+    validateEventTimestamp("", {
+      now,
+      eventId: "evt-7",
+      caller: "context-builder",
+    });
+    expect(warnSpy.mock.calls[0][0]).toContain("[context-builder]");
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -52,6 +52,7 @@ import {
   isAllergyRetracted,
 } from "../utils/event-time-snapshot.js";
 import { buildPatientContext } from "../workers/context-builder.js";
+import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 import { reviewPatientRecord } from "./claude-client.js";
 import { createFlag } from "./flag-service.js";
 
@@ -600,8 +601,12 @@ export async function buildPatientContextForRules(
   // All comparisons go through isoBefore/isoLTE (normalized via Date.parse)
   // rather than lexicographic string compares so offset-form (-05:00) and
   // bare-date (2025-12-01) timestamps sort correctly against Z-form event
-  // timestamps. See #513.
-  const eventAt = event.timestamp;
+  // timestamps. See #513. Validated before use (#517) — malformed timestamps
+  // fall back to `now` with a structured warning.
+  const eventAt = validateEventTimestamp(event.timestamp, {
+    eventId: event.id,
+    caller: "review-service:buildPatientContextForRules",
+  });
 
   function wasActiveAt(
     row: {

--- a/services/ai-oversight/src/utils/validate-event-timestamp.ts
+++ b/services/ai-oversight/src/utils/validate-event-timestamp.ts
@@ -1,0 +1,98 @@
+/**
+ * Validate and normalize a ClinicalEvent.timestamp before it is used as the
+ * right-hand side of a snapshot comparison inside a context builder.
+ *
+ * Background — #517 (follow-up to PR #494): both rule and LLM context builders
+ * filter the patient record "as of event time". When `event.timestamp` is
+ * `undefined`, an empty string, or a malformed string, the lexicographic
+ * comparisons (`row.created_at <= eventAt`) become silently wrong: either
+ * everything is excluded or everything is included. Clinical flags then fire
+ * against a nonsense snapshot, which is a safety hazard.
+ *
+ * Fallback strategy — log a structured warning (with event id only, no PHI)
+ * and substitute the current time (`new Date().toISOString()`). This keeps
+ * the review moving for events whose timestamp happens to be garbage, rather
+ * than failing the review entirely and risking a missed safety signal while
+ * BullMQ retries the job forever. The trade-off is documented in the PR that
+ * introduced this helper.
+ *
+ * Cases detected:
+ *   1. `undefined` / empty / whitespace-only timestamp
+ *   2. Unparseable string (`Date.parse` returns `NaN`)
+ *   3. Future timestamp more than 1 minute past `now` (clock-skew sentinel)
+ *   4. Implausibly old timestamp (before 2000-01-01) — guards against epoch
+ *      values leaking through from default-initialized records
+ */
+
+export interface ValidateEventTimestampOptions {
+  /**
+   * Identifier of the event whose timestamp is being validated. Logged on
+   * fallback so operators can correlate the warning with a specific queue
+   * entry. Safe to include (event id is not PHI).
+   */
+  eventId?: string;
+  /**
+   * Label of the context builder doing the validation. Included in the log
+   * prefix so the same helper can be used from multiple call sites.
+   */
+  caller?: string;
+  /**
+   * Hook for tests — injects a synthetic "now" so the clock-skew branch is
+   * reachable without real-time plumbing. Defaults to `Date.now()`.
+   */
+  now?: () => number;
+}
+
+const MINUTE_MS = 60 * 1000;
+const YEAR_2000_MS = Date.UTC(2000, 0, 1);
+const CLOCK_SKEW_GRACE_MS = MINUTE_MS;
+
+/**
+ * Returns a known-good ISO-8601 string. If the input fails any check, a
+ * warning is logged and the current time (from `options.now` or the system
+ * clock) is returned instead.
+ */
+export function validateEventTimestamp(
+  ts: string | undefined,
+  options: ValidateEventTimestampOptions = {},
+): string {
+  const now = options.now ?? (() => Date.now());
+  const caller = options.caller ?? "event-timestamp";
+  const eventId = options.eventId ?? "unknown";
+
+  const fallback = (reason: string, value: unknown): string => {
+    const iso = new Date(now()).toISOString();
+    console.warn(
+      `[${caller}] invalid event.timestamp (event=${eventId}, reason=${reason}, ` +
+        `value=${JSON.stringify(value)}) — falling back to now=${iso}`,
+    );
+    return iso;
+  };
+
+  if (ts === undefined || ts === null) {
+    return fallback("missing", ts ?? null);
+  }
+
+  if (typeof ts !== "string") {
+    return fallback("not-a-string", ts);
+  }
+
+  if (ts.trim().length === 0) {
+    return fallback("empty", ts);
+  }
+
+  const parsed = Date.parse(ts);
+  if (!Number.isFinite(parsed)) {
+    return fallback("unparseable", ts);
+  }
+
+  if (parsed < YEAR_2000_MS) {
+    return fallback("too-old", ts);
+  }
+
+  if (parsed > now() + CLOCK_SKEW_GRACE_MS) {
+    return fallback("future", ts);
+  }
+
+  return ts;
+}

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -31,6 +31,7 @@ import {
   isDiagnosisRetracted,
   isAllergyRetracted,
 } from "../utils/event-time-snapshot.js";
+import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 
 /**
  * Recursively sanitize all string values in an arbitrary event-data object
@@ -94,7 +95,13 @@ export async function buildPatientContext(
   triggerEvent: ClinicalEvent,
 ): Promise<ReviewContext> {
   const db = getDb();
-  const eventAt = triggerEvent.timestamp;
+  // Validate before use (#517) — see note in review-service.ts. A missing or
+  // malformed event.timestamp would silently corrupt every snapshot filter
+  // below; fall back to `now` with a structured warning instead.
+  const eventAt = validateEventTimestamp(triggerEvent.timestamp, {
+    eventId: triggerEvent.id,
+    caller: "context-builder:buildPatientContext",
+  });
 
   // Run all queries in parallel for speed. We fetch the full history for
   // diagnoses / medications / allergies and then filter in-memory to the


### PR DESCRIPTION
Closes #517.

## Problem

PR #494 introduced `wasActiveAt(row, eventAt)` filtering inside both context builders, using `event.timestamp` as the right-hand side of every snapshot comparison. If the timestamp is missing or malformed, every `row.x <= eventAt` / `row.x > eventAt` silently returns the wrong value and the patient snapshot becomes nonsense — a clinical-safety hazard because rules then fire against an incorrect record.

## Fix

New helper `validateEventTimestamp(ts, { eventId, caller, now? })` at `services/ai-oversight/src/utils/validate-event-timestamp.ts`. It rejects four classes of bad input and falls back to `new Date().toISOString()` with a structured warning (event id only, no PHI):

| Case | Example | Detection |
| --- | --- | --- |
| Missing / empty / whitespace / non-string | `undefined`, `""`, `"   "`, `123` | typeof + trim check |
| Unparseable string | `"not-a-date"` | `Number.isFinite(Date.parse(ts))` |
| Implausibly old | `"1970-01-01T00:00:00Z"` | < year 2000 (epoch-leak guard) |
| Future beyond grace | `now + 5min` | > `now + 1min` clock-skew grace |

Applied at both call sites:
- `services/review-service.ts::buildPatientContextForRules` (deterministic rule path)
- `workers/context-builder.ts::buildPatientContext` (LLM path)

## Fallback strategy: fall-back-to-now vs throw

The original issue proposed throwing on invalid input and letting BullMQ retry. I went with fall-back-to-now-with-warning instead so a malformed event that would always fail (e.g. upstream publisher bug) still gets a best-effort review rather than looping in the BullMQ retry queue. The 1-minute clock-skew grace keeps `now` a reasonable proxy for the true event time in the overwhelming majority of cases (worker runs seconds after emit). If the underlying value is a genuinely-unknowable time (not just delayed), deterministic rules still run but against the current snapshot — safer than silently returning an empty or inclusive-of-everything context. Happy to flip to throw-on-invalid on request.

## Test plan

- [x] New unit tests: `services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts` (10 cases)
  - Valid ISO passes through unchanged (no warning)
  - `undefined`, `""`, `"   "`, non-string → fallback + warn
  - `"not-a-date"` → fallback + warn
  - `> now + 5min` → fallback + warn
  - `now + 30s` (inside grace) → passes through
  - Year-1970 epoch → fallback + warn
  - Custom `caller` label appears in log prefix
- [x] `pnpm --filter @carebridge/ai-oversight test` — 312/312 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only pre-existing unrelated portal warnings)