### PR TITLE
refactor(notifications): cache resolveCategoryLabel in delayed path

### DIFF
--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -287,6 +287,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
         {
           ...event,
           _targeted_user_id: userId,
+          _resolved_category_label: categoryLabel,
         },
         { delay: decision.delay_ms },
       );
@@ -361,10 +362,13 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
 /**
  * Process a delayed single-user notification that was re-queued after quiet hours.
  */
-async function processDelayedNotification(event: NotificationEvent & { _targeted_user_id: string }): Promise<number> {
+async function processDelayedNotification(event: NotificationEvent & { _targeted_user_id: string; _resolved_category_label?: string }): Promise<number> {
   const db = getDb();
   const userId = event._targeted_user_id;
-  const categoryLabel = resolveCategoryLabel(event.category);
+  // Prefer the label cached in the delayed-job payload (set by
+  // processNotificationJob) to avoid redundant resolution — and
+  // duplicate warning logs for unknown categories.
+  const categoryLabel = event._resolved_category_label ?? resolveCategoryLabel(event.category);
   const title = buildNotificationTitle(event, categoryLabel);
   const link = buildFlagLink(event);
   const now = new Date().toISOString();
@@ -423,7 +427,7 @@ export function startDispatchWorker(): Worker {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {
-      const event = job.data as NotificationEvent & { _targeted_user_id?: string };
+      const event = job.data as NotificationEvent & { _targeted_user_id?: string; _resolved_category_label?: string };
 
       log.info("Processing job", {
         jobId: job.id,


### PR DESCRIPTION
## Summary
- Pass the already-resolved `categoryLabel` through the delayed-job payload (`_resolved_category_label`) so `processDelayedNotification` reuses it instead of calling `resolveCategoryLabel` independently
- Falls back to `resolveCategoryLabel` if the cached field is absent (backward-compatible with any in-flight delayed jobs from before this change)
- Eliminates duplicate warning logs for unknown categories on the delayed path

Closes #640

## Test plan
- [ ] Verify typecheck and lint pass (`pnpm typecheck && pnpm lint`)
- [ ] Trigger a notification for a user in quiet hours; confirm the delayed job payload includes `_resolved_category_label`
- [ ] Confirm unknown categories log a warning only once (on the initial dispatch), not again on the delayed path