### PR TITLE
fix(db): remove CONCURRENTLY from migration 0034 for Drizzle compat

### DIFF
--- a/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
+++ b/packages/db-schema/drizzle/0034_gin_trigger_event_ids.sql
@@ -1,5 +1,11 @@
 -- GIN index on clinical_flags.trigger_event_ids for replay-safety
 -- containment lookups (@>). jsonb_path_ops is smaller and faster than
 -- the default jsonb_ops when only @> is used.
+--
+-- NOTE: CONCURRENTLY is intentionally omitted here because Drizzle's
+-- migration runner executes each file inside a transaction block, and
+-- PostgreSQL does not allow CREATE INDEX CONCURRENTLY within a transaction.
+-- For large tables, consider running the index creation manually outside
+-- of the migration runner with CONCURRENTLY to avoid locking.
 CREATE INDEX IF NOT EXISTS idx_flags_trigger_event_ids
   ON clinical_flags USING gin (trigger_event_ids jsonb_path_ops);


### PR DESCRIPTION
## Summary
- Adds explanatory SQL comment to migration `0034_gin_trigger_event_ids.sql` clarifying why `CONCURRENTLY` is not used
- Drizzle's migration runner wraps each file in a transaction block, and PostgreSQL rejects `CREATE INDEX CONCURRENTLY` inside a transaction

## Test plan
- [ ] Verify migration 0034 runs cleanly via `pnpm db:migrate` against a fresh database
- [ ] Confirm the GIN index is created on `clinical_flags.trigger_event_ids`

Closes #617