### PR TITLE
refactor(gateway): replace double-cast req.user with decorateRequest

### DIFF
--- a/services/api-gateway/src/__tests__/auth-jwt.test.ts
+++ b/services/api-gateway/src/__tests__/auth-jwt.test.ts
@@ -134,9 +134,9 @@ describe("authMiddleware — JWT verification", () => {
     expect(mockDb.select).toHaveBeenCalled();
 
     // User was resolved
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeDefined();
-    expect((user as Record<string, unknown>).id).toBe("user-1");
+    expect(user?.id).toBe("user-1");
   });
 
   it("returns unauthenticated (no user) when JWT is invalid", async () => {
@@ -157,7 +157,7 @@ describe("authMiddleware — JWT verification", () => {
 
     // User stays null — middleware does not send 401 for invalid JWT,
     // it just leaves the user unset for downstream handlers to decide.
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
   });
 
@@ -185,7 +185,7 @@ describe("authMiddleware — JWT verification", () => {
     expect(mockVerifyJWT).not.toHaveBeenCalled();
     expect(mockDb.select).not.toHaveBeenCalled();
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
   });
 
@@ -208,7 +208,7 @@ describe("authMiddleware — JWT verification", () => {
 
     expect(mockVerifyJWT).toHaveBeenCalledWith("cookie-jwt-token");
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeDefined();
   });
 });
@@ -238,7 +238,7 @@ describe("authMiddleware — dev bypass", () => {
     await authMiddleware(request, reply);
 
     // Without a Bearer token or cookie, the user stays null
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
 
     // No JWT verification or DB lookup performed

--- a/services/api-gateway/src/__tests__/auth-middleware.test.ts
+++ b/services/api-gateway/src/__tests__/auth-middleware.test.ts
@@ -151,10 +151,10 @@ describe("authMiddleware", () => {
 
     await authMiddleware(request, reply);
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeDefined();
-    expect((user as Record<string, unknown>).id).toBe("user-1");
-    expect((user as Record<string, unknown>).is_active).toBe(true);
+    expect(user?.id).toBe("user-1");
+    expect(user?.is_active).toBe(true);
     expect((reply as unknown as Record<string, unknown>).code).not.toHaveBeenCalled();
   });
 
@@ -170,7 +170,7 @@ describe("authMiddleware", () => {
     await authMiddleware(request, reply);
 
     // Should not attach user
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
 
     // Should respond 401
@@ -195,7 +195,7 @@ describe("authMiddleware", () => {
 
     await authMiddleware(request, reply);
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
     // No 401 sent — the middleware just leaves user null for expired sessions
   });
@@ -211,7 +211,7 @@ describe("authMiddleware", () => {
 
     await authMiddleware(request, reply);
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
   });
 
@@ -263,7 +263,7 @@ describe("authMiddleware", () => {
     await authMiddleware(request, reply);
 
     // User should not be attached — session exceeded absolute lifetime.
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeUndefined();
 
     // Session should have been deleted.
@@ -287,8 +287,8 @@ describe("authMiddleware", () => {
 
     await authMiddleware(request, reply);
 
-    const user = (request as unknown as Record<string, unknown>).user;
+    const user = request.user;
     expect(user).toBeDefined();
-    expect((user as Record<string, unknown>).id).toBe("user-1");
+    expect(user?.id).toBe("user-1");
   });
 });

--- a/services/api-gateway/src/__tests__/patient-read-rate-limit.test.ts
+++ b/services/api-gateway/src/__tests__/patient-read-rate-limit.test.ts
@@ -132,7 +132,7 @@ describe("patient read per-user rate limit", () => {
     const reply = makeReply();
     const req = makeReq("/trpc/patients.getSummary");
     // Remove user
-    (req as unknown as Record<string, unknown>).user = undefined;
+    req.user = undefined;
 
     await hook(req, reply);
     expect(redis.incr).not.toHaveBeenCalled();

--- a/services/api-gateway/src/context.ts
+++ b/services/api-gateway/src/context.ts
@@ -19,9 +19,8 @@ export interface Context {
 export async function createContext(
   opts: CreateFastifyContextOptions,
 ): Promise<Context> {
-  const req = opts.req as unknown as Record<string, unknown>;
-  const user = (req.user as User | null) ?? null;
-  const sessionId = (req.sessionId as string | null) ?? null;
+  const user = opts.req.user ?? null;
+  const sessionId = opts.req.sessionId ?? null;
 
   return {
     db: getDb(),

--- a/services/api-gateway/src/context.ts
+++ b/services/api-gateway/src/context.ts
@@ -1,4 +1,5 @@
 import type { CreateFastifyContextOptions } from "@trpc/server/adapters/fastify";
+import type { FastifyRequest } from "fastify";
 import type { User } from "@carebridge/shared-types";
 import { getDb } from "@carebridge/db-schema";
 import crypto from "node:crypto";
@@ -19,8 +20,12 @@ export interface Context {
 export async function createContext(
   opts: CreateFastifyContextOptions,
 ): Promise<Context> {
-  const user = opts.req.user ?? null;
-  const sessionId = opts.req.sessionId ?? null;
+  // Cast to the decorated shape so this file compiles even when the ambient
+  // module augmentation (./fastify.d.ts) is not in scope — e.g. when the
+  // patient-portal transpiles this package via Next.js transpilePackages.
+  const req = opts.req as FastifyRequest & { user?: User; sessionId?: string };
+  const user = req.user ?? null;
+  const sessionId = req.sessionId ?? null;
 
   return {
     db: getDb(),

--- a/services/api-gateway/src/fastify.d.ts
+++ b/services/api-gateway/src/fastify.d.ts
@@ -1,0 +1,8 @@
+import type { User } from "@carebridge/shared-types";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user?: User;
+    sessionId?: string;
+  }
+}

--- a/services/api-gateway/src/middleware/audit.ts
+++ b/services/api-gateway/src/middleware/audit.ts
@@ -276,7 +276,7 @@ export async function auditMiddleware(
     return;
   }
 
-  const user = (request as unknown as Record<string, unknown>).user as User | undefined;
+  const user = request.user;
   const userId = user?.id ?? "anonymous";
 
   const action = methodToAction(request.method);

--- a/services/api-gateway/src/middleware/auth.ts
+++ b/services/api-gateway/src/middleware/auth.ts
@@ -62,7 +62,7 @@ export async function authMiddleware(
     if (devUserId) {
       const devUser = DEV_USERS[devUserId];
       if (devUser) {
-        (request as unknown as Record<string, unknown>).user = devUser;
+        request.user = devUser;
         return;
       }
       // Unknown dev user ID — fall through to normal JWT auth rather than
@@ -78,10 +78,8 @@ export async function authMiddleware(
   let sessionId: string | undefined;
 
   // Parsed by @fastify/cookie plugin registered in server.ts.
-  const cookies = (request as unknown as { cookies?: Record<string, string> })
-    .cookies;
-  if (cookies?.session) {
-    sessionId = cookies.session;
+  if (request.cookies?.session) {
+    sessionId = request.cookies.session;
   }
 
   if (!sessionId) {
@@ -187,9 +185,7 @@ export async function authMiddleware(
     return;
   }
 
-  const req = request as unknown as Record<string, unknown>;
-
-  req.user = {
+  request.user = {
     id: row.id,
     email: row.email,
     name: row.name,
@@ -202,5 +198,5 @@ export async function authMiddleware(
     updated_at: row.updated_at,
   } satisfies User;
 
-  req.sessionId = sessionId;
+  request.sessionId = sessionId;
 }

--- a/services/api-gateway/src/middleware/patient-read-rate-limit.ts
+++ b/services/api-gateway/src/middleware/patient-read-rate-limit.ts
@@ -15,7 +15,6 @@
 
 import type { FastifyRequest, FastifyReply } from "fastify";
 import type Redis from "ioredis";
-import type { User } from "@carebridge/shared-types";
 import { getDb, auditLog } from "@carebridge/db-schema";
 import crypto from "node:crypto";
 
@@ -110,9 +109,7 @@ export function makePatientReadRateLimitHook(
 
     // Must have an authenticated user — this hook runs as preHandler after
     // authMiddleware, so req.user should be populated. Guard defensively.
-    const user = (req as unknown as Record<string, unknown>).user as
-      | User
-      | undefined;
+    const user = req.user;
     if (!user) return;
 
     const max = limits[procedure]!;

--- a/services/api-gateway/src/routes/notifications-sse.ts
+++ b/services/api-gateway/src/routes/notifications-sse.ts
@@ -31,7 +31,7 @@ export function registerNotificationSSE(server: FastifyInstance): void {
     "/notifications/stream",
     async (request: FastifyRequest, reply: FastifyReply) => {
       // Extract user ID from the auth context (set by authMiddleware)
-      const userId = (request as unknown as { userId?: string }).userId;
+      const userId = request.user?.id;
 
       if (!userId) {
         return reply.code(401).send({ error: "Authentication required" });

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -76,6 +76,13 @@ async function main() {
     },
   });
 
+  // --- Request decorators ---
+  // Register custom properties so Fastify knows about them at startup and
+  // TypeScript can access them without double-casting via the augmentation
+  // in ./fastify.d.ts.
+  server.decorateRequest("user", undefined);
+  server.decorateRequest("sessionId", undefined);
+
   // --- Plugins ---
   // Security headers. This is a JSON API, not an HTML app, so CSP and COEP
   // are disabled — they only make sense for browser-rendered documents.


### PR DESCRIPTION
## Summary
- Add Fastify type augmentation (`fastify.d.ts`) declaring `user?: User` and `sessionId?: string` on `FastifyRequest`
- Register both properties via `server.decorateRequest()` in `server.ts` during setup
- Replace all `(req as unknown as Record<string, unknown>).user` double-cast patterns with direct `req.user` access across middleware (`auth.ts`, `audit.ts`, `patient-read-rate-limit.ts`), `context.ts`, `notifications-sse.ts`, and tests
- Fix `notifications-sse.ts` to read `request.user?.id` instead of the never-set `request.userId`

## Test plan
- [x] `pnpm --filter @carebridge/api-gateway typecheck` passes cleanly
- [x] `pnpm --filter @carebridge/api-gateway test -- --run` — all 237 tests pass

Closes #771