### PR TITLE
docs(clinical): update skipValidation comment to reflect warnings-always behavior

### DIFF
--- a/services/clinical-data/src/repositories/lab-repo.ts
+++ b/services/clinical-data/src/repositories/lab-repo.ts
@@ -33,7 +33,8 @@ export async function createLabPanel(
   // Validate every result before persisting — reject the whole panel if
   // any result has an invalid unit (partial writes are a correctness hazard).
   // Callers that have already validated can pass { skipValidation: true }
-  // to avoid redundant work (e.g. MedLens bridge).
+  // to skip the error/reject path. Warnings are always collected regardless
+  // of this flag.
   const allWarnings: string[] = [];
   const allErrors: string[] = [];
 


### PR DESCRIPTION
## Summary
- Updates the block comment in `lab-repo.ts` around the `skipValidation` option to clarify that it only skips the error/reject path, and that warnings are always collected regardless of the flag.

Closes #730