### PR TITLE
docs(ai): fix allergy_status enum in golden-eval example

### DIFF
--- a/docs/golden-eval.md
+++ b/docs/golden-eval.md
@@ -43,7 +43,7 @@ Each fixture file must conform to the `EvalFixture` interface defined in
     "patient": {
       "age": 45,
       "sex": "female",
-      "allergy_status": "known",        // "nkda" | "known" | "unknown"
+      "allergy_status": "has_allergies",  // "nkda" | "has_allergies" | "unknown"
       "active_diagnoses": ["..."],
       "allergies": [
         {


### PR DESCRIPTION
## Summary
- Fix incorrect `allergy_status` enum value in `docs/golden-eval.md`: `"known"` → `"has_allergies"` and update the inline comment to match

Closes #796

## Test plan
- [ ] Verify the fixture example in the doc matches the actual `allergy_status` enum values used in `ReviewContext`