### PR TITLE
test(clinical): mixed-validity panel + MedLens warnings tests (#642)

### DIFF
--- a/services/clinical-data/src/__tests__/lab-repo.test.ts
+++ b/services/clinical-data/src/__tests__/lab-repo.test.ts
@@ -138,6 +138,41 @@ describe("createLabPanel", () => {
     expect(transactionMock).not.toHaveBeenCalled();
   });
 
+  it("rejects the entire panel when some results are valid and others invalid (all-or-nothing)", async () => {
+    await expect(
+      createLabPanel({
+        patient_id: PATIENT_ID,
+        panel_name: "Mixed Panel",
+        results: [
+          {
+            test_name: "WBC",
+            test_code: "6690-2",
+            value: 7.5,
+            unit: "K/uL",
+          },
+          {
+            test_name: "Hemoglobin",
+            test_code: "718-7",
+            value: 14.0,
+            unit: "g/dL",
+          },
+          {
+            test_name: "Glucose",
+            test_code: "2345-7",
+            value: 95,
+            unit: "mmol/L",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/Lab panel validation failed.*Glucose unit "mmol\/L" is not accepted/);
+
+    // The transaction must never have been started — no partial inserts
+    expect(transactionMock).not.toHaveBeenCalled();
+
+    // No clinical event should have been emitted for the failed panel
+    expect(emitClinicalEvent).not.toHaveBeenCalled();
+  });
+
   it("attaches validation warnings to the emitted clinical event", async () => {
     await createLabPanel({
       patient_id: PATIENT_ID,

--- a/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
+++ b/services/fhir-gateway/src/__tests__/medlens-bridge.test.ts
@@ -185,6 +185,53 @@ describe("importLabs", () => {
       expect(result.result.accepted).toBe(1);
     }
   });
+
+  it("accepts valid-but-warned labs and passes skipValidation to createLabPanel", async () => {
+    const { labRepo } = await import("@carebridge/clinical-data");
+    const createLabPanelSpy = vi.mocked(labRepo.createLabPanel);
+    createLabPanelSpy.mockClear();
+
+    const token = createMedLensToken("patient-1", ["write:labs"]);
+
+    // Glucose at 350 mg/dL is a valid unit but triggers an "above typical
+    // range" warning from validateLabResult. The MedLens bridge pre-validates
+    // with validateLabResult (which returns valid:true + warnings) and then
+    // delegates to createLabPanel with { skipValidation: true } so the panel
+    // is persisted despite the warning.
+    const result = await importLabs(token.token, [
+      {
+        testName: "Glucose",
+        value: 350,
+        unit: "mg/dL",
+        confidence: 0.9,
+        collectedAt: "2026-04-01T10:00:00.000Z",
+        deviceId: "meter-2",
+      },
+    ]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.accepted).toBe(1);
+      expect(result.result.rejected).toBe(0);
+    }
+
+    // Verify createLabPanel was called with skipValidation: true
+    expect(createLabPanelSpy).toHaveBeenCalledOnce();
+    expect(createLabPanelSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patient_id: "patient-1",
+        panel_name: "MedLens: Glucose",
+        results: [
+          expect.objectContaining({
+            test_name: "Glucose",
+            value: 350,
+            unit: "mg/dL",
+          }),
+        ],
+      }),
+      { skipValidation: true },
+    );
+  });
 });
 
 describe("revokeToken", () => {


### PR DESCRIPTION
## Summary
- Add test proving `createLabPanel` rejects the entire panel (all-or-nothing) when a mix of valid results (WBC, Hemoglobin) and one invalid result (Glucose with wrong unit `mmol/L`) are submitted together — no transaction started, no event emitted.
- Add test confirming valid-but-warned labs (Glucose at 350 mg/dL, above typical range) flow through `importLabs` successfully and that `createLabPanel` is called with `{ skipValidation: true }`.

Closes #642

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `vitest run` passes for both `lab-repo.test.ts` (7 tests) and `medlens-bridge.test.ts` (13 tests)