### PR TITLE
test(logger): add unit tests for @carebridge/logger package

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -13,10 +13,12 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/packages/logger/src/__tests__/index.test.ts
+++ b/packages/logger/src/__tests__/index.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createLogger } from "../index.js";
+
+describe("createLogger", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an object with debug, info, warn, error methods", () => {
+    const logger = createLogger("test-service");
+    expect(typeof logger.debug).toBe("function");
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.warn).toBe("function");
+    expect(typeof logger.error).toBe("function");
+  });
+
+  it("sets the service field from the createLogger argument", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logger = createLogger("my-service");
+    logger.info("hello");
+
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry.service).toBe("my-service");
+  });
+
+  describe("NDJSON output", () => {
+    it("emits valid JSON on a single line", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.info("test message");
+
+      expect(spy).toHaveBeenCalledOnce();
+      const raw = spy.mock.calls[0]![0] as string;
+      // Should not contain newlines (NDJSON = one JSON object per line)
+      expect(raw).not.toContain("\n");
+      const parsed = JSON.parse(raw);
+      expect(parsed).toHaveProperty("timestamp");
+      expect(parsed).toHaveProperty("level", "info");
+      expect(parsed).toHaveProperty("service", "svc");
+      expect(parsed).toHaveProperty("msg", "test message");
+    });
+
+    it("includes an ISO 8601 timestamp", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.info("ts check");
+
+      const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+      // ISO 8601 format check — Date constructor should accept it
+      expect(new Date(entry.timestamp).toISOString()).toBe(entry.timestamp);
+    });
+  });
+
+  describe("log level routing", () => {
+    it("routes debug to console.log", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.debug("dbg");
+
+      expect(logSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).not.toHaveBeenCalled();
+      const entry = JSON.parse(logSpy.mock.calls[0]![0] as string);
+      expect(entry.level).toBe("debug");
+    });
+
+    it("routes info to console.log", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.info("inf");
+
+      expect(logSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).not.toHaveBeenCalled();
+      const entry = JSON.parse(logSpy.mock.calls[0]![0] as string);
+      expect(entry.level).toBe("info");
+    });
+
+    it("routes warn to console.error", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.warn("wrn");
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(logSpy).not.toHaveBeenCalled();
+      const entry = JSON.parse(errorSpy.mock.calls[0]![0] as string);
+      expect(entry.level).toBe("warn");
+    });
+
+    it("routes error to console.error", () => {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.error("err");
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(logSpy).not.toHaveBeenCalled();
+      const entry = JSON.parse(errorSpy.mock.calls[0]![0] as string);
+      expect(entry.level).toBe("error");
+    });
+  });
+
+  describe("metadata merging", () => {
+    it("spreads metadata fields into the log entry", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.info("with meta", { requestId: "abc-123", userId: "u-1" });
+
+      const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+      expect(entry.requestId).toBe("abc-123");
+      expect(entry.userId).toBe("u-1");
+      expect(entry.msg).toBe("with meta");
+    });
+
+    it("works without metadata", () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = createLogger("svc");
+      logger.info("no meta");
+
+      const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+      expect(entry.msg).toBe("no meta");
+      // Only base fields present
+      expect(Object.keys(entry).sort()).toEqual(
+        ["level", "msg", "service", "timestamp"].sort(),
+      );
+    });
+
+    it("preserves base fields when metadata has extra keys", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const logger = createLogger("audit-svc");
+      logger.error("failure", { code: 500, detail: "timeout" });
+
+      const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+      expect(entry.service).toBe("audit-svc");
+      expect(entry.level).toBe("error");
+      expect(entry.msg).toBe("failure");
+      expect(entry.code).toBe(500);
+      expect(entry.detail).toBe("timeout");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/medical-logic:
     dependencies:
@@ -5412,8 +5415,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5432,7 +5435,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5443,22 +5446,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5469,7 +5472,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Adds 11 unit tests for `@carebridge/logger` covering all requirements from #675
- Tests validate: valid NDJSON output, ISO 8601 timestamps, debug/info routing to `console.log`, warn/error routing to `console.error`, metadata merging with base fields, and service name propagation from `createLogger` argument
- Adds `vitest` dev dependency and `test` script to the logger package

Closes #675

## Test plan
- [x] `pnpm --filter @carebridge/logger test` — 11/11 passing
- [x] `pnpm typecheck` — all 36 tasks pass
- [x] `pnpm lint` — all 20 tasks pass (no new warnings)