### PR TITLE
chore(ai): add timestamp_fallback_total metric for ops alerting

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@carebridge/medical-logic':
         specifier: workspace:*
         version: link:../../packages/medical-logic
@@ -5415,8 +5418,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5435,7 +5438,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5446,22 +5449,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5472,7 +5475,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/services/ai-oversight/package.json
+++ b/services/ai-oversight/package.json
@@ -20,6 +20,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@carebridge/logger": "workspace:*",
     "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/notifications": "workspace:*",

--- a/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
+++ b/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+import type { LogEntry } from "@carebridge/logger";
+
 import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 
 // Fixed reference time so tests are deterministic across timezones and CI
@@ -8,45 +10,55 @@ import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 const NOW_MS = Date.UTC(2026, 3, 16, 12, 0, 0);
 const now = () => NOW_MS;
 
+/** Parse the structured JSON line emitted by the logger on stderr. */
+function parseLogEntry(spy: ReturnType<typeof vi.spyOn>, callIndex = 0): LogEntry {
+  return JSON.parse(spy.mock.calls[callIndex][0] as string) as LogEntry;
+}
+
 describe("validateEventTimestamp", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("returns a valid ISO-8601 timestamp unchanged and logs nothing", () => {
     const ts = "2026-04-16T11:59:00.000Z";
     const result = validateEventTimestamp(ts, { now });
     expect(result).toBe(ts);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("falls back to now when timestamp is undefined, and warns", () => {
     const result = validateEventTimestamp(undefined, { now, eventId: "evt-1" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("missing");
-    expect(warnSpy.mock.calls[0][0]).toContain("evt-1");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.level).toBe("warn");
+    expect(entry.reason).toBe("missing");
+    expect(entry.eventId).toBe("evt-1");
   });
 
   it("falls back to now when timestamp is an empty string, and warns", () => {
     const result = validateEventTimestamp("", { now, eventId: "evt-2" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("empty");
-    expect(warnSpy.mock.calls[0][0]).toContain("evt-2");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.level).toBe("warn");
+    expect(entry.reason).toBe("empty");
+    expect(entry.eventId).toBe("evt-2");
   });
 
   it("falls back to now when timestamp is whitespace-only", () => {
     const result = validateEventTimestamp("   ", { now });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("empty");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.reason).toBe("empty");
   });
 
   it("falls back to now when timestamp is unparseable, and warns", () => {
@@ -55,9 +67,11 @@ describe("validateEventTimestamp", () => {
       eventId: "evt-3",
     });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("unparseable");
-    expect(warnSpy.mock.calls[0][0]).toContain("evt-3");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.level).toBe("warn");
+    expect(entry.reason).toBe("unparseable");
+    expect(entry.eventId).toBe("evt-3");
   });
 
   it("falls back to now when timestamp is more than 1 minute in the future", () => {
@@ -65,8 +79,9 @@ describe("validateEventTimestamp", () => {
     const future = new Date(NOW_MS + 5 * 60 * 1000).toISOString();
     const result = validateEventTimestamp(future, { now, eventId: "evt-4" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("future");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.reason).toBe("future");
   });
 
   it("accepts a timestamp within the 1-minute clock-skew grace window", () => {
@@ -74,15 +89,16 @@ describe("validateEventTimestamp", () => {
     const slightlyFuture = new Date(NOW_MS + 30 * 1000).toISOString();
     const result = validateEventTimestamp(slightlyFuture, { now });
     expect(result).toBe(slightlyFuture);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
   it("falls back to now when timestamp is before year 2000 (epoch-leak guard)", () => {
     const epoch = "1970-01-01T00:00:00.000Z";
     const result = validateEventTimestamp(epoch, { now, eventId: "evt-5" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("too-old");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.reason).toBe("too-old");
   });
 
   it("falls back when a non-string value leaks through the type boundary", () => {
@@ -94,17 +110,19 @@ describe("validateEventTimestamp", () => {
       { now, eventId: "evt-6" },
     );
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("not-a-string");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.reason).toBe("not-a-string");
   });
 
-  it("uses the caller label in the log prefix", () => {
+  it("uses the caller label in the structured log output", () => {
     validateEventTimestamp("", {
       now,
       eventId: "evt-7",
       caller: "context-builder",
     });
-    expect(warnSpy.mock.calls[0][0]).toContain("[context-builder]");
+    const entry = parseLogEntry(errorSpy);
+    expect(entry.caller).toBe("context-builder");
   });
 
   it("calls now() exactly once even when the fallback path is taken (#585)", () => {

--- a/services/ai-oversight/src/utils/validate-event-timestamp.ts
+++ b/services/ai-oversight/src/utils/validate-event-timestamp.ts
@@ -1,3 +1,7 @@
+import { createLogger } from "@carebridge/logger";
+
+const logger = createLogger("ai-oversight");
+
 /**
  * Validate and normalize a ClinicalEvent.timestamp before it is used as the
  * right-hand side of a snapshot comparison inside a context builder.
@@ -62,10 +66,14 @@ export function validateEventTimestamp(
 
   const fallback = (reason: string, value: unknown): string => {
     const iso = new Date(nowMs).toISOString();
-    console.warn(
-      `[${caller}] invalid event.timestamp (event=${eventId}, reason=${reason}, ` +
-        `value=${JSON.stringify(value)}) — falling back to now=${iso}`,
-    );
+    logger.warn("timestamp_fallback_total", {
+      metric: "timestamp_fallback_total",
+      caller,
+      eventId,
+      reason,
+      value: JSON.stringify(value),
+      fallbackTimestamp: iso,
+    });
     return iso;
   };
 


### PR DESCRIPTION
## Summary
- Replaces raw `console.warn` in `validateEventTimestamp` with structured logging via `@carebridge/logger`
- Emits a `timestamp_fallback_total` warn-level log line with `metric`, `caller`, `eventId`, `reason`, `value`, and `fallbackTimestamp` fields so log aggregators can count fallback occurrences and ops can set threshold alerts
- Adds `@carebridge/logger` as a dependency of `@carebridge/ai-oversight`

Closes #586

## Test plan
- [ ] Verify `pnpm typecheck` and `pnpm lint` pass (confirmed locally)
- [ ] Confirm structured JSON log line appears in stderr when a fallback path is triggered (e.g., missing or malformed timestamp in a clinical event)
- [ ] Validate that existing `validate-event-timestamp` unit tests still pass