### PR TITLE
fix(portal): consolidate duplicate sr-only staleness announcements

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -366,11 +366,9 @@ function VitalsTab({ patientId }: { patientId: string }) {
               >
                 {new Date(vital.recorded_at).toLocaleString()}
               </span>
-              {tier !== "current" && (
+              {tier === "overdue" && (
                 <span className="sr-only">
-                  {tier === "overdue"
-                    ? "This vital is overdue for recheck."
-                    : "This vital is stale. Older than 24 hours — do not treat as current."}
+                  This vital is overdue for recheck.
                 </span>
               )}
               {staleExplainId && (


### PR DESCRIPTION
## Summary
- Remove the duplicate `sr-only` span for stale-tier vital cards, which was redundant with the `aria-describedby`-linked span that provides the same "Older than 24 hours" announcement
- Keep the `sr-only` span for overdue-tier vitals, which has no `aria-describedby` equivalent

Closes #793