### PR TITLE
fix(gateway): restore name_hmac to patientListColumns projection

### DIFF
--- a/services/api-gateway/src/__tests__/patient-records-list-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-list-rbac.test.ts
@@ -13,6 +13,7 @@ const ADMIN_ID = "66666666-6666-4666-8666-666666666666";
 const PATIENT_RECORD_1 = {
   id: "aaaa1111-1111-4111-8111-111111111111",
   name: "Alice Patient",
+  name_hmac: "hmac:Alice Patient",
   date_of_birth: "1980-01-01",
   biological_sex: "female",
   mrn: "MRN001",
@@ -24,6 +25,7 @@ const PATIENT_RECORD_1 = {
 const PATIENT_RECORD_2 = {
   id: "bbbb2222-2222-4222-8222-222222222222",
   name: "Bob Patient",
+  name_hmac: "hmac:Bob Patient",
   date_of_birth: "1990-06-15",
   biological_sex: "male",
   mrn: "MRN002",
@@ -115,6 +117,7 @@ vi.mock("@carebridge/db-schema", () => ({
   patients: {
     id: "patients.id",
     name: "patients.name",
+    name_hmac: "patients.name_hmac",
     date_of_birth: "patients.date_of_birth",
     biological_sex: "patients.biological_sex",
     diagnosis: "patients.diagnosis",

--- a/services/api-gateway/src/__tests__/patient-records-projection.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-projection.test.ts
@@ -15,6 +15,7 @@ const PHYSICIAN_ID = "44444444-4444-4444-8444-444444444444";
 const FULL_PATIENT_ROW = {
   id: PATIENT_ID,
   name: "Alice Patient",
+  name_hmac: "hmac:Alice Patient",
   date_of_birth: "1980-01-01",
   biological_sex: "female",
   diagnosis: "DVT",
@@ -103,6 +104,7 @@ vi.mock("@carebridge/db-schema", () => ({
   patients: {
     id: "patients.id",
     name: "patients.name",
+    name_hmac: "patients.name_hmac",
     date_of_birth: "patients.date_of_birth",
     biological_sex: "patients.biological_sex",
     diagnosis: "patients.diagnosis",
@@ -243,6 +245,7 @@ describe("patients.getById — HIPAA minimum-necessary projection", () => {
     const expected = [
       "id",
       "name",
+      "name_hmac",
       "mrn",
       "date_of_birth",
       "biological_sex",

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -89,6 +89,7 @@ async function enforcePatientAccess(
 const patientListColumns = {
   id: patients.id,
   name: patients.name,
+  name_hmac: patients.name_hmac,
   date_of_birth: patients.date_of_birth,
   biological_sex: patients.biological_sex,
   diagnosis: patients.diagnosis,
@@ -160,6 +161,7 @@ export const patientRecordsRbacRouter = t.router({
         .select({
           id: patients.id,
           name: patients.name,
+          name_hmac: patients.name_hmac,
           date_of_birth: patients.date_of_birth,
           biological_sex: patients.biological_sex,
           diagnosis: patients.diagnosis,


### PR DESCRIPTION
## Summary
- PR #605 extracted a shared `patientListColumns` projection for HIPAA minimum-necessary compliance but omitted `name_hmac`, which is required for HMAC-based patient name search
- Adds `name_hmac` to the `patientListColumns` const and the `getById` inline projection
- Updates test mocks and fixtures in both `patient-records-projection.test.ts` and `patient-records-list-rbac.test.ts` to include the field

## Audit findings
Searched `apps/clinician-portal` and `apps/patient-portal` for usage of the five fields flagged in #637:
- `diagnosis`, `primary_provider_id`, `allergy_status`, `weight_kg` — already present in `patientListColumns` (restored in the second commit of PR #605)
- `name_hmac` — **missing**, needed for deterministic HMAC-based patient name search without decryption

## Test plan
- [x] `patient-records-projection.test.ts` — 6 tests pass (includes `name_hmac` in expected getById fields)
- [x] `patient-records-list-rbac.test.ts` — 14 tests pass (mocks and fixtures updated)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)

Closes #637