### PR TITLE
feat(portal): render completed medications in clinician portal

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -592,6 +592,7 @@ function MedicationsTab({ patientId }: { patientId: string }) {
   const active = medications.filter((m) => m.status === "active");
   const held = medications.filter((m) => m.status === "held");
   const discontinued = medications.filter((m) => m.status === "discontinued");
+  const completed = medications.filter((m) => m.status === "completed");
 
   if (medications.length === 0) {
     return (
@@ -712,6 +713,51 @@ function MedicationsTab({ patientId }: { patientId: string }) {
                       }}
                     >
                       Discontinued
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {completed.length > 0 && (
+        <div className="table-container">
+          <div className="table-header">
+            <span className="table-title" style={{ color: "var(--text-muted)" }}>
+              Completed
+            </span>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Medication</th>
+                <th>Dose</th>
+                <th>Route</th>
+                <th>Frequency</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {completed.map((med) => (
+                <tr key={med.id}>
+                  <td style={{ color: "var(--text-muted)" }}>{med.name}</td>
+                  <td style={{ color: "var(--text-muted)" }}>
+                    {med.dose_amount} {med.dose_unit}
+                  </td>
+                  <td style={{ color: "var(--text-muted)" }}>{med.route}</td>
+                  <td style={{ color: "var(--text-muted)" }}>{med.frequency}</td>
+                  <td>
+                    <span
+                      className="badge"
+                      style={{
+                        background: "rgba(99,179,237,0.1)",
+                        color: "#63b3ed",
+                        border: "1px solid rgba(99,179,237,0.3)",
+                      }}
+                    >
+                      Completed
                     </span>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- Add a "Completed" section to the `MedicationsTab` in the clinician portal patient detail page
- Medications with `status === "completed"` were previously silently dropped; they now render in their own table section below Discontinued
- The Completed badge uses a distinct blue color scheme to differentiate from Discontinued (muted/grey) and other statuses

Closes #596

## Test plan
- [ ] Seed or create a medication with `status: "completed"` for a patient
- [ ] Navigate to the patient detail page, Medications tab
- [ ] Verify the Completed section appears with the blue badge
- [ ] Verify Active, Held, and Discontinued sections are unchanged
- [ ] Verify no section renders when its list is empty