### PR TITLE
fix(ai): normalize brand names in QTC dedup to prevent false positives (#635)

### DIFF
--- a/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import { checkDrugInteractions } from "../rules/drug-interactions.js";
+
+describe("DI-QTC-COMBO brand/generic dedup", () => {
+  describe("brand + generic of the SAME drug should NOT fire", () => {
+    it("pacerone (brand) + amiodarone (generic)", () => {
+      const flags = checkDrugInteractions(["pacerone 200mg", "amiodarone 400mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("cordarone (brand) + amiodarone (generic)", () => {
+      const flags = checkDrugInteractions(["cordarone 200mg", "amiodarone 200mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("betapace (brand) + sotalol (generic)", () => {
+      const flags = checkDrugInteractions(["betapace 80mg", "sotalol 120mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("haldol (brand) + haloperidol (generic)", () => {
+      const flags = checkDrugInteractions(["haldol 5mg", "haloperidol 10mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("seroquel (brand) + quetiapine (generic)", () => {
+      const flags = checkDrugInteractions(["seroquel 100mg", "quetiapine 200mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("zithromax (brand) + azithromycin (generic)", () => {
+      const flags = checkDrugInteractions(["zithromax 250mg", "azithromycin 500mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("two brand names for the same generic (pacerone + cordarone → amiodarone)", () => {
+      const flags = checkDrugInteractions(["pacerone 200mg", "cordarone 200mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+  });
+
+  describe("brand + generic of DIFFERENT drugs SHOULD fire", () => {
+    it("pacerone (amiodarone brand) + seroquel (quetiapine brand)", () => {
+      const flags = checkDrugInteractions(["pacerone 200mg", "seroquel 100mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+
+    it("haldol (haloperidol brand) + zithromax (azithromycin brand)", () => {
+      const flags = checkDrugInteractions(["haldol 5mg", "zithromax 500mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+
+    it("betapace (sotalol brand) + geodon (ziprasidone brand)", () => {
+      const flags = checkDrugInteractions(["betapace 80mg", "geodon 40mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+
+    it("tikosyn (dofetilide brand) + risperdal (risperidone brand)", () => {
+      const flags = checkDrugInteractions(["tikosyn 500mcg", "risperdal 2mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+
+    it("zyprexa (olanzapine brand) + amiodarone (generic)", () => {
+      const flags = checkDrugInteractions(["zyprexa 10mg", "amiodarone 200mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+  });
+
+  describe("generic + generic dedup still works", () => {
+    it("same generic twice does NOT fire", () => {
+      const flags = checkDrugInteractions(["amiodarone 200mg", "amiodarone 400mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(0);
+    });
+
+    it("two different generics SHOULD fire", () => {
+      const flags = checkDrugInteractions(["amiodarone 200mg", "haloperidol 5mg"]);
+      const qtc = flags.filter((f) => f.rule_id === "DI-QTC-COMBO");
+      expect(qtc).toHaveLength(1);
+    });
+  });
+});

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -39,6 +39,69 @@ interface DrugInteractionPair {
 const QTC_PATTERN =
   /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i;
 
+/**
+ * Brand-to-generic normalization map for QTc-prolonging drugs.
+ *
+ * When deduplicating same-list regex matches (e.g. DI-QTC-COMBO), the matched
+ * substring for a brand name ("pacerone") differs from the generic
+ * ("amiodarone"), causing false-positive flags for the same underlying drug.
+ * This map normalizes brand names to their generic equivalents before the
+ * distinctness comparison.
+ */
+const BRAND_TO_GENERIC: Record<string, string> = {
+  pacerone: "amiodarone",
+  cordarone: "amiodarone",
+  betapace: "sotalol",
+  tikosyn: "dofetilide",
+  multaq: "dronedarone",
+  corvert: "ibutilide",
+  norpace: "disopyramide",
+  tambocor: "flecainide",
+  haldol: "haloperidol",
+  mellaril: "thioridazine",
+  thorazine: "chlorpromazine",
+  orap: "pimozide",
+  seroquel: "quetiapine",
+  risperdal: "risperidone",
+  zyprexa: "olanzapine",
+  geodon: "ziprasidone",
+  abilify: "aripiprazole",
+  invega: "paliperidone",
+  fanapt: "iloperidone",
+  zithromax: "azithromycin",
+  biaxin: "clarithromycin",
+  levaquin: "levofloxacin",
+  avelox: "moxifloxacin",
+  cipro: "ciprofloxacin",
+  factive: "gemifloxacin",
+  floxin: "ofloxacin",
+  zofran: "ondansetron",
+  kytril: "granisetron",
+  anzemet: "dolasetron",
+  motilium: "domperidone",
+  plaquenil: "hydroxychloroquine",
+  aralen: "chloroquine",
+  dolophine: "methadone",
+  celexa: "citalopram",
+  lexapro: "escitalopram",
+  aricept: "donepezil",
+  elavil: "amitriptyline",
+  tofranil: "imipramine",
+  pamelor: "nortriptyline",
+  anafranil: "clomipramine",
+  ultane: "sevoflurane",
+  eloxatin: "oxaliplatin",
+  caprelsa: "vandetanib",
+  sutent: "sunitinib",
+  tasigna: "nilotinib",
+};
+
+/** Normalize a matched drug name through the brand-to-generic map. */
+function normalizeToGeneric(matched: string): string {
+  const lower = matched.toLowerCase();
+  return BRAND_TO_GENERIC[lower] ?? lower;
+}
+
 const INTERACTION_PAIRS: DrugInteractionPair[] = [
   {
     id: "DI-WARFARIN-ASPIRIN",
@@ -530,7 +593,7 @@ export function checkDrugInteractions(medications: string[]): RuleFlag[] {
         distinctDrugs =
           matchA != null &&
           matchB != null &&
-          matchA[0] !== matchB[0];
+          normalizeToGeneric(matchA[0]) !== normalizeToGeneric(matchB[0]);
       } else {
         distinctDrugs =
           normalizedMeds[drugAIdx] !== normalizedMeds[drugBIdx];


### PR DESCRIPTION
## Summary
- Added a `BRAND_TO_GENERIC` normalization map for QTc-prolonging drug synonyms (46 brand-to-generic mappings covering all drugs in `QTC_PATTERN`)
- Updated the DI-QTC-COMBO same-list dedup comparison to normalize matched substrings through the map before checking distinctness, so brand+generic pairs of the same drug (e.g. "pacerone" vs "amiodarone") no longer fire false positives
- Added 14 tests covering: brand+generic same-drug pairs (should NOT fire), brand+generic different-drug pairs (SHOULD fire), two-brand same-generic pairs, and generic+generic dedup

## Test plan
- [x] All 14 new tests in `drug-interaction-rules.test.ts` pass
- [x] `pnpm typecheck` passes across the monorepo
- [x] `pnpm lint` passes (no new warnings)
- [ ] Verify existing `rules.test.ts` suite still passes in CI

Closes #635