### PR TITLE
test(ai): CI symmetry check between LLM drug-class anchors and deterministic rules

### DIFF
--- a/packages/ai-prompts/src/drug-class-anchors.ts
+++ b/packages/ai-prompts/src/drug-class-anchors.ts
@@ -15,8 +15,19 @@ export interface DrugClassCrossReaction {
 
 export const DRUG_CLASS_CROSS_REACTIONS: readonly DrugClassCrossReaction[] = [
   { class: "penicillin", examples: ["amoxicillin", "ampicillin", "piperacillin"] },
-  { class: "sulfa", examples: ["sulfonamide antibiotics"] },
-  { class: "aspirin", examples: ["other NSAIDs"] },
+  { class: "cephalosporin", examples: ["cefazolin", "ceftriaxone", "cephalexin", "cefepime"] },
+  { class: "penicillin-cephalosporin-cross", examples: ["penicillin → cephalosporin (~2% cross-reactivity)"] },
+  { class: "sulfa", examples: ["sulfonamide antibiotics", "sulfamethoxazole", "bactrim"] },
+  { class: "aspirin", examples: ["other NSAIDs", "ibuprofen", "naproxen", "celecoxib"] },
+  { class: "opioid", examples: ["codeine", "morphine", "hydrocodone", "oxycodone", "fentanyl"] },
+  { class: "fluoroquinolone", examples: ["ciprofloxacin", "levofloxacin", "moxifloxacin"] },
+  { class: "ACE inhibitor", examples: ["lisinopril", "enalapril", "ramipril", "captopril"] },
+  { class: "statin", examples: ["atorvastatin", "simvastatin", "rosuvastatin", "pravastatin"] },
+  { class: "macrolide", examples: ["azithromycin", "erythromycin", "clarithromycin"] },
+  { class: "tetracycline", examples: ["doxycycline", "minocycline", "tigecycline"] },
+  { class: "benzodiazepine", examples: ["diazepam", "lorazepam", "alprazolam", "clonazepam"] },
+  { class: "iodinated contrast", examples: ["iohexol", "iopamidol", "iodixanol"] },
+  { class: "latex", examples: ["natural rubber latex"] },
 ] as const;
 
 /**

--- a/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { DRUG_CLASS_CROSS_REACTIONS } from "@carebridge/ai-prompts";
+import { CROSS_REACTIVITY_MAP } from "../rules/allergy-medication.js";
+
+/**
+ * Symmetry check: LLM prompt anchors (DRUG_CLASS_CROSS_REACTIONS) and
+ * deterministic rule map (CROSS_REACTIVITY_MAP) must cover the same
+ * drug classes.  A drift between the two means the LLM might flag
+ * something the rules miss (or vice-versa).
+ *
+ * The two maps use slightly different naming conventions (e.g. "sulfa"
+ * vs "sulfonamide"), so we normalise via CANONICAL_NAME before comparing.
+ * When adding a new class to either map, add a canonical entry here so
+ * the test stays green.
+ */
+
+/** Canonical lowercase name used for comparison. */
+const CANONICAL_NAME: Record<string, string> = {
+  // LLM anchor names → canonical
+  penicillin: "penicillin",
+  sulfa: "sulfonamide",
+  aspirin: "nsaid",
+  // Rule map names → canonical (identity or mapped)
+  sulfonamide: "sulfonamide",
+  nsaid: "nsaid",
+  cephalosporin: "cephalosporin",
+  "penicillin-cephalosporin-cross": "penicillin-cephalosporin-cross",
+  opioid: "opioid",
+  fluoroquinolone: "fluoroquinolone",
+  "ace inhibitor": "ace-inhibitor",
+  statin: "statin",
+  macrolide: "macrolide",
+  tetracycline: "tetracycline",
+  benzodiazepine: "benzodiazepine",
+  "iodinated contrast": "iodinated-contrast",
+  latex: "latex",
+  // Shared (both maps use these directly)
+  "ace-inhibitor": "ace-inhibitor",
+  "iodinated-contrast": "iodinated-contrast",
+};
+
+function canonicalise(name: string): string {
+  const lower = name.toLowerCase();
+  return CANONICAL_NAME[lower] ?? lower;
+}
+
+describe("DRUG_CLASS_CROSS_REACTIONS <-> CROSS_REACTIVITY_MAP symmetry", () => {
+  const llmCanonical = new Set(
+    DRUG_CLASS_CROSS_REACTIONS.map((r) => canonicalise(r.class)),
+  );
+
+  const ruleCanonical = new Set(
+    CROSS_REACTIVITY_MAP.map((m) => canonicalise(m.class)),
+  );
+
+  it("every LLM anchor class has a canonical mapping", () => {
+    const unmapped = DRUG_CLASS_CROSS_REACTIONS
+      .map((r) => r.class.toLowerCase())
+      .filter((c) => !(c in CANONICAL_NAME));
+    if (unmapped.length > 0) {
+      console.log("LLM classes without canonical mapping — add them to CANONICAL_NAME:", unmapped);
+    }
+    expect(unmapped).toEqual([]);
+  });
+
+  it("every deterministic rule class has a canonical mapping", () => {
+    const unmapped = CROSS_REACTIVITY_MAP
+      .map((m) => m.class.toLowerCase())
+      .filter((c) => !(c in CANONICAL_NAME));
+    if (unmapped.length > 0) {
+      console.log("Rule classes without canonical mapping — add them to CANONICAL_NAME:", unmapped);
+    }
+    expect(unmapped).toEqual([]);
+  });
+
+  it("every LLM anchor class (canonical) exists in deterministic rules", () => {
+    const missingInRules = [...llmCanonical].filter((c) => !ruleCanonical.has(c));
+    if (missingInRules.length > 0) {
+      console.log(
+        "Canonical classes in LLM anchors but missing from CROSS_REACTIVITY_MAP:",
+        missingInRules,
+      );
+    }
+    expect(missingInRules).toEqual([]);
+  });
+
+  it("every deterministic rule class (canonical) exists in LLM anchors", () => {
+    const missingInLLM = [...ruleCanonical].filter((c) => !llmCanonical.has(c));
+    if (missingInLLM.length > 0) {
+      console.log(
+        "Canonical classes in CROSS_REACTIVITY_MAP but missing from LLM anchors:",
+        missingInLLM,
+      );
+    }
+    expect(missingInLLM).toEqual([]);
+  });
+});

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -17,7 +17,7 @@ import type { PatientContext } from "./cross-specialty.js";
  * Maps an allergen class to medication name patterns that share the same
  * active ingredient or belong to the same drug family.
  */
-const CROSS_REACTIVITY_MAP: Array<{
+export const CROSS_REACTIVITY_MAP: Array<{
   allergenPattern: RegExp;
   medicationPattern: RegExp;
   class: string;

--- a/services/ai-oversight/vitest.config.ts
+++ b/services/ai-oversight/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         __dirname,
         "../../packages/medical-logic/src/index.ts",
       ),
+      "@carebridge/ai-prompts": path.resolve(
+        __dirname,
+        "../../packages/ai-prompts/src/index.ts",
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Adds a vitest symmetry check ensuring `DRUG_CLASS_CROSS_REACTIONS` (LLM prompt anchors in `@carebridge/ai-prompts`) and `CROSS_REACTIVITY_MAP` (deterministic rules in `ai-oversight`) cover the same drug classes
- Exports `CROSS_REACTIVITY_MAP` so it can be imported by the test
- Adds 11 missing drug classes to `DRUG_CLASS_CROSS_REACTIONS` to bring LLM anchors in sync with deterministic rules
- Adds `@carebridge/ai-prompts` alias to `ai-oversight` vitest config

## Test plan
- [x] New test `cross-reactivity-sync.test.ts` passes (4 assertions)
- [x] Existing test suite unaffected (978 tests pass)
- [ ] CI green

Closes #761