### PR TITLE
test(ai): add brand-name and same-drug-duplicate QTC tests

### DIFF
--- a/services/ai-oversight/src/rules/drug-interactions.test.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.test.ts
@@ -480,6 +480,71 @@ describe("checkDrugInteractions", () => {
       expect(match).toBeDefined();
     });
 
+    // Brand-name matching
+    it("flags seroquel (quetiapine) + zithromax (azithromycin)", () => {
+      const flags = checkDrugInteractions([
+        "seroquel 200mg",
+        "zithromax 500mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags cipro (ciprofloxacin) + haldol (haloperidol)", () => {
+      const flags = checkDrugInteractions([
+        "cipro 500mg",
+        "haldol 5mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags pacerone (amiodarone) + lexapro (escitalopram)", () => {
+      const flags = checkDrugInteractions([
+        "pacerone 200mg",
+        "lexapro 20mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags geodon (ziprasidone) + zofran (ondansetron)", () => {
+      const flags = checkDrugInteractions([
+        "geodon 40mg",
+        "zofran 8mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    it("flags abilify (aripiprazole) + avelox (moxifloxacin)", () => {
+      const flags = checkDrugInteractions([
+        "abilify 10mg",
+        "avelox 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeDefined();
+    });
+
+    // Same-drug-different-dose deduplication
+    it("does not flag the same QT drug at different doses (amiodarone 200mg + 400mg)", () => {
+      const flags = checkDrugInteractions([
+        "amiodarone 200mg",
+        "amiodarone 400mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeUndefined();
+    });
+
+    it("does not flag the same QT drug at different doses (sotalol 80mg + 160mg)", () => {
+      const flags = checkDrugInteractions([
+        "sotalol 80mg",
+        "sotalol 160mg",
+      ]);
+      const match = flags.find((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(match).toBeUndefined();
+    });
+
     // Negative / no-false-positive cases
     it("does not flag a single QT-prolonging drug alone", () => {
       const flags = checkDrugInteractions(["quetiapine 200mg"]);

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -518,17 +518,27 @@ export function checkDrugInteractions(medications: string[]): RuleFlag[] {
       }
     }
 
-    // Ensure both sides matched, they refer to different medication entries
-    // (by index), AND the underlying medication strings differ.  The index
-    // check prevents the same list entry from satisfying both sides; the
-    // string check prevents duplicate entries for the same drug (e.g.
-    // "sotalol 80mg" listed twice) from triggering a false flag.
-    if (
-      drugAIdx >= 0 &&
-      drugBIdx >= 0 &&
-      drugAIdx !== drugBIdx &&
-      normalizedMeds[drugAIdx] !== normalizedMeds[drugBIdx]
-    ) {
+    // Ensure both sides matched and they refer to different medication
+    // entries (by index).  For same-list rules (e.g. DI-QTC-COMBO) we also
+    // need to verify the *matched drug name* differs — not just the full
+    // medication string — so that "amiodarone 200mg" + "amiodarone 400mg"
+    // (same drug, different dose) does not fire a false flag.
+    let distinctDrugs = false;
+    if (drugAIdx >= 0 && drugBIdx >= 0 && drugAIdx !== drugBIdx) {
+      if (sameList) {
+        const matchA = normalizedMeds[drugAIdx].match(pair.drugA);
+        const matchB = normalizedMeds[drugBIdx].match(pair.drugB);
+        distinctDrugs =
+          matchA != null &&
+          matchB != null &&
+          matchA[0] !== matchB[0];
+      } else {
+        distinctDrugs =
+          normalizedMeds[drugAIdx] !== normalizedMeds[drugBIdx];
+      }
+    }
+
+    if (distinctDrugs) {
       flags.push({
         severity: pair.severity,
         category: "drug-interaction" as FlagCategory,


### PR DESCRIPTION
## Summary
- Add 5 brand-name positive tests for DI-QTC-COMBO (seroquel+zithromax, cipro+haldol, pacerone+lexapro, geodon+zofran, abilify+avelox)
- Add 2 same-drug-different-dose negative tests (amiodarone 200mg+400mg, sotalol 80mg+160mg)
- Fix dedup logic to compare matched drug names instead of full strings, preventing false positives when the same QT drug appears at different doses

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test` — all 70 drug-interaction tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

Closes #584