### PR TITLE
feat(portal): add skip navigation links and visible focus indicators

### DIFF
--- a/apps/clinician-portal/src/__tests__/layout-skip-nav.test.tsx
+++ b/apps/clinician-portal/src/__tests__/layout-skip-nav.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA compliance: verify the root layout renders a "skip to main
+ * content" link as the first focusable element inside <body>, and that a
+ * corresponding <main id="main-content"> target exists. (Issue #182, 2.4.1
+ * Bypass Blocks.)
+ *
+ * The RootLayout renders <html>/<body>, which React Testing Library cannot
+ * mount inside a jsdom document directly, so we import the layout module
+ * and invoke its exported default against a minimal child, then walk the
+ * resulting element tree.
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock Providers so we don't pull tRPC / auth context during a pure
+// structural test of the layout tree.
+vi.mock("../../app/providers", () => ({
+  Providers: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock Sidebar so we don't pull next/navigation hooks during this render.
+vi.mock("../../app/sidebar", () => ({
+  Sidebar: () => <nav data-testid="sidebar">sidebar</nav>,
+}));
+
+import RootLayout from "../../app/layout";
+
+/**
+ * Recursively collect every React element in the tree into a flat array so
+ * we can reason about ordering and attributes without mounting a full DOM.
+ */
+function flatten(node: React.ReactNode): React.ReactElement[] {
+  const out: React.ReactElement[] = [];
+  const visit = (n: React.ReactNode) => {
+    if (n == null || typeof n === "boolean") return;
+    if (Array.isArray(n)) {
+      n.forEach(visit);
+      return;
+    }
+    if (typeof n === "object" && "type" in n) {
+      out.push(n as React.ReactElement);
+      const children = (n as React.ReactElement).props?.children;
+      if (children !== undefined) visit(children);
+    }
+  };
+  visit(node);
+  return out;
+}
+
+describe("clinician-portal RootLayout skip navigation", () => {
+  const tree = RootLayout({ children: <div data-testid="page-children" /> });
+  const elements = flatten(tree);
+
+  it("renders a skip link whose href targets #main-content", () => {
+    const skipLink = elements.find(
+      (el) => el.type === "a" && el.props?.href === "#main-content",
+    );
+    expect(skipLink).toBeDefined();
+    expect(String(skipLink?.props?.children)).toMatch(/skip to main content/i);
+  });
+
+  it("renders a <main> with id=main-content", () => {
+    const mainEl = elements.find(
+      (el) => el.type === "main" && el.props?.id === "main-content",
+    );
+    expect(mainEl).toBeDefined();
+  });
+
+  it("places the skip link before the <main> element in source order", () => {
+    const skipIdx = elements.findIndex(
+      (el) => el.type === "a" && el.props?.href === "#main-content",
+    );
+    const mainIdx = elements.findIndex(
+      (el) => el.type === "main" && el.props?.id === "main-content",
+    );
+    expect(skipIdx).toBeGreaterThanOrEqual(0);
+    expect(mainIdx).toBeGreaterThan(skipIdx);
+  });
+});

--- a/apps/clinician-portal/vitest.config.ts
+++ b/apps/clinician-portal/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
 export default defineConfig({
+  // Use the automatic JSX runtime so modules that don't `import React`
+  // (e.g. Next.js app-router files like `app/layout.tsx`) still transform
+  // cleanly under vitest. Matches the patient-portal config.
+  esbuild: {
+    jsx: "automatic",
+  },
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),

--- a/apps/patient-portal/app/globals.css
+++ b/apps/patient-portal/app/globals.css
@@ -1,0 +1,68 @@
+/*
+ * Patient-portal global styles.
+ *
+ * Scope intentionally narrow for Issue #182: the patient portal uses
+ * inline-style layout throughout its pages, and introducing a full design
+ * system here is out of scope. This file holds only the CSS required for
+ * WCAG 2.1 AA compliance:
+ *
+ *   - 2.4.1 Bypass Blocks: `.skip-to-main` skip link, visually hidden
+ *     off-screen until keyboard focus brings it on-screen.
+ *   - 2.4.7 Focus Visible: a global `:focus-visible` outline so keyboard
+ *     users can always see where focus is.
+ */
+
+:root {
+  /* Match the patient-portal's existing inline color scheme so tokens
+     resolve to sensible values even without a dedicated theme file. */
+  --bg: #0a0a0a;
+  --accent: #0ea5e9;
+  --accent-contrast: #ffffff;
+}
+
+/* ───── Accessibility: focus indicators (WCAG 2.1 AA §2.4.7) ───── */
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ───── Skip-to-main link (WCAG 2.1 AA §2.4.1) ───── */
+
+.skip-to-main {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 10100;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  padding: 10px 16px;
+  border-radius: 0 0 6px 0;
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.skip-to-main:focus {
+  left: 0;
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+/* Hide the <main id="main-content"> tabindex=-1 focus ring when the
+   user clicks the skip link: the landing focus confirms the jump but
+   doesn't need a persistent outline of its own. */
+main#main-content:focus {
+  outline: none;
+}

--- a/apps/patient-portal/app/layout.tsx
+++ b/apps/patient-portal/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import "./globals.css";
 import { Providers } from "./providers";
 
 export const metadata: Metadata = {
@@ -17,11 +18,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         padding: "2rem",
       }}>
         <Providers>
+          {/* WCAG 2.1 AA §2.4.1 Bypass Blocks: the skip link must be the
+              first focusable element so keyboard users can jump past the
+              header straight to the page's main content. It is visually
+              hidden until it receives keyboard focus (see globals.css). */}
+          <a href="#main-content" className="skip-to-main">
+            Skip to main content
+          </a>
           <header style={{ borderBottom: "1px solid #2a2a2a", paddingBottom: "1rem", marginBottom: "2rem" }}>
             <h1 style={{ margin: 0, fontSize: "1.5rem" }}>CareBridge</h1>
             <p style={{ margin: "0.25rem 0 0", color: "#999", fontSize: "0.875rem" }}>Patient Portal</p>
           </header>
-          {children}
+          <main id="main-content" tabIndex={-1}>
+            {children}
+          </main>
         </Providers>
       </body>
     </html>

--- a/apps/patient-portal/app/page.tsx
+++ b/apps/patient-portal/app/page.tsx
@@ -48,7 +48,7 @@ function PatientDashboard() {
   }
 
   return (
-    <main>
+    <div>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
         <div>
           <h2 style={{ fontSize: "1.25rem", margin: 0 }}>
@@ -234,7 +234,7 @@ function PatientDashboard() {
           </button>
         </Card>
       </div>
-    </main>
+    </div>
   );
 }
 
@@ -250,11 +250,11 @@ export default function PatientHome() {
 
   if (!hydrated || !isAuthenticated) {
     return (
-      <main>
+      <div>
         <p style={{ color: "#999" }}>
           {hydrated ? "Redirecting to login..." : "Loading..."}
         </p>
-      </main>
+      </div>
     );
   }
 

--- a/apps/patient-portal/src/__tests__/layout-skip-nav.test.tsx
+++ b/apps/patient-portal/src/__tests__/layout-skip-nav.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA compliance: verify the root layout renders a "skip to main
+ * content" link as the first focusable element inside <body>, and that a
+ * corresponding <main id="main-content"> target exists. (Issue #182, 2.4.1
+ * Bypass Blocks.)
+ *
+ * The RootLayout renders <html>/<body>, which React Testing Library cannot
+ * mount inside a jsdom document directly, so we import the layout module
+ * and invoke its exported default against a minimal child, then walk the
+ * resulting element tree.
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock Providers so we don't pull tRPC / auth context during a pure
+// structural test of the layout tree.
+vi.mock("../../app/providers", () => ({
+  Providers: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import RootLayout from "../../app/layout";
+
+/**
+ * Recursively collect every React element in the tree into a flat array so
+ * we can reason about ordering and attributes without mounting a full DOM.
+ */
+function flatten(node: React.ReactNode): React.ReactElement[] {
+  const out: React.ReactElement[] = [];
+  const visit = (n: React.ReactNode) => {
+    if (n == null || typeof n === "boolean") return;
+    if (Array.isArray(n)) {
+      n.forEach(visit);
+      return;
+    }
+    if (typeof n === "object" && "type" in n) {
+      out.push(n as React.ReactElement);
+      const children = (n as React.ReactElement).props?.children;
+      if (children !== undefined) visit(children);
+    }
+  };
+  visit(node);
+  return out;
+}
+
+describe("patient-portal RootLayout skip navigation", () => {
+  const tree = RootLayout({ children: <div data-testid="page-children" /> });
+  const elements = flatten(tree);
+
+  it("renders a skip link whose href targets #main-content", () => {
+    const skipLink = elements.find(
+      (el) => el.type === "a" && el.props?.href === "#main-content",
+    );
+    expect(skipLink).toBeDefined();
+    expect(String(skipLink?.props?.children)).toMatch(/skip to main content/i);
+  });
+
+  it("renders a <main> with id=main-content", () => {
+    const mainEl = elements.find(
+      (el) => el.type === "main" && el.props?.id === "main-content",
+    );
+    expect(mainEl).toBeDefined();
+  });
+
+  it("places the skip link before the <main> element in source order", () => {
+    const skipIdx = elements.findIndex(
+      (el) => el.type === "a" && el.props?.href === "#main-content",
+    );
+    const mainIdx = elements.findIndex(
+      (el) => el.type === "main" && el.props?.id === "main-content",
+    );
+    expect(skipIdx).toBeGreaterThanOrEqual(0);
+    expect(mainIdx).toBeGreaterThan(skipIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two WCAG 2.1 AA failures across both portals:
- **§2.4.1 Bypass Blocks** — keyboard users had to tab the entire header/sidebar before reaching page content on every route.
- **§2.4.7 Focus Visible** — no global `:focus-visible` outline, so keyboard focus was effectively invisible on most interactive elements.

### Patient portal
- Add a `.skip-to-main` link as the first focusable element in `app/layout.tsx` and wrap children in `<main id="main-content" tabIndex={-1}>`.
- New `apps/patient-portal/app/globals.css` with off-screen `.skip-to-main` (appears on focus) and a global `:focus-visible` outline.
- Remove inner `<main>` wrappers in `app/page.tsx` so there is one `<main>` per page (invalid HTML otherwise).

### Clinician portal
- Existing layout already renders `.skip-to-main` and global `:focus-visible` — added a layout render test to lock that in.
- Vitest config now uses `esbuild.jsx: "automatic"` so app-router files (which do not `import React`) can be loaded from tests. Matches the patient-portal config.

### Tests
Both portals gain an equivalent `layout-skip-nav.test.tsx` asserting:
- a link with `href="#main-content"` and text "Skip to main content" exists,
- a `<main id="main-content">` exists,
- the skip link precedes the main element in source order.

## Test plan

- [x] `pnpm test` in `apps/patient-portal` (12/12 pass)
- [x] `pnpm test` in `apps/clinician-portal` (new skip-nav test passes; remaining failures are pre-existing `@carebridge/medical-logic` resolution errors on `main`)
- [x] `pnpm typecheck` (all 38 tasks green)
- [x] `pnpm lint` in both portals (no new warnings)
- [ ] Manual keyboard check: first Tab on each portal focuses the skip link; pressing Enter jumps focus past the header/sidebar.

Closes #182