### PR TITLE
fix(ai): add retraction predicates for labs and procedures

### DIFF
--- a/services/ai-oversight/src/__tests__/event-time-snapshot.test.ts
+++ b/services/ai-oversight/src/__tests__/event-time-snapshot.test.ts
@@ -6,6 +6,8 @@ import {
   isDiagnosisRetracted,
   isAllergyRetracted,
   isMedicationRetracted,
+  isLabRetracted,
+  isProcedureRetracted,
 } from "../utils/event-time-snapshot.js";
 
 describe("event-time-snapshot helpers", () => {
@@ -99,6 +101,43 @@ describe("event-time-snapshot helpers", () => {
       expect(isMedicationRetracted({ status: "stopped" })).toBe(false);
       expect(isMedicationRetracted({ status: null })).toBe(false);
       expect(isMedicationRetracted({})).toBe(false);
+    });
+  });
+
+  describe("isLabRetracted", () => {
+    it("returns true for status=entered_in_error", () => {
+      expect(isLabRetracted({ status: "entered_in_error" })).toBe(true);
+    });
+
+    it("returns true for flag=entered_in_error (current schema path)", () => {
+      expect(isLabRetracted({ flag: "entered_in_error" })).toBe(true);
+    });
+
+    it("returns true when both status and flag indicate retraction", () => {
+      expect(isLabRetracted({ status: "entered_in_error", flag: "entered_in_error" })).toBe(true);
+    });
+
+    it("returns false for normal flag values / null / missing", () => {
+      expect(isLabRetracted({ flag: "H" })).toBe(false);
+      expect(isLabRetracted({ flag: "L" })).toBe(false);
+      expect(isLabRetracted({ status: "final" })).toBe(false);
+      expect(isLabRetracted({ status: "preliminary" })).toBe(false);
+      expect(isLabRetracted({ status: null, flag: null })).toBe(false);
+      expect(isLabRetracted({})).toBe(false);
+    });
+  });
+
+  describe("isProcedureRetracted", () => {
+    it("returns true only for status=entered_in_error", () => {
+      expect(isProcedureRetracted({ status: "entered_in_error" })).toBe(true);
+    });
+
+    it("returns false for scheduled / completed / cancelled / null", () => {
+      expect(isProcedureRetracted({ status: "scheduled" })).toBe(false);
+      expect(isProcedureRetracted({ status: "completed" })).toBe(false);
+      expect(isProcedureRetracted({ status: "cancelled" })).toBe(false);
+      expect(isProcedureRetracted({ status: null })).toBe(false);
+      expect(isProcedureRetracted({})).toBe(false);
     });
   });
 });

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -50,6 +50,7 @@ import {
   isDiagnosisRetracted,
   isAllergyRetracted,
   isMedicationRetracted,
+  isLabRetracted,
 } from "../utils/event-time-snapshot.js";
 import { buildPatientContext } from "../workers/context-builder.js";
 import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
@@ -578,6 +579,7 @@ export async function buildPatientContextForRules(
         test_name: labResults.test_name,
         value: labResults.value,
         created_at: labResults.created_at,
+        flag: labResults.flag,
       })
       .from(labResults)
       .innerJoin(labPanels, eq(labResults.panel_id, labPanels.id))
@@ -636,6 +638,7 @@ export async function buildPatientContextForRules(
   const seenLabs = new Set<string>();
   const recentLabs: Array<{ name: string; value: number }> = [];
   for (const row of recentLabRows) {
+    if (isLabRetracted(row)) continue;
     if (isoBefore(eventAt, row.created_at)) continue;
     if (seenLabs.has(row.test_name)) continue;
     seenLabs.add(row.test_name);

--- a/services/ai-oversight/src/utils/event-time-snapshot.ts
+++ b/services/ai-oversight/src/utils/event-time-snapshot.ts
@@ -16,10 +16,10 @@
  * variant the platform ingests.
  *
  * ─── Logical retraction (#515) ────────────────────────────────────────
- * A row marked `entered_in_error` (diagnoses, medications) or
- * `entered_in_error` / `refuted` (allergies) is a charting correction.
- * It was never clinically true and must never drive rule or LLM output,
- * regardless of its timestamps.
+ * A row marked `entered_in_error` (diagnoses, medications, labs,
+ * procedures) or `entered_in_error` / `refuted` (allergies) is a
+ * charting correction. It was never clinically true and must never
+ * drive rule or LLM output, regardless of its timestamps.
  */
 
 /**
@@ -86,5 +86,27 @@ export function isAllergyRetracted(row: { verification_status?: string | null })
  * cross-refs, and LLM context. See #581.
  */
 export function isMedicationRetracted(row: { status?: string | null }): boolean {
+  return row.status === "entered_in_error";
+}
+
+/**
+ * Logical retraction for a lab result row. The `lab_results` table does
+ * not yet carry a dedicated `status` column, but the `flag` field can
+ * hold `"entered_in_error"` when a FHIR import or manual correction
+ * marks the result as erroneous. We also check `status` so that when
+ * the schema adds that column the guard works without further changes.
+ * See #638.
+ */
+export function isLabRetracted(row: { status?: string | null; flag?: string | null }): boolean {
+  return row.status === "entered_in_error" || row.flag === "entered_in_error";
+}
+
+/**
+ * Logical retraction for a procedure row. `status === 'entered_in_error'`
+ * means the procedure was charted by mistake — it never actually occurred
+ * and must be excluded from cross-specialty rules and LLM context.
+ * See #638.
+ */
+export function isProcedureRetracted(row: { status?: string | null }): boolean {
   return row.status === "entered_in_error";
 }

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -31,6 +31,7 @@ import {
   isDiagnosisRetracted,
   isAllergyRetracted,
   isMedicationRetracted,
+  isLabRetracted,
 } from "../utils/event-time-snapshot.js";
 import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 
@@ -237,7 +238,7 @@ export async function buildPatientContext(
       .where(inArray(labResults.panel_id, panelIds));
 
     recentLabResults = allResults
-      .filter((r) => isoLTE(r.created_at, eventAt))
+      .filter((r) => !isLabRetracted(r) && isoLTE(r.created_at, eventAt))
       .slice(0, 50)
       .map((r) => ({
         test_name: r.test_name,


### PR DESCRIPTION
## Summary
- Add `isLabRetracted` and `isProcedureRetracted` predicates to `event-time-snapshot.ts`, matching the existing pattern for diagnoses, allergies, and medications
- Wire `isLabRetracted` into both the LLM context path (`context-builder.ts`) and the deterministic rule path (`review-service.ts`) so `entered_in_error` lab rows are excluded from clinical review
- `isLabRetracted` checks both `status` and `flag` fields since `lab_results` currently uses `flag` rather than a dedicated `status` column
- `isProcedureRetracted` checks `status` on `procedures` (which has an existing status column); not yet wired into filter sites since procedures aren't currently queried in the review pipeline
- Add unit tests for both new predicates

Closes #638

## Test plan
- [x] `isLabRetracted` returns `true` for `status=entered_in_error` and `flag=entered_in_error`
- [x] `isLabRetracted` returns `false` for normal flag values (H, L), other statuses, null, missing
- [x] `isProcedureRetracted` returns `true` only for `status=entered_in_error`
- [x] `isProcedureRetracted` returns `false` for scheduled, completed, cancelled, null, missing
- [x] All 18 event-time-snapshot tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes