### PR TITLE
test(gateway): apply selectColumns projection in mock .limit() handler

### DIFF
--- a/services/api-gateway/src/__tests__/patient-records-projection.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-projection.test.ts
@@ -43,29 +43,31 @@ const mocks = vi.hoisted(() => {
   let selectColumns: Record<string, unknown> | undefined = undefined;
   let resolvedData: unknown[] = [];
 
+  /**
+   * Shared projection helper — if `selectColumns` is set, strip each row
+   * down to only those keys so the mock faithfully simulates Drizzle
+   * column selection. Used by `.where()`, `.limit()`, and `.then()`.
+   */
+  function applyProjection(rows: unknown[]): unknown[] {
+    if (!selectColumns) return rows;
+    const keys = Object.keys(selectColumns);
+    return rows.map((row) => {
+      const out: Record<string, unknown> = {};
+      for (const k of keys) {
+        out[k] = (row as Record<string, unknown>)[k];
+      }
+      return out;
+    });
+  }
+
   function makeSelectChain() {
     const chain: Record<string, unknown> = {};
     chain.from = fn((..._args: unknown[]) => chain);
     chain.innerJoin = fn((..._args: unknown[]) => chain);
     chain.where = fn((..._args: unknown[]) => {
-      // Return projected rows: if selectColumns is set, filter each row
-      // down to only those keys so the mock faithfully simulates Drizzle
-      // column selection.
-      if (selectColumns) {
-        const keys = Object.keys(selectColumns);
-        return Promise.resolve(
-          resolvedData.map((row) => {
-            const out: Record<string, unknown> = {};
-            for (const k of keys) {
-              out[k] = (row as Record<string, unknown>)[k];
-            }
-            return out;
-          }),
-        );
-      }
-      return Promise.resolve(resolvedData);
+      return Promise.resolve(applyProjection(resolvedData));
     });
-    chain.limit = fn(async () => resolvedData);
+    chain.limit = fn(async () => applyProjection(resolvedData));
     // Make the chain thenable for bare `await db.select().from()`
     (chain as Record<string | symbol, unknown>)[Symbol.toStringTag] = "Promise";
     const originalFrom = chain.from;
@@ -74,20 +76,7 @@ const mocks = vi.hoisted(() => {
       (result as Record<string, unknown>).then = (
         resolve: (v: unknown) => void,
       ) => {
-        if (selectColumns) {
-          const keys = Object.keys(selectColumns);
-          resolve(
-            resolvedData.map((row) => {
-              const out: Record<string, unknown> = {};
-              for (const k of keys) {
-                out[k] = (row as Record<string, unknown>)[k];
-              }
-              return out;
-            }),
-          );
-        } else {
-          resolve(resolvedData);
-        }
+        resolve(applyProjection(resolvedData));
         return result;
       };
       return result;


### PR DESCRIPTION
## Summary
- Extract shared `applyProjection` helper in patient-records-projection test mock to eliminate duplicated projection logic
- Apply projection in `.limit()` handler which previously returned raw data without filtering by `selectColumns`
- Consolidate identical projection logic from `.where()` and `.then()` handlers to use the shared helper

Closes #700

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Existing patient-records-projection tests continue to pass with corrected `.limit()` mock behavior