### PR TITLE
refactor(ai): export DEFAULT_RETENTION_AGE_SECONDS from redis-config

### DIFF
--- a/packages/redis-config/src/index.ts
+++ b/packages/redis-config/src/index.ts
@@ -1,2 +1,6 @@
-export { getRedisConnection, CLINICAL_EVENTS_JOB_OPTIONS } from "./redis.js";
+export {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+  DEFAULT_RETENTION_AGE_SECONDS,
+} from "./redis.js";
 export type { RedisConnectionOptions } from "./redis.js";

--- a/packages/redis-config/src/redis.test.ts
+++ b/packages/redis-config/src/redis.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   getRedisConnection,
   CLINICAL_EVENTS_JOB_OPTIONS,
+  DEFAULT_RETENTION_AGE_SECONDS,
 } from "./redis.js";
 
 describe("getRedisConnection", () => {
@@ -103,7 +104,7 @@ describe("CLINICAL_EVENTS_JOB_OPTIONS", () => {
   });
 
   it("keeps history bounded", () => {
-    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnComplete).toEqual({ age: 600, count: 1000 });
+    expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnComplete).toEqual({ age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 });
     expect(CLINICAL_EVENTS_JOB_OPTIONS.removeOnFail).toEqual({ count: 10000 });
   });
 });

--- a/packages/redis-config/src/redis.ts
+++ b/packages/redis-config/src/redis.ts
@@ -35,9 +35,12 @@ export function getRedisConnection(): RedisConnectionOptions {
  * (api-gateway, clinical-data, clinical-notes, patient-records, and
  * messaging) in lockstep so future bumps can't drift.
  */
+/** Default retention age (in seconds) for completed BullMQ jobs. */
+export const DEFAULT_RETENTION_AGE_SECONDS = 600;
+
 export const CLINICAL_EVENTS_JOB_OPTIONS = {
   attempts: 8,
   backoff: { type: "exponential" as const, delay: 2000 },
-  removeOnComplete: { age: 600, count: 1000 },
+  removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 },
   removeOnFail: { count: 10000 },
 };

--- a/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
+++ b/services/ai-oversight/src/__tests__/outbox-reconciler.test.ts
@@ -42,6 +42,7 @@ vi.mock("@carebridge/db-schema", () => ({
 
 vi.mock("@carebridge/redis-config", () => ({
   getRedisConnection: () => ({}),
+  DEFAULT_RETENTION_AGE_SECONDS: 600,
   CLINICAL_EVENTS_JOB_OPTIONS: {
     attempts: 8,
     backoff: { type: "exponential" as const, delay: 2000 },

--- a/services/ai-oversight/src/workers/escalation-worker.ts
+++ b/services/ai-oversight/src/workers/escalation-worker.ts
@@ -29,7 +29,7 @@
 
 import { Queue, Worker } from "bullmq";
 import type { Job } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import { getRedisConnection, DEFAULT_RETENTION_AGE_SECONDS } from "@carebridge/redis-config";
 import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { getDb } from "@carebridge/db-schema";
 import { clinicalFlags } from "@carebridge/db-schema";
@@ -152,7 +152,7 @@ export function setupEscalationQueue(): Queue {
   const queue = new Queue(QUEUE_NAME, {
     connection,
     defaultJobOptions: {
-      removeOnComplete: { age: 600, count: 100 },
+      removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 100 },
       removeOnFail: { count: 100 },
     },
   });

--- a/services/ai-oversight/src/workers/review-worker.ts
+++ b/services/ai-oversight/src/workers/review-worker.ts
@@ -9,7 +9,7 @@
 import { Worker, Queue } from "bullmq";
 import type { Job } from "bullmq";
 import type { ClinicalEvent } from "@carebridge/shared-types";
-import { getRedisConnection } from "@carebridge/redis-config";
+import { getRedisConnection, DEFAULT_RETENTION_AGE_SECONDS } from "@carebridge/redis-config";
 import { redactPatientId } from "@carebridge/phi-sanitizer";
 import { processReviewJob } from "../services/review-service.js";
 
@@ -39,7 +39,7 @@ const WORKER_MAX_STALLED_COUNT = 1;
 const dlq = new Queue(DLQ_NAME, {
   connection,
   defaultJobOptions: {
-    removeOnComplete: { age: 600, count: 1000 },
+    removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 },
     removeOnFail: { count: 10000 },
   },
 });

--- a/services/clinical-data/src/__tests__/events.test.ts
+++ b/services/clinical-data/src/__tests__/events.test.ts
@@ -9,6 +9,7 @@ vi.mock("bullmq", () => ({
 
 vi.mock("@carebridge/redis-config", () => ({
   getRedisConnection: () => ({}),
+  DEFAULT_RETENTION_AGE_SECONDS: 600,
   CLINICAL_EVENTS_JOB_OPTIONS: {
     attempts: 8,
     backoff: { type: "exponential" as const, delay: 2000 },


### PR DESCRIPTION
## Summary
- Exports a `DEFAULT_RETENTION_AGE_SECONDS` constant (600) from `@carebridge/redis-config` to eliminate the magic number `age: 600` scattered across BullMQ queue configs
- Replaces all `age: 600` literals in `redis.ts`, `review-worker.ts`, and `escalation-worker.ts` with the shared constant
- Updates test mocks and assertions to reference the constant

## Test plan
- [x] `pnpm typecheck` passes (36/36 packages)
- [x] `pnpm lint` passes (no new warnings)
- [ ] CI green on PR

Closes #667