### PR TITLE
test(ai): add notify_specialties assertions to statin hepatotoxin tests

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -909,6 +909,8 @@ describe("HEPATIC-HEPATOTOXIN-001 — Hepatic disease + hepatotoxic medication",
     const flag = flags.find((f) => f.rule_id === "HEPATIC-HEPATOTOXIN-001");
     expect(flag).toBeDefined();
     expect(flag!.severity).toBe("warning");
+    expect(flag!.notify_specialties).toContain("hepatology");
+    expect(flag!.notify_specialties).toContain("gastroenterology");
   });
 
   it("fires WARNING for fluvastatin at 80mg (Lescol XL)", () => {
@@ -916,6 +918,8 @@ describe("HEPATIC-HEPATOTOXIN-001 — Hepatic disease + hepatotoxic medication",
     const flag = flags.find((f) => f.rule_id === "HEPATIC-HEPATOTOXIN-001");
     expect(flag).toBeDefined();
     expect(flag!.severity).toBe("warning");
+    expect(flag!.notify_specialties).toContain("hepatology");
+    expect(flag!.notify_specialties).toContain("gastroenterology");
   });
 
   it("does NOT fire for low-dose fluvastatin (< 40mg)", () => {
@@ -929,6 +933,8 @@ describe("HEPATIC-HEPATOTOXIN-001 — Hepatic disease + hepatotoxic medication",
     const flag = flags.find((f) => f.rule_id === "HEPATIC-HEPATOTOXIN-001");
     expect(flag).toBeDefined();
     expect(flag!.severity).toBe("warning");
+    expect(flag!.notify_specialties).toContain("hepatology");
+    expect(flag!.notify_specialties).toContain("gastroenterology");
   });
 
   it("fires WARNING for pitavastatin via brand name (Livalo 4mg)", () => {
@@ -936,6 +942,8 @@ describe("HEPATIC-HEPATOTOXIN-001 — Hepatic disease + hepatotoxic medication",
     const flag = flags.find((f) => f.rule_id === "HEPATIC-HEPATOTOXIN-001");
     expect(flag).toBeDefined();
     expect(flag!.severity).toBe("warning");
+    expect(flag!.notify_specialties).toContain("hepatology");
+    expect(flag!.notify_specialties).toContain("gastroenterology");
   });
 
   it("does NOT fire for low-dose pitavastatin (< 4mg)", () => {


### PR DESCRIPTION
## Summary
- Adds `notify_specialties` assertions for `hepatology` and `gastroenterology` to the 4 positive-case statin tests (fluvastatin 40mg, fluvastatin 80mg/Lescol XL, pitavastatin 4mg, pitavastatin 4mg/Livalo) under HEPATIC-HEPATOTOXIN-001
- These tests previously only asserted `severity`, leaving notification routing uncovered

Closes #623

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test --filter=@carebridge/ai-oversight` passes with new assertions