### PR TITLE
fix(ai): normalize ISO timestamps + exclude retracted clinical records

### DIFF
--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -231,4 +231,182 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
 
     expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 2.1 }]);
   });
+
+  // ─── #513 — normalize ISO timestamp comparisons ────────────────────
+  it("compares offset-form (-05:00) timestamps identically to equivalent Z-form", async () => {
+    // The event timestamp uses UTC Z-form; the diagnosis resolved_date is
+    // the identical instant expressed as -05:00 offset. Lex-compare would
+    // mis-sort these because "T07:00:00.000-05:00" sorts BEFORE
+    // "T12:00:00.000Z" as strings. After Date.parse normalization, both
+    // reduce to the same epoch and the diagnosis is correctly excluded.
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Flu (offset-form resolved_date)",
+        icd10_code: "J10.1",
+        status: "active",
+        onset_date: "2026-04-01T00:00:00.000Z",
+        // Same instant as event timestamp, different suffix — equal, so
+        // `resolved_date <= eventAt` is true and the diagnosis is excluded.
+        resolved_date: "2026-04-16T07:00:00.000-05:00",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_diagnoses).not.toContain("Flu (offset-form resolved_date)");
+  });
+
+  it("compares bare-date (YYYY-MM-DD) timestamps correctly against Z-form event", async () => {
+    // FHIR + seed data sometimes emit bare dates. Date.parse treats
+    // "2026-04-10" as UTC midnight, so a diagnosis with
+    // resolved_date="2026-04-10" IS before event_ts=2026-04-16T12:00Z and
+    // must be excluded.
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Bronchitis (bare-date resolved_date)",
+        icd10_code: "J40",
+        status: "active",
+        onset_date: "2026-04-01",
+        resolved_date: "2026-04-10", // bare date, before event
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        description: "Hypertension (bare-date onset, still active)",
+        icd10_code: "I10",
+        status: "active",
+        onset_date: "2025-01-15", // bare date, well before event
+        resolved_date: null,
+        created_at: "2025-01-15T00:00:00.000Z",
+      },
+    ]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_diagnoses).not.toContain(
+      "Bronchitis (bare-date resolved_date)",
+    );
+    expect(ctx.active_diagnoses).toContain(
+      "Hypertension (bare-date onset, still active)",
+    );
+  });
+
+  // ─── #515 — exclude logical retractions ────────────────────────────
+  it("excludes a diagnosis with status=entered_in_error even when timestamps say active", async () => {
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Myocardial infarction (charting mistake)",
+        icd10_code: "I21.9",
+        status: "entered_in_error", // charting correction
+        onset_date: "2025-01-01T00:00:00.000Z",
+        resolved_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+      {
+        description: "Breast cancer (chronic, real)",
+        icd10_code: "C50.9",
+        status: "chronic",
+        onset_date: "2025-01-01T00:00:00.000Z",
+        resolved_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_diagnoses).not.toContain(
+      "Myocardial infarction (charting mistake)",
+    );
+    expect(ctx.active_diagnoses).toContain("Breast cancer (chronic, real)");
+  });
+
+  it("excludes allergies with verification_status=entered_in_error or refuted", async () => {
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    allergiesSelect.mockResolvedValue([
+      {
+        allergen: "penicillin",
+        verification_status: "entered_in_error",
+        rxnorm_code: "7980",
+        severity: "severe",
+        reaction: "rash",
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+      {
+        allergen: "latex",
+        verification_status: "refuted",
+        rxnorm_code: null,
+        severity: "moderate",
+        reaction: "contact dermatitis",
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+      {
+        allergen: "sulfa",
+        verification_status: "confirmed",
+        rxnorm_code: "10180",
+        severity: "severe",
+        reaction: "anaphylaxis",
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    const allergens = (ctx.allergies ?? []).map((a) => a.allergen);
+    expect(allergens).toEqual(["sulfa"]);
+  });
+
+  it("keeps allergies with verification_status=null (schema default `unconfirmed`)", async () => {
+    // Pre-existing rows may have null verification_status prior to the
+    // #515 migration default. They must NOT be treated as retracted.
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    allergiesSelect.mockResolvedValue([
+      {
+        allergen: "peanut",
+        verification_status: null,
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect((ctx.allergies ?? []).map((a) => a.allergen)).toEqual(["peanut"]);
+  });
 });

--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -287,4 +287,88 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
     expect(ctx.recent_labs).toBeDefined();
     expect(ctx.recent_labs?.map((l) => l.test_name)).toEqual(["WBC"]);
   });
+
+  // ─── #513 — normalize ISO timestamp comparisons ────────────────────
+  it("compares offset-form (-05:00) timestamps identically to equivalent Z-form", async () => {
+    // The resolved_date is expressed with a UTC-5 offset; the event uses
+    // Z-form. Lex compare mis-sorts them; Date.parse normalization treats
+    // them as the same instant, so the diagnosis is correctly excluded.
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Flu (offset-form resolved_date)",
+        icd10_code: "J10.1",
+        status: "active",
+        onset_date: "2026-04-01T00:00:00.000Z",
+        resolved_date: "2026-04-16T07:00:00.000-05:00",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.patient.active_diagnoses).not.toContain(
+      "Flu (offset-form resolved_date)",
+    );
+  });
+
+  it("compares bare-date onset timestamps correctly against Z-form event", async () => {
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Hypertension (bare-date onset, still active)",
+        icd10_code: "I10",
+        status: "active",
+        onset_date: "2025-01-15",
+        resolved_date: null,
+        created_at: "2025-01-15T00:00:00.000Z",
+      },
+      {
+        description: "Bronchitis (bare-date resolved before event)",
+        icd10_code: "J40",
+        status: "active",
+        onset_date: "2026-04-01",
+        resolved_date: "2026-04-10",
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.patient.active_diagnoses).toContain(
+      "Hypertension (bare-date onset, still active)",
+    );
+    expect(ctx.patient.active_diagnoses).not.toContain(
+      "Bronchitis (bare-date resolved before event)",
+    );
+  });
+
+  // ─── #515 — exclude logical retractions ────────────────────────────
+  it("excludes a diagnosis with status=entered_in_error even when timestamps say active", async () => {
+    diagnosesSelect.mockResolvedValue([
+      {
+        description: "Myocardial infarction (charting mistake)",
+        icd10_code: "I21.9",
+        status: "entered_in_error",
+        onset_date: "2025-01-01T00:00:00.000Z",
+        resolved_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+      {
+        description: "Breast cancer (chronic, real)",
+        icd10_code: "C50.9",
+        status: "chronic",
+        onset_date: "2025-01-01T00:00:00.000Z",
+        resolved_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.patient.active_diagnoses).not.toContain(
+      "Myocardial infarction (charting mistake)",
+    );
+    expect(ctx.patient.active_diagnoses).toContain(
+      "Breast cancer (chronic, real)",
+    );
+  });
 });

--- a/services/ai-oversight/src/__tests__/event-time-snapshot.test.ts
+++ b/services/ai-oversight/src/__tests__/event-time-snapshot.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  isoBefore,
+  isoLTE,
+  isDiagnosisRetracted,
+  isAllergyRetracted,
+} from "../utils/event-time-snapshot.js";
+
+describe("event-time-snapshot helpers", () => {
+  describe("isoBefore", () => {
+    it("treats Z-form and equivalent offset-form as equal (not before)", () => {
+      // 2026-04-16T07:00-05:00 === 2026-04-16T12:00Z
+      expect(
+        isoBefore("2026-04-16T07:00:00.000-05:00", "2026-04-16T12:00:00.000Z"),
+      ).toBe(false);
+      expect(
+        isoBefore("2026-04-16T12:00:00.000Z", "2026-04-16T07:00:00.000-05:00"),
+      ).toBe(false);
+    });
+
+    it("returns true when a is genuinely earlier across timezone forms", () => {
+      expect(
+        isoBefore("2026-04-16T06:00:00.000-05:00", "2026-04-16T12:00:00.000Z"),
+      ).toBe(true);
+    });
+
+    it("handles millisecond precision correctly", () => {
+      expect(
+        isoBefore("2026-04-16T12:00:00.000Z", "2026-04-16T12:00:00.001Z"),
+      ).toBe(true);
+      expect(
+        isoBefore("2026-04-16T12:00:00.001Z", "2026-04-16T12:00:00.000Z"),
+      ).toBe(false);
+    });
+
+    it("treats bare dates as UTC midnight", () => {
+      expect(isoBefore("2026-04-15", "2026-04-16T00:00:00.000Z")).toBe(true);
+      expect(isoBefore("2026-04-16", "2026-04-16T00:00:00.000Z")).toBe(false);
+    });
+
+    it("returns false for null / undefined / garbage operands", () => {
+      expect(isoBefore(null, "2026-04-16T12:00:00.000Z")).toBe(false);
+      expect(isoBefore(undefined, "2026-04-16T12:00:00.000Z")).toBe(false);
+      expect(isoBefore("not-a-date", "2026-04-16T12:00:00.000Z")).toBe(false);
+    });
+  });
+
+  describe("isoLTE", () => {
+    it("returns true when operands represent the same instant across suffixes", () => {
+      expect(
+        isoLTE("2026-04-16T07:00:00.000-05:00", "2026-04-16T12:00:00.000Z"),
+      ).toBe(true);
+      expect(
+        isoLTE("2026-04-16T12:00:00.000Z", "2026-04-16T07:00:00.000-05:00"),
+      ).toBe(true);
+    });
+
+    it("returns false for null / undefined / garbage operands", () => {
+      expect(isoLTE(null, "2026-04-16T12:00:00.000Z")).toBe(false);
+      expect(isoLTE("not-a-date", "2026-04-16T12:00:00.000Z")).toBe(false);
+    });
+  });
+
+  describe("isDiagnosisRetracted", () => {
+    it("returns true only for status=entered_in_error", () => {
+      expect(isDiagnosisRetracted({ status: "entered_in_error" })).toBe(true);
+      expect(isDiagnosisRetracted({ status: "active" })).toBe(false);
+      expect(isDiagnosisRetracted({ status: "chronic" })).toBe(false);
+      expect(isDiagnosisRetracted({ status: "resolved" })).toBe(false);
+      expect(isDiagnosisRetracted({ status: null })).toBe(false);
+      expect(isDiagnosisRetracted({})).toBe(false);
+    });
+  });
+
+  describe("isAllergyRetracted", () => {
+    it("returns true for entered_in_error and refuted", () => {
+      expect(isAllergyRetracted({ verification_status: "entered_in_error" })).toBe(true);
+      expect(isAllergyRetracted({ verification_status: "refuted" })).toBe(true);
+    });
+
+    it("returns false for confirmed / unconfirmed / null", () => {
+      expect(isAllergyRetracted({ verification_status: "confirmed" })).toBe(false);
+      expect(isAllergyRetracted({ verification_status: "unconfirmed" })).toBe(false);
+      expect(isAllergyRetracted({ verification_status: null })).toBe(false);
+      expect(isAllergyRetracted({})).toBe(false);
+    });
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -45,6 +45,12 @@ import { screenPatientMessage } from "../rules/message-screening.js";
 import { screenPatientObservation } from "../rules/observation-screening.js";
 import { checkAllergyMedication } from "../rules/allergy-medication.js";
 import type { RuleFlag } from "../rules/critical-values.js";
+import {
+  isoBefore,
+  isoLTE,
+  isDiagnosisRetracted,
+  isAllergyRetracted,
+} from "../utils/event-time-snapshot.js";
 import { buildPatientContext } from "../workers/context-builder.js";
 import { reviewPatientRecord } from "./claude-client.js";
 import { createFlag } from "./flag-service.js";
@@ -527,15 +533,29 @@ export async function buildPatientContextForRules(
   // review time. Without this, a med discontinued or an allergy added between
   // event emit and review causes missed/false flags: the rules see a newer
   // snapshot than the event they are evaluating. See #258.
+  //
+  // All comparisons go through isoBefore/isoLTE (normalized via Date.parse)
+  // rather than lexicographic string compares so offset-form (-05:00) and
+  // bare-date (2025-12-01) timestamps sort correctly against Z-form event
+  // timestamps. See #513.
   const eventAt = event.timestamp;
 
   function wasActiveAt(
-    row: { onset_date?: string | null; resolved_date?: string | null; status: string; created_at: string },
+    row: {
+      onset_date?: string | null;
+      resolved_date?: string | null;
+      status?: string | null;
+      created_at: string;
+    },
     at: string,
   ): boolean {
+    // Logical retraction (#515): a diagnosis marked entered_in_error is a
+    // charting correction and must never appear in the active set,
+    // regardless of its onset/resolved timestamps.
+    if (isDiagnosisRetracted(row)) return false;
     const start = row.onset_date ?? row.created_at;
-    if (start > at) return false; // not yet started at event time
-    if (row.resolved_date && row.resolved_date <= at) return false; // resolved before event
+    if (isoBefore(at, start)) return false; // not yet started at event time
+    if (row.resolved_date && isoLTE(row.resolved_date, at)) return false; // resolved before event
     return true;
   }
 
@@ -548,7 +568,7 @@ export async function buildPatientContextForRules(
   const seenLabs = new Set<string>();
   const recentLabs: Array<{ name: string; value: number }> = [];
   for (const row of recentLabRows) {
-    if (row.created_at > eventAt) continue;
+    if (isoBefore(eventAt, row.created_at)) continue;
     if (seenLabs.has(row.test_name)) continue;
     seenLabs.add(row.test_name);
     recentLabs.push({ name: row.test_name, value: row.value });
@@ -561,14 +581,19 @@ export async function buildPatientContextForRules(
   // schema constraint but guards against partial records.
   const activeMedsList = allMeds.filter((m) => {
     const start = m.started_at ?? m.created_at;
-    if (start > eventAt) return false;
-    if (m.ended_at && m.ended_at <= eventAt) return false;
+    if (isoBefore(eventAt, start)) return false;
+    if (m.ended_at && isoLTE(m.ended_at, eventAt)) return false;
     return true;
   });
 
-  // An allergy is relevant iff it was already recorded before the event.
-  // A post-hoc addition must not retroactively flag the triggering event.
-  const patientAllergies = allAllergies.filter((a) => a.created_at <= eventAt);
+  // An allergy is relevant iff it was already recorded before the event
+  // AND has not been logically retracted (entered_in_error / refuted —
+  // charting corrections that must not drive rule decisions). See #515.
+  const patientAllergies = allAllergies.filter((a) => {
+    if (isoBefore(eventAt, a.created_at)) return false;
+    if (isAllergyRetracted(a)) return false;
+    return true;
+  });
 
   return {
     active_diagnoses: activeDx.map((d) => d.description),

--- a/services/ai-oversight/src/utils/event-time-snapshot.ts
+++ b/services/ai-oversight/src/utils/event-time-snapshot.ts
@@ -1,0 +1,80 @@
+/**
+ * Event-time snapshot helpers shared by the rule-path
+ * (`buildPatientContextForRules` in review-service) and the LLM-path
+ * (`buildPatientContext` in context-builder).
+ *
+ * Keeping both paths on the same primitives guarantees that the
+ * deterministic rules and the LLM reason over identical row sets for a
+ * given trigger event — see #258, #512, #513, #515.
+ *
+ * ─── Timestamp comparison (#513) ──────────────────────────────────────
+ * ISO-8601 strings only sort correctly under lexicographic compare when
+ * every operand is strict UTC Z-form (`YYYY-MM-DDTHH:MM:SS.sssZ`). FHIR
+ * importers and seed data routinely emit offset-form values (`-05:00`)
+ * or bare dates (`2025-12-01`), which silently mis-compare near day
+ * boundaries. Normalizing through `Date.parse` handles every ISO-8601
+ * variant the platform ingests.
+ *
+ * ─── Logical retraction (#515) ────────────────────────────────────────
+ * A row marked `entered_in_error` (diagnoses) or
+ * `entered_in_error` / `refuted` (allergies) is a charting correction.
+ * It was never clinically true and must never drive rule or LLM output,
+ * regardless of its timestamps.
+ */
+
+/**
+ * Parse an ISO-8601 timestamp to a numeric epoch. Returns `NaN` for
+ * missing / malformed input — the caller decides how to treat that.
+ */
+function toEpoch(iso: string | null | undefined): number {
+  if (iso == null) return Number.NaN;
+  return Date.parse(iso);
+}
+
+/**
+ * Is `a` strictly before `b`? Returns `false` when either operand is
+ * unparseable — matching the prior string-compare behavior on
+ * undefined/invalid input (no row is considered "strictly before"
+ * garbage). Callers that need stricter validation should validate
+ * upstream.
+ */
+export function isoBefore(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ea = toEpoch(a);
+  const eb = toEpoch(b);
+  if (Number.isNaN(ea) || Number.isNaN(eb)) return false;
+  return ea < eb;
+}
+
+/**
+ * Is `a` less-than-or-equal to `b`? Returns `false` when either operand
+ * is unparseable (see `isoBefore`).
+ */
+export function isoLTE(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ea = toEpoch(a);
+  const eb = toEpoch(b);
+  if (Number.isNaN(ea) || Number.isNaN(eb)) return false;
+  return ea <= eb;
+}
+
+/**
+ * Logical retraction for a diagnosis row. `status === 'entered_in_error'`
+ * means a clinician struck it as a charting mistake — it is NOT a real
+ * condition and must never appear in the active set. Note that `resolved`
+ * and `chronic` are legitimate active-history states and handled by the
+ * `resolved_date` check upstream, not here.
+ */
+export function isDiagnosisRetracted(row: { status?: string | null }): boolean {
+  return row.status === "entered_in_error";
+}
+
+/**
+ * Logical retraction for an allergy row. `entered_in_error` is a charting
+ * correction; `refuted` means the allergy was tested and disproven. Both
+ * must be excluded from rule evaluation and LLM context.
+ */
+export function isAllergyRetracted(row: { verification_status?: string | null }): boolean {
+  return (
+    row.verification_status === "entered_in_error" ||
+    row.verification_status === "refuted"
+  );
+}

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -25,6 +25,13 @@ import type { ClinicalEvent } from "@carebridge/shared-types";
 import { calculateDelta } from "@carebridge/medical-logic";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
 
+import {
+  isoBefore,
+  isoLTE,
+  isDiagnosisRetracted,
+  isAllergyRetracted,
+} from "../utils/event-time-snapshot.js";
+
 /**
  * Recursively sanitize all string values in an arbitrary event-data object
  * before it is serialized into an LLM prompt. Prevents semantic prompt
@@ -49,6 +56,11 @@ function sanitizeEventData(data: unknown): unknown {
  * Was this diagnosis active AS OF `at` (event time)? Mirrors the helper in
  * buildPatientContextForRules so the LLM and rule paths share the same
  * snapshot semantics. See #258 and #512.
+ *
+ * Excludes logical retractions (status=entered_in_error) per #515 — a
+ * charting correction is not clinically true and must not enter the LLM
+ * context. Timestamp comparisons go through isoBefore/isoLTE so
+ * offset-form and bare-date values normalize correctly (#513).
  */
 function diagnosisWasActiveAt(
   row: {
@@ -59,9 +71,10 @@ function diagnosisWasActiveAt(
   },
   at: string,
 ): boolean {
+  if (isDiagnosisRetracted(row)) return false;
   const start = row.onset_date ?? row.created_at;
-  if (start > at) return false; // not yet started at event time
-  if (row.resolved_date && row.resolved_date <= at) return false; // resolved before event
+  if (isoBefore(at, start)) return false; // not yet started at event time
+  if (row.resolved_date && isoLTE(row.resolved_date, at)) return false; // resolved before event
   return true;
 }
 
@@ -143,8 +156,8 @@ export async function buildPatientContext(
   // back to created_at if started_at is null (defensive; see #516).
   const activeMeds = allMeds.filter((m) => {
     const start = m.started_at ?? m.created_at;
-    if (start > eventAt) return false;
-    if (m.ended_at && m.ended_at <= eventAt) return false;
+    if (isoBefore(eventAt, start)) return false;
+    if (m.ended_at && isoLTE(m.ended_at, eventAt)) return false;
     return true;
   });
 
@@ -153,20 +166,15 @@ export async function buildPatientContext(
   // are charting corrections and must not appear in the LLM context.
   // See #515.
   const patientAllergies = allAllergies.filter((a) => {
-    if (a.created_at > eventAt) return false;
-    if (
-      a.verification_status === "entered_in_error" ||
-      a.verification_status === "refuted"
-    ) {
-      return false;
-    }
+    if (isoBefore(eventAt, a.created_at)) return false;
+    if (isAllergyRetracted(a)) return false;
     return true;
   });
 
   // Event-time snapshot — vitals recorded at/before the event. Keep the
   // 20 most recent eligible rows to match the previous budget.
   const latestVitals = allVitals
-    .filter((v) => v.recorded_at <= eventAt)
+    .filter((v) => isoLTE(v.recorded_at, eventAt))
     .slice(0, 20);
 
   // Calculate patient age
@@ -220,7 +228,7 @@ export async function buildPatientContext(
       .where(inArray(labResults.panel_id, panelIds));
 
     recentLabResults = allResults
-      .filter((r) => r.created_at <= eventAt)
+      .filter((r) => isoLTE(r.created_at, eventAt))
       .slice(0, 50)
       .map((r) => ({
         test_name: r.test_name,


### PR DESCRIPTION
## Summary

Two #494 follow-ups addressed together because they touch the same two
helpers (the event-time snapshot filter) and must stay in parity across
the rule-path (`buildPatientContextForRules` in review-service) and the
LLM-path (`buildPatientContext` in context-builder).

### #513 — normalize timestamp comparisons
Raw string compare (`row.resolved_date <= at`, etc.) only sorts ISO-8601
correctly when every operand is strict UTC Z-form. Offset-form
(`-05:00`) and bare-date (`2025-12-01`) values — both of which the FHIR
importer and seed data produce — silently mis-compare near day
boundaries. Replaced with `isoBefore` / `isoLTE` helpers that normalize
through `Date.parse` so every ISO-8601 variant sorts correctly.

### #515 — exclude retracted clinical records
After #494 dropped `status = 'active'` in favor of timestamp-only
filtering, diagnoses marked `entered_in_error` (charting mistakes) and
allergies with `verification_status IN ('entered_in_error', 'refuted')`
started leaking into rule context. Added `isDiagnosisRetracted` /
`isAllergyRetracted` predicates and applied them in both helpers.

### Schema note
The clinical tables do not carry generic `retracted_at` / `deleted_at`
columns — retraction is modeled via `diagnoses.status =
'entered_in_error'` and `allergies.verification_status IN
('entered_in_error', 'refuted')` per FHIR conventions, which is what
issue #515 explicitly calls for. Medications do not yet have an
equivalent retraction state.

### Two-location parity
Both `services/ai-oversight/src/services/review-service.ts` (rule path)
and `services/ai-oversight/src/workers/context-builder.ts` (LLM path)
import from the new shared module
`services/ai-oversight/src/utils/event-time-snapshot.ts` so the
deterministic rules and the LLM reason over identical row sets for a
given trigger event.

## Test plan
- [x] 10 new unit tests in `event-time-snapshot.test.ts` (Z vs offset
  suffix equality, bare dates, millisecond precision, null/garbage
  operands, retraction predicates)
- [x] +5 tests in `build-patient-context.test.ts` for the rule path
  (offset-form, bare-date, diagnosis `entered_in_error`, allergy
  retractions, null `verification_status` preservation)
- [x] +3 tests in `context-builder.test.ts` for the LLM path
- [x] `pnpm --filter @carebridge/ai-oversight test` — 320 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (pre-existing warnings only)

Closes #513
Closes #515