### PR TITLE
refactor(portal): extract reference-range separators into named constants

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   classifyStaleness,
   type StalenessTier,
 } from "@/lib/vitals-staleness";
+import { formatReferenceRange } from "@/lib/formatting";
 
 const tabs = [
   { key: "overview", label: "Overview" },
@@ -504,14 +505,7 @@ function LabsTab({ patientId }: { patientId: string }) {
                       ? "var(--warning)"
                       : "var(--text-primary)";
 
-                  const referenceRange =
-                    typeof refLow === "number" && typeof refHigh === "number"
-                      ? `${refLow}\u2013${refHigh}`
-                      : typeof refLow === "number"
-                      ? `> ${refLow}`
-                      : typeof refHigh === "number"
-                      ? `< ${refHigh}`
-                      : "\u2014";
+                  const referenceRange = formatReferenceRange(refLow, refHigh);
 
                   // Out-of-range without a server flag — surface an inferred
                   // H/L badge so the clinician has the same visual cue they

--- a/apps/clinician-portal/src/__tests__/formatting.test.ts
+++ b/apps/clinician-portal/src/__tests__/formatting.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  RANGE_SEPARATOR,
+  NO_VALUE,
+  formatReferenceRange,
+} from "../lib/formatting.js";
+
+describe("formatting constants", () => {
+  it("RANGE_SEPARATOR is an en-dash", () => {
+    expect(RANGE_SEPARATOR).toBe("\u2013");
+  });
+
+  it("NO_VALUE is an em-dash", () => {
+    expect(NO_VALUE).toBe("\u2014");
+  });
+});
+
+describe("formatReferenceRange", () => {
+  it("returns low\u2013high when both bounds are present", () => {
+    expect(formatReferenceRange(3.5, 5.0)).toBe("3.5\u20135");
+  });
+
+  it("returns '> low' when only low bound is present", () => {
+    expect(formatReferenceRange(3.5, null)).toBe("> 3.5");
+    expect(formatReferenceRange(3.5, undefined)).toBe("> 3.5");
+  });
+
+  it("returns '< high' when only high bound is present", () => {
+    expect(formatReferenceRange(null, 5.0)).toBe("< 5");
+    expect(formatReferenceRange(undefined, 5.0)).toBe("< 5");
+  });
+
+  it("returns em-dash when neither bound is present", () => {
+    expect(formatReferenceRange(null, null)).toBe("\u2014");
+    expect(formatReferenceRange(undefined, undefined)).toBe("\u2014");
+    expect(formatReferenceRange()).toBe("\u2014");
+  });
+
+  it("treats 0 as a valid numeric bound", () => {
+    expect(formatReferenceRange(0, 10)).toBe("0\u201310");
+    expect(formatReferenceRange(0, null)).toBe("> 0");
+    expect(formatReferenceRange(null, 0)).toBe("< 0");
+  });
+});

--- a/apps/clinician-portal/src/lib/formatting.ts
+++ b/apps/clinician-portal/src/lib/formatting.ts
@@ -1,0 +1,37 @@
+/**
+ * Named constants and helpers for formatting clinical reference ranges.
+ *
+ * Extracted from the LabsTab in `app/patients/[id]/page.tsx` so that
+ * display-level Unicode characters (en-dash, em-dash) are defined once
+ * and unit-testable rather than scattered as inline literals.
+ */
+
+/** En-dash used between low and high bounds of a reference range. */
+export const RANGE_SEPARATOR = '\u2013';
+
+/** Em-dash shown when no reference range is available. */
+export const NO_VALUE = '\u2014';
+
+/**
+ * Format a lab reference range for display.
+ *
+ * - Both bounds present: "low\u2013high"
+ * - Only low:            "> low"
+ * - Only high:           "< high"
+ * - Neither:             "\u2014" (em-dash, meaning "not applicable")
+ */
+export function formatReferenceRange(
+  low?: number | null,
+  high?: number | null,
+): string {
+  if (typeof low === 'number' && typeof high === 'number') {
+    return `${low}${RANGE_SEPARATOR}${high}`;
+  }
+  if (typeof low === 'number') {
+    return `> ${low}`;
+  }
+  if (typeof high === 'number') {
+    return `< ${high}`;
+  }
+  return NO_VALUE;
+}


### PR DESCRIPTION
## Summary
- Extract inline `\u2013` (en-dash) and `\u2014` (em-dash) literals from `LabsTab` in the patient chart page into named constants (`RANGE_SEPARATOR`, `NO_VALUE`) and a `formatReferenceRange()` helper in `apps/clinician-portal/src/lib/formatting.ts`
- Replace the multi-branch ternary in `LabsTab` with a single `formatReferenceRange(refLow, refHigh)` call
- Add 7 unit tests covering both-bounds, single-bound, no-bounds, and zero-as-valid-bound cases

Closes #546

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `vitest run formatting.test.ts` — 7/7 tests pass
- [ ] Manual: open patient chart Labs tab, verify reference ranges render identically