### PR TITLE
fix(ai): lab-flag direction inference + unrecognized-flag handling (#833, #834, #837)

### DIFF
--- a/services/ai-oversight/src/__tests__/critical-values.test.ts
+++ b/services/ai-oversight/src/__tests__/critical-values.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @carebridge/logger so we can assert on logger.warn() calls when an
+// unrecognized lab flag is encountered (issue #834).
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+  }),
+}));
 
 // Mock workspace dependencies before importing the module under test.
 vi.mock("@carebridge/shared-types", () => ({
@@ -515,5 +527,228 @@ describe("CRITICAL_LAB_THRESHOLDS — structure validation", () => {
     expect(warningHigh).not.toBeNull();
     expect(warningHigh!.severity).toBe("warning");
     expect(warningHigh!.direction).toBe("high");
+  });
+});
+
+// ─── Direction inference for critical flag (issue #833) ──────────
+// Regression guard for the half-bounded reference-range case. Prior to the
+// fix, `direction` defaulted to "high" whenever `reference_low` was missing,
+// even when the value was clearly below `reference_high`. A critical-low
+// result mis-tagged as "high" erodes clinician trust and can delay treatment
+// (e.g., a panic-low magnesium reported as "high").
+describe("checkCriticalValues — direction inference (issue #833)", () => {
+  it("infers direction='low' when reference_high is provided, reference_low is absent, and value is below reference_high", () => {
+    // Half-bounded reference range (reference_low missing). Value 0.4 is
+    // clearly below reference_high 1.5, so direction MUST be 'low'.
+    // The fix surfaces direction in the summary: "Critical low lab result"
+    // instead of the previous mis-directed "Critical high lab result".
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker Y",
+          value: 0.4,
+          unit: "mg/dL",
+          reference_high: 1.5,
+          flag: "critical",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    // Regression assertion — the summary must describe direction truthfully.
+    expect(flags[0]!.summary.toLowerCase()).toContain("low");
+    expect(flags[0]!.summary.toLowerCase()).not.toContain("high");
+  });
+
+  it("infers direction='high' when reference_low is provided, reference_high is absent, and value is above reference_low", () => {
+    // Half-bounded the other way — only reference_low present. Value 999 is
+    // clearly above reference_low 10, so direction MUST be 'high'.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker Z",
+          value: 999,
+          unit: "U/L",
+          reference_low: 10,
+          flag: "critical",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("high");
+    // The summary should not claim "low" when the value is above the only
+    // reference bound we have.
+    expect(flags[0]!.summary.toLowerCase()).not.toContain("low");
+  });
+
+  it("defaults direction='high' when no reference bounds are provided (unchanged behavior)", () => {
+    // With neither reference_low nor reference_high, we cannot infer
+    // direction from the reference range. The historical default is 'high'.
+    // Most laboratory "critical" flags are elevations in practice, so this
+    // is a reasonable fallback. Pin the behavior so changes are intentional.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker W",
+          value: 42,
+          unit: "U/L",
+          flag: "critical",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("high");
+  });
+});
+
+// ─── Unrecognized flag handling (issues #834 and #837) ───────────
+// When a lab result carries a non-null `flag` string that is not in the
+// validator enum ('H' | 'L' | 'critical'), we must:
+//   1. Still fall through to the range checks (no behavior change).
+//   2. Emit logger.warn so silent drops of an explicit lab abnormality
+//      signal become observable. Silent drops of explicit lab-marked
+//      abnormalities are exactly the class of bug #244 was filed to fix.
+// We additionally map common HL7v2 abnormal-flag values:
+//   - "HH" (panic high) → warning, direction="high"
+//   - "LL" (panic low)  → warning, direction="low"
+// Other non-enum values (e.g. "abnormal", "A", "") still fall through
+// but the warn fires. See issues #833 and #834 for rationale.
+describe("checkCriticalValues — unrecognized flag handling (issues #834, #837)", () => {
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
+  it("falls through to range checks when flag is an unrecognized value", () => {
+    // Issue #837: pin current fall-through behavior so future regressions are
+    // intentional. Lab with an unrecognized "abnormal" flag, no reference
+    // range, not in COMMON_LAB_TESTS → no flag emitted from the flag branch.
+    // (With HH/LL mapping, the test uses a value that is not HH/LL.)
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 999,
+          unit: "U/L",
+          flag: "abnormal",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(0);
+  });
+
+  it("logs a warning when a non-null flag is not in the recognized enum (empty string)", () => {
+    checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 5,
+          unit: "U/L",
+          flag: "",
+        },
+      ]),
+    );
+    expect(mockWarn).toHaveBeenCalled();
+    const call = mockWarn.mock.calls.find(
+      ([msg]) => typeof msg === "string" && msg.includes("unrecognized_lab_flag"),
+    );
+    expect(call).toBeDefined();
+  });
+
+  it("logs a warning for an unrecognized flag value 'abnormal'", () => {
+    checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 5,
+          unit: "U/L",
+          flag: "abnormal",
+        },
+      ]),
+    );
+    expect(mockWarn).toHaveBeenCalled();
+    const call = mockWarn.mock.calls.find(
+      ([msg]) => typeof msg === "string" && msg.includes("unrecognized_lab_flag"),
+    );
+    expect(call).toBeDefined();
+    // Meta payload should capture the offending flag value (no PHI).
+    const meta = call![1] as Record<string, unknown>;
+    expect(meta.flag).toBe("abnormal");
+    expect(meta.test_name).toBe("Obscure Marker X");
+  });
+
+  it("does not warn when flag is in the recognized enum ('H', 'L', 'critical') or absent", () => {
+    checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Hemoglobin",
+          value: 13.5,
+          unit: "g/dL",
+          flag: "H",
+        },
+        {
+          test_name: "Hemoglobin",
+          value: 11.5,
+          unit: "g/dL",
+          flag: "L",
+        },
+        {
+          test_name: "Hemoglobin",
+          value: 14,
+          unit: "g/dL",
+          flag: "critical",
+        },
+        {
+          test_name: "Hemoglobin",
+          value: 14,
+          unit: "g/dL",
+        },
+      ]),
+    );
+    // None of these should trigger unrecognized_lab_flag warnings.
+    const unrecognizedCalls = mockWarn.mock.calls.filter(
+      ([msg]) => typeof msg === "string" && msg.includes("unrecognized_lab_flag"),
+    );
+    expect(unrecognizedCalls).toHaveLength(0);
+  });
+
+  it("maps HL7v2 'HH' (panic high) to a warning flag with direction='high'", () => {
+    // HL7v2 abnormal-flags: "HH" means panic/critical-high. Treat as warning
+    // (not critical) to avoid over-alerting pending principled mapping —
+    // see issue #834 discussion. Warning is the floor, not the ceiling.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 999,
+          unit: "U/L",
+          flag: "HH",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.summary).toContain("High");
+    // This mapping should still emit the warn log so operators notice
+    // non-enum flags arriving through FHIR/HL7 ingress paths.
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("maps HL7v2 'LL' (panic low) to a warning flag with direction='low'", () => {
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Obscure Marker X",
+          value: 0.01,
+          unit: "U/L",
+          flag: "LL",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.summary).toContain("Low");
+    expect(mockWarn).toHaveBeenCalled();
   });
 });

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -15,6 +15,31 @@ import {
   getVitalRangeForAge,
   ageInYearsFromDOB,
 } from "@carebridge/medical-logic";
+import { createLogger } from "@carebridge/logger";
+
+const logger = createLogger("ai-oversight");
+
+/**
+ * Common HL7v2 abnormal-flag values we promote to at-least-warning severity
+ * pending a principled mapping (see issue #834). We keep these conservative
+ * (warning rather than critical) to avoid over-alerting from ingress paths
+ * that bypass the Zod validator. Callers who want critical severity should
+ * normalize to `"critical"` upstream.
+ *
+ *   - HH → panic/critical-high; mapped to warning direction=high
+ *   - LL → panic/critical-low;  mapped to warning direction=low
+ *
+ * Other common HL7v2 values (A, AA, N, U, '' etc.) remain unmapped and fall
+ * through to the range checks; a structured warn is emitted so operators can
+ * observe silent drops.
+ */
+const HL7_FLAG_MAPPINGS: Record<
+  string,
+  { severity: FlagSeverity; direction: "low" | "high" }
+> = {
+  HH: { severity: "warning", direction: "high" },
+  LL: { severity: "warning", direction: "low" },
+};
 
 // ─── Explicit Critical Lab Thresholds ────────────────────────────
 // These thresholds fire deterministically on lab.resulted events,
@@ -310,6 +335,47 @@ export const CRITICAL_LAB_THRESHOLDS: Record<string, LabCriticalDef> = {
 };
 
 /**
+ * Infer the direction ("low" | "high") of a laboratory-flagged critical
+ * result when the lab itself did not encode direction in the flag string.
+ *
+ * Issue #833: the previous implementation only consulted `reference_low`
+ * and defaulted to `"high"` whenever `reference_low` was missing, even when
+ * the value was clearly below `reference_high`. That misdirected clinician
+ * notifications ("Critical high" when the value was panic-low) and eroded
+ * trust in the deterministic layer.
+ *
+ * Inference strategy, in order:
+ *   1. If both bounds are present, direction is determined by the midpoint:
+ *      values below the midpoint are "low", values above are "high".
+ *      The midpoint is a principled neutral answer for edge cases where
+ *      a value sits inside the reference range but the lab has flagged it
+ *      as critical (e.g. CKD-adjusted baselines).
+ *   2. If only `reference_high` is present, values below it are "low",
+ *      otherwise "high".
+ *   3. If only `reference_low` is present, values below it are "low",
+ *      otherwise "high".
+ *   4. If no bounds are present, default to "high" (documented fallback;
+ *      most laboratory-flagged critical results are elevations).
+ */
+function inferCriticalDirection(
+  value: number,
+  referenceLow: number | undefined,
+  referenceHigh: number | undefined,
+): "low" | "high" {
+  if (referenceLow !== undefined && referenceHigh !== undefined) {
+    const midpoint = (referenceLow + referenceHigh) / 2;
+    return value < midpoint ? "low" : "high";
+  }
+  if (referenceHigh !== undefined) {
+    return value < referenceHigh ? "low" : "high";
+  }
+  if (referenceLow !== undefined) {
+    return value < referenceLow ? "low" : "high";
+  }
+  return "high";
+}
+
+/**
  * Normalize a test name for matching against critical threshold definitions.
  */
 function matchesCriticalLab(
@@ -494,20 +560,32 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
           // Previously, unknown labs with no reference range could slip
           // through silently when the lab had already marked them high /
           // low / critical (see issue #244).
+          //
+          // Issue #834: non-null `flag` values outside the validator enum
+          // (e.g. HL7v2 "HH", "LL", "abnormal", "A", empty string) can
+          // reach this function through ingress paths that skip the Zod
+          // validator (FHIR, HL7v2, direct DB seeding). We now (a) emit a
+          // structured warning so silent drops of explicit lab-marked
+          // abnormalities are observable, and (b) map common HL7v2
+          // panic flags conservatively to warnings so a panic-low lab
+          // does not silently fall through to range checks alone.
           let severity: FlagSeverity | null = null;
           let direction: "low" | "high" | null = null;
           let reason = "";
 
           if (result.flag === "critical") {
             severity = "critical";
-            // Use per-result reference range when present to infer direction;
-            // otherwise default to "high" (most lab-panel critical flags are
-            // elevations; direction is refined below if we can compute it).
-            direction =
-              result.reference_low !== undefined &&
-              result.value < result.reference_low
-                ? "low"
-                : "high";
+            // Infer direction from whatever reference bound is present.
+            // Issue #833: previously, an undefined `reference_low` forced
+            // `direction = "high"` even when the value was clearly below
+            // `reference_high`. Now we also check `reference_high`, and
+            // use the midpoint when both bounds are present. Default
+            // fallback remains `"high"` when no bounds are provided.
+            direction = inferCriticalDirection(
+              result.value,
+              result.reference_low,
+              result.reference_high,
+            );
             reason = `Lab result flagged as critical by the analyzing laboratory.`;
           } else if (result.flag === "H") {
             severity = "warning";
@@ -517,6 +595,24 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
             severity = "warning";
             direction = "low";
             reason = `Lab result flagged as low (L) by the analyzing laboratory.`;
+          } else if (result.flag !== undefined && result.flag !== null) {
+            // Non-enum flag value — warn unconditionally and optionally
+            // map known HL7v2 abnormal-flag values to warnings. Others
+            // fall through to the range checks below.
+            logger.warn("unrecognized_lab_flag", {
+              metric: "unrecognized_lab_flag_total",
+              flag: result.flag,
+              test_name: result.test_name,
+              test_code: result.test_code,
+            });
+            const mapped = HL7_FLAG_MAPPINGS[result.flag];
+            if (mapped) {
+              severity = mapped.severity;
+              direction = mapped.direction;
+              reason =
+                `Lab result flagged as ${result.flag} by the analyzing laboratory ` +
+                `(HL7v2 abnormal-flag mapped to ${mapped.severity} / ${mapped.direction}).`;
+            }
           }
 
           // Per-result reference range is authoritative over COMMON_LAB_TESTS.
@@ -564,9 +660,16 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
 
           if (severity !== null) {
             const resolvedDirection = direction ?? "high";
+            // Include direction in the summary for all severities so that
+            // downstream consumers (and the clinicians reading the flag)
+            // can tell panic-low from panic-high at a glance. Previously
+            // the critical-severity prefix omitted direction, which hid
+            // the #833 direction-inference bug.
             const summaryPrefix =
               severity === "critical"
-                ? "Critical lab result"
+                ? resolvedDirection === "high"
+                  ? "Critical high lab result"
+                  : "Critical low lab result"
                 : resolvedDirection === "high"
                   ? "High lab result"
                   : "Low lab result";


### PR DESCRIPTION
## Summary

Bundled fix for three clinical-safety follow-ups from PR #825 (the #244 fix).
All three issues touch `services/ai-oversight/src/rules/critical-values.ts`,
so they are bundled for coherent review. Each issue is still testable and
diffable in isolation within the change.

- **#833** — half-bounded reference-range direction inference bug: a critical
  lab with only `reference_high` (no `reference_low`) and a value clearly
  below `reference_high` was mis-tagged as `direction=high`. Misdirected
  panic-low flags erode clinician trust and could delay treatment.
- **#834** — silent drop of non-enum flag values (`"HH"`, `"LL"`,
  `"abnormal"`, `"A"`, empty) at the ingress boundary. Intra-app writes are
  Zod-guarded, but FHIR / HL7v2 / direct DB seeding paths bypass the
  validator.
- **#837** — test coverage gap for the unrecognized-flag fall-through.

## What changed

### `services/ai-oversight/src/rules/critical-values.ts`
1. New `inferCriticalDirection(value, referenceLow, referenceHigh)` helper:
   - Both bounds present → direction = midpoint comparison
   - Only `reference_high` present → direction = comparison with `reference_high`
   - Only `reference_low` present → direction = comparison with `reference_low`
   - Neither present → `"high"` (documented fallback)
2. Direction now appears in the critical-severity summary
   (`"Critical low lab result"` vs `"Critical high lab result"`) so the
   #833 fix is observable to clinicians in the rendered flag.
3. Added `logger.warn("unrecognized_lab_flag", { flag, test_name,
   test_code })` whenever a non-null flag falls outside the validator
   enum. Metric-shaped payload; no PHI.
4. Added conservative HL7v2 mapping:
   - `"HH"` → warning, direction `"high"`
   - `"LL"` → warning, direction `"low"`

   **HL7 mapping decision:** I included `HH` / `LL` because their
   semantics are unambiguous in HL7v2 ("panic high" / "panic low"). I
   intentionally did **not** map `"A"` (abnormal-unspecified) or
   `"panic"` because their severity / direction mapping is ambiguous in
   clinical terms — the `logger.warn` is the signal for operators, and
   a future issue can propose a principled mapping. Chosen severity is
   `warning` (not `critical`) as a conservative floor; callers who want
   `critical` severity should normalize to the canonical `"critical"`
   enum value upstream.

### `services/ai-oversight/src/__tests__/critical-values.test.ts`
- Mocked `@carebridge/logger` so `mockWarn` can be asserted against.
- Added `describe("... direction inference (issue #833)")` with three
  cases: half-bounded low, half-bounded high, and no-bounds default.
- Added `describe("... unrecognized flag handling (issues #834, #837)")`
  with the suggested named test from #837 plus tests for: empty-string
  flag, `"abnormal"` flag, no-warn for recognized/absent flags, and the
  new `HH` / `LL` mappings.

## Clinical safety rigor

- `CRITICAL_LAB_THRESHOLDS` and every hard-coded numeric threshold are
  unchanged.
- `rule_id` naming is unchanged (issue #836 is a separate cleanup).
- All PR #825 / issue #244 regression tests pass unchanged.
- Full ai-oversight test suite (552 tests) green.
- `pnpm typecheck` and `pnpm lint` green.

## Test plan

- [x] `pnpm --filter @carebridge/ai-oversight test` — 552 passed
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (only pre-existing portal warnings)
- [x] #244 regression-guard tests still pass unchanged
- [ ] Reviewer to confirm HL7 mapping decision (HH / LL only; A, panic deferred)
- [ ] Reviewer to confirm direction-in-summary wording is acceptable for clinician UI

Closes #833
Closes #834
Closes #837