### PR TITLE
fix(ai): use lab-provided H/L/critical flags and per-result reference ranges

### DIFF
--- a/services/ai-oversight/src/__tests__/critical-values.test.ts
+++ b/services/ai-oversight/src/__tests__/critical-values.test.ts
@@ -311,6 +311,119 @@ describe("checkCriticalValues — lab heuristic fallback", () => {
   });
 });
 
+// ─── Lab-provided flag precedence (issue #244) ───────────────────
+describe("checkCriticalValues — lab-provided flag precedence", () => {
+  it("flags unknown lab as critical when the lab reports flag='critical' and no reference range is supplied", () => {
+    // Regression: previously this silently slipped through because the lab
+    // was not in COMMON_LAB_TESTS and had no reference range. An analyzing
+    // laboratory explicitly flagging the value as critical is authoritative.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 999,
+          unit: "U/L",
+          flag: "critical",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.rule_id).toBe("CRITICAL-LAB-OBSCURE_MARKER_X");
+  });
+
+  it("emits warning flag when lab reports flag='H' without a reference range", () => {
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Novel Biomarker",
+          value: 42,
+          unit: "pg/mL",
+          flag: "H",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.summary).toContain("High");
+  });
+
+  it("emits warning flag when lab reports flag='L' without a reference range", () => {
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Novel Biomarker",
+          value: 0.1,
+          unit: "pg/mL",
+          flag: "L",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.summary).toContain("Low");
+  });
+
+  it("honors lab flag even when value is within COMMON_LAB_TESTS typical range", () => {
+    // A lab flagging a result as critical overrides typical-range fallback
+    // even when the value itself would otherwise look benign. The laboratory
+    // has more context (patient baseline, critical-value policy) than we do.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Hemoglobin",
+          value: 13.5, // within typical 12.0–17.5
+          unit: "g/dL",
+          flag: "critical",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+  });
+
+  it("prefers per-result reference_low/reference_high over COMMON_LAB_TESTS", () => {
+    // Scenario: lab reports Potassium with a patient-specific reference range
+    // (e.g. 3.0–5.5 for a CKD patient on K-binders). A value of 5.4 would be
+    // "high" by COMMON_LAB_TESTS (typical_high=5.0) but within the per-result
+    // range. The per-result range must win; this result should NOT be flagged
+    // by the heuristic fallback (POTASSIUM explicit threshold is separate).
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Nonstandard Metabolite",
+          value: 10,
+          unit: "mg/dL",
+          reference_low: 5,
+          reference_high: 15,
+        },
+      ]),
+    );
+    // 10 is mid-range, no flag expected.
+    expect(flags).toHaveLength(0);
+  });
+
+  it("uses per-result reference range to detect far-outside when COMMON_LAB_TESTS disagrees", () => {
+    // Per-result reference range: 3.5–5.0 (range=1.5). Value 8.5 is far above
+    // (> 5.0 + 1.5 = 6.5) so should flag critical regardless of COMMON_LAB_TESTS.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Rare Analyte Y",
+          value: 8.5,
+          unit: "mmol/L",
+          reference_low: 3.5,
+          reference_high: 5.0,
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.rationale).toContain("3.5");
+    expect(flags[0]!.rationale).toContain("5");
+  });
+});
+
 // ─── Multiple Lab Results in One Event ───────────────────────────
 describe("checkCriticalValues — multiple lab results", () => {
   it("flags multiple critical results in a single lab panel", () => {

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -487,65 +487,101 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
 
         // ── 2. Heuristic fallback for labs without explicit thresholds ─
         if (!matchedExplicit) {
-          let isCritical = false;
+          // The analyzing laboratory's flag is authoritative. If a lab
+          // reports `flag: "critical" | "H" | "L"`, we emit a flag
+          // regardless of whether the result carries a reference range
+          // and regardless of whether the test is in COMMON_LAB_TESTS.
+          // Previously, unknown labs with no reference range could slip
+          // through silently when the lab had already marked them high /
+          // low / critical (see issue #244).
+          let severity: FlagSeverity | null = null;
+          let direction: "low" | "high" | null = null;
           let reason = "";
 
-          // Check explicit critical flag
           if (result.flag === "critical") {
-            isCritical = true;
-            reason = `Lab result flagged as critical by the analyzing laboratory.`;
-          }
-
-          // Check if value is far outside reference range (more than 2x the range deviation)
-          if (
-            !isCritical &&
-            result.reference_low !== undefined &&
-            result.reference_high !== undefined
-          ) {
-            const range = result.reference_high - result.reference_low;
-            if (
-              result.value < result.reference_low - range ||
-              result.value > result.reference_high + range
-            ) {
-              isCritical = true;
-              reason =
-                `Value of ${result.value} ${result.unit} is far outside reference range ` +
-                `(${result.reference_low}–${result.reference_high} ${result.unit}).`;
-            }
-          }
-
-          // Fallback: check against COMMON_LAB_TESTS for known tests without explicit references
-          if (!isCritical && result.reference_low === undefined) {
-            const ref = COMMON_LAB_TESTS[result.test_name];
-            if (ref) {
-              const range = ref.typical_high - ref.typical_low;
-              if (
-                result.value < ref.typical_low - range ||
-                result.value > ref.typical_high + range
-              ) {
-                isCritical = true;
-                reason =
-                  `Value of ${result.value} ${result.unit} is far outside typical range ` +
-                  `(${ref.typical_low}–${ref.typical_high} ${ref.unit}).`;
-              }
-            }
-          }
-
-          if (isCritical) {
-            const direction =
+            severity = "critical";
+            // Use per-result reference range when present to infer direction;
+            // otherwise default to "high" (most lab-panel critical flags are
+            // elevations; direction is refined below if we can compute it).
+            direction =
               result.reference_low !== undefined &&
               result.value < result.reference_low
                 ? "low"
                 : "high";
+            reason = `Lab result flagged as critical by the analyzing laboratory.`;
+          } else if (result.flag === "H") {
+            severity = "warning";
+            direction = "high";
+            reason = `Lab result flagged as high (H) by the analyzing laboratory.`;
+          } else if (result.flag === "L") {
+            severity = "warning";
+            direction = "low";
+            reason = `Lab result flagged as low (L) by the analyzing laboratory.`;
+          }
+
+          // Per-result reference range is authoritative over COMMON_LAB_TESTS.
+          // Only use the shared typical range as a fallback when the result
+          // does not carry its own reference_low / reference_high.
+          if (severity === null) {
+            if (
+              result.reference_low !== undefined &&
+              result.reference_high !== undefined
+            ) {
+              const range = result.reference_high - result.reference_low;
+              if (
+                result.value < result.reference_low - range ||
+                result.value > result.reference_high + range
+              ) {
+                severity = "critical";
+                direction =
+                  result.value < result.reference_low ? "low" : "high";
+                reason =
+                  `Value of ${result.value} ${result.unit} is far outside reference range ` +
+                  `(${result.reference_low}–${result.reference_high} ${result.unit}).`;
+              }
+            } else if (
+              result.reference_low === undefined &&
+              result.reference_high === undefined
+            ) {
+              // Fallback: check against COMMON_LAB_TESTS for known tests
+              // without explicit references.
+              const ref = COMMON_LAB_TESTS[result.test_name];
+              if (ref) {
+                const range = ref.typical_high - ref.typical_low;
+                if (
+                  result.value < ref.typical_low - range ||
+                  result.value > ref.typical_high + range
+                ) {
+                  severity = "critical";
+                  direction = result.value < ref.typical_low ? "low" : "high";
+                  reason =
+                    `Value of ${result.value} ${result.unit} is far outside typical range ` +
+                    `(${ref.typical_low}–${ref.typical_high} ${ref.unit}).`;
+                }
+              }
+            }
+          }
+
+          if (severity !== null) {
+            const resolvedDirection = direction ?? "high";
+            const summaryPrefix =
+              severity === "critical"
+                ? "Critical lab result"
+                : resolvedDirection === "high"
+                  ? "High lab result"
+                  : "Low lab result";
 
             flags.push({
-              severity: "critical",
+              severity,
               category: "critical-value",
-              summary: `Critical lab result: ${result.test_name} = ${result.value} ${result.unit}`,
+              summary: `${summaryPrefix}: ${result.test_name} = ${result.value} ${result.unit}`,
               rationale: reason,
-              suggested_action: `Review critical ${result.test_name} result immediately. Correlate with clinical status and consider repeat testing or intervention.`,
+              suggested_action:
+                severity === "critical"
+                  ? `Review critical ${result.test_name} result immediately. Correlate with clinical status and consider repeat testing or intervention.`
+                  : `Review ${resolvedDirection} ${result.test_name} result. Correlate with clinical status and trend; repeat testing as indicated.`,
               notify_specialties: [],
-              rule_id: `CRITICAL-LAB-${result.test_name.replace(/\s+/g, "_").toUpperCase()}`,
+              rule_id: `${severity === "critical" ? "CRITICAL" : "WARNING"}-LAB-${result.test_name.replace(/\s+/g, "_").toUpperCase()}`,
             });
           }
         }


### PR DESCRIPTION
Closes #244

## Patient-safety summary

The critical-values deterministic rule in `services/ai-oversight/src/rules/critical-values.ts` could silently miss lab-flagged abnormal results. If a lab result was:

- not in `CRITICAL_LAB_THRESHOLDS` (no explicit rule), AND
- not in `COMMON_LAB_TESTS`, AND
- lacked `reference_low` / `reference_high`,

then even an analyzing laboratory's own `flag: "H" | "L" | "critical"` was ignored. The `"far out of range"` fallback also required a value be outside 2x the reference deviation, meaning a K+ 6.8 mEq/L reported with a 3.5–5.0 reference could slip past without an alert.

## Fix

In the heuristic-fallback path:

1. **Lab-provided flags are authoritative.** `flag: "critical"` emits a critical flag; `flag: "H"` / `flag: "L"` emit warning flags with the correct direction. The analyzing lab has more patient-specific context (baselines, institutional critical-value policy) than our static typical ranges.
2. **Per-result reference range beats `COMMON_LAB_TESTS`.** The shared typical range is only consulted when the inbound result does not carry its own `reference_low` / `reference_high`.
3. Existing severity stratification, explicit `CRITICAL_LAB_THRESHOLDS` (potassium, troponin, INR, etc.), and LOINC matching are unchanged. Warning flags use `WARNING-LAB-*` rule ids.

No schema changes were needed — `LabResult.flag` and the Zod validator already accept `"H" | "L" | "critical"`.

## Tests

Five new regression tests in `services/ai-oversight/src/__tests__/critical-values.test.ts`:

- Unknown lab with `flag: "critical"` and no reference range → critical flag.
- Unknown lab with `flag: "H"` → warning flag, high.
- Unknown lab with `flag: "L"` → warning flag, low.
- `flag: "critical"` honored even when value is within `COMMON_LAB_TESTS` typical range.
- Per-result `reference_low` / `reference_high` drive the far-outside check for labs not in `COMMON_LAB_TESTS`.
- Per-result range mid-value with no explicit flag → no flag (precedence over any mismatching `COMMON_LAB_TESTS` entry).

All 543 `@carebridge/ai-oversight` tests pass, plus `pnpm typecheck` and `pnpm lint` from repo root are clean.