### PR TITLE
fix(clinical): restore numeric 88.4 in test descriptions and comments

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -392,8 +392,8 @@ describe("validateLabResult", () => {
     expect(microSign.valid).toBe(asciiU.valid);
   });
 
-  it("accepts Creatinine in umol/L — CREATININE_UMOL_TO_MGDL umol/L converts to 1.0 mg/dL (normal, no warnings)", () => {
-    // CREATININE_UMOL_TO_MGDL µmol/L ÷ CREATININE_UMOL_TO_MGDL = 1.0 mg/dL → within 0.6–1.2 typical range
+  it("accepts Creatinine in umol/L — 88.4 umol/L converts to 1.0 mg/dL (normal, no warnings)", () => {
+    // 88.4 µmol/L ÷ 88.4 = 1.0 mg/dL → within 0.6–1.2 typical range
     const result = validateLabResult("Creatinine", CREATININE_UMOL_TO_MGDL, "umol/L");
     expect(result.valid).toBe(true);
     expect(result.warnings).toHaveLength(0);
@@ -407,7 +407,7 @@ describe("validateLabResult", () => {
   });
 
   it("warns on Creatinine 200 umol/L (above typical range — ~2.26 mg/dL)", () => {
-    // 200 µmol/L ÷ CREATININE_UMOL_TO_MGDL ≈ 2.26 mg/dL → above 1.2 mg/dL typical high
+    // 200 µmol/L ÷ 88.4 ≈ 2.26 mg/dL → above 1.2 mg/dL typical high
     const result = validateLabResult("Creatinine", 200, "umol/L");
     expect(result.valid).toBe(true);
     expect(result.warnings.some((w) => w.includes("above typical range"))).toBe(true);

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -323,7 +323,7 @@ export function validateLabResult(
   if (!ref) return { valid: true, warnings, errors };
 
   // Unit validation — prevents mg/dL vs mmol/L class confusion, a known
-  // sentinel-event source (glucose ×18, creatinine ×CREATININE_UMOL_TO_MGDL). Tests with an
+  // sentinel-event source (glucose ×18, creatinine ×88.4). Tests with an
   // explicit `allowed_units` list reject mismatches as errors; tests
   // without fall back to a warning when the caller's unit doesn't match
   // the canonical reference unit. The compare normalises case and


### PR DESCRIPTION
## Summary
- Restores literal `88.4` in human-readable strings (test descriptions and code comments) where the number aids comprehension
- Keeps `CREATININE_UMOL_TO_MGDL` constant in executable code (function arguments, assertions)
- Fixes over-eager constant extraction from PR #713

## Changed files
- `packages/medical-logic/src/medical-validation.ts` — 1 comment restored
- `packages/medical-logic/src/__tests__/medical-validation.test.ts` — 1 test description + 2 comments restored

## Test plan
- [x] `pnpm --filter @carebridge/medical-logic test -- --run medical-validation` passes (109/109)

Closes #732