### PR TITLE
fix(fhir): add Pragma no-cache to exportPatient response headers

### DIFF
--- a/services/fhir-gateway/src/__tests__/export-headers.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-headers.test.ts
@@ -118,6 +118,27 @@ describe("exportPatient security headers", () => {
     );
   });
 
+  it("sets Pragma: no-cache via setHeader", async () => {
+    patientRows = [
+      {
+        id: "patient-42",
+        first_name: "Ada",
+        last_name: "Lovelace",
+        date_of_birth: "1815-12-10",
+      },
+    ];
+
+    const setHeader = vi.fn();
+    const caller = fhirGatewayRouter.createCaller({
+      user: adminUser,
+      setHeader,
+    });
+
+    await caller.exportPatient({ patientId: "patient-42" });
+
+    expect(setHeader).toHaveBeenCalledWith("Pragma", "no-cache");
+  });
+
   it("sets Content-Disposition: attachment with export-id filename via setHeader", async () => {
     patientRows = [
       {

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -374,6 +374,7 @@ export const fhirGatewayRouter = t.router({
             "Content-Disposition",
             `attachment; filename="bundle-${exportId}.json"`,
           );
+          ctx.setHeader("Pragma", "no-cache");
         }
 
         // The bundle is returned inline rather than via a signed short-TTL


### PR DESCRIPTION
## Summary
- Adds `Pragma: no-cache` response header to the `exportPatient` procedure alongside the existing `Cache-Control` and `Content-Disposition` headers for broader HTTP/1.0 proxy compatibility
- Adds a test case asserting the new header is set

Closes #760