### PR TITLE
feat(gateway): log export count in FHIR rate-limit audit events

### DIFF
--- a/services/api-gateway/src/__tests__/fhir-export-rate-limit.test.ts
+++ b/services/api-gateway/src/__tests__/fhir-export-rate-limit.test.ts
@@ -187,6 +187,30 @@ describe("FHIR export per-user rate limit", () => {
     expect(event.ip).toBe("1.2.3.4");
   });
 
+  it("includes current request count in audit event for trend analysis", async () => {
+    const MAX = 5;
+    const hook = makeHook({ max: MAX });
+
+    // Exhaust the budget (5 allowed requests)
+    for (let i = 0; i < MAX; i++) {
+      await hook(makeReq("/trpc/fhir.exportPatient"), makeReply());
+    }
+    expect(auditEvents).toHaveLength(0);
+
+    // 6th request: borderline exceedance (count === 6)
+    await hook(makeReq("/trpc/fhir.exportPatient"), makeReply());
+    await flushMicrotasks();
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]!.count).toBe(6);
+
+    // Simulate a scraping pattern: jump counter to 50 and send another request.
+    redis._counts.set(`${FHIR_EXPORT_KEY_PREFIX}user-1`, 49);
+    await hook(makeReq("/trpc/fhir.exportPatient"), makeReply());
+    await flushMicrotasks();
+    expect(auditEvents).toHaveLength(2);
+    expect(auditEvents[1]!.count).toBe(50);
+  });
+
   it("rate-limits per user independently", async () => {
     const hook = makeHook({ max: 2 });
 

--- a/services/api-gateway/src/middleware/fhir-export-rate-limit.ts
+++ b/services/api-gateway/src/middleware/fhir-export-rate-limit.ts
@@ -28,6 +28,12 @@ export interface FhirExportAuditEvent {
   userId: string;
   procedureName: string;
   ip: string;
+  /**
+   * Current request count for this user in the active window. Included so
+   * downstream trend analysis can distinguish borderline exceedances
+   * (e.g. 6/5) from aggressive scraping patterns (e.g. 50/5).
+   */
+  count: number;
 }
 
 export interface FhirExportRateLimitOptions {
@@ -52,6 +58,9 @@ async function defaultAuditEmitter(event: FhirExportAuditEvent): Promise<void> {
     resource_id: "",
     procedure_name: event.procedureName,
     patient_id: null,
+    // Persist the current request count so trend analysis can distinguish
+    // borderline exceedances (e.g. 6/5) from scraping patterns (e.g. 50/5).
+    details: JSON.stringify({ count: event.count }),
     ip_address: event.ip,
     http_status_code: 429,
     success: false,
@@ -103,6 +112,7 @@ export function makeFhirExportRateLimitHook(
         userId: user.id,
         procedureName: "fhir.exportPatient",
         ip: req.ip,
+        count,
       }).catch((err: unknown) => {
         req.log?.warn?.({ err }, "Failed to write FHIR export rate-limit audit event");
       });


### PR DESCRIPTION
Adds the current request `count` to `FhirExportAuditEvent` (and persists it to `audit_log.details`) so trend analysis can distinguish borderline exceedances (6/5) from scraping patterns (50/5).

Closes #816