### PR TITLE
test(gateway): harden mock thenable to respect selectColumns filtering

### DIFF
--- a/services/api-gateway/src/__tests__/patient-records-projection.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-projection.test.ts
@@ -74,7 +74,20 @@ const mocks = vi.hoisted(() => {
       (result as Record<string, unknown>).then = (
         resolve: (v: unknown) => void,
       ) => {
-        resolve(resolvedData);
+        if (selectColumns) {
+          const keys = Object.keys(selectColumns);
+          resolve(
+            resolvedData.map((row) => {
+              const out: Record<string, unknown> = {};
+              for (const k of keys) {
+                out[k] = (row as Record<string, unknown>)[k];
+              }
+              return out;
+            }),
+          );
+        } else {
+          resolve(resolvedData);
+        }
         return result;
       };
       return result;


### PR DESCRIPTION
## Summary
- Fixes #630
- The mock `.from` chain's `.then` handler was resolving raw `resolvedData` without applying `selectColumns` filtering, which meant bare `await db.select(cols).from(table)` calls bypassed column projection in tests
- Updated `.then` on `.from` to apply the same `selectColumns` key-filtering logic already used in `.where`, ensuring the mock faithfully simulates Drizzle column selection

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` in `services/api-gateway` confirms projection tests still pass with the hardened mock