### PR TITLE
test(ai): add Zod schema validation for golden-eval fixtures (#764)

### DIFF
--- a/packages/ai-prompts/evals/eval-runner.ts
+++ b/packages/ai-prompts/evals/eval-runner.ts
@@ -9,6 +9,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 import { buildReviewPrompt } from "../src/clinical-review.js";
 import { estimateTokens, enforceTokenBudget, DEFAULT_TOKEN_BUDGET } from "../src/token-budget.js";
 import type { ReviewContext } from "../src/clinical-review.js";
@@ -16,18 +17,86 @@ import type { ReviewContext } from "../src/clinical-review.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = join(__dirname, "fixtures");
 
-export interface EvalFixture {
-  id: string;
-  description: string;
-  context: ReviewContext;
-  expected: {
-    shouldFlag: boolean;
-    expectedCategories?: string[];
-    forbiddenCategories?: string[];
-    minimumSeverity?: "critical" | "warning" | "info";
-    mustMentionInPrompt: string[];
-  };
-}
+const trendSchema = z.enum(["rising", "falling", "stable"]);
+
+const reviewContextSchema = z.object({
+  patient: z.object({
+    age: z.number(),
+    sex: z.string(),
+    allergy_status: z.enum(["nkda", "unknown", "has_allergies"]).optional(),
+    active_diagnoses: z.array(z.string()),
+    allergies: z.array(
+      z.union([
+        z.string(),
+        z.object({ allergen: z.string(), verification_status: z.string() }),
+      ]),
+    ),
+  }),
+  active_medications: z.array(
+    z.object({
+      name: z.string(),
+      dose: z.string(),
+      route: z.string(),
+      frequency: z.string(),
+      started_at: z.string(),
+    }),
+  ),
+  latest_vitals: z.record(
+    z.object({
+      value: z.number(),
+      unit: z.string(),
+      recorded_at: z.string(),
+      trend: trendSchema.optional(),
+    }),
+  ),
+  recent_labs: z
+    .array(
+      z.object({
+        test_name: z.string(),
+        value: z.number(),
+        unit: z.string(),
+        flag: z.string().nullable(),
+        trend: trendSchema.optional(),
+        collected_at: z.string(),
+      }),
+    )
+    .optional(),
+  triggering_event: z.object({
+    type: z.string(),
+    summary: z.string(),
+    detail: z.string(),
+  }),
+  recent_flags: z.array(
+    z.object({
+      severity: z.string(),
+      summary: z.string(),
+      status: z.string(),
+      created_at: z.string(),
+    }),
+  ),
+  care_team: z.array(
+    z.object({
+      name: z.string(),
+      specialty: z.string(),
+      recent_note_date: z.string().optional(),
+    }),
+  ),
+});
+
+export const evalFixtureSchema = z.object({
+  id: z.string(),
+  description: z.string(),
+  context: reviewContextSchema,
+  expected: z.object({
+    shouldFlag: z.boolean(),
+    expectedCategories: z.array(z.string()).optional(),
+    forbiddenCategories: z.array(z.string()).optional(),
+    minimumSeverity: z.enum(["critical", "warning", "info"]).optional(),
+    mustMentionInPrompt: z.array(z.string()),
+  }),
+});
+
+export type EvalFixture = z.infer<typeof evalFixtureSchema>;
 
 export interface EvalResult {
   fixtureId: string;
@@ -43,7 +112,7 @@ export function loadFixtures(): EvalFixture[] {
   const files = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith(".json"));
   return files.map((file) => {
     const raw = readFileSync(join(FIXTURES_DIR, file), "utf-8");
-    return JSON.parse(raw) as EvalFixture;
+    return evalFixtureSchema.parse(JSON.parse(raw));
   });
 }
 

--- a/packages/ai-prompts/package.json
+++ b/packages/ai-prompts/package.json
@@ -19,7 +19,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@carebridge/shared-types": "workspace:*"
+    "@carebridge/shared-types": "workspace:*",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/ai-prompts/src/__tests__/golden-eval.test.ts
+++ b/packages/ai-prompts/src/__tests__/golden-eval.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   loadFixtures,
   evaluateFixture,
+  evalFixtureSchema,
   type EvalFixture,
 } from "../../evals/eval-runner.js";
 import { buildReviewPrompt } from "../clinical-review.js";
@@ -171,5 +172,125 @@ describe("golden-eval: negative cases", () => {
     expect(fixture.expected.shouldFlag).toBe(false);
     expect(fixture.expected.forbiddenCategories).toContain("drug-interaction");
     expect(fixture.expected.forbiddenCategories).toContain("medication-safety");
+  });
+});
+
+describe("golden-eval: Zod schema validation", () => {
+  it("rejects a fixture missing required fields with a clear error", () => {
+    const malformed = {
+      id: "bad-fixture",
+      description: "missing context and expected",
+    };
+    const result = evalFixtureSchema.safeParse(malformed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join("."));
+      expect(paths).toContain("context");
+      expect(paths).toContain("expected");
+    }
+  });
+
+  it("rejects a fixture with an invalid minimumSeverity value", () => {
+    const malformed = {
+      id: "bad-severity",
+      description: "invalid severity enum",
+      context: {
+        patient: {
+          age: 40,
+          sex: "female",
+          active_diagnoses: [],
+          allergies: [],
+        },
+        active_medications: [],
+        latest_vitals: {},
+        triggering_event: { type: "test", summary: "s", detail: "d" },
+        recent_flags: [],
+        care_team: [],
+      },
+      expected: {
+        shouldFlag: true,
+        minimumSeverity: "urgent",
+        mustMentionInPrompt: [],
+      },
+    };
+    const result = evalFixtureSchema.safeParse(malformed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const severityIssue = result.error.issues.find((i) =>
+        i.path.includes("minimumSeverity"),
+      );
+      expect(severityIssue).toBeDefined();
+    }
+  });
+
+  it("rejects a fixture with wrong type for shouldFlag", () => {
+    const malformed = {
+      id: "bad-flag",
+      description: "shouldFlag is a string",
+      context: {
+        patient: {
+          age: 50,
+          sex: "male",
+          active_diagnoses: [],
+          allergies: [],
+        },
+        active_medications: [],
+        latest_vitals: {},
+        triggering_event: { type: "test", summary: "s", detail: "d" },
+        recent_flags: [],
+        care_team: [],
+      },
+      expected: {
+        shouldFlag: "yes",
+        mustMentionInPrompt: [],
+      },
+    };
+    const result = evalFixtureSchema.safeParse(malformed);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const flagIssue = result.error.issues.find((i) =>
+        i.path.includes("shouldFlag"),
+      );
+      expect(flagIssue).toBeDefined();
+    }
+  });
+
+  it("accepts a valid fixture without errors", () => {
+    const valid = {
+      id: "valid-fixture",
+      description: "a well-formed fixture",
+      context: {
+        patient: {
+          age: 55,
+          sex: "male",
+          allergy_status: "nkda" as const,
+          active_diagnoses: ["Hypertension"],
+          allergies: [],
+        },
+        active_medications: [
+          {
+            name: "Lisinopril",
+            dose: "10 mg",
+            route: "oral",
+            frequency: "daily",
+            started_at: "2026-01-01",
+          },
+        ],
+        latest_vitals: {},
+        triggering_event: {
+          type: "lab_result",
+          summary: "Routine labs",
+          detail: "Normal results",
+        },
+        recent_flags: [],
+        care_team: [{ name: "Dr. Test", specialty: "Internal Medicine" }],
+      },
+      expected: {
+        shouldFlag: false,
+        mustMentionInPrompt: ["Hypertension"],
+      },
+    };
+    const result = evalFixtureSchema.safeParse(valid);
+    expect(result.success).toBe(true);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../shared-types
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.7.0


### PR DESCRIPTION
## Summary
- Adds Zod schema for EvalFixture, replacing unsafe `as` cast in loadFixtures()
- 4 new validation tests: missing fields, invalid enum, wrong type, valid fixture

## Test plan
- [x] All 71 tests pass

Closes #764