### PR TITLE
chore(infra): add CODEOWNERS for clinical safety files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Clinical safety–critical files require domain review
+packages/ai-prompts/src/drug-class-anchors.ts @blamechris
+packages/ai-prompts/src/clinical-review.ts @blamechris


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` requiring `@blamechris` review for `packages/ai-prompts/src/drug-class-anchors.ts` and `packages/ai-prompts/src/clinical-review.ts`
- Guards clinical safety logic from unreviewed changes

Closes #759