### PR TITLE
docs(clinical): document NFKC superscript-digit flattening in normalizeUnit

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -412,6 +412,21 @@ describe("validateLabResult", () => {
     expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);
   });
 
+  // NFKC normalisation flattens superscript digits (² → 2, ³ → 3) so that
+  // units like "kg/m²" and "kg/m2" compare identically. This is intentional:
+  // some FHIR/HL7 feeds emit Unicode superscripts in composite units, and we
+  // want them to match the plain-ASCII canonical form. See issue #669.
+  it("treats superscript digits as equivalent to ASCII digits (NFKC flattening)", () => {
+    // Hemoglobin has unit "g/dL" and no allowed_units, so a non-matching
+    // unit triggers a warning. Both "cells/mm\u00b2" and "cells/mm2" should
+    // normalise identically and produce the same validation outcome.
+    const superscript = validateLabResult("Hemoglobin", 14, "g/dL\u00b2");
+    const ascii = validateLabResult("Hemoglobin", 14, "g/dL2");
+    expect(superscript.valid).toBe(ascii.valid);
+    expect(superscript.warnings).toHaveLength(ascii.warnings.length);
+    expect(superscript.errors).toHaveLength(ascii.errors.length);
+  });
+
   it("error message quotes the caller's original (non-normalized) unit", () => {
     // Normalisation is only used for comparison; the operator's typed
     // string should surface verbatim so they can see what they entered.

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -257,7 +257,12 @@ export function validateMedicationDose(
  */
 function normalizeUnit(u: string): string {
   return u
-    .normalize("NFKC") // collapse Unicode lookalikes (e.g. µ → μ)
+    // NFKC collapses Unicode compatibility equivalents. This intentionally
+    // flattens superscript digits (e.g. ² → 2, ³ → 3) so that units like
+    // "m²" become "m2". This is the desired behaviour: we compare units by
+    // their ASCII-canonical form, and superscript variants from FHIR/HL7
+    // feeds should match their plain-digit counterparts.
+    .normalize("NFKC")
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "")


### PR DESCRIPTION
## Summary
- Added inline comment near the `.normalize("NFKC")` call in `normalizeUnit()` explaining that NFKC intentionally flattens Unicode superscript digits (e.g. ² → 2, ³ → 3) so that units like "m²" match their ASCII canonical form "m2"
- Added a test asserting that superscript digits and ASCII digits produce identical validation outcomes when used in lab unit strings

Closes #669

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm --filter @carebridge/medical-logic test` passes (109 tests, including the new superscript-flattening test)