### PR TITLE
refactor(portal): unify AllergyStatus type and runtime Set (#625)

### DIFF
--- a/apps/clinician-portal/src/lib/allergy-display.ts
+++ b/apps/clinician-portal/src/lib/allergy-display.ts
@@ -20,13 +20,9 @@
  * LLM reviewer agree on what an empty list means.
  */
 
-export type AllergyStatus = "nkda" | "unknown" | "has_allergies";
-
-const VALID_ALLERGY_STATUSES: ReadonlySet<string> = new Set<string>([
-  "nkda",
-  "unknown",
-  "has_allergies",
-]);
+const VALID_ALLERGY_STATUSES = ["nkda", "unknown", "has_allergies"] as const;
+export type AllergyStatus = (typeof VALID_ALLERGY_STATUSES)[number];
+const statusSet: ReadonlySet<string> = new Set(VALID_ALLERGY_STATUSES);
 
 /**
  * Runtime guard for allergy_status values coming from the DB or API.
@@ -36,7 +32,7 @@ const VALID_ALLERGY_STATUSES: ReadonlySet<string> = new Set<string>([
 export function parseAllergyStatus(
   value: unknown,
 ): AllergyStatus | null {
-  if (typeof value === "string" && VALID_ALLERGY_STATUSES.has(value)) {
+  if (typeof value === "string" && statusSet.has(value)) {
     return value as AllergyStatus;
   }
   return null;


### PR DESCRIPTION
## Summary
- Derive `AllergyStatus` type from the `VALID_ALLERGY_STATUSES` const array instead of maintaining both independently, preventing silent drift between the type union and the runtime validation set.
- Replaces the duplicated `ReadonlySet<string>` with a derived `statusSet` built from the single source-of-truth array.

## Test plan
- [x] `pnpm typecheck` passes (all 34 tasks)
- [x] `pnpm lint` passes (no new warnings)
- [ ] Existing `allergy-display.test.ts` tests continue to pass
- [ ] Verify allergy display renders correctly in clinician portal

Closes #625