### PR TITLE
fix(clinical): accept IFCC mmol/mol unit for HbA1c

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -206,12 +206,36 @@ describe("validateLabResult", () => {
     expect(validateLabResult("Potassium", 4.1, "mmol/L").valid).toBe(true);
   });
 
-  it("warns (not errors) on unit mismatch for a test without allowed_units", () => {
-    // HbA1c uses %, no allowed_units allow-list — so a different unit is a
-    // warning, not a blocking error.
-    const result = validateLabResult("HbA1c", 5.5, "mmol/mol");
+  it("accepts HbA1c in NGSP % with value in typical range", () => {
+    const result = validateLabResult("HbA1c", 5.4, "%");
     expect(result.valid).toBe(true);
-    expect(result.warnings.some((w) => w.includes("does not match expected"))).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("accepts HbA1c in IFCC mmol/mol — 37 mmol/mol (~5.5 %) in range, no warnings", () => {
+    // 37 mmol/mol ≈ 5.54 % NGSP → within 4.0–5.6 typical range
+    const result = validateLabResult("HbA1c", 37, "mmol/mol");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("warns on HbA1c 75 mmol/mol (above typical range — ~9.0 %)", () => {
+    // 75 mmol/mol ≈ 9.01 % NGSP → above 5.6 % typical high
+    const result = validateLabResult("HbA1c", 75, "mmol/mol");
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);
+  });
+
+  it("rejects HbA1c with an unrecognized unit", () => {
+    const result = validateLabResult("HbA1c", 5.5, "g/dL");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("unit"))).toBe(true);
+  });
+
+  it("requires a unit for HbA1c (allowed_units is set)", () => {
+    const result = validateLabResult("HbA1c", 5.5);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("without a unit"))).toBe(true);
   });
 
   // Unit comparison tolerates case/whitespace variants. Real-world FHIR/HL7

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -248,6 +248,24 @@ function normalizeUnit(u: string): string {
   return u.trim().toLowerCase().replace(/\s+/g, "");
 }
 
+/**
+ * Unit conversion definitions for tests where the canonical unit differs
+ * from an accepted alternate unit. Each entry maps a normalized
+ * `fromUnit` to a function that converts a value to the canonical unit.
+ *
+ * Currently supported:
+ *  - HbA1c: IFCC mmol/mol → NGSP % via the IFCC master equation
+ *    NGSP% = (IFCC / 10.929) + 2.15
+ */
+const UNIT_CONVERSIONS: Record<
+  string,
+  Record<string, (value: number) => number>
+> = {
+  HbA1c: {
+    "mmol/mol": (v: number) => v / 10.929 + 2.15,
+  },
+};
+
 export function validateLabResult(
   testName: string,
   value: number,
@@ -296,12 +314,25 @@ export function validateLabResult(
     );
   }
 
-  if (value < ref.typical_low) {
+  // Convert submitted value to canonical unit for range comparison when the
+  // caller used an accepted alternate unit (e.g. IFCC mmol/mol → NGSP %).
+  // Without this, a valid 37 mmol/mol HbA1c (≈ 5.5 %) would be flagged as
+  // below the 4.0–5.6 % typical range.
+  let compareValue = value;
+  if (unit && normalizeUnit(unit) !== normalizeUnit(ref.unit)) {
+    const conversions = UNIT_CONVERSIONS[testName];
+    const converter = conversions?.[normalizeUnit(unit)];
+    if (converter) {
+      compareValue = converter(value);
+    }
+  }
+
+  if (compareValue < ref.typical_low) {
     warnings.push(
       `${testName} value ${value} ${unit ?? ref.unit} is below typical range (${ref.typical_low}–${ref.typical_high} ${ref.unit})`
     );
   }
-  if (value > ref.typical_high) {
+  if (compareValue > ref.typical_high) {
     warnings.push(
       `${testName} value ${value} ${unit ?? ref.unit} is above typical range (${ref.typical_low}–${ref.typical_high} ${ref.unit})`
     );

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -284,7 +284,23 @@ export const COMMON_LAB_TESTS: Record<string, CommonLabTest> = {
   // Other
   Lipase: { unit: "U/L", typical_low: 0, typical_high: 160 },
   Amylase: { unit: "U/L", typical_low: 28, typical_high: 100 },
-  HbA1c: { unit: "%", typical_low: 4.0, typical_high: 5.6 },
+  /**
+   * HbA1c — glycated hemoglobin.
+   *
+   * Two reporting standards exist:
+   *  - NGSP (US): `%`       — normal < 5.7 %, diabetic >= 6.5 %
+   *  - IFCC (international): `mmol/mol` — normal < 42, diabetic >= 48
+   *
+   * Canonical unit is `%` (NGSP). Values submitted in `mmol/mol` are
+   * converted to NGSP for range comparison using the IFCC master equation:
+   *   NGSP% = (IFCC mmol/mol / 10.929) + 2.15
+   */
+  HbA1c: {
+    unit: "%",
+    typical_low: 4.0,
+    typical_high: 5.6,
+    allowed_units: ["%", "mmol/mol"],
+  },
 };
 
 export function getLabRange(


### PR DESCRIPTION
## Summary
- Add `mmol/mol` to HbA1c `allowed_units` alongside existing NGSP `%`
- Add `UNIT_CONVERSIONS` map with IFCC-to-NGSP conversion (`NGSP = IFCC/10.929 + 2.15`) so range checks use the canonical `%` scale
- Update tests: 37 mmol/mol (in-range) passes clean, 75 mmol/mol (high) triggers warning, unrecognized units and missing units are rejected

## Test plan
- [x] `validateLabResult("HbA1c", 37, "mmol/mol")` -- valid, no warnings
- [x] `validateLabResult("HbA1c", 75, "mmol/mol")` -- valid, above-range warning
- [x] `validateLabResult("HbA1c", 5.4, "%")` -- valid, no warnings (existing behavior)
- [x] `validateLabResult("HbA1c", 5.5, "g/dL")` -- rejected (not in allowed_units)
- [x] `validateLabResult("HbA1c", 5.5)` -- rejected (unit required)
- [x] All 167 existing tests pass
- [x] `pnpm typecheck` and `pnpm lint` clean

Closes #540