### PR TITLE
fix(clinical): add Creatinine umol/L to mg/dL unit conversion (#670)

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -391,17 +391,25 @@ describe("validateLabResult", () => {
     expect(microSign.valid).toBe(asciiU.valid);
   });
 
-  it("normalises µmol/L (U+00B5) to umol/L in allowed_units rejection", () => {
-    // Creatinine only allows mg/dL — both µmol/L and umol/L must be
-    // rejected identically, proving normalisation runs before the
-    // allowed_units comparison (positive-path acceptance requires a
-    // corresponding UNIT_CONVERSIONS entry, so we test equivalence here).
-    const microSign = validateLabResult("Creatinine", 88.4, "\u00b5mol/L");
-    const asciiU = validateLabResult("Creatinine", 88.4, "umol/L");
-    expect(microSign.valid).toBe(false);
-    expect(asciiU.valid).toBe(false);
-    expect(microSign.errors).toHaveLength(1);
-    expect(asciiU.errors).toHaveLength(1);
+  it("accepts Creatinine in umol/L — 88.4 umol/L converts to 1.0 mg/dL (normal, no warnings)", () => {
+    // 88.4 µmol/L ÷ 88.4 = 1.0 mg/dL → within 0.6–1.2 typical range
+    const result = validateLabResult("Creatinine", 88.4, "umol/L");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("accepts Creatinine in µmol/L (U+00B5) — normalises to umol/L", () => {
+    // µ (MICRO SIGN U+00B5) normalises to u, so µmol/L matches umol/L
+    const result = validateLabResult("Creatinine", 88.4, "\u00b5mol/L");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("warns on Creatinine 200 umol/L (above typical range — ~2.26 mg/dL)", () => {
+    // 200 µmol/L ÷ 88.4 ≈ 2.26 mg/dL → above 1.2 mg/dL typical high
+    const result = validateLabResult("Creatinine", 200, "umol/L");
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);
   });
 
   it("error message quotes the caller's original (non-normalized) unit", () => {

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -288,6 +288,9 @@ const UNIT_CONVERSIONS: Record<
   HbA1c: {
     "mmol/mol": (v: number) => IFCC_SLOPE * v + IFCC_INTERCEPT,
   },
+  Creatinine: {
+    "umol/l": (v: number) => v / 88.4,
+  },
 };
 
 export function validateLabResult(

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -225,7 +225,7 @@ export const COMMON_LAB_TESTS: Record<string, CommonLabTest> = {
   // administered as 200 mmol/L insulin dosing guidance is fatal.
   Glucose: { unit: "mg/dL", typical_low: 70, typical_high: 100, allowed_units: ["mg/dL"] },
   BUN: { unit: "mg/dL", typical_low: 7, typical_high: 20, allowed_units: ["mg/dL"] },
-  Creatinine: { unit: "mg/dL", typical_low: 0.6, typical_high: 1.2, allowed_units: ["mg/dL"] },
+  Creatinine: { unit: "mg/dL", typical_low: 0.6, typical_high: 1.2, allowed_units: ["mg/dL", "umol/L"] },
   GFR: { unit: "mL/min", typical_low: 90, typical_high: 120 },
   Sodium: { unit: "mEq/L", typical_low: 136, typical_high: 145, allowed_units: ["mEq/L", "mmol/L"] },
   Potassium: { unit: "mEq/L", typical_low: 3.5, typical_high: 5.0, allowed_units: ["mEq/L", "mmol/L"] },


### PR DESCRIPTION
## Summary
- Add `umol/L` back to Creatinine's `allowed_units` in `COMMON_LAB_TESTS` (was removed by PR #658)
- Add Creatinine entry to `UNIT_CONVERSIONS` with factor `v / 88.4` (umol/L to mg/dL)
- Update tests: 88.4 umol/L converts to 1.0 mg/dL (within normal range, no warnings), Unicode micro sign normalisation, and above-range detection at 200 umol/L

Closes #670

## Test plan
- [x] `pnpm typecheck` passes (36/36 packages)
- [x] `pnpm lint` passes (no new warnings)
- [x] `vitest run` in medical-logic passes (183/183 tests, including 3 new Creatinine umol/L tests)