### PR TITLE
fix(fhir): emit audit warning for re-requests past recommended_purge_at (#762)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@carebridge/medical-logic':
         specifier: workspace:*
         version: link:../../packages/medical-logic
@@ -5799,8 +5802,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5819,7 +5822,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5830,22 +5833,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5856,7 +5859,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/services/fhir-gateway/package.json
+++ b/services/fhir-gateway/package.json
@@ -13,6 +13,7 @@
     "@carebridge/clinical-data": "workspace:*",
     "@carebridge/medical-logic": "workspace:*",
     "@carebridge/validators": "workspace:*",
+    "@carebridge/logger": "workspace:*",
     "@carebridge/phi-sanitizer": "workspace:*",
     "@trpc/server": "^11.0.0",
     "drizzle-orm": "^0.38.0",

--- a/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
@@ -76,6 +76,20 @@ vi.mock("@carebridge/db-schema", () => ({
 // stub `eq` to a no-op sentinel.
 vi.mock("drizzle-orm", () => ({
   eq: (_col: unknown, _val: unknown) => ({ __eq: true }),
+  and: (..._args: unknown[]) => ({ __and: true }),
+  sql: Object.assign(
+    (_strings: TemplateStringsArray, ..._values: unknown[]) => ({ __sql: true }),
+    { raw: (s: string) => ({ __raw: s }) },
+  ),
+}));
+
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
 }));
 
 // The router also imports FHIR generators — mock to identity-ish stubs so

--- a/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
@@ -21,12 +21,15 @@ const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
 let patientRows: Record<string, unknown>[] = [];
+// Rows returned when the router queries audit_log for prior expired exports.
+let priorAuditRows: Record<string, unknown>[] = [];
 
 function selectMock() {
   return {
     from: (table: unknown) => ({
       where: async () => {
         if (table === patientsTable) return patientRows;
+        if (table === auditLogTable) return priorAuditRows;
         return [];
       },
     }),
@@ -60,18 +63,11 @@ vi.mock("drizzle-orm", () => ({
   eq: (_col: unknown, _val: unknown) => ({ __eq: true }),
   and: (..._args: unknown[]) => ({ __and: true }),
   sql: Object.assign(
-    (_strings: TemplateStringsArray, ..._values: unknown[]) => ({ __sql: true }),
+    (_strings: TemplateStringsArray, ..._values: unknown[]) => ({
+      __sql: true,
+    }),
     { raw: (s: string) => ({ __raw: s }) },
   ),
-}));
-
-vi.mock("@carebridge/logger", () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
 }));
 
 vi.mock("../generators/index.js", () => ({
@@ -85,6 +81,17 @@ vi.mock("../generators/index.js", () => ({
 
 vi.mock("@carebridge/phi-sanitizer", () => ({
   sanitizeFreeText: (s: string) => s,
+}));
+
+// Capture logger.warn calls.
+const loggerWarnSpy = vi.fn();
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnSpy,
+    error: vi.fn(),
+  }),
 }));
 
 // ── Import after mocks ─────────────────────────────────────────
@@ -104,11 +111,13 @@ beforeEach(() => {
   insertCalls.length = 0;
   insertMock.mockClear();
   transactionMock.mockClear();
+  loggerWarnSpy.mockClear();
   patientRows = [];
+  priorAuditRows = [];
 });
 
-describe("exportPatient security headers", () => {
-  it("sets Cache-Control: no-store, no-cache, must-revalidate via setHeader", async () => {
+describe("exportPatient purge-at audit warning", () => {
+  it("emits a structured warning when a prior export has an expired recommended_purge_at", async () => {
     patientRows = [
       {
         id: "patient-42",
@@ -118,21 +127,55 @@ describe("exportPatient security headers", () => {
       },
     ];
 
-    const setHeader = vi.fn();
-    const caller = fhirGatewayRouter.createCaller({
-      user: adminUser,
-      setHeader,
-    });
+    const pastPurge = new Date(Date.now() - 60_000).toISOString();
+    priorAuditRows = [
+      {
+        id: "audit-prev-1",
+        details: JSON.stringify({
+          export_type: "patient_full_bundle",
+          export_id: "prev-export-id",
+          recommended_purge_at: pastPurge,
+        }),
+        timestamp: new Date(Date.now() - 120_000).toISOString(),
+      },
+    ];
 
+    const caller = fhirGatewayRouter.createCaller({ user: adminUser });
+    const bundle = await caller.exportPatient({ patientId: "patient-42" });
+
+    expect(bundle.resourceType).toBe("Bundle");
+
+    // Logger should have been called with the warning.
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    const [msg, meta] = loggerWarnSpy.mock.calls[0]!;
+    expect(msg).toBe("re-export requested after recommended_purge_at");
+    expect(meta).toMatchObject({
+      user_id: "user-admin-1",
+      patient_id: "patient-42",
+      prior_export_id: "prev-export-id",
+      prior_recommended_purge_at: pastPurge,
+      expired_export_count: 1,
+    });
+  });
+
+  it("does not emit a warning when there are no prior expired exports", async () => {
+    patientRows = [
+      {
+        id: "patient-42",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        date_of_birth: "1815-12-10",
+      },
+    ];
+    priorAuditRows = []; // No prior exports.
+
+    const caller = fhirGatewayRouter.createCaller({ user: adminUser });
     await caller.exportPatient({ patientId: "patient-42" });
 
-    expect(setHeader).toHaveBeenCalledWith(
-      "Cache-Control",
-      "no-store, no-cache, must-revalidate",
-    );
+    expect(loggerWarnSpy).not.toHaveBeenCalled();
   });
 
-  it("sets Content-Disposition: attachment with export-id filename via setHeader", async () => {
+  it("includes expired_export_count when multiple prior exports exist", async () => {
     patientRows = [
       {
         id: "patient-42",
@@ -142,60 +185,36 @@ describe("exportPatient security headers", () => {
       },
     ];
 
-    const setHeader = vi.fn();
-    const caller = fhirGatewayRouter.createCaller({
-      user: adminUser,
-      setHeader,
-    });
-
-    const bundle = await caller.exportPatient({ patientId: "patient-42" });
-
-    // Extract the export_id from the bundle meta extension to verify the
-    // Content-Disposition filename matches.
-    const ext = bundle.meta!.extension![0]!;
-    const extPayload = JSON.parse(ext.valueString as string) as Record<
-      string,
-      unknown
-    >;
-    const exportId = extPayload.export_id as string;
-
-    expect(setHeader).toHaveBeenCalledWith(
-      "Content-Disposition",
-      `attachment; filename="bundle-${exportId}.json"`,
-    );
-  });
-
-  it("does not throw when setHeader is absent (createCaller without HTTP context)", async () => {
-    patientRows = [
+    const pastPurge1 = new Date(Date.now() - 120_000).toISOString();
+    const pastPurge2 = new Date(Date.now() - 60_000).toISOString();
+    priorAuditRows = [
       {
-        id: "patient-42",
-        first_name: "Ada",
-        last_name: "Lovelace",
-        date_of_birth: "1815-12-10",
+        id: "audit-prev-1",
+        details: JSON.stringify({
+          export_type: "patient_full_bundle",
+          export_id: "prev-export-1",
+          recommended_purge_at: pastPurge1,
+        }),
+        timestamp: new Date(Date.now() - 180_000).toISOString(),
+      },
+      {
+        id: "audit-prev-2",
+        details: JSON.stringify({
+          export_type: "patient_full_bundle",
+          export_id: "prev-export-2",
+          recommended_purge_at: pastPurge2,
+        }),
+        timestamp: new Date(Date.now() - 90_000).toISOString(),
       },
     ];
 
-    // No setHeader in context — simulates direct createCaller usage.
     const caller = fhirGatewayRouter.createCaller({ user: adminUser });
+    await caller.exportPatient({ patientId: "patient-42" });
 
-    const bundle = await caller.exportPatient({ patientId: "patient-42" });
-    expect(bundle.resourceType).toBe("Bundle");
-  });
-
-  it("does not set headers on failure (patient not found)", async () => {
-    patientRows = [];
-
-    const setHeader = vi.fn();
-    const caller = fhirGatewayRouter.createCaller({
-      user: adminUser,
-      setHeader,
-    });
-
-    await expect(
-      caller.exportPatient({ patientId: "nonexistent" }),
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
-
-    // Headers are only set on the success path.
-    expect(setHeader).not.toHaveBeenCalled();
+    expect(loggerWarnSpy).toHaveBeenCalledTimes(1);
+    const [, meta] = loggerWarnSpy.mock.calls[0]!;
+    expect(meta.expired_export_count).toBe(2);
+    // Should reference the most recent (last) prior export.
+    expect(meta.prior_export_id).toBe("prev-export-2");
   });
 });

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -12,7 +12,8 @@ import {
   diagnoses,
   allergies,
 } from "@carebridge/db-schema";
-import { eq } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
+import { createLogger } from "@carebridge/logger";
 import crypto from "node:crypto";
 import type { Vital, LabResult, User } from "@carebridge/shared-types";
 import {
@@ -25,6 +26,8 @@ import {
 } from "./generators/index.js";
 import { fhirBundleSchema } from "./schemas/bundle.js";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
+
+const logger = createLogger("fhir-gateway");
 
 /**
  * Context for the raw FHIR gateway router.
@@ -231,6 +234,44 @@ export const fhirGatewayRouter = t.router({
       assertRawPatientAccess(ctx.user, input.patientId, ctx.rbacVerified);
       const db = getDb();
       const { patientId } = input;
+
+      // Check for a previous export by the same user for this patient whose
+      // recommended_purge_at has passed. This indicates the client may be
+      // holding onto PHI beyond the recommended retention window and is
+      // re-requesting it — worth a structured audit warning.
+      const now = new Date();
+      const priorExpiredExports = await db
+        .select({
+          id: auditLog.id,
+          details: auditLog.details,
+          timestamp: auditLog.timestamp,
+        })
+        .from(auditLog)
+        .where(
+          and(
+            eq(auditLog.user_id, ctx.user.id),
+            eq(auditLog.action, "fhir_export"),
+            eq(auditLog.patient_id, patientId),
+            eq(auditLog.success, true),
+            sql`${auditLog.details}::jsonb->>'recommended_purge_at' < ${now.toISOString()}`,
+          ),
+        );
+
+      if (priorExpiredExports.length > 0) {
+        const mostRecent = priorExpiredExports[priorExpiredExports.length - 1]!;
+        const priorDetails = mostRecent.details
+          ? (JSON.parse(mostRecent.details) as Record<string, unknown>)
+          : {};
+        logger.warn("re-export requested after recommended_purge_at", {
+          user_id: ctx.user.id,
+          patient_id: patientId,
+          prior_export_id: priorDetails.export_id ?? mostRecent.id,
+          prior_export_at: mostRecent.timestamp,
+          prior_recommended_purge_at: priorDetails.recommended_purge_at ?? null,
+          expired_export_count: priorExpiredExports.length,
+        });
+      }
+
       const exportId = crypto.randomUUID();
       const exportedAt = new Date().toISOString();
       const recommendedPurgeAt = new Date(


### PR DESCRIPTION
## Summary
- Checks audit_log for prior exports by same user/patient with expired recommended_purge_at
- Emits structured warning via @carebridge/logger when detected
- 3 new tests covering warning emission, no-warning path, and multi-export count

## Test plan
- [x] All 66 tests pass

Closes #762