### PR TITLE
refactor(ai): apply age-based removeOnComplete to all BullMQ queues

### DIFF
--- a/services/auth/src/cleanup-worker.ts
+++ b/services/auth/src/cleanup-worker.ts
@@ -1,5 +1,5 @@
 import { Queue, Worker } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import { getRedisConnection, DEFAULT_RETENTION_AGE_SECONDS } from "@carebridge/redis-config";
 import { cleanupExpiredSessions } from "./session-cleanup.js";
 
 const QUEUE_NAME = "session-cleanup";
@@ -18,7 +18,7 @@ export async function startCleanupWorker(): Promise<{
   const queue = new Queue(QUEUE_NAME, {
     connection,
     defaultJobOptions: {
-      removeOnComplete: { count: 1000 },
+      removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 },
       removeOnFail: { count: 10000 },
     },
   });

--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -60,6 +60,7 @@ vi.mock("@carebridge/db-schema", () => ({
 
 vi.mock("@carebridge/redis-config", () => ({
   getRedisConnection: () => ({}),
+  DEFAULT_RETENTION_AGE_SECONDS: 600,
 }));
 
 vi.mock("bullmq", () => ({

--- a/services/notifications/src/queue.ts
+++ b/services/notifications/src/queue.ts
@@ -6,7 +6,7 @@
  */
 
 import { Queue } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import { getRedisConnection, DEFAULT_RETENTION_AGE_SECONDS } from "@carebridge/redis-config";
 
 const QUEUE_NAME = "notifications";
 
@@ -29,7 +29,7 @@ export const notificationsQueue = new Queue(QUEUE_NAME, {
   defaultJobOptions: {
     attempts: 3,
     backoff: { type: "exponential", delay: 2000 },
-    removeOnComplete: { count: 1000 },
+    removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 },
     removeOnFail: { count: 5000 },
   },
 });

--- a/services/notifications/src/workers/dispatch-worker.ts
+++ b/services/notifications/src/workers/dispatch-worker.ts
@@ -13,7 +13,7 @@
 
 import { Worker, Queue } from "bullmq";
 import type { Job } from "bullmq";
-import { getRedisConnection } from "@carebridge/redis-config";
+import { getRedisConnection, DEFAULT_RETENTION_AGE_SECONDS } from "@carebridge/redis-config";
 import { getDb } from "@carebridge/db-schema";
 import { notifications, users, careTeamAssignments } from "@carebridge/db-schema";
 import { eq, and, isNull, inArray } from "drizzle-orm";
@@ -88,7 +88,7 @@ const connection = getRedisConnection();
 const dlq = new Queue(DLQ_NAME, {
   connection,
   defaultJobOptions: {
-    removeOnComplete: { count: 1000 },
+    removeOnComplete: { age: DEFAULT_RETENTION_AGE_SECONDS, count: 1000 },
     removeOnFail: { count: 10000 },
   },
 });


### PR DESCRIPTION
## Summary
- Add `age: DEFAULT_RETENTION_AGE_SECONDS` alongside existing `count` caps on three BullMQ queues that were missing it: notifications queue, notifications-failed DLQ, and session-cleanup
- Import the shared constant from `@carebridge/redis-config` in each file, matching the pattern already used by ai-oversight workers
- Update the dispatch-worker test mock to export `DEFAULT_RETENTION_AGE_SECONDS`

Closes #665

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [ ] Verify dispatch-worker tests pass with updated mock