### PR TITLE
fix(ai): update validate-event-timestamp tests for structured logger

### DIFF
--- a/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
+++ b/services/ai-oversight/src/__tests__/validate-event-timestamp.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import type { LogEntry } from "@carebridge/logger";
+// Mock the @carebridge/logger module so we can assert against logger.warn()
+// calls directly rather than spying on console.error (which is an
+// implementation detail of the logger).
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+  }),
+}));
 
 import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 
@@ -10,55 +21,44 @@ import { validateEventTimestamp } from "../utils/validate-event-timestamp.js";
 const NOW_MS = Date.UTC(2026, 3, 16, 12, 0, 0);
 const now = () => NOW_MS;
 
-/** Parse the structured JSON line emitted by the logger on stderr. */
-function parseLogEntry(spy: ReturnType<typeof vi.spyOn>, callIndex = 0): LogEntry {
-  return JSON.parse(spy.mock.calls[callIndex][0] as string) as LogEntry;
-}
-
 describe("validateEventTimestamp", () => {
-  let errorSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
-    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    errorSpy.mockRestore();
+    mockWarn.mockClear();
   });
 
   it("returns a valid ISO-8601 timestamp unchanged and logs nothing", () => {
     const ts = "2026-04-16T11:59:00.000Z";
     const result = validateEventTimestamp(ts, { now });
     expect(result).toBe(ts);
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
   });
 
   it("falls back to now when timestamp is undefined, and warns", () => {
     const result = validateEventTimestamp(undefined, { now, eventId: "evt-1" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.level).toBe("warn");
-    expect(entry.reason).toBe("missing");
-    expect(entry.eventId).toBe("evt-1");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [msg, meta] = mockWarn.mock.calls[0];
+    expect(msg).toBe("timestamp_fallback_total");
+    expect(meta.reason).toBe("missing");
+    expect(meta.eventId).toBe("evt-1");
   });
 
   it("falls back to now when timestamp is an empty string, and warns", () => {
     const result = validateEventTimestamp("", { now, eventId: "evt-2" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.level).toBe("warn");
-    expect(entry.reason).toBe("empty");
-    expect(entry.eventId).toBe("evt-2");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [msg, meta] = mockWarn.mock.calls[0];
+    expect(msg).toBe("timestamp_fallback_total");
+    expect(meta.reason).toBe("empty");
+    expect(meta.eventId).toBe("evt-2");
   });
 
   it("falls back to now when timestamp is whitespace-only", () => {
     const result = validateEventTimestamp("   ", { now });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.reason).toBe("empty");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [, meta] = mockWarn.mock.calls[0];
+    expect(meta.reason).toBe("empty");
   });
 
   it("falls back to now when timestamp is unparseable, and warns", () => {
@@ -67,11 +67,11 @@ describe("validateEventTimestamp", () => {
       eventId: "evt-3",
     });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.level).toBe("warn");
-    expect(entry.reason).toBe("unparseable");
-    expect(entry.eventId).toBe("evt-3");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [msg, meta] = mockWarn.mock.calls[0];
+    expect(msg).toBe("timestamp_fallback_total");
+    expect(meta.reason).toBe("unparseable");
+    expect(meta.eventId).toBe("evt-3");
   });
 
   it("falls back to now when timestamp is more than 1 minute in the future", () => {
@@ -79,9 +79,9 @@ describe("validateEventTimestamp", () => {
     const future = new Date(NOW_MS + 5 * 60 * 1000).toISOString();
     const result = validateEventTimestamp(future, { now, eventId: "evt-4" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.reason).toBe("future");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [, meta] = mockWarn.mock.calls[0];
+    expect(meta.reason).toBe("future");
   });
 
   it("accepts a timestamp within the 1-minute clock-skew grace window", () => {
@@ -89,16 +89,16 @@ describe("validateEventTimestamp", () => {
     const slightlyFuture = new Date(NOW_MS + 30 * 1000).toISOString();
     const result = validateEventTimestamp(slightlyFuture, { now });
     expect(result).toBe(slightlyFuture);
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
   });
 
   it("falls back to now when timestamp is before year 2000 (epoch-leak guard)", () => {
     const epoch = "1970-01-01T00:00:00.000Z";
     const result = validateEventTimestamp(epoch, { now, eventId: "evt-5" });
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.reason).toBe("too-old");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [, meta] = mockWarn.mock.calls[0];
+    expect(meta.reason).toBe("too-old");
   });
 
   it("falls back when a non-string value leaks through the type boundary", () => {
@@ -110,19 +110,19 @@ describe("validateEventTimestamp", () => {
       { now, eventId: "evt-6" },
     );
     expect(result).toBe(new Date(NOW_MS).toISOString());
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.reason).toBe("not-a-string");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    const [, meta] = mockWarn.mock.calls[0];
+    expect(meta.reason).toBe("not-a-string");
   });
 
-  it("uses the caller label in the structured log output", () => {
+  it("uses the caller label in the structured log metadata", () => {
     validateEventTimestamp("", {
       now,
       eventId: "evt-7",
       caller: "context-builder",
     });
-    const entry = parseLogEntry(errorSpy);
-    expect(entry.caller).toBe("context-builder");
+    const [, meta] = mockWarn.mock.calls[0];
+    expect(meta.caller).toBe("context-builder");
   });
 
   it("calls now() exactly once even when the fallback path is taken (#585)", () => {


### PR DESCRIPTION
## Summary
- Replace `console.error` spy with `vi.mock` of `@carebridge/logger` so tests assert against the mock logger's `.warn()` calls and structured metadata arguments directly
- Use `vi.hoisted()` to avoid the reference-before-initialization issue with vitest's module mock hoisting
- Update the "caller label" test to assert against the metadata `caller` field instead of parsing a JSON string from console output

## Test plan
- [x] All 11 tests in `validate-event-timestamp.test.ts` pass
- [x] No new typecheck errors introduced in the changed file

Closes #737