### PR TITLE
refactor(ai): use Drizzle InferSelectModel for ClaimedRow type

### DIFF
--- a/services/ai-oversight/src/workers/outbox-reconciler.ts
+++ b/services/ai-oversight/src/workers/outbox-reconciler.ts
@@ -24,7 +24,7 @@
 
 import { Queue, Worker } from "bullmq";
 import type { Job } from "bullmq";
-import { and, eq, sql } from "drizzle-orm";
+import { type InferSelectModel, and, eq, sql } from "drizzle-orm";
 import {
   getRedisConnection,
   CLINICAL_EVENTS_JOB_OPTIONS,
@@ -71,16 +71,7 @@ export interface ReconcileResult {
   failed: number;
 }
 
-type ClaimedRow = {
-  id: string;
-  event_type: string;
-  patient_id: string;
-  event_payload: unknown;
-  status: string;
-  retry_count: number | null;
-  created_at: string;
-  updated_at: string | null;
-};
+type ClaimedRow = InferSelectModel<typeof failedClinicalEvents>;
 
 /**
  * Drain one batch of pending outbox rows. Exported for tests.


### PR DESCRIPTION
## Summary
- Replace manually duplicated `ClaimedRow` type in `outbox-reconciler.ts` with `InferSelectModel<typeof failedClinicalEvents>` from drizzle-orm
- Eliminates drift risk between the DB schema and the worker's row type

Closes #590

## Test plan
- [x] `pnpm typecheck` passes (ai-oversight cache miss, rebuilt clean)
- [x] `pnpm lint` passes with no new warnings