### PR TITLE
chore(portal): wire up @testing-library/jest-dom in vitest setup

### DIFF
--- a/apps/clinician-portal/src/test-setup.ts
+++ b/apps/clinician-portal/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/apps/clinician-portal/vitest.config.ts
+++ b/apps/clinician-portal/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   test: {
     globals: false,
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Create `apps/clinician-portal/src/test-setup.ts` importing `@testing-library/jest-dom/vitest`
- Add `setupFiles` entry to `apps/clinician-portal/vitest.config.ts`
- All 94 tests pass; one pre-existing suite failure (unrelated `@carebridge/validators` resolution issue) remains unchanged

Closes #766