### PR TITLE
perf(db): add GIN index on clinical_flags.trigger_event_ids

### DIFF
--- a/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
+++ b/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
@@ -1,0 +1,5 @@
+-- GIN index on clinical_flags.trigger_event_ids for replay-safety
+-- containment lookups (@>). jsonb_path_ops is smaller and faster than
+-- the default jsonb_ops when only @> is used.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_flags_trigger_event_ids
+  ON clinical_flags USING gin (trigger_event_ids jsonb_path_ops);

--- a/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
+++ b/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
@@ -1,5 +1,5 @@
 -- GIN index on clinical_flags.trigger_event_ids for replay-safety
 -- containment lookups (@>). jsonb_path_ops is smaller and faster than
 -- the default jsonb_ops when only @> is used.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_flags_trigger_event_ids
+CREATE INDEX IF NOT EXISTS idx_flags_trigger_event_ids
   ON clinical_flags USING gin (trigger_event_ids jsonb_path_ops);

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -39,6 +39,7 @@ export const clinicalFlags = pgTable("clinical_flags", {
     table.acknowledged_at,
     table.escalation_count,
   ),
+  index("idx_flags_trigger_event_ids").using("gin", sql`trigger_event_ids jsonb_path_ops`),
   uniqueIndex("idx_flags_open_rule_dedup")
     .on(table.patient_id, table.rule_id)
     .where(sql`status = 'open' AND rule_id IS NOT NULL`),


### PR DESCRIPTION
## Summary
- Adds migration `0034_gin_trigger_event_ids.sql` with a `jsonb_path_ops` GIN index on `clinical_flags.trigger_event_ids`
- Updates Drizzle schema declaration in `ai-flags.ts` to include the new index
- Accelerates `@>` containment lookups used by the replay-safety idempotency check in `createFlag`

## Test plan
- [ ] `pnpm db:migrate` applies the new migration without errors
- [ ] Verify index exists: `\di idx_flags_trigger_event_ids` in psql
- [ ] `EXPLAIN` the replay-safety query confirms bitmap index scan on the GIN index

Closes #509