### PR TITLE
test(clinical): add HbA1c boundary and case-variant unit tests

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -292,6 +292,22 @@ describe("validateLabResult", () => {
     expect(result.errors.some((e) => e.includes("without a unit"))).toBe(true);
   });
 
+  it("flags HbA1c 42 mmol/mol as above typical range (prediabetes boundary ~6.0 % NGSP)", () => {
+    // 42 mmol/mol → NGSP via IFCC master equation: 42 / 10.929 + 2.15 ≈ 5.993
+    // This exceeds typical_high of 5.6 %, so it should trigger a high warning.
+    const result = validateLabResult("HbA1c", 42, "mmol/mol");
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);
+  });
+
+  it("accepts HbA1c with uppercase unit MMOL/MOL (case-insensitive normalisation)", () => {
+    // Same value as above but with all-caps unit — normalizeUnit should
+    // handle it identically to lowercase "mmol/mol".
+    const result = validateLabResult("HbA1c", 42, "MMOL/MOL");
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);
+  });
+
   // Unit comparison tolerates case/whitespace variants. Real-world FHIR/HL7
   // feeds frequently send "mg/dl" (UCUM canonical) or "MG/DL" (lab vendor
   // shorthand); normalising both sides prevents false-reject errors on


### PR DESCRIPTION
## Summary
- Add test for HbA1c 42 mmol/mol (prediabetes boundary) — converts to ~6.0% NGSP via IFCC master equation, verifying it is correctly flagged as above typical_high 5.6%
- Add test for uppercase unit `"MMOL/MOL"` — confirms normalizeUnit handles case-variant IFCC units and the conversion + range check still applies

Closes #621

## Test plan
- [x] Both new tests pass in `pnpm --filter @carebridge/medical-logic exec vitest run`
- [x] `pnpm typecheck` passes (34/34 tasks)
- [x] `pnpm lint` passes (19/19 tasks)