### PR TITLE
fix(clinical): wire validateLabResult into lab-repo and MedLens write paths

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/medical-logic':
+        specifier: workspace:*
+        version: link:../../packages/medical-logic
       '@carebridge/redis-config':
         specifier: workspace:*
         version: link:../../packages/redis-config
@@ -542,6 +545,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/medical-logic':
+        specifier: workspace:*
+        version: link:../../packages/medical-logic
       '@carebridge/phi-sanitizer':
         specifier: workspace:*
         version: link:../../packages/phi-sanitizer

--- a/services/clinical-data/package.json
+++ b/services/clinical-data/package.json
@@ -22,6 +22,7 @@
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/medical-logic": "workspace:*",
     "drizzle-orm": "^0.38.0",
     "bullmq": "^5.30.0",
     "@trpc/server": "^11.0.0",

--- a/services/clinical-data/src/__tests__/lab-repo.test.ts
+++ b/services/clinical-data/src/__tests__/lab-repo.test.ts
@@ -117,6 +117,47 @@ describe("createLabPanel", () => {
       },
     });
   });
+
+  it("rejects a panel when a result has an invalid unit", async () => {
+    await expect(
+      createLabPanel({
+        patient_id: PATIENT_ID,
+        panel_name: "BMP",
+        results: [
+          {
+            test_name: "Glucose",
+            test_code: "2345-7",
+            value: 200,
+            unit: "mmol/L",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/Lab panel validation failed.*Glucose unit "mmol\/L" is not accepted/);
+
+    // No transaction should have been started
+    expect(transactionMock).not.toHaveBeenCalled();
+  });
+
+  it("attaches validation warnings to the emitted clinical event", async () => {
+    await createLabPanel({
+      patient_id: PATIENT_ID,
+      panel_name: "BMP",
+      results: [
+        {
+          test_name: "Glucose",
+          test_code: "2345-7",
+          value: 350,
+          unit: "mg/dL",
+        },
+      ],
+    });
+
+    const emittedEvent = emitClinicalEvent.mock.calls[0][0];
+    expect(emittedEvent.data.validationWarnings).toBeDefined();
+    expect(emittedEvent.data.validationWarnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("above typical range")]),
+    );
+  });
 });
 
 describe("getLabPanelsByPatient", () => {

--- a/services/clinical-data/src/repositories/lab-repo.ts
+++ b/services/clinical-data/src/repositories/lab-repo.ts
@@ -2,6 +2,7 @@ import { eq, and, desc } from "drizzle-orm";
 import { getDb, labPanels, labResults } from "@carebridge/db-schema";
 import type { CreateLabPanelInput } from "@carebridge/validators";
 import type { LabPanel, LabResult } from "@carebridge/shared-types";
+import { validateLabResult } from "@carebridge/medical-logic";
 import { emitClinicalEvent } from "../events.js";
 
 /**
@@ -27,6 +28,23 @@ export async function createLabPanel(
     encounter_id: input.encounter_id ?? null,
     created_at: now,
   };
+
+  // Validate every result before persisting — reject the whole panel if
+  // any result has an invalid unit (partial writes are a correctness hazard).
+  const allWarnings: string[] = [];
+  const allErrors: string[] = [];
+
+  for (const r of input.results) {
+    const v = validateLabResult(r.test_name, r.value, r.unit);
+    allErrors.push(...v.errors);
+    allWarnings.push(...v.warnings);
+  }
+
+  if (allErrors.length > 0) {
+    throw new Error(
+      `Lab panel validation failed: ${allErrors.join("; ")}`,
+    );
+  }
 
   const resultRecords = input.results.map((r) => ({
     id: crypto.randomUUID(),
@@ -55,7 +73,12 @@ export async function createLabPanel(
     type: "lab.resulted",
     patient_id: input.patient_id,
     timestamp: now,
-    data: { resourceId: panelId, panelName: input.panel_name, resultCount: input.results.length },
+    data: {
+      resourceId: panelId,
+      panelName: input.panel_name,
+      resultCount: input.results.length,
+      ...(allWarnings.length > 0 ? { validationWarnings: allWarnings } : {}),
+    },
   });
 
   const panel: LabPanel = {

--- a/services/fhir-gateway/package.json
+++ b/services/fhir-gateway/package.json
@@ -11,6 +11,7 @@
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
     "@carebridge/clinical-data": "workspace:*",
+    "@carebridge/medical-logic": "workspace:*",
     "@carebridge/validators": "workspace:*",
     "@carebridge/phi-sanitizer": "workspace:*",
     "@trpc/server": "^11.0.0",

--- a/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
+++ b/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
@@ -144,6 +144,29 @@ describe("importLabs", () => {
     }
   });
 
+  it("rejects labs with an invalid unit and reports the reason", async () => {
+    const token = createMedLensToken("patient-1", ["write:labs"]);
+    const result = await importLabs(token.token, [
+      {
+        testName: "Glucose",
+        value: 200,
+        unit: "mmol/L",
+        confidence: 0.9,
+        collectedAt: new Date().toISOString(),
+        deviceId: "meter-1",
+      },
+    ]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.rejected).toBe(1);
+      expect(result.result.accepted).toBe(0);
+      expect(result.result.rejectionReasons[0]).toMatch(
+        /Glucose.*unit "mmol\/L" is not accepted/,
+      );
+    }
+  });
+
   it("accepts labs with confidence >= 0.5", async () => {
     const token = createMedLensToken("patient-1", ["write:labs"]);
     const result = await importLabs(token.token, [

--- a/services/fhir-gateway/src/medlens-bridge.ts
+++ b/services/fhir-gateway/src/medlens-bridge.ts
@@ -10,6 +10,7 @@
 
 import crypto from "node:crypto";
 import { vitalRepo, labRepo } from "@carebridge/clinical-data";
+import { validateLabResult } from "@carebridge/medical-logic";
 import type { CreateVitalInput, CreateLabPanelInput } from "@carebridge/validators";
 
 type VitalType = CreateVitalInput["type"];
@@ -232,6 +233,17 @@ export async function importLabs(
       result.rejected++;
       result.rejectionReasons.push(
         `${lab.testName}: confidence ${lab.confidence} below threshold ${LAB_CONFIDENCE_THRESHOLD}`,
+      );
+      continue;
+    }
+
+    // Validate unit before persisting — reject early so the error shows up
+    // in the MedLens ImportResult rather than as a DB-level exception.
+    const validation = validateLabResult(lab.testName, lab.value, lab.unit);
+    if (!validation.valid) {
+      result.rejected++;
+      result.rejectionReasons.push(
+        `${lab.testName}: ${validation.errors.join("; ")}`,
       );
       continue;
     }


### PR DESCRIPTION
## Summary
- Import and call `validateLabResult` in `lab-repo.ts#createLabPanel` before the DB transaction — rejects the entire panel if any result has an invalid unit (e.g. Glucose in `mmol/L`)
- Import and call `validateLabResult` in `medlens-bridge.ts#importLabs` before `createLabPanel` — rejected labs appear in `ImportResult.rejected` with the reason string
- Non-fatal validation warnings are forwarded on the `clinical-events` payload (`data.validationWarnings`) so ai-oversight can surface them

## Test plan
- [x] New test: `createLabPanel` with Glucose in `mmol/L` throws before insert (lab-repo.test.ts)
- [x] New test: `createLabPanel` with high Glucose attaches warnings to emitted event (lab-repo.test.ts)
- [x] New test: MedLens `importLabs` with `mmol/L` counts rejection with reason (medlens-bridge.test.ts)
- [x] All 117 existing tests pass (46 clinical-data + 71 fhir-gateway)
- [x] `pnpm typecheck` and `pnpm lint` clean

Closes #539