### PR TITLE
fix(clinical): tighten adult pulse-pressure thresholds

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -90,6 +90,60 @@ describe("validateVital", () => {
     expect(result.warnings.some((w) => w.toLowerCase().includes("pulse pressure"))).toBe(false);
   });
 
+  // ─── Pulse-pressure boundary tests (issue #519) ────────────────
+
+  it("warns on narrow pulse pressure at boundary PP=25 (no warning)", () => {
+    // 100/75 — PP=25, just above the narrow threshold
+    const result = validateVital("blood_pressure", 100, 75);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(false);
+  });
+
+  it("warns on narrow pulse pressure at boundary PP=24 (warning)", () => {
+    // 100/76 — PP=24, just inside the narrow warning band
+    const result = validateVital("blood_pressure", 100, 76);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(true);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically narrow"))).toBe(false);
+  });
+
+  it("critically warns on very narrow pulse pressure PP=15 (boundary, no critical)", () => {
+    // 90/75 — PP=15, at the critical threshold boundary (not critical)
+    const result = validateVital("blood_pressure", 90, 75);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(true);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically narrow"))).toBe(false);
+  });
+
+  it("critically warns on very narrow pulse pressure PP=14", () => {
+    // 89/75 — PP=14, inside the critical narrow band
+    const result = validateVital("blood_pressure", 89, 75);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically narrow"))).toBe(true);
+  });
+
+  it("warns on moderately wide pulse pressure PP=61", () => {
+    // 141/80 — PP=61, just above the wide warning threshold
+    const result = validateVital("blood_pressure", 141, 80);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("wide pulse pressure"))).toBe(true);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically wide"))).toBe(false);
+  });
+
+  it("does not warn on pulse pressure at boundary PP=60 (no warning)", () => {
+    // 140/80 — PP=60, at the wide threshold boundary (not wide)
+    const result = validateVital("blood_pressure", 140, 80);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("wide pulse pressure"))).toBe(false);
+  });
+
+  it("warns on critically wide pulse pressure PP=101", () => {
+    // 181/80 — PP=101, inside the critical wide band
+    const result = validateVital("blood_pressure", 181, 80);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically wide"))).toBe(true);
+  });
+
+  it("does not critically warn on wide pulse pressure PP=100 (boundary)", () => {
+    // 180/80 — PP=100, at the critical boundary (not critical)
+    const result = validateVital("blood_pressure", 180, 80);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("critically wide"))).toBe(false);
+    expect(result.warnings.some((w) => w.toLowerCase().includes("wide pulse pressure"))).toBe(true);
+  });
+
   it("returns valid for temperature in normal range", () => {
     const result = validateVital("temperature", 98.6);
     expect(result.valid).toBe(true);

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -181,22 +181,33 @@ export function validateVital(
       errors.push(`Diastolic ${secondary} is outside plausible range (20–200)`);
     }
 
-    // Pulse-pressure plausibility check. Normal adult pulse pressure is
-    // ~30-50 mmHg; a narrow (<20) PP usually indicates shock, tamponade,
-    // or an artifact, and a wide (>100) PP suggests aortic regurgitation
-    // or measurement error. Either extreme is physically implausible
-    // without clinical context that should be confirmed on the record.
+    // Pulse-pressure tiered check (issue #519). Normal adult PP ~30-50 mmHg.
+    // Narrow PP: <25 warning (low stroke volume, tamponade, hypovolemia),
+    //            <15 critical (impending circulatory collapse).
+    // Wide PP:   >60 warning (aortic stiffening, AR, thyrotoxicosis),
+    //            >100 critical (severe AR or measurement error).
+    // Refs: Dart & Gregoire 2012, ESC 2018 arterial stiffness guidelines.
     if (secondary < primary) {
       const pulsePressure = primary - secondary;
-      if (pulsePressure < 20) {
+      if (pulsePressure < 15) {
+        warnings.push(
+          `Critically narrow pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
+            `consider impending circulatory collapse, cardiac tamponade, or measurement artifact`,
+        );
+      } else if (pulsePressure < 25) {
         warnings.push(
           `Narrow pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
-            `consider shock, cardiac tamponade, or measurement artifact`,
+            `consider shock, cardiac tamponade, or hypovolemia`,
         );
       } else if (pulsePressure > 100) {
         warnings.push(
+          `Critically wide pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
+            `consider severe aortic regurgitation or measurement error`,
+        );
+      } else if (pulsePressure > 60) {
+        warnings.push(
           `Wide pulse pressure ${pulsePressure} mmHg (${primary}/${secondary}) — ` +
-            `consider aortic regurgitation or measurement error`,
+            `consider aortic stiffening, aortic regurgitation, or thyrotoxicosis`,
         );
       }
     }


### PR DESCRIPTION
## Summary
- Tiered pulse-pressure warnings replace single-threshold checks
- **Narrow PP**: <25 mmHg warning, <15 mmHg critical (was <20 single threshold)
- **Wide PP**: >60 mmHg warning, >100 mmHg critical (was >100 single threshold)
- 8 boundary tests added at PP = 14, 15, 24, 25, 60, 61, 100, 101

## Clinical rationale
Dart & Gregoire 2012; ESC 2018 arterial stiffness guidelines. The 20-24 mmHg band catches early shock; the 61-100 mmHg band catches aortic regurgitation and stiffening before PP exceeds 100.

## Test plan
- [x] All 171 medical-logic tests pass (96 in validation suite)
- [x] Typecheck clean
- [x] Lint clean

Closes #519