### PR TITLE
test(portal): use vi.useFakeTimers() in StaleDataBanner tests

### DIFF
--- a/apps/clinician-portal/src/__tests__/stale-data-banner.test.tsx
+++ b/apps/clinician-portal/src/__tests__/stale-data-banner.test.tsx
@@ -2,22 +2,31 @@
  * @vitest-environment jsdom
  */
 import React from "react";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 import { StaleDataBanner } from "@/components/stale-data-banner.js";
 
+/** Frozen reference point for all date arithmetic. */
+const NOW = new Date("2026-04-17T12:00:00Z");
+
 describe("StaleDataBanner", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   /** Timestamp 10 days in the past. */
   const staleDate = new Date(
-    Date.now() - 10 * 24 * 60 * 60 * 1000,
+    NOW.getTime() - 10 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
   /** Timestamp 1 hour in the past (current data). */
-  const currentDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const currentDate = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString();
 
   // ── Accessibility attributes ──────────────────────────────────────
 
@@ -70,7 +79,7 @@ describe("StaleDataBanner", () => {
 
   it("uses singular 'day' for exactly 1 day old data", () => {
     const oneDayAgo = new Date(
-      Date.now() - 1 * 24 * 60 * 60 * 1000,
+      NOW.getTime() - 1 * 24 * 60 * 60 * 1000,
     ).toISOString();
     const { container } = render(
       <StaleDataBanner lastRecordedAt={oneDayAgo} label="vitals" />,


### PR DESCRIPTION
## Summary
- Replace `Date.now()` calls at module scope with `vi.useFakeTimers()` + `vi.setSystemTime()` frozen to `2026-04-17T12:00:00Z`
- All date arithmetic now uses the fixed reference point, eliminating potential drift in CI
- All 11 tests pass

Closes #767

## Test plan
- [x] `pnpm --filter @carebridge/clinician-portal test -- --run stale-data-banner` — 11 tests pass