### PR TITLE
refactor(portal): normalize flag casing in labValueColor (#768)

### DIFF
--- a/apps/clinician-portal/src/lib/lab-display.ts
+++ b/apps/clinician-portal/src/lib/lab-display.ts
@@ -34,9 +34,11 @@ export function isOutOfRange(
 /**
  * Map server flag + out-of-range status to a CSS colour variable.
  *
+ * Flag is normalized to lowercase so "H", "h", "high", etc. all match.
+ *
  * Priority order:
  * 1. Server "critical" flag → critical colour
- * 2. Server "H" or "L" flag → warning colour
+ * 2. Server H/L flag (any casing, short or long form) → warning colour
  * 3. Client-detected out-of-range → warning colour
  * 4. Otherwise → default text colour
  */
@@ -44,8 +46,10 @@ export function labValueColor(
   flag: LabFlag | "" | undefined | null,
   outOfRange: boolean,
 ): ValueColor {
-  if (flag === "critical") return "var(--critical)";
-  if (flag === "H" || flag === "L") return "var(--warning)";
+  const norm = flag?.toLowerCase() ?? "";
+  if (norm === "critical") return "var(--critical)";
+  if (norm === "h" || norm === "l" || norm === "high" || norm === "low")
+    return "var(--warning)";
   if (outOfRange) return "var(--warning)";
   return "var(--text-primary)";
 }


### PR DESCRIPTION
## Summary
- Normalize the `flag` parameter to lowercase in `labValueColor()` so that both short-form (`"H"`/`"L"`) and long-form (`"high"`/`"low"`) server values are correctly mapped to the warning colour, regardless of casing.
- This aligns `labValueColor` with the disagreement check in `LabsTab` which already normalizes via `flag.toLowerCase()`.

## Test plan
- [ ] Verify `labValueColor("H", false)` returns `var(--warning)`
- [ ] Verify `labValueColor("high", false)` returns `var(--warning)`
- [ ] Verify `labValueColor("low", false)` returns `var(--warning)`
- [ ] Verify `labValueColor("critical", false)` returns `var(--critical)`
- [ ] Verify `labValueColor("", false)` returns `var(--text-primary)`
- [ ] Typecheck passes with no new errors

Closes #768