### PR TITLE
refactor(ai): reduce public API surface of phi-sanitizer exports

### DIFF
--- a/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
+++ b/packages/phi-sanitizer/src/__tests__/llm-validator.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  validateLLMResponse,
-  MAX_FLAGS,
-  SUSPICIOUS_FLAG_THRESHOLD,
-} from "../llm-validator.js";
+import { validateLLMResponse } from "../llm-validator.js";
+import { MAX_FLAGS, SUSPICIOUS_FLAG_THRESHOLD } from "../constants.js";
 
 function makeFlag(overrides: Record<string, unknown> = {}) {
   return {

--- a/packages/phi-sanitizer/src/constants.ts
+++ b/packages/phi-sanitizer/src/constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared constants for the phi-sanitizer package.
+ *
+ * These are intentionally NOT re-exported from the package barrel
+ * (`index.ts`) to keep the public API surface minimal.
+ */
+
+/** Hard ceiling on the number of flags a single LLM review may produce. */
+export const MAX_FLAGS = 50;
+
+/**
+ * Threshold at which a single LLM review's flag count is considered
+ * "suspiciously high" and a warning is appended to the validation result.
+ *
+ * Originally 15 when MAX_FLAGS was 20 (see PR #493 history) — i.e. 75% of
+ * cap, which reads as "the LLM is approaching the hard ceiling; something
+ * may be off (prompt regression, prompt-injection probe, runaway model)."
+ *
+ * When MAX_FLAGS was raised 20 -> 50, this constant was left at 15, which
+ * meant the warning fired at 30% of capacity. At that level a multi-system
+ * oncology patient routinely trips the warning, drowning real signal in
+ * noise (see issue #511).
+ *
+ * We re-peg the threshold to the original "near-cap" semantics at ~75%
+ * of MAX_FLAGS. floor(50 * 0.75) = 37. Derived from MAX_FLAGS so future
+ * cap changes automatically preserve the ratio; the suspicious-count
+ * test asserts the numeric value to catch accidental drift.
+ */
+export const SUSPICIOUS_FLAG_THRESHOLD = Math.floor(MAX_FLAGS * 0.75);

--- a/packages/phi-sanitizer/src/index.ts
+++ b/packages/phi-sanitizer/src/index.ts
@@ -1,2 +1,9 @@
 export * from "./redactor.js";
-export * from "./llm-validator.js";
+export {
+  validateLLMResponse,
+  type LLMFlag,
+  type TruncationInfo,
+  type ValidationSuccess,
+  type ValidationFailure,
+  type ValidationResult,
+} from "./llm-validator.js";

--- a/packages/phi-sanitizer/src/llm-validator.ts
+++ b/packages/phi-sanitizer/src/llm-validator.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger } from "@carebridge/logger";
+import { MAX_FLAGS, SUSPICIOUS_FLAG_THRESHOLD } from "./constants.js";
 
 const log = createLogger("llm-validator");
 
@@ -20,28 +21,6 @@ const VALID_CATEGORIES = [
   "trend-concern",
   "documentation-discrepancy",
 ] as const;
-
-export const MAX_FLAGS = 50;
-
-/**
- * Threshold at which a single LLM review's flag count is considered
- * "suspiciously high" and a warning is appended to the validation result.
- *
- * Originally 15 when MAX_FLAGS was 20 (see PR #493 history) — i.e. 75% of
- * cap, which reads as "the LLM is approaching the hard ceiling; something
- * may be off (prompt regression, prompt-injection probe, runaway model)."
- *
- * When MAX_FLAGS was raised 20 -> 50, this constant was left at 15, which
- * meant the warning fired at 30% of capacity. At that level a multi-system
- * oncology patient routinely trips the warning, drowning real signal in
- * noise (see issue #511).
- *
- * We re-peg the threshold to the original "near-cap" semantics at ~75%
- * of MAX_FLAGS. floor(50 * 0.75) = 37. Derived from MAX_FLAGS so future
- * cap changes automatically preserve the ratio; the suspicious-count
- * test asserts the numeric value to catch accidental drift.
- */
-export const SUSPICIOUS_FLAG_THRESHOLD = Math.floor(MAX_FLAGS * 0.75);
 
 /** Ordering used when a response overflows MAX_FLAGS: critical survive first. */
 const SEVERITY_RANK: Record<(typeof VALID_SEVERITIES)[number], number> = {


### PR DESCRIPTION
## Summary
- Moves `MAX_FLAGS` and `SUSPICIOUS_FLAG_THRESHOLD` from `llm-validator.ts` to a new `constants.ts` in `packages/phi-sanitizer/src/`
- Updates the barrel export (`index.ts`) to use named exports instead of `export *` for `llm-validator.js`, keeping the two constants out of the public API
- Updates test imports to reference `constants.js` directly

Closes #575

## Test plan
- [x] `pnpm typecheck` passes across all packages
- [x] `pnpm lint` passes (pre-existing warnings only)
- [ ] CI green on PR checks