### PR TITLE
fix(portal): guard classifyStaleness against NaN/invalid timestamps

### DIFF
--- a/apps/clinician-portal/src/__tests__/vitals-staleness.test.ts
+++ b/apps/clinician-portal/src/__tests__/vitals-staleness.test.ts
@@ -109,9 +109,11 @@ describe("classifyStaleness", () => {
     expect(classifyStaleness(future)).toBe("current");
   });
 
-  it('invalid ISO string falls through to "current" (NaN comparisons)', () => {
+  it('returns "stale" for invalid ISO strings (NaN guard)', () => {
     // new Date("not-a-date").getTime() => NaN; Date.now() - NaN => NaN
-    // NaN > 24h => false; NaN > 4h => false => falls through to "current"
-    expect(classifyStaleness("not-a-date")).toBe("current");
+    // NaN is caught by the Number.isNaN guard and treated as stale
+    expect(classifyStaleness("not-a-date")).toBe("stale");
+    expect(classifyStaleness("")).toBe("stale");
+    expect(classifyStaleness("abc123")).toBe("stale");
   });
 });

--- a/apps/clinician-portal/src/lib/vitals-staleness.ts
+++ b/apps/clinician-portal/src/lib/vitals-staleness.ts
@@ -37,6 +37,7 @@ export type StalenessTier = "current" | "overdue" | "stale";
 
 export function classifyStaleness(recordedAtIso: string): StalenessTier {
   const ageMs = Date.now() - new Date(recordedAtIso).getTime();
+  if (Number.isNaN(ageMs)) return "stale";
   if (ageMs > 24 * 60 * 60 * 1000) return "stale";
   if (ageMs > 4 * 60 * 60 * 1000) return "overdue";
   return "current";


### PR DESCRIPTION
## Summary
- Add `Number.isNaN(ageMs)` guard to `classifyStaleness()` in `vitals-staleness.ts`, returning `"stale"` for invalid/unparseable timestamps instead of silently falling through to `"current"`
- Matches the existing guard pattern in `formatAge()` which already handles NaN
- Update test to expect `"stale"` for invalid inputs and add additional invalid-string cases

Closes #698

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [ ] `vitest` unit tests for `classifyStaleness` confirm `"stale"` for `"not-a-date"`, `""`, `"abc123"`