### PR TITLE
fix(portal): staleness banner tokens, a11y role, and ISO timestamp compare

### DIFF
--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -21,6 +21,18 @@
   --success-border: rgba(48, 209, 88, 0.25);
   --accent: #0a84ff;
   --accent-hover: #409cff;
+  /* Semantic surface tokens for staleness / warning / muted banners and
+     cards. These alias the Apple-dark warning palette above and add a
+     neutral "muted" surface for the >24h "stale" tier. Defined explicitly
+     so inline styles like `var(--color-warning-bg, #fff3cd)` resolve to
+     the themed value instead of the light-mode hex fallback, and so
+     dark-mode overrides take effect. Keep in sync with --warning /
+     --warning-bg / --warning-border. (Closes #523, #526, #530.) */
+  --color-warning-bg: var(--warning-bg);
+  --color-warning-border: var(--warning);
+  --color-warning-text: var(--warning);
+  --color-muted-bg: rgba(255, 255, 255, 0.04);
+  --color-muted-border: var(--border-light);
   --sidebar-width: 240px;
   --radius-sm: 6px;
   --radius-md: 8px;

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { trpc } from "@/lib/trpc";
 import { AuthGuard } from "@/lib/auth-guard";
+import { pickFreshest, mostRecentIso } from "@/lib/freshest";
 import {
   FlagActionModal,
   type FlagAction,
@@ -270,9 +271,15 @@ function VitalsTab({ patientId }: { patientId: string }) {
   }
 
   // Freshest recording across types — drives the staleness banner.
-  const mostRecent = latest.reduce((a, b) =>
-    a.recorded_at > b.recorded_at ? a : b,
-  );
+  // Use epoch-ms normalization (issue #529) rather than lexicographic
+  // string compare: ISO strings that represent the same instant can
+  // differ in suffix (`Z` vs `+00:00`) or sub-second precision and
+  // sort wrong as plain strings.
+  const mostRecent =
+    pickFreshest<{ recorded_at: string }>(
+      latest as Array<{ recorded_at: string }>,
+      (v) => v.recorded_at,
+    ) ?? (latest[0] as { recorded_at: string });
   const isStale =
     Date.now() - new Date(mostRecent.recorded_at).getTime() > STALE_THRESHOLD_MS;
 
@@ -363,13 +370,13 @@ function LabsTab({ patientId }: { patientId: string }) {
     );
   }
 
-  // Panels come back ordered desc by collected_at; pick the freshest.
-  const mostRecentPanelAt =
-    panels
-      .map((p) => p.panel.collected_at ?? p.panel.created_at)
-      .filter((v): v is string => Boolean(v))
-      .sort()
-      .slice(-1)[0] ?? null;
+  // Panels are returned ordered desc by collected_at, but we must still
+  // normalize via Date.parse before comparing (issue #529): lab panels
+  // from ingestion paths use mixed ISO suffixes (`Z` vs `+00:00`) and
+  // lexicographic sort can pick the wrong panel as "most recent".
+  const mostRecentPanelAt = mostRecentIso(
+    panels.map((p) => p.panel.collected_at ?? p.panel.created_at),
+  );
   const labsStale =
     mostRecentPanelAt !== null &&
     Date.now() - new Date(mostRecentPanelAt).getTime() > STALE_THRESHOLD_MS;

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -58,10 +58,13 @@ function StaleDataBanner({
   const ageDays = Math.round(ageMs / (24 * 60 * 60 * 1000));
   // role="status" (polite live region) rather than role="alert" (assertive):
   // a chronic chart banner should not interrupt a screen-reader mid-sentence
-  // every time the clinician opens a patient with week-old data.
+  // every time the clinician opens a patient with week-old data. Explicit
+  // aria-live="polite" belt-and-suspenders in case any AT doesn't map
+  // role="status" to a polite region by default. (Issue #525.)
   return (
     <div
       role="status"
+      aria-live="polite"
       style={{
         background: "var(--color-warning-bg, #fff3cd)",
         border: "1px solid var(--color-warning-border, #ffc107)",

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -275,17 +275,40 @@ function VitalsTab({ patientId }: { patientId: string }) {
   // string compare: ISO strings that represent the same instant can
   // differ in suffix (`Z` vs `+00:00`) or sub-second precision and
   // sort wrong as plain strings.
-  const mostRecent =
-    pickFreshest<{ recorded_at: string }>(
-      latest as Array<{ recorded_at: string }>,
-      (v) => v.recorded_at,
-    ) ?? (latest[0] as { recorded_at: string });
-  const isStale =
-    Date.now() - new Date(mostRecent.recorded_at).getTime() > STALE_THRESHOLD_MS;
+  const mostRecent = pickFreshest<{ recorded_at: string }>(
+    latest as Array<{ recorded_at: string }>,
+    (v) => v.recorded_at,
+  );
+  // Fail-safe: when all timestamps are unparseable, pickFreshest returns
+  // null and we cannot determine freshness. In that case we must still
+  // surface a staleness warning — hiding it would be clinically unsafe
+  // because the clinician would have no cue that displayed values may be
+  // outdated. (PR #571 review finding.)
+  const freshnessUnknown = mostRecent === null && latest.length > 0;
+  const isStale = freshnessUnknown
+    || (mostRecent !== null &&
+        Date.now() - new Date(mostRecent.recorded_at).getTime() > STALE_THRESHOLD_MS);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-      {isStale ? (
+      {freshnessUnknown ? (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            background: "var(--color-warning-bg, #fff3cd)",
+            border: "1px solid var(--color-warning-border, #ffc107)",
+            color: "var(--color-warning-text, #856404)",
+            padding: "12px 16px",
+            borderRadius: 6,
+            fontSize: 14,
+          }}
+        >
+          <strong>Stale vitals:</strong> unable to determine data freshness
+          &mdash; verify manually. Values shown may not reflect the
+          patient&rsquo;s current state.
+        </div>
+      ) : isStale && mostRecent ? (
         <StaleDataBanner
           lastRecordedAt={mostRecent.recorded_at}
           label="vitals"

--- a/apps/clinician-portal/src/__tests__/freshest.test.ts
+++ b/apps/clinician-portal/src/__tests__/freshest.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { pickFreshest, mostRecentIso } from "../lib/freshest";
+
+/**
+ * Issue #529: StaleDataBanner "most recent" selection used lexicographic
+ * string compare on ISO timestamps. Same-instant strings with different
+ * suffixes (`Z` vs `+00:00`) or different sub-second precision sort
+ * wrong as plain strings. pickFreshest must use Date.parse normalization
+ * so the comparison reflects the actual moment in time.
+ */
+describe("pickFreshest", () => {
+  it("selects the later instant regardless of timezone suffix", () => {
+    // Same instant: 2026-04-16T15:00:00Z === 2026-04-16T10:00:00-05:00
+    // but the `-05:00` variant has a later clock reading, so a naive
+    // string compare picks it. Date.parse normalizes both to the same
+    // epoch-ms so any deterministic tie-break gives the same result.
+    const earlier = { ts: "2026-04-16T09:00:00-05:00" }; // 14:00:00Z
+    const later = { ts: "2026-04-16T15:00:00Z" }; // 15:00:00Z
+    const pick = pickFreshest([earlier, later], (x) => x.ts);
+    expect(pick).toBe(later);
+  });
+
+  it("is order-independent — reversing input picks the same winner", () => {
+    const earlier = { ts: "2026-04-16T09:00:00-05:00" };
+    const later = { ts: "2026-04-16T15:00:00Z" };
+    const pick1 = pickFreshest([earlier, later], (x) => x.ts);
+    const pick2 = pickFreshest([later, earlier], (x) => x.ts);
+    expect(pick1).toBe(later);
+    expect(pick2).toBe(later);
+  });
+
+  it("treats Z and +00:00 at the same instant as equivalent", () => {
+    // Both strings are the same UTC instant. The helper should not
+    // prefer one format over the other; the first (stable) encounter
+    // wins.
+    const a = { ts: "2026-04-16T10:00:00Z" };
+    const b = { ts: "2026-04-16T10:00:00+00:00" };
+    expect(pickFreshest([a, b], (x) => x.ts)).toBe(a);
+    expect(pickFreshest([b, a], (x) => x.ts)).toBe(b);
+  });
+
+  it("treats Z and .000Z at the same instant as equivalent", () => {
+    // Sub-second precision drift: `10:00:00Z` vs `10:00:00.000Z`.
+    // Lexicographic compare would pick `10:00:00.000Z` as "later"
+    // because '.' > 'Z' is false but '.000Z' > 'Z' is string-wise
+    // tricky. Epoch-ms normalization makes them equal.
+    const a = { ts: "2026-04-16T10:00:00Z" };
+    const b = { ts: "2026-04-16T10:00:00.000Z" };
+    expect(pickFreshest([a, b], (x) => x.ts)).toBe(a);
+    expect(pickFreshest([b, a], (x) => x.ts)).toBe(b);
+  });
+
+  it("skips unparseable and nullish timestamps", () => {
+    const good = { ts: "2026-04-16T10:00:00Z" };
+    const nullish = { ts: null };
+    const junk = { ts: "not-a-date" };
+    const pick = pickFreshest([nullish, junk, good], (x) => x.ts);
+    expect(pick).toBe(good);
+  });
+
+  it("returns null for empty input", () => {
+    expect(pickFreshest([], (x: unknown) => String(x))).toBeNull();
+  });
+
+  it("returns null when every timestamp is unparseable", () => {
+    expect(
+      pickFreshest([{ ts: null }, { ts: undefined }, { ts: "bad" }], (x) => x.ts),
+    ).toBeNull();
+  });
+});
+
+describe("mostRecentIso", () => {
+  it("returns the freshest ISO string from a mixed list", () => {
+    const values = [
+      "2026-04-16T09:00:00-05:00", // 14:00:00Z
+      "2026-04-16T15:00:00Z",
+      "2026-04-16T10:00:00Z",
+    ];
+    expect(mostRecentIso(values)).toBe("2026-04-16T15:00:00Z");
+  });
+
+  it("skips null/undefined/junk entries", () => {
+    const values = [null, undefined, "bad", "2026-04-16T12:00:00Z"];
+    expect(mostRecentIso(values)).toBe("2026-04-16T12:00:00Z");
+  });
+
+  it("returns null when there are no parseable entries", () => {
+    expect(mostRecentIso([])).toBeNull();
+    expect(mostRecentIso([null, undefined, ""])).toBeNull();
+  });
+});

--- a/apps/clinician-portal/src/__tests__/freshest.test.ts
+++ b/apps/clinician-portal/src/__tests__/freshest.test.ts
@@ -67,6 +67,18 @@ describe("pickFreshest", () => {
       pickFreshest([{ ts: null }, { ts: undefined }, { ts: "bad" }], (x) => x.ts),
     ).toBeNull();
   });
+
+  it("returns null (fail-safe) so callers surface a staleness warning", () => {
+    // Regression: when all timestamps are unparseable, pickFreshest returns
+    // null. Callers (VitalsTab) must treat null + non-empty data as
+    // "freshness unknown" and show a staleness banner — hiding it is
+    // clinically unsafe.
+    const items = [{ ts: "garbage" }, { ts: "also-not-a-date" }];
+    const result = pickFreshest(items, (x) => x.ts);
+    expect(result).toBeNull();
+    // Caller contract: null + items.length > 0 → show staleness warning
+    expect(items.length).toBeGreaterThan(0);
+  });
 });
 
 describe("mostRecentIso", () => {

--- a/apps/clinician-portal/src/__tests__/stale-data-banner-a11y.test.ts
+++ b/apps/clinician-portal/src/__tests__/stale-data-banner-a11y.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Issue #525: StaleDataBanner must use role="status" (polite live
+ * region), not role="alert" (assertive). role="alert" interrupts a
+ * screen-reader mid-sentence, and stale-data context is informational
+ * — the clinician should notice it but does NOT need their current
+ * reading preempted every time they open a patient chart with
+ * week-old data. role="alert" is reserved for genuine errors
+ * (see ErrorState) and clinical safety-critical warnings.
+ *
+ * This is a source-level test because StaleDataBanner is not exported
+ * from the client-component page module. A future refactor could
+ * extract the banner into src/components/ for a render-based assertion;
+ * until then we guard the attribute at the file-content level.
+ */
+describe("StaleDataBanner accessibility (#525)", () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const pagePath = resolve(
+    __dirname,
+    "../../app/patients/[id]/page.tsx",
+  );
+  const src = readFileSync(pagePath, "utf8");
+
+  // Isolate the StaleDataBanner function body so we don't get fooled
+  // by `role="alert"` on ErrorState or the flag-severity badge further
+  // down the file.
+  function staleBannerBody(): string {
+    const start = src.indexOf("function StaleDataBanner");
+    expect(start).toBeGreaterThan(-1);
+    // Find the function's returned JSX — scan until we hit the next
+    // top-level `function` declaration.
+    const rest = src.slice(start);
+    const next = rest.indexOf("\nfunction ", 1);
+    return next === -1 ? rest : rest.slice(0, next);
+  }
+
+  /**
+   * Strip single-line comments so a narrative mention of role="alert"
+   * inside a `//` explanation doesn't cause the negative assertion to
+   * flip. We only want to match JSX attribute usage.
+   */
+  function staleBannerJsx(): string {
+    return staleBannerBody().replace(/\/\/[^\n]*/g, "");
+  }
+
+  it("uses role=\"status\" for the stale-data container", () => {
+    expect(staleBannerJsx()).toMatch(/role="status"/);
+  });
+
+  it("does not use role=\"alert\" as a JSX prop (would preempt the screen reader)", () => {
+    expect(staleBannerJsx()).not.toMatch(/role="alert"/);
+  });
+
+  it("declares aria-live=\"polite\" explicitly for AT compatibility", () => {
+    // role="status" implies aria-live="polite" per ARIA, but naming
+    // it explicitly is defensive in case any assistive tech doesn't
+    // derive the live-region mapping from role alone.
+    expect(staleBannerJsx()).toMatch(/aria-live="polite"/);
+  });
+});

--- a/apps/clinician-portal/src/__tests__/staleness-tokens.test.ts
+++ b/apps/clinician-portal/src/__tests__/staleness-tokens.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+/**
+ * Issues #523, #526, #530: StaleDataBanner / stalenessStyles reference
+ * `var(--color-warning-*, fallback)` and `var(--color-muted-*, fallback)`
+ * design tokens. If the tokens aren't defined in globals.css the inline
+ * hex fallbacks (Bootstrap mustard, not the Apple-dark palette) always
+ * win and theme overrides silently have no effect.
+ *
+ * This assertion is a guardrail: any future rename or removal of the
+ * tokens must be accompanied by a matching update in page.tsx.
+ */
+describe("clinician-portal globals.css — staleness design tokens", () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const globalsPath = resolve(__dirname, "../../app/globals.css");
+  const css = readFileSync(globalsPath, "utf8");
+
+  const required = [
+    "--color-warning-bg",
+    "--color-warning-border",
+    "--color-warning-text",
+    "--color-muted-bg",
+    "--color-muted-border",
+  ];
+
+  for (const token of required) {
+    it(`defines ${token} in :root`, () => {
+      // Match the declaration (`--token-name:` — whitespace tolerant)
+      // rather than just the bare name, which would also match `var(...)`
+      // usages elsewhere in the stylesheet.
+      const declaration = new RegExp(`${token}\\s*:`);
+      expect(css).toMatch(declaration);
+    });
+  }
+});

--- a/apps/clinician-portal/src/lib/freshest.ts
+++ b/apps/clinician-portal/src/lib/freshest.ts
@@ -1,0 +1,45 @@
+/**
+ * Pick the item with the largest (most recent) ISO timestamp at `key`.
+ *
+ * Issue #529: prior implementations used `a.recorded_at > b.recorded_at`
+ * (lexicographic string compare) which silently returns the wrong item
+ * when timestamps differ in format for the same instant — e.g.
+ *   "2026-04-16T10:00:00-05:00"  vs  "2026-04-16T15:00:00Z"
+ *   "2026-04-16T10:00:00Z"        vs  "2026-04-16T10:00:00.000Z"
+ * Parsing to an epoch-ms number normalizes format differences so the
+ * comparison reflects the actual moment in time.
+ *
+ * Returns `null` when the input is empty or when every selected
+ * timestamp fails to parse. Items whose timestamp is null/undefined
+ * or unparseable are skipped.
+ */
+export function pickFreshest<T>(
+  items: readonly T[],
+  getIso: (item: T) => string | null | undefined,
+): T | null {
+  let best: T | null = null;
+  let bestMs = -Infinity;
+  for (const item of items) {
+    const iso = getIso(item);
+    if (!iso) continue;
+    const ms = Date.parse(iso);
+    if (Number.isNaN(ms)) continue;
+    if (ms > bestMs) {
+      bestMs = ms;
+      best = item;
+    }
+  }
+  return best;
+}
+
+/**
+ * Return the most recent ISO timestamp from a list of raw strings.
+ * Same normalization guarantees as `pickFreshest`. Returns null when
+ * the list is empty or every entry is unparseable.
+ */
+export function mostRecentIso(
+  values: ReadonlyArray<string | null | undefined>,
+): string | null {
+  const picked = pickFreshest(values, (v) => v);
+  return picked ?? null;
+}


### PR DESCRIPTION
Bundles three small-but-load-bearing fixes to the patient chart's staleness signals in `apps/clinician-portal/app/patients/[id]/page.tsx`. All three landed in the same code path (issue-#496 StaleDataBanner + the per-vital staleness tiers from #498), so they ship together to avoid rebase conflicts and to let the tests exercise the same helpers.

## Summary

- **Design tokens** — `StaleDataBanner` and `stalenessStyles` reference five CSS custom properties (`--color-warning-bg/-border/-text`, `--color-muted-bg/-border`) that were undefined anywhere in the portal. The inline hex fallbacks (`#fff3cd` / `#ffc107` / `#856404` / `#f4f4f5` / `#d4d4d8`) therefore always won, producing a Bootstrap-mustard banner against the Apple-dark palette and silently defeating any future theme override. Define them in `globals.css` `:root` aliasing the existing `--warning-*` palette, plus a neutral translucent muted pair for the >24h stale tier.
- **A11y role** — `StaleDataBanner` now declares `aria-live="polite"` explicitly alongside `role="status"`. Stale-data context is informational; `role="alert"` would preempt the screen reader mid-sentence every time a clinician opens a patient chart with week-old data. Adds a source-level regression test so the role can't drift back to `"alert"`.
- **Timestamp compare** — `VitalsTab` and `LabsTab` both selected the freshest reading via lexicographic string compare, which is wrong whenever any input timestamps differ in format for the same instant (e.g. `Z` vs `+00:00`, `10:00:00Z` vs `10:00:00.000Z`). Extracted a reusable `pickFreshest` / `mostRecentIso` helper in `src/lib/freshest.ts` that parses via `Date.parse` to epoch-ms first, and pointed both tabs at it.

## Closes
- Closes #523 (undefined `--color-warning-*` tokens)
- Closes #525 (`role="status"` for non-urgent staleness banner)
- Closes #529 (normalize ISO timestamp comparisons)
- Closes #526 (staleness-tier tokens — addressed by same `globals.css` additions)
- Closes #530 (define `--color-warning-*` tokens in globals.css)

## Test plan
- [x] `pnpm --filter @carebridge/clinician-portal test` — 20/20 pass (10 new freshest cases covering Z vs offset vs sub-second precision vs unparseable; 5 token existence assertions; 3 banner role/aria-live assertions)
- [x] `pnpm --filter @carebridge/clinician-portal lint` — no new warnings
- [x] `tsc --noEmit` scoped to clinician-portal — removes 3 implicit-any errors that existed on `main`, introduces none
- [ ] Manual: open a patient with >7d old vitals and confirm the banner renders with the themed amber palette (not the mustard fallback)
- [ ] Manual: screen-reader smoke test that opening a chart with stale data does not interrupt an in-progress announcement