### PR TITLE
refactor(notifications): extract DelayedNotificationPayload type alias

### DIFF
--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -59,6 +59,17 @@ type SafeCategory = keyof typeof CATEGORY_LABELS;
 
 const UNKNOWN_CATEGORY_LABEL = "Clinical alert";
 
+/**
+ * Payload shape for delayed single-user notifications re-queued after quiet
+ * hours. Extends the base `NotificationEvent` with an optional targeted user
+ * and a cached category label to avoid redundant resolution (and duplicate
+ * warning logs for unknown categories).
+ */
+type DelayedNotificationPayload = NotificationEvent & {
+  _targeted_user_id?: string;
+  _resolved_category_label?: string;
+};
+
 function isSafeCategory(category: string): category is SafeCategory {
   return Object.prototype.hasOwnProperty.call(CATEGORY_LABELS, category);
 }
@@ -362,7 +373,7 @@ async function processNotificationJob(event: NotificationEvent): Promise<number>
 /**
  * Process a delayed single-user notification that was re-queued after quiet hours.
  */
-async function processDelayedNotification(event: NotificationEvent & { _targeted_user_id: string; _resolved_category_label?: string }): Promise<number> {
+async function processDelayedNotification(event: DelayedNotificationPayload & { _targeted_user_id: string }): Promise<number> {
   const db = getDb();
   const userId = event._targeted_user_id;
   // Prefer the label cached in the delayed-job payload (set by
@@ -427,7 +438,7 @@ export function startDispatchWorker(): Worker {
   const worker = new Worker(
     QUEUE_NAME,
     async (job: Job) => {
-      const event = job.data as NotificationEvent & { _targeted_user_id?: string; _resolved_category_label?: string };
+      const event = job.data as DelayedNotificationPayload;
 
       log.info("Processing job", {
         jobId: job.id,
@@ -448,7 +459,7 @@ export function startDispatchWorker(): Worker {
             userId: event._targeted_user_id,
           });
           count = await processDelayedNotification(
-            event as NotificationEvent & { _targeted_user_id: string },
+            event as DelayedNotificationPayload & { _targeted_user_id: string },
           );
         } else {
           count = await processNotificationJob(event);


### PR DESCRIPTION
## Summary
- Extracts a named `DelayedNotificationPayload` type alias from the repeated inline intersection `NotificationEvent & { _targeted_user_id?: string; _resolved_category_label?: string }` in `dispatch-worker.ts`
- Replaces all three occurrences (function signature, `job.data` cast, and call-site cast) with the new type alias
- No behavioral changes; `pnpm typecheck` and `pnpm lint` pass cleanly

Closes #705

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Existing notification dispatch tests continue to pass in CI