### PR TITLE
fix(portal): log warning when parseAllergyStatus receives unexpected value

### DIFF
--- a/apps/clinician-portal/src/__tests__/allergy-display.test.ts
+++ b/apps/clinician-portal/src/__tests__/allergy-display.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   deriveAllergyDisplayState,
   parseAllergyStatus,
@@ -150,5 +150,31 @@ describe("parseAllergyStatus", () => {
 
   it("returns null for undefined", () => {
     expect(parseAllergyStatus(undefined)).toBeNull();
+  });
+
+  it("emits console.warn for an unexpected string value", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseAllergyStatus("bogus");
+    expect(spy).toHaveBeenCalledWith(
+      '[allergy-display] unexpected allergy_status: "bogus"',
+    );
+    spy.mockRestore();
+  });
+
+  it("emits console.warn for a non-string unexpected value", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseAllergyStatus(42);
+    expect(spy).toHaveBeenCalledWith(
+      "[allergy-display] unexpected allergy_status: 42",
+    );
+    spy.mockRestore();
+  });
+
+  it("does not warn for null or undefined", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseAllergyStatus(null);
+    parseAllergyStatus(undefined);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/apps/clinician-portal/src/lib/allergy-display.ts
+++ b/apps/clinician-portal/src/lib/allergy-display.ts
@@ -39,6 +39,9 @@ export function parseAllergyStatus(
   if (typeof value === "string" && VALID_ALLERGY_STATUSES.has(value)) {
     return value as AllergyStatus;
   }
+  if (value !== null && value !== undefined) {
+    console.warn(`[allergy-display] unexpected allergy_status: ${JSON.stringify(value)}`);
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Adds `console.warn` in `parseAllergyStatus()` when an unexpected non-null/non-undefined value is encountered, making unexpected clinical data observable in logs
- Null and undefined inputs still return `null` silently (these are expected absent-value cases)
- Adds three new test cases verifying warning emission for unexpected strings, non-string values, and no-warn for null/undefined

Closes #629

## Test plan
- [x] Existing allergy-display tests still pass (57/57)
- [x] New tests verify `console.warn` is called with the expected message format for unexpected values
- [x] New test verifies no warning for null/undefined inputs
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes