### PR TITLE
refactor(clinical): skip redundant re-validation in createLabPanel

### DIFF
--- a/services/clinical-data/src/repositories/lab-repo.ts
+++ b/services/clinical-data/src/repositories/lab-repo.ts
@@ -11,6 +11,7 @@ import { emitClinicalEvent } from "../events.js";
  */
 export async function createLabPanel(
   input: CreateLabPanelInput,
+  options?: { skipValidation?: boolean },
 ): Promise<{ panel: LabPanel; results: LabResult[] }> {
   const db = getDb();
   const now = new Date().toISOString();
@@ -31,13 +32,17 @@ export async function createLabPanel(
 
   // Validate every result before persisting — reject the whole panel if
   // any result has an invalid unit (partial writes are a correctness hazard).
+  // Callers that have already validated can pass { skipValidation: true }
+  // to avoid redundant work (e.g. MedLens bridge).
   const allWarnings: string[] = [];
   const allErrors: string[] = [];
 
-  for (const r of input.results) {
-    const v = validateLabResult(r.test_name, r.value, r.unit);
-    allErrors.push(...v.errors);
-    allWarnings.push(...v.warnings);
+  if (!options?.skipValidation) {
+    for (const r of input.results) {
+      const v = validateLabResult(r.test_name, r.value, r.unit);
+      allErrors.push(...v.errors);
+      allWarnings.push(...v.warnings);
+    }
   }
 
   if (allErrors.length > 0) {

--- a/services/fhir-gateway/src/medlens-bridge.ts
+++ b/services/fhir-gateway/src/medlens-bridge.ts
@@ -264,7 +264,7 @@ export async function importLabs(
           },
         ],
       };
-      await labRepo.createLabPanel(panelInput);
+      await labRepo.createLabPanel(panelInput, { skipValidation: true });
       result.accepted++;
     } catch (err) {
       result.rejected++;


### PR DESCRIPTION
## Summary
- Add optional `skipValidation` parameter to `createLabPanel` so pre-validated callers can avoid redundant `validateLabResult` calls
- Update MedLens bridge `importLabs` to pass `{ skipValidation: true }` since it already validates each lab result before calling `createLabPanel`

## Test plan
- [ ] Existing `lab-repo.test.ts` tests pass (default path still validates)
- [ ] `medlens-bridge.test.ts` tests pass (bridge still validates before calling createLabPanel)
- [ ] Manual: import a lab with an invalid unit via MedLens bridge -- rejection still surfaces in ImportResult
- [ ] Manual: create a lab panel via tRPC route (no skipValidation) -- validation still runs

Closes #641