### PR TITLE
refactor(services): extract shared emitClinicalEvent into @carebridge/outbox

### DIFF
--- a/packages/outbox/package.json
+++ b/packages/outbox/package.json
@@ -19,7 +19,9 @@
   },
   "dependencies": {
     "@carebridge/db-schema": "workspace:*",
+    "@carebridge/redis-config": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
+    "bullmq": "^5.30.0",
     "drizzle-orm": "^0.38.0"
   },
   "devDependencies": {

--- a/packages/outbox/src/__tests__/emit.test.ts
+++ b/packages/outbox/src/__tests__/emit.test.ts
@@ -18,15 +18,17 @@ vi.mock("@carebridge/redis-config", () => ({
   },
 }));
 
-// ── Mock @carebridge/outbox ─────────────────────────────────────
+// ── Mock the outbox write surface ───────────────────────────────
+// emit.ts imports writeOutboxEntry from "./index.js" so we intercept
+// that module to avoid pulling in the real DB-backed implementation.
 const writeOutboxEntryMock = vi.fn().mockResolvedValue(undefined);
 
-vi.mock("@carebridge/outbox", () => ({
+vi.mock("../index.js", () => ({
   writeOutboxEntry: writeOutboxEntryMock,
 }));
 
 // ── Import after mocks ──────────────────────────────────────────
-const { emitClinicalEvent } = await import("../events.js");
+const { emitClinicalEvent } = await import("../emit.js");
 
 const sampleEvent: ClinicalEvent = {
   id: "evt-1",

--- a/packages/outbox/src/emit.ts
+++ b/packages/outbox/src/emit.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared clinical event emitter.
+ *
+ * Single source of truth for publishing clinical events to the BullMQ
+ * "clinical-events" queue. If the primary emit fails (Redis down,
+ * queue unreachable), the event is persisted to the outbox table via
+ * {@link writeOutboxEntry} and later reconciled by the ai-oversight
+ * outbox-reconciler worker.
+ *
+ * Both `@carebridge/clinical-data` and `@carebridge/clinical-notes`
+ * previously defined byte-identical copies of this function. They now
+ * depend on this module as the single source of truth.
+ *
+ * See: https://github.com/blamechris/carebridge/issues/817
+ */
+
+import { Queue } from "bullmq";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+import { writeOutboxEntry } from "./index.js";
+
+const connection = getRedisConnection();
+
+const clinicalEventsQueue = new Queue("clinical-events", {
+  connection,
+  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+});
+
+export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
+  try {
+    await clinicalEventsQueue.add(event.type, event);
+  } catch (queueError) {
+    // Redis/BullMQ unavailable — persist to DB outbox for later retry
+    try {
+      await writeOutboxEntry(
+        event,
+        queueError instanceof Error ? queueError : String(queueError),
+      );
+    } catch (dbError) {
+      // Both Redis and DB fallback failed — log critical error as last resort
+      console.error(
+        `[CRITICAL] Failed to emit clinical event and DB fallback also failed. ` +
+        `Event type: ${event.type}, patient: ${event.patient_id}. ` +
+        `Queue error: ${queueError instanceof Error ? queueError.message : String(queueError)}. ` +
+        `DB error: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
+      );
+    }
+  }
+}

--- a/packages/outbox/src/index.ts
+++ b/packages/outbox/src/index.ts
@@ -15,6 +15,8 @@ import type { ClinicalEvent } from "@carebridge/shared-types";
 
 export type { ClinicalEvent };
 
+export { emitClinicalEvent } from "./emit.js";
+
 export type OutboxRow = InferSelectModel<typeof failedClinicalEvents>;
 
 /** Rows with retry_count equal to this after a failure are parked as `failed`. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,15 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../db-schema
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../redis-config
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../shared-types
+      bullmq:
+        specifier: ^5.30.0
+        version: 5.73.0
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/react@19.2.14)(postgres@3.4.8)(react@19.2.4)
@@ -6042,8 +6048,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6062,7 +6068,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6073,22 +6079,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6099,7 +6105,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/services/clinical-data/src/events.ts
+++ b/services/clinical-data/src/events.ts
@@ -1,38 +1,9 @@
-import { Queue } from "bullmq";
-import {
-  getRedisConnection,
-  CLINICAL_EVENTS_JOB_OPTIONS,
-} from "@carebridge/redis-config";
-import { writeOutboxEntry } from "@carebridge/outbox";
-import type { ClinicalEvent } from "@carebridge/shared-types";
-
-export type { ClinicalEvent };
-
-const connection = getRedisConnection();
-
-const clinicalEventsQueue = new Queue("clinical-events", {
-  connection,
-  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
-});
-
-export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  try {
-    await clinicalEventsQueue.add(event.type, event);
-  } catch (queueError) {
-    // Redis/BullMQ unavailable — persist to DB outbox for later retry
-    try {
-      await writeOutboxEntry(
-        event,
-        queueError instanceof Error ? queueError : String(queueError),
-      );
-    } catch (dbError) {
-      // Both Redis and DB fallback failed — log critical error as last resort
-      console.error(
-        `[CRITICAL] Failed to emit clinical event and DB fallback also failed. ` +
-        `Event type: ${event.type}, patient: ${event.patient_id}. ` +
-        `Queue error: ${queueError instanceof Error ? queueError.message : String(queueError)}. ` +
-        `DB error: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
-      );
-    }
-  }
-}
+/**
+ * Re-export of the shared clinical event emitter.
+ *
+ * The single source of truth lives in `@carebridge/outbox` so that
+ * both `clinical-data` and `clinical-notes` share one implementation.
+ * See: https://github.com/blamechris/carebridge/issues/817
+ */
+export { emitClinicalEvent } from "@carebridge/outbox";
+export type { ClinicalEvent } from "@carebridge/shared-types";

--- a/services/clinical-notes/src/events.ts
+++ b/services/clinical-notes/src/events.ts
@@ -1,38 +1,9 @@
-import { Queue } from "bullmq";
-import {
-  getRedisConnection,
-  CLINICAL_EVENTS_JOB_OPTIONS,
-} from "@carebridge/redis-config";
-import { writeOutboxEntry } from "@carebridge/outbox";
-import type { ClinicalEvent } from "@carebridge/shared-types";
-
-export type { ClinicalEvent };
-
-const connection = getRedisConnection();
-
-const clinicalEventsQueue = new Queue("clinical-events", {
-  connection,
-  defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
-});
-
-export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
-  try {
-    await clinicalEventsQueue.add(event.type, event);
-  } catch (queueError) {
-    // Redis/BullMQ unavailable — persist to DB outbox for later retry
-    try {
-      await writeOutboxEntry(
-        event,
-        queueError instanceof Error ? queueError : String(queueError),
-      );
-    } catch (dbError) {
-      // Both Redis and DB fallback failed — log critical error as last resort
-      console.error(
-        `[CRITICAL] Failed to emit clinical event and DB fallback also failed. ` +
-        `Event type: ${event.type}, patient: ${event.patient_id}. ` +
-        `Queue error: ${queueError instanceof Error ? queueError.message : String(queueError)}. ` +
-        `DB error: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
-      );
-    }
-  }
-}
+/**
+ * Re-export of the shared clinical event emitter.
+ *
+ * The single source of truth lives in `@carebridge/outbox` so that
+ * both `clinical-data` and `clinical-notes` share one implementation.
+ * See: https://github.com/blamechris/carebridge/issues/817
+ */
+export { emitClinicalEvent } from "@carebridge/outbox";
+export type { ClinicalEvent } from "@carebridge/shared-types";


### PR DESCRIPTION
## Summary

- `services/clinical-data/src/events.ts` and `services/clinical-notes/src/events.ts` were byte-identical after #806 — extract the shared `emitClinicalEvent` into `@carebridge/outbox` as the single source of truth.
- Chose `@carebridge/outbox` as the host because it already groups the related clinical-event primitives (`writeOutboxEntry`, `readPendingBatch`, `markProcessed`, `markRetry`, `markFailed`, `recoverStaleProcessing`). Adding `emitClinicalEvent` there keeps the "emit + outbox fallback" behavior co-located with the fallback storage surface, and avoids introducing a new workspace package for a single function.
- The service-level `events.ts` files are now two-line re-export shims so every existing call site (`vital-repo.ts`, `medication-repo.ts`, `lab-repo.ts`, `procedure-repo.ts`, `note-service.ts`) and their `vi.mock("../events.js", ...)` tests keep working unchanged — pure code move, zero behavior change.

## Changes

- New `packages/outbox/src/emit.ts` — hosts `emitClinicalEvent`.
- `packages/outbox/src/index.ts` re-exports `emitClinicalEvent`.
- `packages/outbox/package.json` adds `bullmq` and `@carebridge/redis-config` deps (previously held by the two service packages).
- `services/clinical-data/src/events.ts` and `services/clinical-notes/src/events.ts` become thin re-export shims from `@carebridge/outbox`.
- Unit test moved from `services/clinical-data/src/__tests__/events.test.ts` to `packages/outbox/src/__tests__/emit.test.ts` — tests the shared implementation directly.

## Test plan

- [x] `pnpm --filter @carebridge/outbox test` — 20 pass (14 outbox + 6 emit)
- [x] `pnpm --filter @carebridge/clinical-data test` — 41 pass
- [x] `pnpm --filter @carebridge/clinical-notes test` — 23 pass
- [x] `pnpm --filter @carebridge/ai-oversight test` — 543 pass (reconciler untouched)
- [x] `pnpm typecheck` — 40/40 green
- [x] `pnpm lint` — 22/22 green

Closes #817