### PR TITLE
refactor(portal): narrow User.role to UserRole literal union

### DIFF
--- a/apps/clinician-portal/app/login/page.tsx
+++ b/apps/clinician-portal/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { UserRole } from "@carebridge/shared-types";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
 import { PasswordInput } from "@carebridge/portal-shared/password-input";
@@ -33,7 +34,7 @@ export default function LoginPage() {
         return;
       }
       const loginResult = result as {
-        user: { id: string; name: string; email: string; role: string };
+        user: { id: string; name: string; email: string; role: UserRole };
         session: { id: string };
       };
       setSession(loginResult.user, loginResult.session.id);

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { UserRole } from "@carebridge/shared-types";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
 import { PasswordInput } from "@carebridge/portal-shared/password-input";
@@ -33,7 +34,7 @@ export default function LoginPage() {
         return;
       }
       const loginResult = result as {
-        user: { id: string; name: string; email: string; role: string };
+        user: { id: string; name: string; email: string; role: UserRole };
         session: { id: string };
       };
       setSession(loginResult.user, loginResult.session.id);

--- a/packages/portal-shared/package.json
+++ b/packages/portal-shared/package.json
@@ -11,6 +11,7 @@
     "./password-input": "./src/password-input.tsx"
   },
   "dependencies": {
+    "@carebridge/shared-types": "workspace:*",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",

--- a/packages/portal-shared/src/auth.test.tsx
+++ b/packages/portal-shared/src/auth.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "./auth";
 import type { User } from "./auth";
+import type { UserRole } from "@carebridge/shared-types";
 import type { ReactNode } from "react";
 
 // ---------------------------------------------------------------------------
@@ -187,6 +188,54 @@ describe("AuthProvider /auth/me hydration", () => {
 
     expect(clearSpy).toHaveBeenCalled();
     expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("pins User.role to the UserRole literal union (issue #829)", () => {
+    // This test is deliberately compile-time driven: if someone widens
+    // `User.role` back to `string`, the `UserRole` assignment below will
+    // fail `tsc`. If someone narrows it further (e.g. drops a role), the
+    // exhaustive switch loses its `never` fallthrough and also fails `tsc`.
+    const user: User = {
+      id: "role-check",
+      email: "r@carebridge.dev",
+      name: "Role Check",
+      role: "physician",
+    };
+
+    // 1. Direct assignability: `user.role` must flow into `UserRole` with
+    //    no cast. This fails if `role: string` is reintroduced.
+    const narrowed: UserRole = user.role;
+    expect(narrowed).toBe("physician");
+
+    // 2. Exhaustive switch: omitting any member of the union makes
+    //    `_exhaustive` a non-`never` value and fails compilation.
+    function describeRole(role: UserRole): string {
+      switch (role) {
+        case "patient":
+          return "patient";
+        case "nurse":
+          return "nurse";
+        case "physician":
+          return "physician";
+        case "specialist":
+          return "specialist";
+        case "admin":
+          return "admin";
+        default: {
+          const _exhaustive: never = role;
+          return _exhaustive;
+        }
+      }
+    }
+
+    expect(describeRole(user.role)).toBe("physician");
+
+    // 3. Runtime typo guard: assigning a string not in the union should
+    //    be a compile-time error. We express that with a `@ts-expect-error`
+    //    so the test file itself breaks if the type ever re-widens.
+    // @ts-expect-error "doctor" is not a member of UserRole
+    const _typo: User = { ...user, role: "doctor" };
+    void _typo;
   });
 
   it("skips /auth/me when no session flag exists in localStorage", async () => {

--- a/packages/portal-shared/src/auth.tsx
+++ b/packages/portal-shared/src/auth.tsx
@@ -3,13 +3,19 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 import type { QueryClient } from "@tanstack/react-query";
+import type { UserRole } from "@carebridge/shared-types";
 import { getApiBaseUrl } from "./trpc";
 
 export interface User {
   id: string;
   email: string;
   name: string;
-  role: string;
+  /**
+   * Narrowed to the `UserRole` literal union from `@carebridge/shared-types`
+   * so consumers get exhaustiveness checking on role-based switches and the
+   * compiler rejects typos (e.g. "doctor" vs "physician"). See issue #829.
+   */
+  role: UserRole;
   specialty?: string;
   department?: string;
   // Patient-role users link to their patient record via this id. Set on the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,9 @@ importers:
 
   packages/portal-shared:
     dependencies:
+      '@carebridge/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       '@tanstack/react-query':
         specifier: ^5.60.0
         version: 5.96.2(react@19.2.4)
@@ -6024,8 +6027,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6044,7 +6047,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6055,22 +6058,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6081,7 +6084,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Switch `User.role` in `@carebridge/portal-shared`'s auth context from `string` to the `UserRole` literal union from `@carebridge/shared-types` (`"patient" | "nurse" | "physician" | "specialist" | "admin"`).
- Adds `@carebridge/shared-types` as a `workspace:*` dependency of `portal-shared`, matching the convention used by `validators`, `medical-logic`, `db-schema`, `ai-prompts`, and `outbox`.
- Adds a type-level test in `auth.test.tsx` that pins the narrowing via three independent probes:
  1. Direct `UserRole` assignability from `user.role`.
  2. Exhaustive `switch` over the union with a `never` fallthrough.
  3. `@ts-expect-error` on an out-of-union value (`"doctor"`).
  If the field ever re-widens to `string`, `tsc` fails; if a role is dropped, the exhaustive switch fails; if a bogus role is accepted, the expect-error probe fails.

## Rationale
Consumers of `useAuth()` previously received `user.role: string`, so role-based branching was silently tolerant of typos and never triggered exhaustiveness warnings. The canonical `UserRole` union already exists in `@carebridge/shared-types`; this widening was purely an integration gap.

## Scope
- In scope: `User.role` only.
- Out of scope (per issue #829 notes): `specialty?` and `department?` remain free-form `string` — those are harder to narrow cleanly and not urgent.

## Downstream consumer audit
Greppled `user.role` across the repo. All string comparisons (`=== "admin"`, `=== "patient"`, `=== "physician"`, `=== "specialist"`, `=== "nurse"`) are members of the union and continue to type-check. I did not find any portal-side comparison of `user.role` against an out-of-union literal (e.g. `"doctor"`). Gateway-side `(ctx.user.role as string) === "family_caregiver"` checks live on a different `User` type (server-side `shared-types` `User`, which already has `role: UserRole`) and are unaffected.

## Test plan
- [x] `pnpm typecheck` — 38/38 tasks pass
- [x] `pnpm lint` — 21/21 tasks pass (warnings pre-existing)
- [x] `pnpm --filter @carebridge/portal-shared test` — 6/6 passing (5 existing + 1 new type-pin test)
- [x] `pnpm --filter @carebridge/patient-portal test` — 9/9 passing
- [x] `pnpm --filter @carebridge/clinician-portal test` — 173/173 passing

Closes #829