### PR TITLE
refactor(types): extract shared AllergyStatus union (#579)

### DIFF
--- a/apps/clinician-portal/src/lib/allergy-display.ts
+++ b/apps/clinician-portal/src/lib/allergy-display.ts
@@ -20,8 +20,11 @@
  * LLM reviewer agree on what an empty list means.
  */
 
-const VALID_ALLERGY_STATUSES = ["nkda", "unknown", "has_allergies"] as const;
-export type AllergyStatus = (typeof VALID_ALLERGY_STATUSES)[number];
+import type { AllergyStatus } from "@carebridge/shared-types";
+
+export type { AllergyStatus };
+
+const VALID_ALLERGY_STATUSES: readonly AllergyStatus[] = ["nkda", "unknown", "has_allergies"];
 const statusSet: ReadonlySet<string> = new Set(VALID_ALLERGY_STATUSES);
 
 /**

--- a/packages/ai-prompts/src/clinical-review.ts
+++ b/packages/ai-prompts/src/clinical-review.ts
@@ -3,6 +3,7 @@
  * These are versioned and testable — changes to prompts are tracked.
  */
 
+import type { AllergyStatus } from "@carebridge/shared-types";
 import { PROMPT_SECTIONS } from "./prompt-sections.js";
 
 export const PROMPT_VERSION = "1.1.0";
@@ -57,7 +58,7 @@ export interface ReviewContext {
   patient: {
     age: number;
     sex: string;
-    allergy_status?: "nkda" | "unknown" | "has_allergies";
+    allergy_status?: AllergyStatus;
     active_diagnoses: string[];
     allergies: (string | { allergen: string; verification_status: string })[];
   };

--- a/packages/shared-types/src/patient.ts
+++ b/packages/shared-types/src/patient.ts
@@ -2,6 +2,16 @@ import type { MutableRecord } from "./base.js";
 
 export type BiologicalSex = "male" | "female" | "unknown";
 
+/**
+ * Patient allergy assessment status.
+ *
+ * - `nkda`           — confirmed no known drug allergies.
+ * - `unknown`        — never assessed (safer default — do NOT treat as NKDA).
+ * - `has_allergies`  — patient has documented allergies (even if the list is empty,
+ *                      indicating a documentation gap).
+ */
+export type AllergyStatus = "nkda" | "unknown" | "has_allergies";
+
 export interface Patient extends MutableRecord {
   name: string;
   date_of_birth?: string;


### PR DESCRIPTION
## Summary
- Extract the `AllergyStatus` type (`"nkda" | "unknown" | "has_allergies"`) from its duplicate definitions in `apps/clinician-portal/src/lib/allergy-display.ts` and `packages/ai-prompts/src/clinical-review.ts` into `packages/shared-types/src/patient.ts`.
- Both consumers now import from `@carebridge/shared-types`, eliminating the independent inline definitions.
- The clinician-portal retains its runtime `VALID_ALLERGY_STATUSES` array and `parseAllergyStatus()` guard, now typed against the shared union.

## Test plan
- [x] `pnpm typecheck` passes across all 23 packages (36 tasks)
- [x] `pnpm lint` passes with no new warnings

Closes #579