### PR TITLE
fix(test): rename misleading pulse-pressure boundary test name

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -105,7 +105,7 @@ describe("validateVital", () => {
     expect(result.warnings.some((w) => w.toLowerCase().includes("critically narrow"))).toBe(false);
   });
 
-  it("critically warns on very narrow pulse pressure PP=15 (boundary, no critical)", () => {
+  it("does not critically warn on narrow pulse pressure at boundary PP=15", () => {
     // 90/75 — PP=15, at the critical threshold boundary (not critical)
     const result = validateVital("blood_pressure", 90, 75);
     expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(true);


### PR DESCRIPTION
## Summary
- Renames the test `"critically warns on very narrow pulse pressure PP=15 (boundary, no critical)"` to `"does not critically warn on narrow pulse pressure at boundary PP=15"` to accurately reflect that the test asserts the **absence** of a critical warning at the PP=15 boundary.

Closes #616

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Test name now matches the assertion logic (expects no critical warning)