### PR TITLE
test(portal): add boundary-value tests for lab flag inference (#769)

### DIFF
--- a/apps/clinician-portal/src/__tests__/lab-flag-precedence.test.ts
+++ b/apps/clinician-portal/src/__tests__/lab-flag-precedence.test.ts
@@ -80,6 +80,22 @@ describe("lab flag precedence", () => {
     it("returns empty string when value is null", () => {
       expect(deriveInferredFlag("", null, 3.5, 5.0)).toBe("");
     });
+
+    it("returns empty string when value equals refLow exactly", () => {
+      expect(deriveInferredFlag("", 3.5, 3.5, 5.0)).toBe("");
+    });
+
+    it("returns empty string when value equals refHigh exactly", () => {
+      expect(deriveInferredFlag("", 5.0, 3.5, 5.0)).toBe("");
+    });
+
+    it("returns 'low' when value is one cent below refLow", () => {
+      expect(deriveInferredFlag("", 3.49, 3.5, 5.0)).toBe("low");
+    });
+
+    it("returns 'high' when value is one cent above refHigh", () => {
+      expect(deriveInferredFlag("", 5.01, 3.5, 5.0)).toBe("high");
+    });
   });
 
   describe("server/client disagreement warning", () => {


### PR DESCRIPTION
## Summary
- Adds 4 boundary-value tests for lab flag inference at exactly refLow/refHigh
- Tests: value=refLow → no flag, value=refHigh → no flag, value<refLow → LOW, value>refHigh → HIGH

## Test plan
- [x] All tests pass
- [x] Typecheck clean

Closes #769