### PR TITLE
fix(ai): align BullMQ removeOnComplete retention with reconcile interval

### DIFF
--- a/packages/redis-config/src/redis.test.ts
+++ b/packages/redis-config/src/redis.test.ts
@@ -103,7 +103,7 @@ describe("CLINICAL_EVENTS_JOB_OPTIONS", () => {
   });
 
   it("keeps history bounded", () => {
-    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnComplete).toEqual({ count: 1000 });
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnComplete).toEqual({ age: 600, count: 1000 });
     expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnFail).toEqual({ count: 10000 });
   });
 });

--- a/packages/redis-config/src/redis.ts
+++ b/packages/redis-config/src/redis.ts
@@ -38,6 +38,6 @@ export function getRedisConnection(): RedisConnectionOptions {
 export const CLINICAL_EVENTS_JOB_OPTIONS = {
   attempts: 8,
   backoff: { type: "exponential" as const, delay: 2000 },
-  removeOnComplete: { count: 1000 },
+  removeOnComplete: { age: 600, count: 1000 },
   removeOnFail: { count: 10000 },
 };

--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -45,7 +45,7 @@ vi.mock("@carebridge/redis-config", () => ({
   CLINICAL_EVENTS_JOB_OPTIONS: {
     attempts: 8,
     backoff: { type: "exponential" as const, delay: 2000 },
-    removeOnComplete: { count: 1000 },
+    removeOnComplete: { age: 600, count: 1000 },
     removeOnFail: { count: 10000 },
   },
 }));

--- a/services/ai-oversight/src/workers/escalation-worker.ts
+++ b/services/ai-oversight/src/workers/escalation-worker.ts
@@ -152,7 +152,7 @@ export function setupEscalationQueue(): Queue {
   const queue = new Queue(QUEUE_NAME, {
     connection,
     defaultJobOptions: {
-      removeOnComplete: { count: 100 },
+      removeOnComplete: { age: 600, count: 100 },
       removeOnFail: { count: 100 },
     },
   });

--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -235,7 +235,7 @@ export function setupOutboxReconcilerQueue(): Queue {
   const queue = new Queue(RECONCILER_QUEUE_NAME, {
     connection,
     defaultJobOptions: {
-      removeOnComplete: { count: 100 },
+      removeOnComplete: { age: 2 * RECONCILE_INTERVAL_MS / 1000, count: 100 },
       removeOnFail: { count: 100 },
     },
   });

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -39,7 +39,7 @@ const WORKER_MAX_STALLED_COUNT = 1;
 const dlq = new Queue(DLQ_NAME, {
   connection,
   defaultJobOptions: {
-    removeOnComplete: { count: 1000 },
+    removeOnComplete: { age: 600, count: 1000 },
     removeOnFail: { count: 10000 },
   },
 });

--- a/services/clinical-data/src/__tests__/events.test.ts
+++ b/services/clinical-data/src/__tests__/events.test.ts
@@ -12,7 +12,7 @@ vi.mock("@carebridge/redis-config", () => ({
   CLINICAL_EVENTS_JOB_OPTIONS: {
     attempts: 8,
     backoff: { type: "exponential" as const, delay: 2000 },
-    removeOnComplete: { count: 1000 },
+    removeOnComplete: { age: 600, count: 1000 },
     removeOnFail: { count: 10000 },
   },
 }));


### PR DESCRIPTION
## Summary
- Switches all BullMQ `removeOnComplete` options from count-only (`{ count: N }`) to time-based with a count cap (`{ age: 600, count: N }`), ensuring completed jobs survive at least 10 minutes (2x the 5-minute reconcile interval) before eviction.
- In the outbox reconciler queue, the age is derived directly from `RECONCILE_INTERVAL_MS` so the two values stay in lockstep.
- Updates test mocks and assertions to match the new shape.

Closes #589

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [ ] Verify `pnpm test` in ai-oversight, redis-config, and clinical-data packages
- [ ] Under burst load, confirm completed jobs remain visible to the reconciler for the full 10-minute window