### PR TITLE
fix(clinical): preserve validationWarnings when skipValidation is true

### DIFF
--- a/services/clinical-data/src/repositories/lab-repo.ts
+++ b/services/clinical-data/src/repositories/lab-repo.ts
@@ -37,11 +37,11 @@ export async function createLabPanel(
   const allWarnings: string[] = [];
   const allErrors: string[] = [];
 
-  if (!options?.skipValidation) {
-    for (const r of input.results) {
-      const v = validateLabResult(r.test_name, r.value, r.unit);
+  for (const r of input.results) {
+    const v = validateLabResult(r.test_name, r.value, r.unit);
+    allWarnings.push(...v.warnings);
+    if (!options?.skipValidation) {
       allErrors.push(...v.errors);
-      allWarnings.push(...v.warnings);
     }
   }
 


### PR DESCRIPTION
## Summary
- Always run the `validateLabResult` warning-collection pass in `createLabPanel`, even when `skipValidation: true`
- Only skip the error-collection/reject path when `skipValidation` is set
- Fixes #704: `allWarnings` array was empty when callers (e.g. MedLens bridge) passed `skipValidation: true`, causing `validationWarnings` to be missing from emitted clinical events

## Test plan
- [ ] Call `createLabPanel` with `skipValidation: true` and results that trigger warnings; verify `validationWarnings` is present in the emitted `lab.resulted` event
- [ ] Call `createLabPanel` without `skipValidation` and results with errors; verify the panel is still rejected
- [ ] Call `createLabPanel` without `skipValidation` and results with warnings only; verify warnings are collected and errors array is empty