### PR TITLE
test(ai): remove hardcoded 150 assertion in db-clock idempotency test

### DIFF
--- a/services/ai-oversight/src/__tests__/review-service-db-clock-idempotency.test.ts
+++ b/services/ai-oversight/src/__tests__/review-service-db-clock-idempotency.test.ts
@@ -212,7 +212,6 @@ describe("DB-clock interval derivation in idempotency probe", () => {
     // vice versa), this test catches the drift because the derivation now
     // uses the constant directly.
     const expectedSec = IN_FLIGHT_WINDOW_MS / 1000;
-    expect(expectedSec).toBe(150);
     expect(Number.isInteger(expectedSec)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Removes the hardcoded `expect(expectedSec).toBe(150)` assertion in the db-clock idempotency test
- Keeps the `Number.isInteger` check so the test still validates the constant produces a whole-second interval without being brittle to value changes

Closes #672

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes