### PR TITLE
refactor(notifications): adopt structured logger (#636)

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@carebridge/phi-sanitizer",
+  "name": "@carebridge/logger",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -14,15 +14,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
     "clean": "rm -rf dist"
   },
-  "dependencies": {
-    "@carebridge/logger": "workspace:*"
-  },
   "devDependencies": {
-    "typescript": "^5.7.0",
-    "@types/node": "^22.0.0",
-    "vitest": "^3.0.0"
+    "typescript": "^5.7.0"
   }
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Lightweight structured JSON logger for CareBridge services.
+ *
+ * Outputs one JSON object per line (newline-delimited JSON) so log
+ * aggregators (Datadog, Loki, CloudWatch Insights) can parse fields
+ * without regex extraction.
+ *
+ * No external dependencies — wraps Node's console with structured output.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  service: string;
+  msg: string;
+  [key: string]: unknown;
+}
+
+export interface Logger {
+  debug(msg: string, meta?: Record<string, unknown>): void;
+  info(msg: string, meta?: Record<string, unknown>): void;
+  warn(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: string, meta?: Record<string, unknown>): void;
+}
+
+/**
+ * Create a structured logger scoped to a service name.
+ *
+ * Every call emits a single JSON line to stdout (info/debug) or
+ * stderr (warn/error), matching the convention that structured log
+ * shippers expect.
+ */
+export function createLogger(service: string): Logger {
+  function emit(level: LogLevel, msg: string, meta?: Record<string, unknown>): void {
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      service,
+      msg,
+      ...meta,
+    };
+
+    const line = JSON.stringify(entry);
+
+    if (level === "error" || level === "warn") {
+      // eslint-disable-next-line no-console
+      console.error(line);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(line);
+    }
+  }
+
+  return {
+    debug: (msg, meta) => emit("debug", msg, meta),
+    info: (msg, meta) => emit("info", msg, meta),
+    warn: (msg, meta) => emit("warn", msg, meta),
+    error: (msg, meta) => emit("error", msg, meta),
+  };
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
@@ -217,17 +217,18 @@ describe("validateLLMResponse — configuration constants", () => {
 });
 
 describe("validateLLMResponse — truncation observability", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // The structured logger emits warn-level messages to stderr via console.error
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
-  it("emits a structured console.warn when flags exceed MAX_FLAGS", () => {
+  it("emits a structured log when flags exceed MAX_FLAGS", () => {
     const criticals = Array.from({ length: 2 }, () =>
       makeFlag({ severity: "critical" }),
     );
@@ -242,8 +243,8 @@ describe("validateLLMResponse — truncation observability", () => {
     const result = validateLLMResponse(input);
 
     expect(result.ok).toBe(true);
-    // Find the structured truncation log (JSON string, not a raw object).
-    const structuredCall = warnSpy.mock.calls.find(
+    // Find the structured truncation log (JSON string via structured logger).
+    const structuredCall = errorSpy.mock.calls.find(
       (call) => {
         if (typeof call[0] !== "string") return false;
         try {
@@ -257,6 +258,8 @@ describe("validateLLMResponse — truncation observability", () => {
     expect(structuredCall).toBeDefined();
     const parsed = JSON.parse(structuredCall![0] as string);
     expect(parsed).toMatchObject({
+      level: "warn",
+      service: "llm-validator",
       event: "llm_findings_truncated",
       received: 65,
       kept: 50,
@@ -275,7 +278,7 @@ describe("validateLLMResponse — truncation observability", () => {
     const result = validateLLMResponse(JSON.stringify(flags));
 
     expect(result.ok).toBe(true);
-    const structuredCall = warnSpy.mock.calls.find(
+    const structuredCall = errorSpy.mock.calls.find(
       (call) => {
         if (typeof call[0] !== "string") return false;
         try {

--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -6,6 +6,10 @@
  * enforces output limits.
  */
 
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("llm-validator");
+
 const VALID_SEVERITIES = ["critical", "warning", "info"] as const;
 const VALID_CATEGORIES = [
   "cross-specialty",
@@ -247,19 +251,15 @@ export function validateLLMResponse(raw: string): ValidationResult {
         `warning=${droppedBySeverity.warning}, info=${droppedBySeverity.info})`,
     );
     // Structured emission so log aggregators (Datadog, Loki, CloudWatch
-    // Insights) can alert on truncation counts over time. Issue #510:
-    // string-formatted alerts from the ai-oversight worker aren't reliably
-    // parseable as a counter source. Consumers that wrap a metrics emitter
-    // can still read `truncation` from the return value; this log is the
-    // low-lift stopgap until a service-wide structured logger lands.
-    console.warn(JSON.stringify({
+    // Insights) can alert on truncation counts over time.
+    log.warn("LLM findings truncated", {
       event: "llm_findings_truncated",
       received: all.length,
       kept: capped.length,
       dropped: dropped.length,
       droppedBySeverity,
       maxFlags: MAX_FLAGS,
-    }));
+    });
   }
 
   return { ok: true, flags: capped, warnings, ...(truncation ? { truncation } : {}) };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,12 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/logger:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/medical-logic:
     dependencies:
       '@carebridge/shared-types':
@@ -192,6 +198,10 @@ importers:
         version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/phi-sanitizer:
+    dependencies:
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../logger
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -613,6 +623,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@carebridge/phi-sanitizer':
         specifier: workspace:*
         version: link:../../packages/phi-sanitizer

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/logger": "workspace:*",
     "@carebridge/phi-sanitizer": "workspace:*",
     "@carebridge/redis-config": "workspace:*",
     "@trpc/server": "^11.0.0",

--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -369,8 +369,8 @@ describe("dispatch-worker", () => {
       it(`renders whitelisted category "${category}" as "${label}"`, async () => {
         primeRecipients();
 
-        const warnSpy = vi
-          .spyOn(console, "warn")
+        const errorSpy = vi
+          .spyOn(console, "error")
           .mockImplementation(() => undefined);
 
         const event = makeEvent({ severity: "warning", category });
@@ -384,17 +384,26 @@ describe("dispatch-worker", () => {
           `Clinical flag — ${label}. Open the portal to view details.`,
         );
         // Known categories must not trigger the unknown-category warning.
-        expect(warnSpy).not.toHaveBeenCalled();
+        const unknownCatCalls = errorSpy.mock.calls.filter((call) => {
+          if (typeof call[0] !== "string") return false;
+          try {
+            const parsed = JSON.parse(call[0]);
+            return parsed.msg?.includes("Unknown notification category");
+          } catch {
+            return false;
+          }
+        });
+        expect(unknownCatCalls).toHaveLength(0);
 
-        warnSpy.mockRestore();
+        errorSpy.mockRestore();
       });
     }
 
     it("falls back to 'Clinical alert' for unknown categories", async () => {
       primeRecipients();
 
-      const warnSpy = vi
-        .spyOn(console, "warn")
+      const errorSpy = vi
+        .spyOn(console, "error")
         .mockImplementation(() => undefined);
 
       const event = makeEvent({
@@ -422,26 +431,28 @@ describe("dispatch-worker", () => {
       // or fix the upstream rule/LLM output.
       // Issue #591: resolveCategoryLabel is called once per event, so the
       // unknown-category warning must fire exactly once (not once per helper).
-      const unknownWarnCalls = warnSpy.mock.calls.filter((call) =>
-        String(call[0]).includes("Unknown notification category"),
-      );
+      const unknownWarnCalls = errorSpy.mock.calls.filter((call) => {
+        if (typeof call[0] !== "string") return false;
+        try {
+          const parsed = JSON.parse(call[0]);
+          return parsed.msg?.includes("Unknown notification category");
+        } catch {
+          return false;
+        }
+      });
       expect(unknownWarnCalls).toHaveLength(1);
-      const warnCall = warnSpy.mock.calls.find((call) =>
-        String(call[0]).includes("Unknown notification category"),
-      );
-      expect(warnCall).toBeDefined();
-      const context = warnCall![1] as { category: string; fallback: string };
-      expect(context.category).toBe("hiv-status-change");
-      expect(context.fallback).toBe("Clinical alert");
+      const parsed = JSON.parse(unknownWarnCalls[0]![0] as string);
+      expect(parsed.category).toBe("hiv-status-change");
+      expect(parsed.fallback).toBe("Clinical alert");
 
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
     });
 
     it("published lock-screen payload uses fallback label and carries no PHI for unknown categories", async () => {
       primeRecipients();
 
-      const warnSpy = vi
-        .spyOn(console, "warn")
+      const errorSpy = vi
+        .spyOn(console, "error")
         .mockImplementation(() => undefined);
 
       const event = makeEvent({
@@ -463,7 +474,7 @@ describe("dispatch-worker", () => {
       expect(payload.body).not.toContain("MRN");
       expect(payload.body).not.toMatch(/\d/);
 
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -18,6 +18,7 @@ import { getDb } from "@carebridge/db-schema";
 import { notifications, users, careTeamAssignments } from "@carebridge/db-schema";
 import { eq, and, isNull, inArray } from "drizzle-orm";
 import crypto from "node:crypto";
+import { createLogger } from "@carebridge/logger";
 import type { NotificationEvent } from "../queue.js";
 import { notificationsQueue } from "../queue.js";
 import { publishNotification } from "../publish.js";
@@ -26,6 +27,8 @@ import type { FlagCategory } from "@carebridge/shared-types";
 import { filterRecipientsBySpecialty } from "./specialty-filter.js";
 import type { CandidateRecipient } from "./specialty-filter.js";
 import { getUserPreferences, evaluateDelivery } from "./preferences.js";
+
+const log = createLogger("dispatch-worker");
 
 /**
  * Whitelist of clinical flag categories that are safe to surface on a
@@ -70,10 +73,10 @@ function resolveCategoryLabel(category: string): string {
   if (isSafeCategory(category)) {
     return CATEGORY_LABELS[category];
   }
-  console.warn(
-    "[dispatch-worker] Unknown notification category — falling back to generic label",
-    { category, fallback: UNKNOWN_CATEGORY_LABEL },
-  );
+  log.warn("Unknown notification category — falling back to generic label", {
+    category,
+    fallback: UNKNOWN_CATEGORY_LABEL,
+  });
   return UNKNOWN_CATEGORY_LABEL;
 }
 
@@ -228,10 +231,11 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
   );
 
   if (recipientIds.length === 0) {
-    console.log(
-      `[dispatch-worker] No recipients found for flag ${event.flag_id} ` +
-        `(patient: ${redactPatientId(event.patient_id)}, specialties: ${event.notify_specialties.join(", ")})`,
-    );
+    log.info("No recipients found for flag", {
+      flagId: event.flag_id,
+      patient: redactPatientId(event.patient_id),
+      specialties: event.notify_specialties,
+    });
     return 0;
   }
 
@@ -266,9 +270,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
 
     if (!decision.deliver_in_app) {
       skippedCount++;
-      console.log(
-        `[dispatch-worker] Skipping notification for user ${userId} — channel disabled`,
-      );
+      log.info("Skipping notification — channel disabled", { userId });
       continue;
     }
 
@@ -276,9 +278,10 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
       // Re-queue the notification with a delay for this specific user.
       // We create a targeted delayed job rather than holding the current job.
       delayedCount++;
-      console.log(
-        `[dispatch-worker] Delaying notification for user ${userId} by ${Math.round(decision.delay_ms / 60000)}min (quiet hours)`,
-      );
+      log.info("Delaying notification (quiet hours)", {
+        userId,
+        delayMinutes: Math.round(decision.delay_ms / 60000),
+      });
       await notificationsQueue.add(
         "delayed-single",
         {
@@ -336,18 +339,21 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
         created_at: record.created_at,
       });
     } catch (error) {
-      console.error("[dispatch-worker] Failed to publish notification to Redis", {
+      log.error("Failed to publish notification to Redis", {
         notificationId: record.id,
         userId: record.user_id,
-        error,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
   }
 
-  console.log(
-    `[dispatch-worker] Flag ${event.flag_id} (severity: ${event.severity}): ` +
-      `${immediateCount} immediate, ${delayedCount} delayed, ${skippedCount} skipped`,
-  );
+  log.info("Flag dispatch complete", {
+    flagId: event.flag_id,
+    severity: event.severity,
+    immediateCount,
+    delayedCount,
+    skippedCount,
+  });
 
   return immediateCount;
 }
@@ -394,16 +400,18 @@ async function processDelayedNotification(event: NotificationEvent & { _targeted
       created_at: record.created_at,
     });
   } catch (error) {
-    console.error("[dispatch-worker] Failed to publish delayed notification to Redis", {
+    log.error("Failed to publish delayed notification to Redis", {
       notificationId: record.id,
       userId: record.user_id,
-      error,
+      error: error instanceof Error ? error.message : String(error),
     });
   }
 
-  console.log(
-    `[dispatch-worker] Delivered delayed notification ${record.id} to user ${userId} for flag ${event.flag_id}`,
-  );
+  log.info("Delivered delayed notification", {
+    notificationId: record.id,
+    userId,
+    flagId: event.flag_id,
+  });
 
   return 1;
 }
@@ -417,10 +425,12 @@ export function startDispatchWorker(): Worker {
     async (job: Job) => {
       const event = job.data as NotificationEvent & { _targeted_user_id?: string };
 
-      console.log(
-        `[dispatch-worker] Processing job ${job.id} — flag: ${event.flag_id} ` +
-          `(severity: ${event.severity}, patient: ${redactPatientId(event.patient_id)})`,
-      );
+      log.info("Processing job", {
+        jobId: job.id,
+        flagId: event.flag_id,
+        severity: event.severity,
+        patient: redactPatientId(event.patient_id),
+      });
 
       const startTime = Date.now();
 
@@ -428,10 +438,11 @@ export function startDispatchWorker(): Worker {
         let count: number;
 
         if (job.name === "delayed-single" && event._targeted_user_id) {
-          console.log(
-            `[dispatch-worker] Processing delayed job ${job.id} — flag: ${event.flag_id} ` +
-              `(user: ${event._targeted_user_id})`,
-          );
+          log.info("Processing delayed job", {
+            jobId: job.id,
+            flagId: event.flag_id,
+            userId: event._targeted_user_id,
+          });
           count = await processDelayedNotification(
             event as NotificationEvent & { _targeted_user_id: string },
           );
@@ -440,15 +451,19 @@ export function startDispatchWorker(): Worker {
         }
 
         const elapsed = Date.now() - startTime;
-        console.log(
-          `[dispatch-worker] Job ${job.id} completed in ${elapsed}ms — ${count} notifications created`,
-        );
+        log.info("Job completed", {
+          jobId: job.id,
+          elapsedMs: elapsed,
+          notificationsCreated: count,
+        });
       } catch (error) {
         const elapsed = Date.now() - startTime;
         const message = error instanceof Error ? error.message : String(error);
-        console.error(
-          `[dispatch-worker] Job ${job.id} failed after ${elapsed}ms: ${message}`,
-        );
+        log.error("Job failed", {
+          jobId: job.id,
+          elapsedMs: elapsed,
+          error: message,
+        });
         throw error;
       }
     },
@@ -459,7 +474,7 @@ export function startDispatchWorker(): Worker {
   );
 
   worker.on("ready", () => {
-    console.log(`[dispatch-worker] Worker ready, listening on queue "${QUEUE_NAME}"`);
+    log.info("Worker ready", { queue: QUEUE_NAME });
   });
 
   worker.on("failed", (job: Job | undefined, error: Error) => {
@@ -467,9 +482,12 @@ export function startDispatchWorker(): Worker {
     const maxAttempts = job?.opts?.attempts ?? 1;
     const isExhausted = attemptsMade >= maxAttempts;
 
-    console.error(
-      `[dispatch-worker] Job ${job?.id} failed (attempt ${attemptsMade}/${maxAttempts}): ${error.message}`,
-    );
+    log.error("Job failed", {
+      jobId: job?.id,
+      attemptsMade,
+      maxAttempts,
+      error: error.message,
+    });
 
     if (isExhausted && job != null) {
       const dlqPayload = {
@@ -483,15 +501,16 @@ export function startDispatchWorker(): Worker {
 
       dlq.add("dead-letter", dlqPayload).catch((dlqError: unknown) => {
         const msg = dlqError instanceof Error ? dlqError.message : String(dlqError);
-        console.error(
-          `[dispatch-worker] Failed to move job ${job.id} to DLQ: ${msg}`,
-        );
+        log.error("Failed to move job to DLQ", {
+          jobId: job.id,
+          error: msg,
+        });
       });
     }
   });
 
   worker.on("error", (error: Error) => {
-    console.error(`[dispatch-worker] Worker error: ${error.message}`);
+    log.error("Worker error", { error: error.message });
   });
 
   return worker;


### PR DESCRIPTION
## Summary
- Adds `@carebridge/logger`, a lightweight zero-dependency structured JSON logger that outputs newline-delimited JSON (timestamp, level, service, msg, metadata) for log aggregator parsing
- Replaces all raw `console.warn`/`console.error`/`console.log` calls in `services/notifications/src/workers/dispatch-worker.ts` with structured `log.info`/`log.warn`/`log.error` calls carrying metadata objects
- Replaces the manual `JSON.stringify` + `console.warn` call in `packages/phi-sanitizer/src/llm-validator.ts` with a structured `log.warn` call
- Updates llm-validator tests to assert against the new structured output format

Closes #636

## Test plan
- [x] `pnpm typecheck` passes (36/36 tasks)
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm --filter @carebridge/phi-sanitizer test` passes (83/83 tests)
- [ ] Verify JSON log output is parseable by your log aggregator in staging