### PR TITLE
docs(clinical): update UNIT_CONVERSIONS JSDoc to include Creatinine

### DIFF
--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -280,6 +280,7 @@ const IFCC_INTERCEPT = 2.152;
  * Currently supported:
  *  - HbA1c: IFCC mmol/mol → NGSP % via the IFCC master equation
  *    NGSP% = 0.09148 × IFCC + 2.152
+ *  - Creatinine: µmol/L → mg/dL (divide by 88.4)
  */
 const UNIT_CONVERSIONS: Record<
   string,


### PR DESCRIPTION
## Summary
- Add the Creatinine conversion (umol/L to mg/dL, divide by 88.4) to the `UNIT_CONVERSIONS` JSDoc comment so the enumerated list matches the actual map entries.

Closes #697

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- Comment-only change; no runtime behavior affected