### PR TITLE
fix(ai,notifications): JSON truncation log, single category resolve, FlagCategory constraint

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
@@ -242,15 +242,21 @@ describe("validateLLMResponse — truncation observability", () => {
     const result = validateLLMResponse(input);
 
     expect(result.ok).toBe(true);
-    // Find the structured truncation log (object arg, not a raw string).
+    // Find the structured truncation log (JSON string, not a raw object).
     const structuredCall = warnSpy.mock.calls.find(
-      (call) =>
-        typeof call[0] === "object" &&
-        call[0] !== null &&
-        (call[0] as { event?: string }).event === "llm_findings_truncated",
+      (call) => {
+        if (typeof call[0] !== "string") return false;
+        try {
+          const parsed = JSON.parse(call[0]);
+          return parsed.event === "llm_findings_truncated";
+        } catch {
+          return false;
+        }
+      },
     );
     expect(structuredCall).toBeDefined();
-    expect(structuredCall![0]).toMatchObject({
+    const parsed = JSON.parse(structuredCall![0] as string);
+    expect(parsed).toMatchObject({
       event: "llm_findings_truncated",
       received: 65,
       kept: 50,
@@ -270,10 +276,15 @@ describe("validateLLMResponse — truncation observability", () => {
 
     expect(result.ok).toBe(true);
     const structuredCall = warnSpy.mock.calls.find(
-      (call) =>
-        typeof call[0] === "object" &&
-        call[0] !== null &&
-        (call[0] as { event?: string }).event === "llm_findings_truncated",
+      (call) => {
+        if (typeof call[0] !== "string") return false;
+        try {
+          const parsed = JSON.parse(call[0]);
+          return parsed.event === "llm_findings_truncated";
+        } catch {
+          return false;
+        }
+      },
     );
     expect(structuredCall).toBeUndefined();
   });

--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -252,14 +252,14 @@ export function validateLLMResponse(raw: string): ValidationResult {
     // parseable as a counter source. Consumers that wrap a metrics emitter
     // can still read `truncation` from the return value; this log is the
     // low-lift stopgap until a service-wide structured logger lands.
-    console.warn({
+    console.warn(JSON.stringify({
       event: "llm_findings_truncated",
       received: all.length,
       kept: capped.length,
       dropped: dropped.length,
       droppedBySeverity,
       maxFlags: MAX_FLAGS,
-    });
+    }));
   }
 
   return { ok: true, flags: capped, warnings, ...(truncation ? { truncation } : {}) };

--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -420,7 +420,12 @@ describe("dispatch-worker", () => {
       // Observability: unknown categories are logged with structured context
       // so the operator can triage and either admit them to the whitelist
       // or fix the upstream rule/LLM output.
-      expect(warnSpy).toHaveBeenCalled();
+      // Issue #591: resolveCategoryLabel is called once per event, so the
+      // unknown-category warning must fire exactly once (not once per helper).
+      const unknownWarnCalls = warnSpy.mock.calls.filter((call) =>
+        String(call[0]).includes("Unknown notification category"),
+      );
+      expect(unknownWarnCalls).toHaveLength(1);
       const warnCall = warnSpy.mock.calls.find((call) =>
         String(call[0]).includes("Unknown notification category"),
       );

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -22,6 +22,7 @@ import type { NotificationEvent } from "../queue.js";
 import { notificationsQueue } from "../queue.js";
 import { publishNotification } from "../publish.js";
 import { redactPatientId } from "@carebridge/phi-sanitizer";
+import type { FlagCategory } from "@carebridge/shared-types";
 import { filterRecipientsBySpecialty } from "./specialty-filter.js";
 import type { CandidateRecipient } from "./specialty-filter.js";
 import { getUserPreferences, evaluateDelivery } from "./preferences.js";
@@ -49,7 +50,7 @@ const CATEGORY_LABELS = {
   "trend-concern": "Trend concern",
   "documentation-discrepancy": "Documentation discrepancy",
   "patient-reported": "Patient-reported concern",
-} as const satisfies Record<string, string>;
+} as const satisfies Record<FlagCategory, string>;
 
 type SafeCategory = keyof typeof CATEGORY_LABELS;
 
@@ -165,9 +166,8 @@ async function findNotificationRecipients(
  * enforces a whitelist and falls back to "Clinical alert" for any
  * unexpected value (see `CATEGORY_LABELS`).
  */
-function buildNotificationTitle(event: NotificationEvent): string {
+function buildNotificationTitle(event: NotificationEvent, categoryLabel: string): string {
   const severityLabel = event.severity === "critical" ? "CRITICAL" : event.severity === "warning" ? "Warning" : "Info";
-  const categoryLabel = resolveCategoryLabel(event.category);
   return `${severityLabel}: Clinical flag — ${categoryLabel}`;
 }
 
@@ -186,10 +186,9 @@ function buildNotificationTitle(event: NotificationEvent): string {
  * `notifications.summary_safe` so later fetches can surface the safe
  * variant without re-deriving it.
  */
-function buildSafeSummary(event: NotificationEvent): string {
+function buildSafeSummary(categoryLabel: string): string {
   // Trust nothing from the event.summary — always fall back to the
   // whitelisted category label (which itself guards against unknown values).
-  const categoryLabel = resolveCategoryLabel(event.category);
   return `Clinical flag — ${categoryLabel}. Open the portal to view details.`;
 }
 
@@ -236,11 +235,12 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
     return 0;
   }
 
-  const title = buildNotificationTitle(event);
+  const categoryLabel = resolveCategoryLabel(event.category);
+  const title = buildNotificationTitle(event, categoryLabel);
   const link = buildFlagLink(event);
   const now = new Date().toISOString();
   const urgent = isUrgentFlag(event.severity);
-  const safeSummary = buildSafeSummary(event);
+  const safeSummary = buildSafeSummary(categoryLabel);
 
   let immediateCount = 0;
   let delayedCount = 0;
@@ -358,11 +358,12 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
 async function processDelayedNotification(event: NotificationEvent & { _targeted_user_id: string }): Promise<number> {
   const db = getDb();
   const userId = event._targeted_user_id;
-  const title = buildNotificationTitle(event);
+  const categoryLabel = resolveCategoryLabel(event.category);
+  const title = buildNotificationTitle(event, categoryLabel);
   const link = buildFlagLink(event);
   const now = new Date().toISOString();
 
-  const safeSummary = buildSafeSummary(event);
+  const safeSummary = buildSafeSummary(categoryLabel);
   const record = {
     id: crypto.randomUUID(),
     user_id: userId,


### PR DESCRIPTION
## Summary
- **#578**: Wrap `console.warn` structured payload in `JSON.stringify()` in `llm-validator.ts` so log aggregators (Datadog, Loki) can parse truncation events as JSON instead of Node `util.inspect` format.
- **#591**: Resolve `resolveCategoryLabel()` once per event in `dispatch-worker.ts` and pass the label to both `buildNotificationTitle` and `buildSafeSummary`, eliminating duplicate `console.warn` for unknown categories.
- **#592**: Constrain `CATEGORY_LABELS` from `Record<string, string>` to `Record<FlagCategory, string>` so key typos are compile-time errors.

## Test plan
- [x] `llm-validator.test.ts` updated: truncation log assertion now parses JSON string instead of matching raw object
- [x] `dispatch-worker.test.ts` updated: unknown-category test asserts exactly 1 warn call (not 2)
- [x] `pnpm typecheck` passes (34/34)
- [x] `pnpm lint` passes
- [x] All 75 relevant tests pass

Closes #578
Closes #591
Closes #592