### PR TITLE
refactor(notifications): adopt structured logger in server.ts and router.ts

### DIFF
--- a/services/notifications/src/router.ts
+++ b/services/notifications/src/router.ts
@@ -4,7 +4,10 @@ import { getDb } from "@carebridge/db-schema";
 import { notifications, notificationPreferences } from "@carebridge/db-schema";
 import { eq, and, desc } from "drizzle-orm";
 import crypto from "node:crypto";
+import { createLogger } from "@carebridge/logger";
 import { publishNotification } from "./publish.js";
+
+const log = createLogger("notifications");
 
 const t = initTRPC.create();
 
@@ -67,10 +70,10 @@ export const notificationsRouter = t.router({
           created_at: notification.created_at,
         });
       } catch (error) {
-        console.error("[notifications] Failed to publish notification to Redis", {
+        log.error("Failed to publish notification to Redis", {
           notificationId: notification.id,
           userId: notification.user_id,
-          error,
+          error: error instanceof Error ? error.message : String(error),
         });
       }
 

--- a/services/notifications/src/server.ts
+++ b/services/notifications/src/server.ts
@@ -6,8 +6,11 @@
  */
 
 import { createServer } from "node:http";
+import { createLogger } from "@carebridge/logger";
 import { startDispatchWorker } from "./workers/dispatch-worker.js";
 import { shutdownPublisher } from "./publish.js";
+
+const log = createLogger("notifications");
 
 const HEALTH_PORT = Number(process.env.NOTIFICATION_HEALTH_PORT ?? 4002);
 
@@ -48,15 +51,15 @@ const healthServer = createServer(async (req, res) => {
 });
 
 healthServer.listen(HEALTH_PORT, () => {
-  console.log(`[notifications] Health check listening on port ${HEALTH_PORT}`);
+  log.info(`Health check listening on port ${HEALTH_PORT}`);
 });
 
 async function shutdown(signal: string) {
-  console.log(`[notifications] Received ${signal}, shutting down…`);
+  log.info(`Received ${signal}, shutting down…`);
   healthServer.close();
   await worker.close();
   await shutdownPublisher();
-  console.log("[notifications] Shutdown complete");
+  log.info("Shutdown complete");
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Replace 3 raw `console.log`/`console.error` calls in `services/notifications/src/server.ts` with `createLogger("notifications")` from `@carebridge/logger`
- Replace 1 raw `console.error` call in `services/notifications/src/router.ts` with the structured logger
- Serializes the error object in router.ts to a string for clean JSON log output

Closes #676

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [ ] Verify health-check startup log emits structured JSON
- [ ] Verify graceful shutdown logs emit structured JSON
- [ ] Verify Redis publish failure logs structured JSON with notificationId/userId