### PR TITLE
refactor(ai): lift RuleFlag into @carebridge/shared-types

### DIFF
--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { pgTable, text, integer, boolean, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import type { RuleFlag } from "@carebridge/shared-types";
 import { patients } from "./patients.js";
 
 export const clinicalFlags = pgTable("clinical_flags", {
@@ -74,7 +75,7 @@ export const reviewJobs = pgTable("review_jobs", {
   // notify_specialties, rule_id) so regulatory and forensic audits can
   // reconstruct the decision without replaying the rule engine against
   // (possibly-mutated) patient state. See migration 0032.
-  rules_output: jsonb("rules_output").$type<Array<Record<string, unknown>>>().default([]),
+  rules_output: jsonb("rules_output").$type<RuleFlag[]>().default([]),
   llm_request_tokens: integer("llm_request_tokens"),
   llm_response_tokens: integer("llm_response_tokens"),
   redacted_prompt: text("redacted_prompt"),

--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -55,6 +55,20 @@ export interface ClinicalFlag extends BaseRecord {
   last_escalated_at?: string;
 }
 
+// ─── Rule Engine Output ─────────────────────────────────────────
+// Canonical shape emitted by every deterministic rule function in
+// services/ai-oversight. Persisted verbatim as review_jobs.rules_output.
+
+export interface RuleFlag {
+  severity: FlagSeverity;
+  category: FlagCategory;
+  summary: string;
+  rationale: string;
+  suggested_action: string;
+  notify_specialties: string[];
+  rule_id: string;
+}
+
 // ─── Clinical Rules ──────────────────────────────────────────────
 
 export interface ClinicalRuleCondition {

--- a/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
+++ b/services/ai-oversight/src/__tests__/review-dedup-precedence.test.ts
@@ -5,7 +5,7 @@ import {
   severityRank,
   categoryRank,
 } from "../services/review-service.js";
-import type { RuleFlag } from "../rules/critical-values.js";
+import type { RuleFlag } from "@carebridge/shared-types";
 
 function ruleFlag(overrides: Partial<RuleFlag> = {}): RuleFlag {
   return {

--- a/services/ai-oversight/src/__tests__/review-service.test.ts
+++ b/services/ai-oversight/src/__tests__/review-service.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi } from "vitest";
  * to validate the word-overlap heuristic independently.
  */
 
-import type { RuleFlag } from "../rules/critical-values.js";
+import type { RuleFlag } from "@carebridge/shared-types";
 
 // Replicate the isDuplicate logic from review-service.ts for unit testing.
 // This mirrors the exact algorithm: >40% overlap of significant words (length > 3)

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -9,8 +9,7 @@
  * Rule IDs follow pattern: ALLERGY-MED-{SEQ}
  */
 
-import type { FlagSeverity, FlagCategory } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagSeverity, FlagCategory, RuleFlag } from "@carebridge/shared-types";
 import type { PatientContext } from "./cross-specialty.js";
 
 /**

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -7,7 +7,7 @@
 
 import type { VitalType } from "@carebridge/shared-types";
 import { COMMON_LAB_TESTS } from "@carebridge/shared-types";
-import type { ClinicalEvent, FlagSeverity, FlagCategory } from "@carebridge/shared-types";
+import type { ClinicalEvent, FlagSeverity, FlagCategory, RuleFlag } from "@carebridge/shared-types";
 import {
   DIASTOLIC_DANGER_ZONE,
   checkDiastolicBP,
@@ -323,15 +323,7 @@ function matchesCriticalLab(
   return false;
 }
 
-export interface RuleFlag {
-  severity: FlagSeverity;
-  category: FlagCategory;
-  summary: string;
-  rationale: string;
-  suggested_action: string;
-  notify_specialties: string[];
-  rule_id: string;
-}
+export type { RuleFlag };
 
 export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
   const flags: RuleFlag[] = [];

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -7,8 +7,7 @@
  * specialists might miss because they only see their piece.
  */
 
-import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagSeverity, FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
 
 export interface PatientAllergy {
   allergen: string;

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -18,8 +18,7 @@
  * as two antipsychotics, or antipsychotic + fluoroquinolone — trigger the flag.
  */
 
-import type { FlagSeverity, FlagCategory } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagSeverity, FlagCategory, RuleFlag } from "@carebridge/shared-types";
 
 interface DrugInteractionPair {
   id: string;

--- a/services/ai-oversight/src/rules/medication-reconciliation.ts
+++ b/services/ai-oversight/src/rules/medication-reconciliation.ts
@@ -9,8 +9,7 @@
  * Fires on encounter status changes via the clinical-events queue.
  */
 
-import type { FlagSeverity, FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagSeverity, FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
 import { getDb } from "@carebridge/db-schema";
 import { medications, encounters } from "@carebridge/db-schema";
 import { eq, and, desc } from "drizzle-orm";

--- a/services/ai-oversight/src/rules/message-screening.ts
+++ b/services/ai-oversight/src/rules/message-screening.ts
@@ -9,8 +9,7 @@
  * Does NOT auto-reply to patients — only creates flags for clinical review.
  */
 
-import type { FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
 import {
   SHARED_CRITICAL_PATTERNS,
   materializePattern,

--- a/services/ai-oversight/src/rules/observation-screening.ts
+++ b/services/ai-oversight/src/rules/observation-screening.ts
@@ -11,8 +11,7 @@
  * `patient.observation` events.
  */
 
-import type { FlagCategory, ClinicalEvent } from "@carebridge/shared-types";
-import type { RuleFlag } from "./critical-values.js";
+import type { FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
 import {
   SHARED_CRITICAL_PATTERNS,
   materializePattern,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -23,7 +23,7 @@ import {
   labResults,
   encounters,
 } from "@carebridge/db-schema";
-import type { ClinicalEvent, FlagSource } from "@carebridge/shared-types";
+import type { ClinicalEvent, FlagSource, RuleFlag } from "@carebridge/shared-types";
 import {
   CLINICAL_REVIEW_SYSTEM_PROMPT,
   PROMPT_VERSION,
@@ -44,7 +44,6 @@ import { checkDrugInteractions } from "../rules/drug-interactions.js";
 import { screenPatientMessage } from "../rules/message-screening.js";
 import { screenPatientObservation } from "../rules/observation-screening.js";
 import { checkAllergyMedication } from "../rules/allergy-medication.js";
-import type { RuleFlag } from "../rules/critical-values.js";
 import {
   isoBefore,
   isoLTE,
@@ -498,7 +497,7 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         // Full rule output (severity, category, rationale, notify_specialties,
         // rule_id per match) — required for forensic/regulatory audit.
         // See #241 and migration 0032.
-        rules_output: allRuleFlags as unknown as Array<Record<string, unknown>>,
+        rules_output: allRuleFlags,
         flags_generated: flagIds,
         processing_time_ms: processingTime,
         ...(llmFailed ? { error: llmErrorMessage } : {}),


### PR DESCRIPTION
## Summary
- Move `RuleFlag` interface from `services/ai-oversight/src/rules/critical-values.ts` into `packages/shared-types/src/ai-flags.ts`
- Type `review_jobs.rules_output` as `RuleFlag[]` in the Drizzle schema instead of `Array<Record<string, unknown>>`
- Remove the double cast (`as unknown as Array<Record<string, unknown>>`) in `review-service.ts`
- Update all 10 consumer files to import `RuleFlag` from `@carebridge/shared-types`

## Test plan
- [x] `pnpm typecheck` passes (all 34 tasks)
- [x] `pnpm lint` passes (no new warnings)
- [ ] CI green

Closes #535