### PR TITLE
test(ai): medication retraction filtering integration tests (#632)

### DIFF
--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -392,14 +392,12 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     diagnosesSelect.mockResolvedValue([]);
     medicationsSelect.mockResolvedValue([]);
     labsSelect.mockResolvedValue([
-      // Retracted lab — charting mistake, must not appear in recent_labs.
       {
         test_name: "ANC",
         value: 200,
         created_at: "2026-04-16T08:00:00.000Z",
         flag: "entered_in_error",
       },
-      // Valid lab — should appear.
       {
         test_name: "WBC",
         value: 4.5,
@@ -411,7 +409,6 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
 
     expect(ctx.recent_labs).toBeDefined();
     expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 4.5 }]);
-    // Verify the retracted lab is explicitly absent.
     const labNames = (ctx.recent_labs ?? []).map((l) => l.name);
     expect(labNames).not.toContain("ANC");
   });
@@ -440,6 +437,63 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     const ctx = await buildPatientContextForRules("p-1", event);
 
     expect(ctx.recent_labs).toBeUndefined();
+  });
+
+  // ─── #632 — exclude entered_in_error medications ───────────────────
+  it("excludes a medication with status=entered_in_error even when timestamps say active", async () => {
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Methotrexate (charting mistake)",
+        status: "entered_in_error",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        name: "Cisplatin",
+        status: "active",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-01T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_medications).not.toContain(
+      "Methotrexate (charting mistake)",
+    );
+    expect(ctx.active_medications).toContain("Cisplatin");
+  });
+
+  it("excludes entered_in_error medication even when it has no ended_at (open-ended retraction)", async () => {
+    const event: ClinicalEvent = {
+      ...stubEvent,
+      timestamp: "2026-04-16T12:00:00.000Z",
+    };
+
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Warfarin (never actually ordered)",
+        status: "entered_in_error",
+        started_at: "2026-04-10T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-10T00:00:00.000Z",
+      },
+    ]);
+    labsSelect.mockResolvedValue([]);
+
+    const ctx = await buildPatientContextForRules("p-1", event);
+
+    expect(ctx.active_medications).toHaveLength(0);
   });
 
   it("keeps allergies with verification_status=null (schema default `unconfirmed`)", async () => {

--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -341,6 +341,60 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
     );
   });
 
+  // ─── #632 — exclude entered_in_error medications ───────────────────
+  it("excludes a medication with status=entered_in_error even when timestamps say active", async () => {
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Methotrexate (charting mistake)",
+        status: "entered_in_error",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-01T00:00:00.000Z",
+        dose_amount: "15",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "Weekly",
+      },
+      {
+        name: "Cisplatin",
+        status: "active",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-01T00:00:00.000Z",
+        dose_amount: "75",
+        dose_unit: "mg/m2",
+        route: "IV",
+        frequency: "Q3W",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    const medNames = ctx.active_medications.map((m) => m.name);
+    expect(medNames).not.toContain("Methotrexate (charting mistake)");
+    expect(medNames).toContain("Cisplatin");
+  });
+
+  it("excludes entered_in_error medication even when it has no ended_at (open-ended retraction)", async () => {
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Warfarin (never actually ordered)",
+        status: "entered_in_error",
+        started_at: "2026-04-10T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-10T00:00:00.000Z",
+        dose_amount: "5",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "Daily",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    expect(ctx.active_medications).toHaveLength(0);
+  });
+
   // ─── #515 — exclude logical retractions ────────────────────────────
   it("excludes a diagnosis with status=entered_in_error even when timestamps say active", async () => {
     diagnosesSelect.mockResolvedValue([


### PR DESCRIPTION
## Summary
- Add integration tests verifying `entered_in_error` medication rows are excluded by `buildPatientContextForRules` (rule path) and `buildPatientContext` (LLM path)
- Each path gets two tests: one confirming retracted meds are excluded while active meds remain, and one confirming an open-ended retraction (no `ended_at`) is also excluded
- Follows existing test patterns for diagnosis and allergy retraction filtering established in #515

## Test plan
- [x] All 473 ai-oversight tests pass (including 4 new)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Verified new tests match mock patterns from sibling retraction tests

Closes #632