### PR TITLE
refactor(clinical): use NFKC normalization in normalizeUnit

### DIFF
--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -257,10 +257,11 @@ export function validateMedicationDose(
  */
 function normalizeUnit(u: string): string {
   return u
+    .normalize("NFKC") // collapse Unicode lookalikes (e.g. µ → μ)
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "")
-    .replace(/[\u00b5\u03bc]/g, "u"); // µ (MICRO SIGN) and μ (GREEK MU) → u
+    .replace(/\u03bc/g, "u"); // μ (GREEK MU, incl. former MICRO SIGN) → u
 }
 
 /**


### PR DESCRIPTION
## Summary
- Apply `.normalize("NFKC")` as the first step in `normalizeUnit()` to automatically collapse Unicode lookalikes (e.g. U+00B5 MICRO SIGN → U+03BC GREEK MU) before further processing
- Simplify the manual regex from matching both `\u00b5` and `\u03bc` to only `\u03bc`, since NFKC already handles the former
- All 178 existing tests pass unchanged

## Test plan
- [x] `pnpm --filter @carebridge/medical-logic test` — 178/178 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (no new warnings)

Closes #618