### PR TITLE
fix(test): rename misleading PP=25 boundary test name

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -92,7 +92,7 @@ describe("validateVital", () => {
 
   // ─── Pulse-pressure boundary tests (issue #519) ────────────────
 
-  it("warns on narrow pulse pressure at boundary PP=25 (no warning)", () => {
+  it("does not warn on pulse pressure at boundary PP=25", () => {
     // 100/75 — PP=25, just above the narrow threshold
     const result = validateVital("blood_pressure", 100, 75);
     expect(result.warnings.some((w) => w.toLowerCase().includes("narrow pulse pressure"))).toBe(false);


### PR DESCRIPTION
## Summary
- Renames test `"warns on narrow pulse pressure at boundary PP=25 (no warning)"` to `"does not warn on pulse pressure at boundary PP=25"` to accurately reflect its assertion (expects no warning)

Closes #663

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes