### PR TITLE
fix(portal): runtime guard for allergy_status cast + aria-live

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { VitalsTrendChart } from "@/components/vitals-trend-chart";
 import {
   deriveAllergyDisplayState,
-  type AllergyStatus,
+  parseAllergyStatus,
 } from "@/lib/allergy-display";
 
 const tabs = [
@@ -170,7 +170,7 @@ function OverviewTab({ patientId }: { patientId: string }) {
   // formatAllergies() in @carebridge/ai-prompts.
   const allergyState = deriveAllergyDisplayState(
     allergiesQuery,
-    (patient.allergy_status as AllergyStatus | null | undefined) ?? null,
+    parseAllergyStatus(patient.allergy_status),
   );
 
   return (
@@ -210,7 +210,7 @@ function OverviewTab({ patientId }: { patientId: string }) {
         )}
       </div>
 
-      <div className="detail-card">
+      <div className="detail-card" aria-live="polite">
         <div className="detail-card-title">Allergies</div>
         {allergyState.kind === "loading" ? (
           <div style={{ color: "var(--text-muted)", fontSize: 13 }}>

--- a/apps/clinician-portal/src/__tests__/allergy-display.test.ts
+++ b/apps/clinician-portal/src/__tests__/allergy-display.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   deriveAllergyDisplayState,
+  parseAllergyStatus,
   type AllergyQueryLike,
 } from "../lib/allergy-display";
 
@@ -104,6 +105,17 @@ describe("deriveAllergyDisplayState", () => {
     expect(state.kind).toBe("unknown");
   });
 
+  it("falls back to 'unknown' when allergy_status is an unexpected string", () => {
+    // Issue #583: if the DB returns a value outside the known enum,
+    // parseAllergyStatus returns null and deriveAllergyDisplayState
+    // defaults to "unknown" — the safer clinical assumption.
+    const state = deriveAllergyDisplayState(
+      makeQuery({ data: [] }),
+      parseAllergyStatus("garbage_value"),
+    );
+    expect(state.kind).toBe("unknown");
+  });
+
   it("error with no message surfaces a fallback string", () => {
     const state = deriveAllergyDisplayState(
       makeQuery({ isError: true, error: null }),
@@ -113,5 +125,30 @@ describe("deriveAllergyDisplayState", () => {
     if (state.kind === "error") {
       expect(state.message).toBe("Unknown error");
     }
+  });
+});
+
+describe("parseAllergyStatus", () => {
+  it.each(["nkda", "unknown", "has_allergies"] as const)(
+    "returns '%s' for the valid value '%s'",
+    (value) => {
+      expect(parseAllergyStatus(value)).toBe(value);
+    },
+  );
+
+  it("returns null for an unexpected string", () => {
+    expect(parseAllergyStatus("bogus")).toBeNull();
+  });
+
+  it("returns null for a number", () => {
+    expect(parseAllergyStatus(42)).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(parseAllergyStatus(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(parseAllergyStatus(undefined)).toBeNull();
   });
 });

--- a/apps/clinician-portal/src/lib/allergy-display.ts
+++ b/apps/clinician-portal/src/lib/allergy-display.ts
@@ -22,6 +22,26 @@
 
 export type AllergyStatus = "nkda" | "unknown" | "has_allergies";
 
+const VALID_ALLERGY_STATUSES: ReadonlySet<string> = new Set<string>([
+  "nkda",
+  "unknown",
+  "has_allergies",
+]);
+
+/**
+ * Runtime guard for allergy_status values coming from the DB or API.
+ * Returns null for any value not in the known set so the downstream
+ * helper defaults to "unknown" (the clinically safer assumption).
+ */
+export function parseAllergyStatus(
+  value: unknown,
+): AllergyStatus | null {
+  if (typeof value === "string" && VALID_ALLERGY_STATUSES.has(value)) {
+    return value as AllergyStatus;
+  }
+  return null;
+}
+
 export type AllergyDisplayState =
   | { kind: "loading" }
   | { kind: "error"; message: string }


### PR DESCRIPTION
## Summary
- Replace unsafe `as AllergyStatus` cast in `page.tsx:173` with a new `parseAllergyStatus()` runtime guard that validates against known values (`nkda`, `unknown`, `has_allergies`) and returns `null` for unexpected strings, letting the display helper default to `"unknown"`.
- Add `aria-live="polite"` on the allergy card so screen readers announce loading/error/content transitions.
- Add unit tests for `parseAllergyStatus` (valid values, unexpected string, number, null, undefined) and the end-to-end unexpected-value path through `deriveAllergyDisplayState`.

## Test plan
- [x] `pnpm --filter @carebridge/clinician-portal test` — 39 tests pass (18 in allergy-display)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings

Closes #583