### PR TITLE
fix(ai): broaden review-job idempotency + close in-flight race

### DIFF
--- a/services/ai-oversight/src/__tests__/llm-timeout-fallback.test.ts
+++ b/services/ai-oversight/src/__tests__/llm-timeout-fallback.test.ts
@@ -76,6 +76,8 @@ vi.mock("drizzle-orm", () => ({
   desc: vi.fn((col: unknown) => col),
   gte: vi.fn((...args: unknown[]) => args),
   and: vi.fn((...args: unknown[]) => args),
+  or: vi.fn((...args: unknown[]) => args),
+  inArray: vi.fn((...args: unknown[]) => args),
   sql: vi.fn(),
 }));
 

--- a/services/ai-oversight/src/__tests__/review-idempotency.test.ts
+++ b/services/ai-oversight/src/__tests__/review-idempotency.test.ts
@@ -45,6 +45,8 @@ vi.mock("@carebridge/db-schema", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  or: vi.fn(),
+  inArray: vi.fn(),
   desc: vi.fn(),
   gte: vi.fn(),
   sql: vi.fn(),
@@ -122,40 +124,138 @@ describe("processReviewJob — idempotency", () => {
   });
 
   it("skips processing when a completed review_jobs row already exists for the event", async () => {
-    // First select.limit() call is the idempotency probe — return a prior
-    // completed row. No other mocks need priming because the function
-    // returns before touching anything else.
     limitMock.mockResolvedValueOnce([
-      { id: "prior-job-id", status: "completed" },
+      {
+        id: "prior-job-id",
+        status: "completed",
+        created_at: new Date().toISOString(),
+      },
     ]);
 
     await processReviewJob(makeEvent());
 
-    // No insert, no flag creation, no update.
     expect(insertMock).not.toHaveBeenCalled();
     expect(mockCreateFlag).not.toHaveBeenCalled();
   });
 
-  it("proceeds with processing when no prior completed review exists", async () => {
-    // Idempotency probe returns [] — no prior run. All downstream selects
-    // (patient context builder, encounters, etc.) also get [] to keep the
-    // pipeline unblocked through to the insert.
+  // #520: parameterized across all three terminal statuses
+  it.each([
+    ["completed"],
+    ["llm_timeout"],
+    ["llm_error"],
+  ])("skips processing when prior run ended in terminal status '%s'", async (status) => {
+    limitMock.mockResolvedValueOnce([
+      {
+        id: `prior-${status}-id`,
+        status,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+
+    await processReviewJob(makeEvent({ id: `evt-term-${status}` }));
+
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(mockCreateFlag).not.toHaveBeenCalled();
+  });
+
+  // #520: `failed` is NOT terminal — retry IS desired
+  it("proceeds when prior run ended in 'failed' (retry is desired)", async () => {
     limitMock.mockResolvedValue([]);
 
-    // The downstream pipeline still needs usable mocks — at minimum the
-    // insert into review_jobs must be reached. Everything after that is
-    // short-circuited by the empty rule results mocked above.
-    const event = makeEvent({ id: "evt-new" });
-
-    // We expect this NOT to return early; the job row insert is proof.
     try {
-      await processReviewJob(event);
+      await processReviewJob(makeEvent({ id: "evt-failed-retry" }));
     } catch {
-      // The rest of the pipeline is stubbed lightly — exceptions from
-      // context-builder etc. are acceptable; we only care that we got past
-      // the idempotency guard.
+      // Downstream mocks may throw
     }
 
     expect(insertMock).toHaveBeenCalled();
+  });
+
+  // #522: recent in-flight `processing` row blocks duplicate
+  it("skips processing when a recent 'processing' row exists (in-flight race)", async () => {
+    limitMock.mockResolvedValueOnce([
+      {
+        id: "concurrent-worker-job-id",
+        status: "processing",
+        created_at: new Date(Date.now() - 5_000).toISOString(),
+      },
+    ]);
+
+    await processReviewJob(makeEvent({ id: "evt-in-flight" }));
+
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(mockCreateFlag).not.toHaveBeenCalled();
+  });
+
+  // #522: stale `processing` row (orphan) does NOT block
+  it("proceeds when only a stale 'processing' row exists (orphaned crash)", async () => {
+    limitMock.mockResolvedValue([]);
+
+    try {
+      await processReviewJob(makeEvent({ id: "evt-stale-orphan" }));
+    } catch {
+      // Downstream mocks may throw
+    }
+
+    expect(insertMock).toHaveBeenCalled();
+  });
+
+  it("proceeds with processing when no prior completed review exists", async () => {
+    limitMock.mockResolvedValue([]);
+
+    const event = makeEvent({ id: "evt-new" });
+
+    try {
+      await processReviewJob(event);
+    } catch {
+      // Downstream mocks may throw
+    }
+
+    expect(insertMock).toHaveBeenCalled();
+  });
+});
+
+describe("processReviewJob — idempotency probe predicate shape", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertMock.mockReturnValue({ values: insertValues });
+    updateMock.mockReturnValue({ set: updateSet });
+    updateSet.mockReturnValue({ where: updateSetWhere });
+    selectMock.mockImplementation(() => ({ from: selectFrom }));
+    selectFrom.mockReturnValue({ where: selectWhere });
+    selectWhere.mockReturnValue({ limit: limitMock });
+    limitMock.mockResolvedValue([]);
+  });
+
+  it("calls inArray with the three terminal statuses", async () => {
+    const drizzle = await import("drizzle-orm");
+    const inArrayMock = vi.mocked(drizzle.inArray);
+
+    try {
+      await processReviewJob(makeEvent({ id: "evt-probe-shape" }));
+    } catch {
+      // Ignore downstream errors
+    }
+
+    const statusCall = inArrayMock.mock.calls.find(([, values]) =>
+      Array.isArray(values) &&
+      values.includes("completed") &&
+      values.includes("llm_timeout") &&
+      values.includes("llm_error"),
+    );
+    expect(statusCall).toBeDefined();
+  });
+
+  it("includes an in-flight 'processing' branch in the probe via or()", async () => {
+    const drizzle = await import("drizzle-orm");
+    const orMock = vi.mocked(drizzle.or);
+
+    try {
+      await processReviewJob(makeEvent({ id: "evt-probe-or" }));
+    } catch {
+      // Ignore downstream errors
+    }
+
+    expect(orMock).toHaveBeenCalled();
   });
 });

--- a/services/ai-oversight/src/__tests__/review-service-fallback.test.ts
+++ b/services/ai-oversight/src/__tests__/review-service-fallback.test.ts
@@ -63,6 +63,8 @@ vi.mock("drizzle-orm", () => ({
   desc: vi.fn(),
   gte: vi.fn(),
   and: vi.fn(),
+  or: vi.fn(),
+  inArray: vi.fn(),
   sql: vi.fn(),
 }));
 

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -9,7 +9,7 @@
  * The review_jobs table records every run for auditability.
  */
 
-import { eq, desc, gte, and } from "drizzle-orm";
+import { eq, desc, gte, and, inArray, or } from "drizzle-orm";
 import { getDb } from "@carebridge/db-schema";
 import {
   reviewJobs,
@@ -49,6 +49,38 @@ import { buildPatientContext } from "../workers/context-builder.js";
 import { reviewPatientRecord } from "./claude-client.js";
 import { createFlag } from "./flag-service.js";
 
+
+/**
+ * Statuses that represent a fully-run pipeline. A review_jobs row in any of
+ * these states has already executed deterministic rules AND (for the two
+ * `llm_*` statuses) attempted or intentionally skipped the LLM step — so
+ * redelivering the triggering event must NOT re-execute. Adding a new
+ * terminal status to the pipeline requires adding it here as well.
+ *
+ * Intentionally excludes:
+ *   - `pending` / `processing`: non-terminal, handled by the in-flight
+ *     freshness window below (see IN_FLIGHT_WINDOW_MS).
+ *   - `failed`: the pipeline threw before flag writes; a retry IS desired.
+ */
+const TERMINAL_REVIEW_STATUSES: readonly string[] = [
+  "completed",
+  "llm_timeout",
+  "llm_error",
+];
+
+/**
+ * In-flight freshness window for the idempotency probe. A `processing`
+ * row newer than this is treated as another worker actively running the
+ * pipeline — we short-circuit rather than run a concurrent duplicate.
+ * Older `processing` rows are treated as orphans (crashed worker) and
+ * the pipeline proceeds normally.
+ *
+ * Chosen comfortably longer than BullMQ `lockDuration` (120s) so a live
+ * worker still holding its Redis lock cannot have its row fall outside
+ * the window. See #522.
+ */
+const IN_FLIGHT_WINDOW_MS = 150_000;
+
 /**
  * Process a clinical event through the full review pipeline.
  */
@@ -57,32 +89,63 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
   const jobId = crypto.randomUUID();
   const startTime = Date.now();
 
-  // Idempotency: if a completed review already exists for this trigger event,
-  // skip. BullMQ can re-deliver a job when a worker crashes mid-processing
-  // (lock expires → stalled-scan reclaims the job) or the same event is
-  // replayed via the outbox reconciler. Without this check each redelivery
-  // writes an extra review_jobs row and — for rules whose dedup cannot cover
-  // the replay window — potentially duplicate flags.
-  const existingCompleted = await db
-    .select({ id: reviewJobs.id, status: reviewJobs.status })
+  // Idempotency: short-circuit if the pipeline has already run — or is
+  // actively running — for this trigger event.
+  //
+  // BullMQ can re-deliver a job when a worker crashes mid-processing (lock
+  // expires → stalled-scan reclaims the job) or the same event is replayed
+  // via the outbox reconciler / a manual requeue. Without this check each
+  // redelivery writes an extra review_jobs row and — for rules whose dedup
+  // cannot cover the replay window — potentially duplicate flags.
+  //
+  // The probe matches two disjoint cases:
+  //
+  //   1) Terminal run: prior row in a "fully-run" status (completed,
+  //      llm_timeout, llm_error). Re-running would either duplicate flags
+  //      or re-call Claude for a degraded-LLM path we already logged.
+  //      `failed` is intentionally NOT terminal — the pipeline threw before
+  //      flag writes, so a retry is desired. See #520.
+  //
+  //   2) In-flight run: prior row in `processing` that is fresh
+  //      (< IN_FLIGHT_WINDOW_MS old). Another worker is mid-pipeline for
+  //      this event — running concurrently risks duplicate flags for any
+  //      rule whose open-flag dedup can’t span the race window. Stale
+  //      `processing` rows (orphans from crashed workers) fall outside
+  //      the window and do NOT short-circuit — matching the prior
+  //      behavior for crash recovery. See #522.
+  const inFlightCutoff = new Date(Date.now() - IN_FLIGHT_WINDOW_MS).toISOString();
+
+  const existingJob = await db
+    .select({
+      id: reviewJobs.id,
+      status: reviewJobs.status,
+      created_at: reviewJobs.created_at,
+    })
     .from(reviewJobs)
     .where(
       and(
         eq(reviewJobs.trigger_event_id, event.id),
-        eq(reviewJobs.status, "completed"),
+        or(
+          inArray(reviewJobs.status, TERMINAL_REVIEW_STATUSES as string[]),
+          and(
+            eq(reviewJobs.status, "processing"),
+            gte(reviewJobs.created_at, inFlightCutoff),
+          ),
+        ),
       ),
     )
     .limit(1);
 
-  if (existingCompleted.length > 0) {
+  if (existingJob.length > 0) {
+    const prior = existingJob[0]!;
     console.log(
       `[review-service] Skipping duplicate review for event ${event.id} ` +
-        `(prior completed job ${existingCompleted[0]!.id})`,
+        `(prior job ${prior.id}, status=${prior.status})`,
     );
     return;
   }
 
-  // Step 1: Create a review_jobs record
+    // Step 1: Create a review_jobs record
   await db.insert(reviewJobs).values({
     id: jobId,
     patient_id: event.patient_id,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -145,7 +145,7 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
     return;
   }
 
-    // Step 1: Create a review_jobs record
+  // Step 1: Create a review_jobs record
   await db.insert(reviewJobs).values({
     id: jobId,
     patient_id: event.patient_id,


### PR DESCRIPTION
## Summary

- **#520 (terminal status predicate)**: The idempotency probe in `processReviewJob` only matched `status='completed'`, missing `llm_timeout` and `llm_error`. A redelivered event whose prior run hit the degraded-LLM path re-executed the full pipeline (duplicate deterministic-rule flags, wasted Claude API calls). Now uses `inArray(status, TERMINAL_REVIEW_STATUSES)` covering all three terminal statuses. `failed` is intentionally excluded — it means the pipeline threw before flag writes, so a retry is desired.

- **#522 (in-flight race)**: Two workers handed the same `trigger_event_id` could both pass the SELECT probe (no terminal row yet) and both INSERT their own `processing` row, running the pipeline concurrently and risking duplicate flags. Extended the probe with an `or()` branch that short-circuits when a recent `processing` row exists (`created_at >= now - 150s`, comfortably beyond BullMQ `lockDuration=120s`). Stale `processing` rows (crashed-worker orphans) fall outside the freshness window and do NOT block retry, preserving crash-recovery semantics.

## Approach

Application-level query predicate changes only — no migration needed. The `TERMINAL_REVIEW_STATUSES` constant and `IN_FLIGHT_WINDOW_MS` window are defined as module-level constants for clarity.

The in-flight window narrows but does not fully close the race (two concurrent probes within the same millisecond can both see no prior row). A DB-level unique constraint would conflict with stale-orphan semantics (old `processing` rows must not block new runs) and is deferred.

## Test plan

- [x] Parameterized test across `completed`, `llm_timeout`, `llm_error` — all skip (10 idempotency tests)
- [x] `failed` status does NOT skip — pipeline proceeds to INSERT
- [x] Recent `processing` row (5s old) blocks duplicate execution
- [x] Stale `processing` row (orphan) does NOT block — pipeline proceeds
- [x] Predicate shape tests: `inArray` called with all 3 terminal statuses, `or()` used
- [x] Existing `llm-timeout-fallback` and `review-service-fallback` tests updated with `or`/`inArray` mocks
- [x] All 310 ai-oversight tests pass, typecheck clean

Closes #520
Closes #522