### PR TITLE
fix(portal): guard formatAge against NaN / invalid ISO input

### DIFF
--- a/apps/clinician-portal/src/__tests__/vitals-staleness.test.ts
+++ b/apps/clinician-portal/src/__tests__/vitals-staleness.test.ts
@@ -56,6 +56,12 @@ describe("formatAge", () => {
   it("boundary: exactly 48 hours transitions to days", () => {
     expect(formatAge(ago(48 * HOUR))).toBe("2d ago");
   });
+
+  it('returns "unknown" for invalid ISO strings', () => {
+    expect(formatAge("not-a-date")).toBe("unknown");
+    expect(formatAge("")).toBe("unknown");
+    expect(formatAge("abc123")).toBe("unknown");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/clinician-portal/src/lib/vitals-staleness.ts
+++ b/apps/clinician-portal/src/lib/vitals-staleness.ts
@@ -12,6 +12,7 @@
  */
 export function formatAge(recordedAtIso: string): string {
   const ageMs = Date.now() - new Date(recordedAtIso).getTime();
+  if (Number.isNaN(ageMs)) return "unknown";
   if (ageMs < 60_000) return "just now";
   const mins = Math.round(ageMs / 60_000);
   if (mins < 60) return `${mins}m ago`;


### PR DESCRIPTION
## Summary
- Adds a `Number.isNaN(ageMs)` early-return guard in `formatAge` that returns `"unknown"` instead of `"NaNd ago"` when given an invalid ISO string
- Adds test cases covering invalid ISO inputs (`"not-a-date"`, `""`, `"abc123"`)

Closes #628

## Test plan
- [x] `pnpm --filter clinician-portal test` — all 16 formatAge tests pass (3 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (no new warnings)