### PR TITLE
refactor(gateway): reuse AuthMeReply type in auth-me.test.ts MockReply

### DIFF
--- a/services/api-gateway/src/__tests__/auth-me.test.ts
+++ b/services/api-gateway/src/__tests__/auth-me.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { User } from "@carebridge/shared-types";
-import { handleAuthMe } from "../handlers/auth-me.js";
+import { handleAuthMe, type AuthMeReply } from "../handlers/auth-me.js";
 
 /**
  * Tests for the GET /auth/me endpoint behaviour.
@@ -13,9 +13,15 @@ import { handleAuthMe } from "../handlers/auth-me.js";
  *
  *   - 401 when `request.user` is falsy
  *   - User profile payload when `request.user` is present
+ *
+ * MockReply extends AuthMeReply so the reply contract stays in lockstep with
+ * the handler: any future change to AuthMeReply will force this mock (and its
+ * consumers) to follow. The mock only adds two assertion-only fields the real
+ * Fastify reply does not expose on our interface — `statusCode` and `body` —
+ * which capture what `code()` / `send()` received for test inspection.
  */
 
-interface MockReply {
+interface MockReply extends AuthMeReply {
   statusCode: number;
   body: unknown;
   code(c: number): MockReply;


### PR DESCRIPTION
## Summary
- `MockReply` in `services/api-gateway/src/__tests__/auth-me.test.ts` duplicated the `code()` / `send()` shape already exported as `AuthMeReply` from `services/api-gateway/src/handlers/auth-me.ts` (added in #823).
- Refactored `MockReply` to `extends AuthMeReply` so the test's mock stays in lockstep with the real handler's reply contract. Any future change to `AuthMeReply` will force the mock (and its consumers) to follow.
- Kept the two assertion-only fields (`statusCode` / `body`) that capture what `code()` / `send()` received; these are the minimal extension the test spy needs and are not part of the handler's reply contract.

Pure DRY refactor, no behaviour change.

## Test plan
- [x] `pnpm --filter @carebridge/api-gateway test` — 257 tests pass (auth-me.test.ts: 3/3).
- [x] `pnpm typecheck` — 40 tasks successful.
- [x] `pnpm lint` — 22 tasks successful (only pre-existing warnings in unrelated portal files).

Closes #828