### PR TITLE
test(ai): add negative test for sub-threshold TID acetaminophen dose

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -894,6 +894,14 @@ describe("HEPATIC-HEPATOTOXIN-001 — Hepatic disease + hepatotoxic medication",
     expect(flag).toBeUndefined();
   });
 
+  it("does NOT fire for sub-threshold TID acetaminophen (500mg × 3 = 1.5g/day < 3g)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      hepaticCtx(["acetaminophen 500mg TID"]),
+    );
+    const flag = flags.find((f) => f.rule_id === "HEPATIC-HEPATOTOXIN-001");
+    expect(flag).toBeUndefined();
+  });
+
   it("does NOT fire for low-dose statin (atorvastatin 10mg)", () => {
     const flags = checkCrossSpecialtyPatterns(
       hepaticCtx(["atorvastatin 10mg daily"]),


### PR DESCRIPTION
## Summary
- Adds a negative test case for HEPATIC-HEPATOTOXIN-001 verifying that `acetaminophen 500mg TID` (1.5g/day) does **not** fire the rule, since it falls below the 3g/day threshold
- Guards against regex drift now that the rule matches TID/q8h frequency cues

Closes #624

## Test plan
- [x] New test passes: `pnpm --filter @carebridge/ai-oversight test`
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes