### PR TITLE
fix(ai): warn on null started_at medication fallback

### DIFF
--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Mock the @carebridge/logger module so we can assert against logger.warn()
+// calls (e.g. the null started_at fallback warning from #516).
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+  }),
+}));
+
 // Mock db-schema BEFORE importing the module under test.
 //
 // buildPatientContext issues eight parallel reads (patient, diagnoses,
@@ -73,6 +85,8 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
     labResultsSelect.mockReset();
     usersSelect.mockReset();
     patientFindFirst.mockReset();
+
+    mockWarn.mockClear();
 
     // Sensible defaults — tests override as needed.
     patientFindFirst.mockResolvedValue({
@@ -465,6 +479,64 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
     // labs to show) rather than an empty array — the LLM prompt omits
     // the section entirely.
     expect(ctx.recent_labs).toBeUndefined();
+  });
+
+  // ─── #516 — warn when started_at is null and created_at is used ────
+  it("emits a structured warning when medication started_at is null and created_at is used as fallback", async () => {
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Dexamethasone",
+        status: "active",
+        started_at: null,
+        ended_at: null,
+        created_at: "2026-04-10T08:00:00.000Z",
+        dose_amount: "4",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "Daily",
+      },
+    ]);
+
+    const ctx = await buildPatientContext("p-1", baseEvent);
+
+    // The medication should still be included (warn-and-include, not fail-closed).
+    expect(ctx.active_medications.map((m) => m.name)).toContain("Dexamethasone");
+
+    // A structured warning must have been emitted with the expected metadata.
+    expect(mockWarn).toHaveBeenCalledWith(
+      "medication_started_at_null_fallback",
+      expect.objectContaining({
+        metric: "medication_started_at_null_fallback",
+        patient_id_prefix: "p-1".slice(0, 8),
+        medication_name: "Dexamethasone",
+        created_at_used: "2026-04-10T08:00:00.000Z",
+        caller: "context-builder:buildPatientContext",
+      }),
+    );
+  });
+
+  it("does not warn when medication started_at is present", async () => {
+    medicationsSelect.mockResolvedValue([
+      {
+        name: "Apixaban",
+        status: "active",
+        started_at: "2026-04-01T00:00:00.000Z",
+        ended_at: null,
+        created_at: "2026-04-01T00:00:00.000Z",
+        dose_amount: "5",
+        dose_unit: "mg",
+        route: "PO",
+        frequency: "BID",
+      },
+    ]);
+
+    await buildPatientContext("p-1", baseEvent);
+
+    // No null-fallback warning should fire.
+    const fallbackCalls = mockWarn.mock.calls.filter(
+      ([msg]: [string]) => msg === "medication_started_at_null_fallback",
+    );
+    expect(fallbackCalls).toHaveLength(0);
   });
 
   // ─── #515 — exclude logical retractions ────────────────────────────

--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -534,7 +534,7 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
 
     // No null-fallback warning should fire.
     const fallbackCalls = mockWarn.mock.calls.filter(
-      ([msg]: [string]) => msg === "medication_started_at_null_fallback",
+      ([msg]: any[]) => msg === "medication_started_at_null_fallback",
     );
     expect(fallbackCalls).toHaveLength(0);
   });

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -36,6 +36,9 @@ import {
   redactPatientId,
   validateLLMResponse,
 } from "@carebridge/phi-sanitizer";
+import { createLogger } from "@carebridge/logger";
+
+const logger = createLogger("ai-oversight");
 
 import { checkCriticalValues } from "../rules/critical-values.js";
 import { checkCrossSpecialtyPatterns } from "../rules/cross-specialty.js";
@@ -651,11 +654,19 @@ export async function buildPatientContextForRules(
   // A medication was "active at event time" if it had started (started_at
   // present and <= event time) and had not yet ended (ended_at null or
   // strictly after event time). Falls back to created_at when started_at
-  // is missing — defensive, should not be needed under the non-null
-  // schema constraint but guards against partial records.
+  // is missing (warn-and-include; #516).
   const activeMedsList = allMeds.filter((m) => {
     if (isMedicationRetracted(m)) return false;
     const start = m.started_at ?? m.created_at;
+    if (!m.started_at) {
+      logger.warn("medication_started_at_null_fallback", {
+        metric: "medication_started_at_null_fallback",
+        patient_id_prefix: patientId.slice(0, 8),
+        medication_name: m.name,
+        created_at_used: m.created_at,
+        caller: "review-service:buildPatientContextForRules",
+      });
+    }
     if (isoBefore(eventAt, start)) return false;
     if (m.ended_at && isoLTE(m.ended_at, eventAt)) return false;
     return true;

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -24,6 +24,9 @@ import type { ReviewContext } from "@carebridge/ai-prompts";
 import type { AllergyStatus, ClinicalEvent } from "@carebridge/shared-types";
 import { calculateDeltaFromBaseline } from "@carebridge/medical-logic";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
+import { createLogger } from "@carebridge/logger";
+
+const logger = createLogger("ai-oversight");
 
 import {
   isoBefore,
@@ -162,10 +165,19 @@ export async function buildPatientContext(
   // Event-time snapshot filtering — medications active at event time.
   // A med is active if it started at/before event time AND either is
   // still open (no ended_at) or ended strictly after event time. Falls
-  // back to created_at if started_at is null (defensive; see #516).
+  // back to created_at if started_at is null (warn-and-include; #516).
   const activeMeds = allMeds.filter((m) => {
     if (isMedicationRetracted(m)) return false;
     const start = m.started_at ?? m.created_at;
+    if (!m.started_at) {
+      logger.warn("medication_started_at_null_fallback", {
+        metric: "medication_started_at_null_fallback",
+        patient_id_prefix: patientId.slice(0, 8),
+        medication_name: m.name,
+        created_at_used: m.created_at,
+        caller: "context-builder:buildPatientContext",
+      });
+    }
     if (isoBefore(eventAt, start)) return false;
     if (m.ended_at && isoLTE(m.ended_at, eventAt)) return false;
     return true;


### PR DESCRIPTION
## Summary
- Implements Option 2 (warn-and-include) from #516 for the null `started_at` medication fallback
- Both context builders (LLM path in `context-builder.ts` and rule path in `review-service.ts`) now emit a structured `medication_started_at_null_fallback` log warning when `started_at` is null and `created_at` is used as fallback
- Warning includes redacted `patient_id_prefix` (first 8 chars), medication name, `created_at` value used, and caller label — no PHI
- Medication is still included in the active set (warn-and-include, not fail-closed)
- Two new tests verify the warning fires when `started_at` is null and does not fire when it is present

Closes #516

## Test plan
- [x] New test: structured warning emitted when `started_at` is null
- [x] New test: no warning when `started_at` is present
- [x] All 15 context-builder tests pass
- [x] All 410 runnable ai-oversight tests pass (7 pre-existing suite failures from unbuilt transitive deps)