### PR TITLE
refactor(ai): use shared AllergyStatus type in context-builder

### DIFF
--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -21,7 +21,7 @@ import {
 } from "@carebridge/db-schema";
 import { users } from "@carebridge/db-schema";
 import type { ReviewContext } from "@carebridge/ai-prompts";
-import type { ClinicalEvent } from "@carebridge/shared-types";
+import type { AllergyStatus, ClinicalEvent } from "@carebridge/shared-types";
 import { calculateDelta } from "@carebridge/medical-logic";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
 
@@ -273,7 +273,7 @@ export async function buildPatientContext(
     patient: {
       age,
       sex: patientRow?.biological_sex ?? "unknown",
-      allergy_status: (patientRow?.allergy_status as "nkda" | "unknown" | "has_allergies") ?? "unknown",
+      allergy_status: (patientRow?.allergy_status as AllergyStatus) ?? "unknown",
       active_diagnoses: activeDiagnoses.map((d) => d.description),
       allergies: patientAllergies.map((a) => ({
         allergen: a.allergen,


### PR DESCRIPTION
## Summary
- Replace inline `"nkda" | "unknown" | "has_allergies"` cast in `context-builder.ts` with `AllergyStatus` import from `@carebridge/shared-types`
- Keeps the allergy status type definition in a single source of truth

## Changes
- `services/ai-oversight/src/workers/context-builder.ts`: added `AllergyStatus` to the existing `@carebridge/shared-types` import and replaced the inline cast on line 276

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight typecheck` passes
- [x] `pnpm --filter @carebridge/ai-oversight test -- --run` passes (482 tests, 24 files)

Closes #733