### PR TITLE
fix(ai): add evals/ to type-checking coverage

### DIFF
--- a/packages/ai-prompts/package.json
+++ b/packages/ai-prompts/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "test": "vitest run",
     "eval": "vitest run --config vitest.config.ts golden-eval",
     "clean": "rm -rf dist"

--- a/packages/ai-prompts/tsconfig.check.json
+++ b/packages/ai-prompts/tsconfig.check.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "evals"],
+  "exclude": ["dist", "node_modules", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.check.json` that extends the main tsconfig with `include: ["src", "evals"]` so evals are type-checked
- Update `typecheck` script to use `tsconfig.check.json`
- Build output (`tsc` via `build` script) is unchanged and does not emit evals to `dist/`

## Test plan
- [x] `pnpm --filter @carebridge/ai-prompts typecheck` passes and covers evals files
- [x] `pnpm --filter @carebridge/ai-prompts build` still works, no evals in dist/

Closes #763