### PR TITLE
test(ai): sync assertion for QTC_PATTERN vs BRAND_TO_GENERIC

### DIFF
--- a/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
@@ -1,6 +1,44 @@
 import { describe, it, expect } from "vitest";
 
-import { checkDrugInteractions } from "../rules/drug-interactions.js";
+import {
+  checkDrugInteractions,
+  QTC_PATTERN,
+  BRAND_TO_GENERIC,
+} from "../rules/drug-interactions.js";
+
+describe("QTC_PATTERN ↔ BRAND_TO_GENERIC sync", () => {
+  const alternates = QTC_PATTERN.source.split("|");
+
+  it("every BRAND_TO_GENERIC key appears in QTC_PATTERN alternates", () => {
+    for (const brand of Object.keys(BRAND_TO_GENERIC)) {
+      expect(alternates).toContain(brand);
+    }
+  });
+
+  it("every BRAND_TO_GENERIC value (generic) appears in QTC_PATTERN alternates", () => {
+    const genericValues = [...new Set(Object.values(BRAND_TO_GENERIC))];
+    for (const generic of genericValues) {
+      expect(alternates).toContain(generic);
+    }
+  });
+
+  it("every alternate is either a generic (not in BRAND_TO_GENERIC keys) or a known brand", () => {
+    const brandKeys = new Set(Object.keys(BRAND_TO_GENERIC));
+    const genericValues = new Set(Object.values(BRAND_TO_GENERIC));
+
+    for (const alt of alternates) {
+      const isBrand = brandKeys.has(alt);
+      const isGeneric = !brandKeys.has(alt);
+      // If it's a brand, it must map to a generic that's also in the pattern
+      if (isBrand) {
+        expect(genericValues).toContain(BRAND_TO_GENERIC[alt]);
+        expect(alternates).toContain(BRAND_TO_GENERIC[alt]!);
+      }
+      // Every alternate must be accounted for: either a brand key or a standalone generic
+      expect(isBrand || isGeneric).toBe(true);
+    }
+  });
+});
 
 describe("DI-QTC-COMBO brand/generic dedup", () => {
   describe("brand + generic of the SAME drug should NOT fire", () => {

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -36,7 +36,7 @@ interface DrugInteractionPair {
  * DI-QTC-COMBO rule so the pattern is defined in exactly one place. Curated
  * from CredibleMeds QTDrugs (Known Risk + Possible Risk) and FDA labeling.
  */
-const QTC_PATTERN =
+export const QTC_PATTERN =
   /amiodarone|pacerone|cordarone|sotalol|betapace|dofetilide|tikosyn|dronedarone|multaq|ibutilide|corvert|quinidine|procainamide|disopyramide|norpace|flecainide|tambocor|haloperidol|haldol|thioridazine|mellaril|chlorpromazine|thorazine|pimozide|orap|droperidol|quetiapine|seroquel|risperidone|risperdal|olanzapine|zyprexa|ziprasidone|geodon|aripiprazole|abilify|paliperidone|invega|iloperidone|fanapt|azithromycin|zithromax|erythromycin|clarithromycin|biaxin|levofloxacin|levaquin|moxifloxacin|avelox|ciprofloxacin|cipro|gemifloxacin|factive|ofloxacin|floxin|ondansetron|zofran|granisetron|kytril|dolasetron|anzemet|domperidone|motilium|hydroxychloroquine|plaquenil|chloroquine|aralen|quinine|methadone|dolophine|citalopram|celexa|escitalopram|lexapro|donepezil|aricept|amitriptyline|elavil|imipramine|tofranil|nortriptyline|pamelor|clomipramine|anafranil|sevoflurane|ultane|oxaliplatin|eloxatin|vandetanib|caprelsa|sunitinib|sutent|nilotinib|tasigna/i;
 
 /**
@@ -48,7 +48,7 @@ const QTC_PATTERN =
  * This map normalizes brand names to their generic equivalents before the
  * distinctness comparison.
  */
-const BRAND_TO_GENERIC: Record<string, string> = {
+export const BRAND_TO_GENERIC: Record<string, string> = {
   pacerone: "amiodarone",
   cordarone: "amiodarone",
   betapace: "sotalol",


### PR DESCRIPTION
## Summary
- Export `QTC_PATTERN` and `BRAND_TO_GENERIC` from `drug-interactions.ts` so they can be tested directly
- Add three sync-assertion tests that verify every `BRAND_TO_GENERIC` key appears in `QTC_PATTERN` alternates, every generic value appears in the alternates, and every brand in the pattern maps back correctly
- Guards against drift between the regex and the normalization map

Closes #668

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] All 17 tests in `drug-interaction-rules.test.ts` pass (14 existing + 3 new)