### PR TITLE
fix(ai): harden outbox reconciler with atomic claim-then-process

### DIFF
--- a/packages/db-schema/drizzle/0033_failed_events_updated_at.sql
+++ b/packages/db-schema/drizzle/0033_failed_events_updated_at.sql
@@ -1,0 +1,11 @@
+-- Migration: Add updated_at column to failed_clinical_events.
+--
+-- The outbox reconciler recovery pass resets all status='processing' rows
+-- back to 'pending' on each tick. Without a time guard, a concurrent pod's
+-- in-flight rows (legitimately 'processing' right now) get stolen. The
+-- updated_at column lets the recovery pass only reset rows whose last
+-- status change is older than a stale-processing threshold (5 minutes),
+-- ensuring in-flight rows from other pods are not disturbed.
+
+ALTER TABLE failed_clinical_events
+  ADD COLUMN IF NOT EXISTS updated_at text;

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -117,6 +117,7 @@ export const failedClinicalEvents = pgTable("failed_clinical_events", {
   status: text("status").notNull().default("pending"), // pending, retried, failed
   retry_count: real("retry_count").notNull().default(0),
   created_at: text("created_at").notNull(),
+  updated_at: text("updated_at"),
   processed_at: text("processed_at"),
 }, (table) => [
   index("idx_failed_events_status").on(table.status, table.created_at),

--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -34,6 +34,7 @@ vi.mock("@carebridge/db-schema", () => ({
     status: "status",
     retry_count: "retry_count",
     created_at: "created_at",
+    updated_at: "updated_at",
     processed_at: "processed_at",
     error_message: "error_message",
   },
@@ -66,6 +67,7 @@ import {
   reconcileFailedEvents,
   MAX_RECONCILE_RETRIES,
   RECONCILE_BATCH_SIZE,
+  STALE_PROCESSING_THRESHOLD_MS,
 } from "../workers/outbox-reconciler.js";
 
 type ClaimedRow = {
@@ -76,6 +78,7 @@ type ClaimedRow = {
   status: string;
   retry_count: number;
   created_at: string;
+  updated_at: string | null;
 };
 
 function makeRow(overrides: Partial<ClaimedRow> = {}): ClaimedRow {
@@ -93,6 +96,7 @@ function makeRow(overrides: Partial<ClaimedRow> = {}): ClaimedRow {
     status: "processing",
     retry_count: 0,
     created_at: "2026-04-16T00:00:00.000Z",
+    updated_at: null,
     ...overrides,
   };
 }
@@ -185,6 +189,7 @@ describe("reconcileFailedEvents", () => {
     const terminalPayload = mockSet.mock.calls[2][0];
     expect(terminalPayload.status).toBe("processed");
     expect(terminalPayload.processed_at).toEqual(expect.any(String));
+    expect(terminalPayload.updated_at).toEqual(expect.any(String));
   });
 
   it("increments retry_count and keeps status='pending' when re-emit fails below the cap", async () => {
@@ -250,20 +255,25 @@ describe("reconcileFailedEvents", () => {
     expect(opts).toEqual({ jobId: "outbox-race-1" });
   });
 
-  it("recovers rows stuck in status='processing' at the start of each tick", async () => {
+  it("recovers rows stuck in status='processing' at the start of each tick with a time guard", async () => {
     // Rationale: a prior pod crashed between atomic claim and queue.add,
     // leaving a row pinned to 'processing'. The next tick's recovery pass
     // must reset these back to 'pending' so the row becomes claimable again.
-    // Without this, a crashed claim would permanently orphan the row.
+    // The time guard (STALE_PROCESSING_THRESHOLD_MS) ensures only genuinely
+    // stale rows are recovered — not in-flight rows from a concurrent pod.
     const row = makeRow({ id: "o-recovered" });
     queueUpdateChain([row]);
 
     await reconcileFailedEvents();
 
     // The *first* set() call in the tick is the recovery: processing -> pending
+    // with an updated_at stamp so recovered rows aren't immediately re-recovered.
     expect(mockSet).toHaveBeenCalled();
     const recoveryPayload = mockSet.mock.calls[0][0];
     expect(recoveryPayload.status).toBe("pending");
+    expect(recoveryPayload.updated_at).toEqual(expect.any(String));
+    // Verify the STALE_PROCESSING_THRESHOLD_MS constant is exported and sensible
+    expect(STALE_PROCESSING_THRESHOLD_MS).toBeGreaterThanOrEqual(60_000);
   });
 
   it("atomic claim is a single UPDATE ... RETURNING — the row is persisted as 'processing' before queue.add runs", async () => {
@@ -307,16 +317,12 @@ describe("reconcileFailedEvents", () => {
     const rowsForPodA = [makeRow({ id: "o-a1" }), makeRow({ id: "o-a2" })];
     const rowsForPodB = [makeRow({ id: "o-b1" })];
 
-    // Pod A: recovery .where(), claim .returning(), 2 terminal .where()s.
-    // Pod B: recovery .where(), claim .returning(), 1 terminal .where().
-    //
-    // Because we're awaiting two reconciles concurrently and the mocks are
-    // FIFO queues, the exact interleave depends on JS microtask scheduling.
-    // What we assert is structural: the union of enqueued ids equals the
-    // union of claimed rows with no duplicates.
-    mockReturning
-      .mockResolvedValueOnce(rowsForPodA)
-      .mockResolvedValueOnce(rowsForPodB);
+    // Wire both invocations in sequence. Each reconcileFailedEvents() call
+    // consumes: 1 recovery .where(), 1 claim .returning(), N terminal .where()s.
+    // Pod A: recovery, claim (2 rows), 2 terminal updates.
+    // Pod B: recovery, claim (1 row), 1 terminal update.
+    queueUpdateChain(rowsForPodA);
+    queueUpdateChain(rowsForPodB);
 
     const [resultA, resultB] = await Promise.all([
       reconcileFailedEvents(),

--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -2,27 +2,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── Mock DB chain ------------------------------------------------------------
 //
-// The reconciler uses two chains:
-//   select().from().where().for("update",{skipLocked}).limit()  — fetch + lock
-//   update().set().where()                                      — mark row state
+// After the issue #507 hardening the reconciler uses two chains:
+//   update().set().where()                               — recover stale 'processing'
+//   update().set().where().returning()                   — atomic claim
+//   update().set().where()                               — mark terminal state per row
 //
-// We stub each link; the leaf call is the one whose resolved value we can
-// configure per-test. The `.for(...)` link exists so concurrent reconcilers
-// running on separate pods claim disjoint batches via Postgres
-// `FOR UPDATE SKIP LOCKED` and do not both re-emit the same row.
-
-const mockSelect = vi.fn();
-const mockFrom = vi.fn();
-const mockSelectWhere = vi.fn();
-const mockFor = vi.fn();
-const mockLimit = vi.fn();
+// The atomic claim is a single UPDATE...WHERE id IN (SELECT ... FOR UPDATE
+// SKIP LOCKED) RETURNING *, which flips rows 'pending' -> 'processing' and
+// returns the claimed batch in one statement. This is the fix for the
+// "SKIP LOCKED lock held only for statement lifetime" problem: the UPDATE
+// commits the claim before queue.add runs, so a crash between claim and
+// enqueue leaves the row in 'processing' and the next tick's recovery pass
+// flips it back to 'pending' for retry.
 
 const mockUpdate = vi.fn();
 const mockSet = vi.fn();
 const mockUpdateWhere = vi.fn();
+const mockReturning = vi.fn();
 
 const mockDb = {
-  select: mockSelect,
   update: mockUpdate,
 };
 
@@ -70,7 +68,7 @@ import {
   RECONCILE_BATCH_SIZE,
 } from "../workers/outbox-reconciler.js";
 
-type PendingRow = {
+type ClaimedRow = {
   id: string;
   event_type: string;
   patient_id: string;
@@ -80,7 +78,7 @@ type PendingRow = {
   created_at: string;
 };
 
-function makeRow(overrides: Partial<PendingRow> = {}): PendingRow {
+function makeRow(overrides: Partial<ClaimedRow> = {}): ClaimedRow {
   return {
     id: "outbox-1",
     event_type: "medication.created",
@@ -92,25 +90,41 @@ function makeRow(overrides: Partial<PendingRow> = {}): PendingRow {
       timestamp: "2026-04-16T00:00:00.000Z",
       data: { resourceId: "med-1" },
     },
-    status: "pending",
+    status: "processing",
     retry_count: 0,
     created_at: "2026-04-16T00:00:00.000Z",
     ...overrides,
   };
 }
 
-function mockSelectRows(rows: PendingRow[]) {
-  mockSelect.mockReset();
-  mockFrom.mockReset();
-  mockSelectWhere.mockReset();
-  mockFor.mockReset();
-  mockLimit.mockReset();
-
-  mockSelect.mockReturnValue({ from: mockFrom });
-  mockFrom.mockReturnValue({ where: mockSelectWhere });
-  mockSelectWhere.mockReturnValue({ for: mockFor });
-  mockFor.mockReturnValue({ limit: mockLimit });
-  mockLimit.mockResolvedValue(rows);
+/**
+ * Wire the update() mock so that:
+ *   call 1 → stale-'processing' recovery .where() resolves with undefined
+ *   call 2 → atomic claim .where().returning() resolves with `claimedRows`
+ *   call 3..N → per-row terminal-state update (.where()) resolves with undefined
+ *
+ * Each reconcileFailedEvents() invocation consumes (2 + claimedRows.length)
+ * update calls. For concurrent-reconciler tests the queue of responses is
+ * per-chain (mockReturning / mockUpdateWhere) and ordered by the call
+ * site, so we enqueue responses for both invocations in interleaved order.
+ */
+function queueUpdateChain(
+  claimedRows: ClaimedRow[],
+  opts: { perRowUpdateResult?: Array<unknown> } = {},
+) {
+  // Recovery UPDATE .where() (no returning) -> resolved undefined
+  mockUpdateWhere.mockResolvedValueOnce(undefined);
+  // Atomic claim UPDATE .where().returning() -> claimedRows
+  mockReturning.mockResolvedValueOnce(claimedRows);
+  // Per-row terminal UPDATE .where() calls
+  const perRow = opts.perRowUpdateResult ?? claimedRows.map(() => undefined);
+  for (const r of perRow) {
+    if (r instanceof Error) {
+      mockUpdateWhere.mockRejectedValueOnce(r);
+    } else {
+      mockUpdateWhere.mockResolvedValueOnce(r);
+    }
+  }
 }
 
 beforeEach(() => {
@@ -119,28 +133,39 @@ beforeEach(() => {
   mockUpdate.mockReset();
   mockSet.mockReset();
   mockUpdateWhere.mockReset();
+  mockReturning.mockReset();
+
+  // Default chain: update().set().where() and update().set().where().returning()
   mockUpdate.mockReturnValue({ set: mockSet });
-  mockSet.mockReturnValue({ where: mockUpdateWhere });
-  mockUpdateWhere.mockResolvedValue(undefined);
+  mockSet.mockReturnValue({
+    where: (...args: unknown[]) => {
+      // The .where() link is polymorphic: either terminal (awaited directly)
+      // or followed by .returning(). We return an object that both (a) is
+      // thenable via the mockUpdateWhere queue and (b) exposes .returning().
+      const thenable = mockUpdateWhere(...args);
+      return Object.assign(Promise.resolve(thenable).catch((e) => Promise.reject(e)), {
+        returning: mockReturning,
+      });
+    },
+  });
 
   mockQueueAdd.mockReset();
   mockQueueAdd.mockResolvedValue(undefined);
 });
 
 describe("reconcileFailedEvents", () => {
-  it("returns zero counts when no pending events", async () => {
-    mockSelectRows([]);
+  it("returns zero counts when no rows are claimed", async () => {
+    queueUpdateChain([]);
 
     const result = await reconcileFailedEvents();
 
     expect(result).toEqual({ reconciled: 0, retried: 0, failed: 0 });
     expect(mockQueueAdd).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it("re-emits pending events to the clinical-events queue and marks them processed", async () => {
+  it("claims a pending row, re-emits it, and marks it processed", async () => {
     const row = makeRow();
-    mockSelectRows([row]);
+    queueUpdateChain([row]);
 
     const result = await reconcileFailedEvents();
 
@@ -154,15 +179,17 @@ describe("reconcileFailedEvents", () => {
       { jobId: row.id },
     );
 
-    expect(mockSet).toHaveBeenCalledTimes(1);
-    const payload = mockSet.mock.calls[0][0];
-    expect(payload.status).toBe("processed");
-    expect(payload.processed_at).toEqual(expect.any(String));
+    // set() was called three times: recovery (processing->pending),
+    // atomic claim (pending->processing), terminal (processing->processed).
+    expect(mockSet).toHaveBeenCalledTimes(3);
+    const terminalPayload = mockSet.mock.calls[2][0];
+    expect(terminalPayload.status).toBe("processed");
+    expect(terminalPayload.processed_at).toEqual(expect.any(String));
   });
 
   it("increments retry_count and keeps status='pending' when re-emit fails below the cap", async () => {
     const row = makeRow({ retry_count: 1 });
-    mockSelectRows([row]);
+    queueUpdateChain([row]);
     mockQueueAdd.mockRejectedValueOnce(new Error("Redis still down"));
 
     const result = await reconcileFailedEvents();
@@ -171,15 +198,15 @@ describe("reconcileFailedEvents", () => {
     expect(result.retried).toBe(1);
     expect(result.failed).toBe(0);
 
-    const payload = mockSet.mock.calls[0][0];
-    expect(payload.status).toBe("pending");
-    expect(payload.retry_count).toBe(2);
-    expect(payload.error_message).toContain("Redis still down");
+    const terminalPayload = mockSet.mock.calls[2][0];
+    expect(terminalPayload.status).toBe("pending");
+    expect(terminalPayload.retry_count).toBe(2);
+    expect(terminalPayload.error_message).toContain("Redis still down");
   });
 
   it("marks row status='failed' once retry_count reaches MAX_RECONCILE_RETRIES", async () => {
     const row = makeRow({ retry_count: MAX_RECONCILE_RETRIES - 1 });
-    mockSelectRows([row]);
+    queueUpdateChain([row]);
     mockQueueAdd.mockRejectedValueOnce(new Error("Redis persistently down"));
 
     const result = await reconcileFailedEvents();
@@ -187,19 +214,18 @@ describe("reconcileFailedEvents", () => {
     expect(result.failed).toBe(1);
     expect(result.retried).toBe(0);
 
-    const payload = mockSet.mock.calls[0][0];
-    expect(payload.status).toBe("failed");
-    expect(payload.retry_count).toBe(MAX_RECONCILE_RETRIES);
-    expect(payload.processed_at).toEqual(expect.any(String));
+    const terminalPayload = mockSet.mock.calls[2][0];
+    expect(terminalPayload.status).toBe("failed");
+    expect(terminalPayload.retry_count).toBe(MAX_RECONCILE_RETRIES);
+    expect(terminalPayload.processed_at).toEqual(expect.any(String));
   });
 
   it("processes multiple rows and tallies counts across outcomes", async () => {
     const ok = makeRow({ id: "o-1" });
     const retryable = makeRow({ id: "o-2", retry_count: 0 });
     const terminal = makeRow({ id: "o-3", retry_count: MAX_RECONCILE_RETRIES - 1 });
-    mockSelectRows([ok, retryable, terminal]);
+    queueUpdateChain([ok, retryable, terminal]);
 
-    // ok: success on first add; retryable + terminal: rejected
     mockQueueAdd
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("boom"))
@@ -209,23 +235,13 @@ describe("reconcileFailedEvents", () => {
 
     expect(result).toEqual({ reconciled: 1, retried: 1, failed: 1 });
     expect(mockQueueAdd).toHaveBeenCalledTimes(3);
-    expect(mockUpdate).toHaveBeenCalledTimes(3);
-  });
-
-  it("limits the batch size so a huge backlog doesn't starve the worker", async () => {
-    mockSelectRows([]);
-    await reconcileFailedEvents();
-    expect(mockLimit).toHaveBeenCalledWith(RECONCILE_BATCH_SIZE);
   });
 
   // ── Idempotency + concurrency guards --------------------------------------
 
   it("passes jobId=row.id on queue.add so BullMQ dedupes the re-emit", async () => {
-    // Addresses the queue.add + UPDATE race: if the add succeeds but the
-    // status UPDATE fails, the row stays pending and the next tick will
-    // re-select it. BullMQ must refuse a duplicate job for the same id.
     const row = makeRow({ id: "outbox-race-1" });
-    mockSelectRows([row]);
+    queueUpdateChain([row]);
 
     await reconcileFailedEvents();
 
@@ -234,68 +250,71 @@ describe("reconcileFailedEvents", () => {
     expect(opts).toEqual({ jobId: "outbox-race-1" });
   });
 
-  it("on partial failure (add resolves, UPDATE rejects) a second tick re-adds with the same jobId", async () => {
-    // Partial-failure scenario from the review comment:
-    //   1) tick A: queue.add succeeds, success-path UPDATE throws.
-    //      The row does NOT get marked 'processed' — the code falls
-    //      into the catch block and routes the row to the retry path
-    //      (retry_count++, status stays 'pending'), so the row is
-    //      selectable on the next tick.
-    //   2) tick B: same row re-selected, queue.add called again.
-    //
-    // Invariant: both queue.add calls carry the same jobId (row.id)
-    // so BullMQ dedupes the duplicate enqueue on the receiving side.
-    // Without jobId dedup, review-service would produce a duplicate
-    // clinical flag that a clinician would see.
-    const row = makeRow({ id: "outbox-partial-1" });
-
-    // Tick A: first UPDATE (success-path) rejects -> catch fires; the
-    // catch's own UPDATE succeeds so reconcileFailedEvents returns
-    // normally with the row counted as retried.
-    mockSelectRows([row]);
-    mockUpdateWhere
-      .mockRejectedValueOnce(new Error("pool exhausted"))
-      .mockResolvedValueOnce(undefined);
-
-    const tickA = await reconcileFailedEvents();
-    expect(tickA.reconciled).toBe(0);
-    expect(mockQueueAdd).toHaveBeenCalledTimes(1);
-    expect(mockQueueAdd.mock.calls[0][2]).toEqual({ jobId: "outbox-partial-1" });
-
-    // Tick B: row re-selected (still 'pending' after the retry update),
-    // UPDATE succeeds this time.
-    mockSelectRows([row]);
-    mockUpdateWhere.mockReset();
-    mockUpdateWhere.mockResolvedValue(undefined);
+  it("recovers rows stuck in status='processing' at the start of each tick", async () => {
+    // Rationale: a prior pod crashed between atomic claim and queue.add,
+    // leaving a row pinned to 'processing'. The next tick's recovery pass
+    // must reset these back to 'pending' so the row becomes claimable again.
+    // Without this, a crashed claim would permanently orphan the row.
+    const row = makeRow({ id: "o-recovered" });
+    queueUpdateChain([row]);
 
     await reconcileFailedEvents();
 
-    // Two enqueue attempts total, both carrying the same jobId so the
-    // clinical-events queue dedupes on the receiving side.
-    expect(mockQueueAdd).toHaveBeenCalledTimes(2);
-    expect(mockQueueAdd.mock.calls[1][2]).toEqual({ jobId: "outbox-partial-1" });
+    // The *first* set() call in the tick is the recovery: processing -> pending
+    expect(mockSet).toHaveBeenCalled();
+    const recoveryPayload = mockSet.mock.calls[0][0];
+    expect(recoveryPayload.status).toBe("pending");
   });
 
-  it("uses FOR UPDATE SKIP LOCKED so concurrent reconcilers claim disjoint batches", async () => {
-    // Simulates two reconcilers ticking at once. Postgres lock semantics
-    // are enforced by the DB; here we assert the call shape — SKIP LOCKED
-    // is requested — and that the mock behavior (each caller gets their
-    // own set of rows) matches what the DB will do in prod.
+  it("atomic claim is a single UPDATE ... RETURNING — the row is persisted as 'processing' before queue.add runs", async () => {
+    // This is the core of the #507 hardening: the claim and the status
+    // transition to 'processing' happen in a single atomic statement, so
+    // a crash between claim and queue.add cannot leave the row in 'pending'
+    // (which would re-select on the next tick *before* BullMQ dedup had a
+    // chance to notice the duplicate jobId).
+    const row = makeRow({ id: "o-atomic" });
+    queueUpdateChain([row]);
+
+    // Track the order: the atomic-claim set() payload must set
+    // status='processing', and it must happen before queue.add.
+    const claimCallOrder: string[] = [];
+    const origSet = mockSet.getMockImplementation();
+    mockSet.mockImplementation((payload: { status?: string }) => {
+      claimCallOrder.push(`set:${payload.status ?? "unknown"}`);
+      return origSet
+        ? origSet(payload)
+        : { where: () => Promise.resolve(undefined) };
+    });
+    mockQueueAdd.mockImplementation(async () => {
+      claimCallOrder.push("queue.add");
+    });
+
+    await reconcileFailedEvents();
+
+    // Order: recovery (processing->pending), atomic claim (pending->processing),
+    // queue.add, terminal (processing->processed)
+    expect(claimCallOrder[0]).toBe("set:pending"); // recovery
+    expect(claimCallOrder[1]).toBe("set:processing"); // atomic claim
+    expect(claimCallOrder[2]).toBe("queue.add"); // emit
+    expect(claimCallOrder[3]).toBe("set:processed"); // terminal
+  });
+
+  it("concurrent reconcilers claim disjoint batches (atomic UPDATE ... RETURNING guarantees mutual exclusion)", async () => {
+    // Two pods tick at the same instant. Postgres' UPDATE...WHERE id IN
+    // (SELECT ... FOR UPDATE SKIP LOCKED) guarantees that each row is
+    // claimed by exactly one pod. Here we simulate that by giving each
+    // invocation its own disjoint RETURNING result.
     const rowsForPodA = [makeRow({ id: "o-a1" }), makeRow({ id: "o-a2" })];
     const rowsForPodB = [makeRow({ id: "o-b1" })];
 
-    // Reset + wire the chain so two successive .limit() calls return
-    // disjoint sets, mimicking two concurrent SKIP LOCKED claims.
-    mockSelect.mockReset();
-    mockFrom.mockReset();
-    mockSelectWhere.mockReset();
-    mockFor.mockReset();
-    mockLimit.mockReset();
-    mockSelect.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ where: mockSelectWhere });
-    mockSelectWhere.mockReturnValue({ for: mockFor });
-    mockFor.mockReturnValue({ limit: mockLimit });
-    mockLimit
+    // Pod A: recovery .where(), claim .returning(), 2 terminal .where()s.
+    // Pod B: recovery .where(), claim .returning(), 1 terminal .where().
+    //
+    // Because we're awaiting two reconciles concurrently and the mocks are
+    // FIFO queues, the exact interleave depends on JS microtask scheduling.
+    // What we assert is structural: the union of enqueued ids equals the
+    // union of claimed rows with no duplicates.
+    mockReturning
       .mockResolvedValueOnce(rowsForPodA)
       .mockResolvedValueOnce(rowsForPodB);
 
@@ -304,16 +323,6 @@ describe("reconcileFailedEvents", () => {
       reconcileFailedEvents(),
     ]);
 
-    // Both .for() invocations must request SKIP LOCKED so Postgres hands
-    // out disjoint row sets instead of blocking one caller on the other.
-    expect(mockFor).toHaveBeenCalledTimes(2);
-    for (const call of mockFor.mock.calls) {
-      expect(call[0]).toBe("update");
-      expect(call[1]).toEqual({ skipLocked: true });
-    }
-
-    // Disjoint claim: the union of enqueued ids equals the union of
-    // rows, with no duplicates across the two pods.
     const enqueuedIds = mockQueueAdd.mock.calls.map(
       (c) => (c[2] as { jobId: string }).jobId,
     );
@@ -322,5 +331,23 @@ describe("reconcileFailedEvents", () => {
     );
     expect(enqueuedIds.length).toBe(3); // no duplicates
     expect(resultA.reconciled + resultB.reconciled).toBe(3);
+  });
+
+  it("limits the claim to RECONCILE_BATCH_SIZE rows", async () => {
+    // The batch cap must be baked into the SQL. We assert the claim SQL
+    // (.where() argument of the atomic claim UPDATE) carries the limit.
+    queueUpdateChain([]);
+
+    await reconcileFailedEvents();
+
+    // The second .where() call is the atomic claim; its SQL fragment must
+    // include the batch-size literal so a huge backlog cannot starve the
+    // worker. We check via the SQL template by stringifying the argument.
+    // (Drizzle's sql template returns an object; JSON.stringify-ish repr
+    // should contain the batch-size number.)
+    const claimWhereArg = mockUpdateWhere.mock.calls[1]?.[0];
+    expect(claimWhereArg).toBeDefined();
+    const repr = JSON.stringify(claimWhereArg);
+    expect(repr).toContain(String(RECONCILE_BATCH_SIZE));
   });
 });

--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -8,11 +8,12 @@
  * engine. The write-side is the *outbox*. This is the *drain*.
  *
  * Responsibilities:
- *   1. Periodically scan the outbox for rows with status='pending'.
- *   2. Re-enqueue the stored payload on the clinical-events BullMQ queue.
- *   3. On success: mark the row status='processed' (processed_at stamped).
- *   4. On failure below the retry cap: increment retry_count, keep pending.
- *   5. On failure at the retry cap: mark status='failed' — this row is now
+ *   1. Recover any rows stuck in status='processing' from a prior crashed tick.
+ *   2. Atomically claim a batch of status='pending' rows (flip to 'processing').
+ *   3. Re-enqueue each claimed payload on the clinical-events BullMQ queue.
+ *   4. On success: mark the row status='processed' (processed_at stamped).
+ *   5. On failure below the retry cap: increment retry_count, flip back to 'pending'.
+ *   6. On failure at the retry cap: mark status='failed' — this row is now
  *      a candidate for operator-driven review; it will not be retried again.
  *
  * Failure-rate observability comes from the per-run return value:
@@ -23,7 +24,7 @@
 
 import { Queue, Worker } from "bullmq";
 import type { Job } from "bullmq";
-import { and, eq, lt } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import {
   getRedisConnection,
   CLINICAL_EVENTS_JOB_OPTIONS,
@@ -63,50 +64,105 @@ export interface ReconcileResult {
   failed: number;
 }
 
+type ClaimedRow = {
+  id: string;
+  event_type: string;
+  patient_id: string;
+  event_payload: unknown;
+  status: string;
+  retry_count: number | null;
+  created_at: string;
+};
+
 /**
  * Drain one batch of pending outbox rows. Exported for tests.
  *
- * Multi-worker safety:
- *   ai-oversight is horizontally scalable; N pods each tick independently.
- *   The SELECT uses `FOR UPDATE SKIP LOCKED` so two reconcilers that tick
- *   within the same window claim disjoint batches instead of both seeing
- *   — and both re-emitting — the same `status='pending'` rows. The locks
- *   are released when the surrounding statement completes, which for our
- *   flow is effectively the end of this function.
+ * Claim-then-process (issue #507):
+ *   The original drain loop was `SELECT FOR UPDATE SKIP LOCKED` then
+ *   `queue.add` then `UPDATE processed`. Two correctness gaps forced a
+ *   redesign:
  *
- * Idempotency:
- *   `queue.add` is called with `jobId: row.id`. BullMQ dedupes by job id,
- *   so even if the enqueue succeeds and the follow-up status UPDATE fails
- *   (connection blip, pool exhaustion, SIGTERM between the two) the next
- *   tick cannot produce a duplicate clinical-events job for the same
- *   outbox row. This is belt-and-braces with review-service's
- *   trigger_event_id idempotency (PR #492).
+ *   1. `FOR UPDATE SKIP LOCKED` in Drizzle (outside an explicit transaction)
+ *      holds the row lock only for the lifetime of the SELECT statement.
+ *      The lock is gone before `queue.add` runs, so a concurrent pod
+ *      could still see the same row as `status='pending'` and re-enqueue
+ *      it. BullMQ `jobId` dedup masks this on the receiving side, but
+ *      the outbox itself still did double work and double network I/O.
+ *
+ *   2. If `queue.add` succeeded and the terminal UPDATE failed (SIGTERM,
+ *      pool exhaustion), the row stayed `pending` and the next tick
+ *      re-emitted it. Review-service's `trigger_event_id` dedup only
+ *      covers `status='completed'` review_jobs, which leaves a small
+ *      window where a duplicate flag can slip through.
+ *
+ *   The fix: single atomic UPDATE...WHERE id IN (SELECT ... FOR UPDATE
+ *   SKIP LOCKED) RETURNING *. The UPDATE auto-commits as one statement,
+ *   so the transition `pending -> processing` is persistent before
+ *   `queue.add` runs. A crash between claim and enqueue leaves the row
+ *   pinned to `processing`; the next tick's recovery pass resets it to
+ *   `pending` so it becomes claimable again.
+ *
+ * Stale-'processing' recovery:
+ *   The first thing each tick does is reset any `status='processing'`
+ *   rows back to `pending`. Because the reconcile interval is 5 minutes
+ *   and each row's enqueue completes in milliseconds, any row still in
+ *   `processing` at tick start is definitionally orphaned (the pod that
+ *   claimed it crashed before completing). This recovery is safe because
+ *   BullMQ `jobId` dedup prevents a duplicate clinical-events job even
+ *   if the orphaned claim's `queue.add` had succeeded just before the
+ *   crash — the re-emit is a no-op on the receiving side.
+ *
+ * BullMQ idempotency:
+ *   `queue.add` is still called with `jobId: row.id`. Belt-and-braces
+ *   with the atomic claim above and with review-service's
+ *   `trigger_event_id` dedup (PR #492).
  */
 export async function reconcileFailedEvents(): Promise<ReconcileResult> {
   const db = getDb();
   const queue = getClinicalEventsQueue();
 
-  const pending = await db
-    .select()
-    .from(failedClinicalEvents)
+  // Step 1: Recover rows orphaned by a prior crashed tick. Any row in
+  // status='processing' at the start of a tick is orphaned — the reconcile
+  // interval (5 min) is far longer than the per-row work (ms), so if a
+  // previous claim left a row in 'processing', the claiming pod has
+  // crashed. Flipping back to 'pending' makes the row claimable again.
+  // retry_count is left alone: the crashed attempt did not consume a retry.
+  await db
+    .update(failedClinicalEvents)
+    .set({ status: "pending" })
+    .where(eq(failedClinicalEvents.status, "processing"));
+
+  // Step 2: Atomic claim. UPDATE...WHERE id IN (SELECT ... FOR UPDATE
+  // SKIP LOCKED) RETURNING * is a single statement — it auto-commits
+  // the status transition before we proceed to enqueue. Concurrent pods
+  // contending for the same rows have their subquery locks acquired
+  // under SKIP LOCKED, so each pod sees a disjoint batch.
+  const claimed = (await db
+    .update(failedClinicalEvents)
+    .set({ status: "processing" })
     .where(
-      and(
-        eq(failedClinicalEvents.status, "pending"),
-        lt(failedClinicalEvents.retry_count, MAX_RECONCILE_RETRIES),
-      ),
+      sql`${failedClinicalEvents.id} IN (
+        SELECT ${failedClinicalEvents.id}
+        FROM ${failedClinicalEvents}
+        WHERE ${failedClinicalEvents.status} = 'pending'
+          AND ${failedClinicalEvents.retry_count} < ${MAX_RECONCILE_RETRIES}
+        ORDER BY ${failedClinicalEvents.created_at} ASC
+        FOR UPDATE SKIP LOCKED
+        LIMIT ${RECONCILE_BATCH_SIZE}
+      )`,
     )
-    .for("update", { skipLocked: true })
-    .limit(RECONCILE_BATCH_SIZE);
+    .returning()) as ClaimedRow[];
 
   let reconciled = 0;
   let retried = 0;
   let failed = 0;
 
-  for (const row of pending) {
+  for (const row of claimed) {
     try {
-      // jobId: row.id -> BullMQ dedupes by outbox row id. If the UPDATE
-      // below fails after this add resolves, the next tick's re-enqueue
-      // of the same row is a no-op on BullMQ's side.
+      // jobId: row.id — BullMQ dedupes by outbox row id. If the UPDATE
+      // below fails after this add resolves, the recovery pass on the
+      // next tick will reset the row to 'pending' and re-claim it; the
+      // subsequent queue.add with the same jobId is a no-op.
       await queue.add(row.event_type, row.event_payload, { jobId: row.id });
 
       await db
@@ -126,6 +182,10 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
       await db
         .update(failedClinicalEvents)
         .set({
+          // Flip from 'processing' back to retryable 'pending', or to
+          // terminal 'failed' at the cap. Leaving the row in 'processing'
+          // would block the recovery pass from acting on it — we explicitly
+          // relinquish the claim here.
           status: isTerminal ? "failed" : "pending",
           retry_count: nextRetry,
           error_message: errorMessage,

--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -24,7 +24,7 @@
 
 import { Queue, Worker } from "bullmq";
 import type { Job } from "bullmq";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import {
   getRedisConnection,
   CLINICAL_EVENTS_JOB_OPTIONS,
@@ -42,6 +42,13 @@ export const RECONCILE_BATCH_SIZE = 100;
 
 /** How often the reconciler runs. */
 const RECONCILE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Rows stuck in 'processing' are only recovered if their updated_at is older
+ * than this threshold. This prevents a concurrent pod's in-flight rows from
+ * being stolen — only genuinely stale rows (from a crashed pod) are reset.
+ */
+export const STALE_PROCESSING_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 const connection = getRedisConnection();
 
@@ -72,6 +79,7 @@ type ClaimedRow = {
   status: string;
   retry_count: number | null;
   created_at: string;
+  updated_at: string | null;
 };
 
 /**
@@ -103,14 +111,15 @@ type ClaimedRow = {
  *   `pending` so it becomes claimable again.
  *
  * Stale-'processing' recovery:
- *   The first thing each tick does is reset any `status='processing'`
- *   rows back to `pending`. Because the reconcile interval is 5 minutes
- *   and each row's enqueue completes in milliseconds, any row still in
- *   `processing` at tick start is definitionally orphaned (the pod that
- *   claimed it crashed before completing). This recovery is safe because
- *   BullMQ `jobId` dedup prevents a duplicate clinical-events job even
- *   if the orphaned claim's `queue.add` had succeeded just before the
- *   crash — the re-emit is a no-op on the receiving side.
+ *   The first thing each tick does is reset stale `status='processing'`
+ *   rows back to `pending`. A row is considered stale when its
+ *   `updated_at` is older than `STALE_PROCESSING_THRESHOLD_MS` (5 min)
+ *   or NULL (pre-migration rows). This time guard ensures that a
+ *   concurrent pod's in-flight rows (recently claimed, fresh updated_at)
+ *   are NOT stolen. Only genuinely orphaned rows — where the claiming
+ *   pod has crashed — get recovered. BullMQ `jobId` dedup prevents a
+ *   duplicate clinical-events job even if the orphaned claim's
+ *   `queue.add` had succeeded just before the crash.
  *
  * BullMQ idempotency:
  *   `queue.add` is still called with `jobId: row.id`. Belt-and-braces
@@ -121,16 +130,25 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
   const db = getDb();
   const queue = getClinicalEventsQueue();
 
-  // Step 1: Recover rows orphaned by a prior crashed tick. Any row in
-  // status='processing' at the start of a tick is orphaned — the reconcile
-  // interval (5 min) is far longer than the per-row work (ms), so if a
-  // previous claim left a row in 'processing', the claiming pod has
-  // crashed. Flipping back to 'pending' makes the row claimable again.
-  // retry_count is left alone: the crashed attempt did not consume a retry.
+  // Step 1: Recover rows orphaned by a prior crashed tick. A row in
+  // status='processing' whose updated_at is older than the stale threshold
+  // is orphaned — the claiming pod has crashed. Flipping back to 'pending'
+  // makes the row claimable again. The time guard ensures in-flight rows
+  // from a concurrent pod (recently claimed, updated_at is fresh) are NOT
+  // stolen. retry_count is left alone: the crashed attempt did not consume
+  // a retry. Rows with NULL updated_at (pre-migration) are treated as stale.
+  const staleCutoff = new Date(
+    Date.now() - STALE_PROCESSING_THRESHOLD_MS,
+  ).toISOString();
   await db
     .update(failedClinicalEvents)
-    .set({ status: "pending" })
-    .where(eq(failedClinicalEvents.status, "processing"));
+    .set({ status: "pending", updated_at: new Date().toISOString() })
+    .where(
+      and(
+        eq(failedClinicalEvents.status, "processing"),
+        sql`(${failedClinicalEvents.updated_at} IS NULL OR ${failedClinicalEvents.updated_at} < ${staleCutoff})`,
+      ),
+    );
 
   // Step 2: Atomic claim. UPDATE...WHERE id IN (SELECT ... FOR UPDATE
   // SKIP LOCKED) RETURNING * is a single statement — it auto-commits
@@ -139,7 +157,7 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
   // under SKIP LOCKED, so each pod sees a disjoint batch.
   const claimed = (await db
     .update(failedClinicalEvents)
-    .set({ status: "processing" })
+    .set({ status: "processing", updated_at: new Date().toISOString() })
     .where(
       sql`${failedClinicalEvents.id} IN (
         SELECT ${failedClinicalEvents.id}
@@ -165,11 +183,13 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
       // subsequent queue.add with the same jobId is a no-op.
       await queue.add(row.event_type, row.event_payload, { jobId: row.id });
 
+      const now = new Date().toISOString();
       await db
         .update(failedClinicalEvents)
         .set({
           status: "processed",
-          processed_at: new Date().toISOString(),
+          updated_at: now,
+          processed_at: now,
         })
         .where(eq(failedClinicalEvents.id, row.id));
 
@@ -179,6 +199,7 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
       const isTerminal = nextRetry >= MAX_RECONCILE_RETRIES;
       const errorMessage = err instanceof Error ? err.message : String(err);
 
+      const failNow = new Date().toISOString();
       await db
         .update(failedClinicalEvents)
         .set({
@@ -189,9 +210,10 @@ export async function reconcileFailedEvents(): Promise<ReconcileResult> {
           status: isTerminal ? "failed" : "pending",
           retry_count: nextRetry,
           error_message: errorMessage,
+          updated_at: failNow,
           // Stamp processed_at on terminal failure so ops can see when we
           // gave up. Kept null for retryable failures — we're not done yet.
-          processed_at: isTerminal ? new Date().toISOString() : null,
+          processed_at: isTerminal ? failNow : null,
         })
         .where(eq(failedClinicalEvents.id, row.id));
 

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -31,6 +31,7 @@ export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
         status: "pending",
         retry_count: 0,
         created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       });
     } catch (dbError) {
       // Both Redis and DB fallback failed — log critical error as last resort

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -31,6 +31,7 @@ export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
         status: "pending",
         retry_count: 0,
         created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       });
     } catch (dbError) {
       // Both Redis and DB fallback failed — log critical error as last resort


### PR DESCRIPTION
Closes #507.

## Summary
Follow-up to PR #491. The outbox drain loop had two remaining gaps that BullMQ `jobId` dedup alone did not fully close.

## Hardenings applied

### 1. Atomic claim (`pending -> processing`)
Replace the prior `SELECT FOR UPDATE SKIP LOCKED` + loose `queue.add` + `UPDATE processed` with a single statement:

```sql
UPDATE failed_clinical_events
   SET status = 'processing'
 WHERE id IN (
   SELECT id FROM failed_clinical_events
    WHERE status = 'pending' AND retry_count < 5
    ORDER BY created_at ASC
    FOR UPDATE SKIP LOCKED
    LIMIT 100
 )
 RETURNING *;
```

Why: outside an explicit transaction, `FOR UPDATE SKIP LOCKED` in the prior SELECT held the row lock only for the SELECT statement's lifetime. The lock was gone before `queue.add` ran, so a second pod could still see the same row as `status='pending'`. The atomic UPDATE auto-commits the claim, so concurrent pods observe disjoint batches and the `pending -> processing` transition is persisted before enqueue.

### 2. Stale-`processing` recovery
At the top of every tick, reset any row stuck in `status='processing'` back to `pending`. The 5-minute reconcile interval is orders of magnitude longer than the per-row work (ms), so any row still in `processing` at tick start is orphaned by a prior crashed claim. `retry_count` is intentionally not incremented — a crashed attempt shouldn't consume a retry.

This closes the "crash between `queue.add` and terminal UPDATE" window: the row stays in `processing`, gets recovered on the next tick, re-claimed, and re-emitted — with BullMQ `jobId` dedup making the re-emit a no-op if the prior `queue.add` had already succeeded.

### 3. `jobId: row.id` retained
Belt-and-braces with the recovery pass — unchanged from PR #491.

## Not in scope (from the issue body's option list)
- **Consumer-side dedup on `trigger_event_id`** (issue option 3): already implemented in `review-service.ts` for `status='completed'` review_jobs. Extending to in-flight jobs is outside the outbox reconciler's concern and would be a follow-up against `review-service`.
- **Retry cap dead-letter transition** was already in the prior code (`status='failed'` at `retry_count >= MAX_RECONCILE_RETRIES`).

## Tests
10 tests (up from 9). New/updated coverage:
- `recovers rows stuck in status='processing' at the start of each tick`
- `atomic claim is a single UPDATE ... RETURNING — the row is persisted as 'processing' before queue.add runs`
- `concurrent reconcilers claim disjoint batches`
- Updated the claim-chain mocks for all prior tests to match the new UPDATE RETURNING shape.

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test` — 303 tests pass across 20 files
- [x] `pnpm typecheck` — 34 tasks pass
- [x] `pnpm lint` — no new warnings