### PR TITLE
feat(ai): add 2 cross-specialty rules (ACE/ARB+pregnancy, QT+hypoK)

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -1137,3 +1137,276 @@ describe("RENAL-AMINOGLYCOSIDE-001 — Renal impairment + aminoglycoside", () =>
     expect(flag).toBeUndefined();
   });
 });
+
+describe("CROSS-ACE-ARB-PREG-001 — Pregnancy + ACE-I/ARB (teratogenic, all trimesters)", () => {
+  const pregnantCtx = (
+    meds: string[],
+    overrides: Partial<PatientContext> = {},
+  ): PatientContext => ({
+    active_diagnoses: ["Pregnancy, second trimester"],
+    active_diagnosis_codes: ["Z34.02"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: ["obstetrics"],
+    ...overrides,
+  });
+
+  it.each([
+    ["lisinopril 10mg daily"],
+    ["enalapril 5mg BID"],
+    ["ramipril"],
+    ["captopril"],
+    ["benazepril 20mg"],
+    ["quinapril"],
+    ["fosinopril"],
+    ["perindopril"],
+    ["trandolapril"],
+    ["moexipril"],
+  ])("fires CRITICAL for ACE inhibitor: %s", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx([drug]));
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+    expect(flag!.category).toBe("medication-safety");
+    expect(flag!.notify_specialties).toContain("obstetrics");
+  });
+
+  it.each([
+    ["losartan 50mg"],
+    ["valsartan 80mg"],
+    ["irbesartan 150mg"],
+    ["candesartan"],
+    ["olmesartan"],
+    ["telmisartan 40mg"],
+    ["azilsartan"],
+    ["eprosartan"],
+  ])("fires CRITICAL for ARB: %s", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx([drug]));
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it.each([
+    ["Cozaar 50mg", "losartan brand name"],
+    ["Diovan 80mg", "valsartan brand name"],
+    ["Benicar", "olmesartan brand name"],
+    ["Micardis", "telmisartan brand name"],
+    ["Vasotec", "enalapril brand name"],
+    ["Altace", "ramipril brand name"],
+    ["Lotensin", "benazepril brand name"],
+    ["Capoten", "captopril brand name"],
+  ])("fires CRITICAL for brand name: %s (%s)", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx([drug]));
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it("fires when pregnancy detected by ICD-10 Z33 code", () => {
+    const ctx = pregnantCtx(["Lisinopril 10mg"], {
+      active_diagnoses: ["Pregnant state, incidental"],
+      active_diagnosis_codes: ["Z33.1"],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-ACE-ARB-PREG-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("fires when pregnancy detected by ICD-10 O-code", () => {
+    const ctx = pregnantCtx(["Losartan 50mg"], {
+      active_diagnoses: ["Supervision of normal pregnancy"],
+      active_diagnosis_codes: ["O09.91"],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-ACE-ARB-PREG-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("fires when pregnancy detected by description only (no ICD code)", () => {
+    const ctx = pregnantCtx(["Enalapril 10mg"], {
+      active_diagnoses: ["Pregnant, 22 weeks gestational age"],
+      active_diagnosis_codes: [""],
+    });
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-ACE-ARB-PREG-001",
+    );
+    expect(flag).toBeDefined();
+  });
+
+  it("notifies both obstetrics and cardiology", () => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx(["lisinopril"]));
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeDefined();
+    expect(flag!.notify_specialties).toEqual(
+      expect.arrayContaining(["obstetrics", "cardiology"]),
+    );
+  });
+
+  it("does NOT fire without pregnancy diagnosis", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: ["Hypertension"],
+      active_diagnosis_codes: ["I10"],
+      active_medications: ["lisinopril 10mg"],
+      new_symptoms: [],
+      care_team_specialties: ["primary_care"],
+    };
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-ACE-ARB-PREG-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire for pregnant patient without ACE/ARB (pregnancy-safe antihypertensive)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      pregnantCtx(["labetalol 200mg BID", "methyldopa 250mg"]),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire for pregnant patient on acetaminophen only", () => {
+    const flags = checkCrossSpecialtyPatterns(pregnantCtx(["acetaminophen 500mg"]));
+    const flag = flags.find((f) => f.rule_id === "CROSS-ACE-ARB-PREG-001");
+    expect(flag).toBeUndefined();
+  });
+});
+
+describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk)", () => {
+  const qtHypoKCtx = (
+    meds: string[],
+    potassiumValue: number | null,
+    overrides: Partial<PatientContext> = {},
+  ): PatientContext => ({
+    active_diagnoses: ["Hypertension"],
+    active_diagnosis_codes: ["I10"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: [],
+    recent_labs:
+      potassiumValue === null
+        ? []
+        : [{ name: "Potassium", value: potassiumValue }],
+    ...overrides,
+  });
+
+  it.each([
+    ["amiodarone 200mg daily"],
+    ["sotalol 80mg BID"],
+    ["haloperidol 2mg"],
+    ["ondansetron 4mg IV"],
+    ["methadone 10mg"],
+    ["azithromycin 500mg"],
+    ["levofloxacin 500mg"],
+    ["ciprofloxacin 500mg BID"],
+    ["citalopram 20mg"],
+    ["escitalopram 10mg"],
+    ["quetiapine 100mg"],
+  ])("fires WARNING for QT-prolonger %s with K+ between 3.0 and 3.5", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(qtHypoKCtx([drug], 3.2));
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+    expect(flag!.category).toBe("cross-specialty");
+    expect(flag!.notify_specialties).toContain("cardiology");
+  });
+
+  it.each([
+    ["Zofran 4mg", "ondansetron brand"],
+    ["Haldol 2mg", "haloperidol brand"],
+    ["Zithromax 500mg", "azithromycin brand"],
+    ["Seroquel 100mg", "quetiapine brand"],
+    ["Pacerone 200mg", "amiodarone brand"],
+    ["Lexapro 10mg", "escitalopram brand"],
+  ])("fires WARNING for QT-prolonger brand name %s with hypokalemia (%s)", (drug) => {
+    const flags = checkCrossSpecialtyPatterns(qtHypoKCtx([drug], 3.3));
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("fires CRITICAL when K+ < 3.0 (severe hypokalemia elevates torsades risk)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["azithromycin 500mg"], 2.7),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it("fires WARNING at K+ boundary just below 3.5", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["ondansetron 4mg"], 3.4),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("detects potassium by alternative lab name 'K+'", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["haloperidol 2mg"], null, {
+        recent_labs: [{ name: "K+", value: 3.1 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("detects potassium by alternative lab name 'K'", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["methadone 10mg"], null, {
+        recent_labs: [{ name: "K", value: 3.0 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("does NOT fire when potassium is normal (K+ >= 3.5)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["azithromycin 500mg"], 4.0),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire at exactly K+ 3.5 (boundary is strict <3.5)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["ondansetron 4mg"], 3.5),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire when potassium lab is unknown", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["azithromycin 500mg"], null),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire without a QT-prolonging drug", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      qtHypoKCtx(["lisinopril 10mg", "metformin 500mg"], 2.9),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire when recent_labs is undefined", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: [],
+      active_diagnosis_codes: [],
+      active_medications: ["azithromycin 500mg"],
+      new_symptoms: [],
+      care_team_specialties: [],
+    };
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+});

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -8,6 +8,7 @@
  */
 
 import type { FlagSeverity, FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
+import { QTC_PATTERN } from "./drug-interactions.js";
 
 export interface PatientAllergy {
   allergen: string;
@@ -791,6 +792,112 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       "pregnancy-safe alternative. Consult obstetrics and relevant specialty. If continued, ensure informed " +
       "consent and enhanced fetal monitoring.",
     notify_specialties: ["obstetrics", "pharmacology"],
+  },
+  {
+    // CROSS-ACE-ARB-PREG-001 — ACE inhibitors and ARBs are known teratogens.
+    // First-trimester exposure is associated with cardiovascular and CNS
+    // malformations; second- and third-trimester exposure causes fetal
+    // renal failure, oligohydramnios, pulmonary hypoplasia, skull
+    // hypoplasia, and neonatal death (ACE inhibitor fetopathy). FDA labels
+    // both classes as contraindicated in pregnancy (Category D historically;
+    // equivalent current boxed warning). This complements the existing
+    // Category X/D rules, which do NOT cover ACE/ARB.
+    id: "CROSS-ACE-ARB-PREG-001",
+    name: "Pregnancy + ACE inhibitor or ARB (teratogenic / fetopathic)",
+    check: (ctx: PatientContext) => {
+      const isPregnant =
+        ctx.active_diagnosis_codes.some((code) =>
+          PREGNANCY_ICD10_PATTERN.test(code),
+        ) ||
+        ctx.active_diagnoses.some((d) =>
+          PREGNANCY_DESCRIPTION_PATTERN.test(d),
+        );
+      if (!isPregnant) return false;
+      return ctx.active_medications.some((m) => ACE_ARB_PATTERN.test(m));
+    },
+    severity: "critical" as const,
+    category: "medication-safety" as const,
+    summary:
+      "Pregnant patient on ACE inhibitor or ARB — contraindicated, risk of fetal renal failure and malformations",
+    rationale:
+      "ACE inhibitors and ARBs are contraindicated in all trimesters of pregnancy. First-trimester " +
+      "exposure is associated with cardiovascular and CNS malformations. Second- and third-trimester " +
+      "exposure causes ACE inhibitor fetopathy: fetal renal failure, oligohydramnios, pulmonary hypoplasia, " +
+      "skull hypoplasia (membranous calvaria), limb contractures, hypotension, and neonatal death. Both " +
+      "classes carry an FDA boxed warning. Safer alternatives for hypertension in pregnancy include " +
+      "labetalol, nifedipine, and methyldopa.",
+    suggested_action:
+      "IMMEDIATE medication review required. Discontinue the ACE inhibitor or ARB and switch to a " +
+      "pregnancy-safe antihypertensive (labetalol, nifedipine, or methyldopa). Consult obstetrics and " +
+      "maternal-fetal medicine. Assess fetal exposure duration; if past 18 weeks, obtain an urgent " +
+      "fetal ultrasound to evaluate amniotic fluid volume and renal anatomy.",
+    notify_specialties: ["obstetrics", "cardiology", "pharmacology"],
+  },
+  {
+    // CROSS-QT-HYPOK-001 — Co-occurrence of any QT-prolonging agent with
+    // hypokalemia (K+ < 3.5 mEq/L) sharply elevates risk of torsades de
+    // pointes. CredibleMeds and FDA QT-prolongation labeling flag hypokalemia
+    // as a key modifier. Neither DI-QTC-COMBO (requires two QT drugs) nor
+    // the individual critical-values potassium rule (no drug context) covers
+    // this clinically important combination. Severity follows potassium depth:
+    // K+ < 3.0 is critical (aligned with critical-values.ts), K+ 3.0–3.4 is
+    // warning.
+    id: "CROSS-QT-HYPOK-001",
+    name: "QT-prolonging drug + hypokalemia (torsades risk)",
+    check: (ctx: PatientContext) => {
+      const onQTDrug = ctx.active_medications.some((m) => QTC_PATTERN.test(m));
+      if (!onQTDrug) return false;
+      const k = ctx.recent_labs?.find((l) =>
+        /^(potassium|k\+?)$/i.test(l.name.trim()),
+      )?.value;
+      if (k === undefined) return false;
+      return k < 3.5;
+    },
+    buildSeverity: (ctx: PatientContext) => {
+      const k = ctx.recent_labs?.find((l) =>
+        /^(potassium|k\+?)$/i.test(l.name.trim()),
+      )?.value;
+      // Severe hypokalemia (K+ < 3.0) compounds torsades risk and is
+      // independently critical per critical-values.ts. Escalate accordingly.
+      if (k !== undefined && k < 3.0) return "critical";
+      return "warning";
+    },
+    severity: "warning" as const,
+    category: "cross-specialty" as const,
+    summary:
+      "Patient on QT-prolonging medication with hypokalemia (K+ < 3.5) — elevated risk of torsades de pointes",
+    rationale:
+      "Hypokalemia prolongs ventricular repolarization by reducing the outward IKr current, independently " +
+      "increasing QT interval. When combined with a QT-prolonging drug (class I/III antiarrhythmics, " +
+      "antipsychotics, macrolides, fluoroquinolones, ondansetron, methadone, citalopram/escitalopram, " +
+      "or other agents on the CredibleMeds QTDrugs list), the additive effect markedly elevates the risk " +
+      "of torsades de pointes, a polymorphic ventricular tachycardia that can degenerate to ventricular " +
+      "fibrillation. Risk compounds further with hypomagnesemia, bradycardia, female sex, heart failure, " +
+      "and hepatic/renal impairment.",
+    suggested_action:
+      "Replete potassium to > 4.0 mEq/L. Check magnesium concurrently and repeat if low (hypomagnesemia " +
+      "impairs potassium correction and independently prolongs QT). Obtain baseline ECG and calculate " +
+      "QTc — if > 500 ms or > 60 ms above baseline, hold the QT-prolonging agent and consult cardiology. " +
+      "Continuous telemetry until electrolytes corrected.",
+    buildSuggestedAction: (ctx: PatientContext) => {
+      const k = ctx.recent_labs?.find((l) =>
+        /^(potassium|k\+?)$/i.test(l.name.trim()),
+      )?.value;
+      const base =
+        "Replete potassium to > 4.0 mEq/L. Check magnesium concurrently and repeat if low (hypomagnesemia " +
+        "impairs potassium correction and independently prolongs QT). Obtain baseline ECG and calculate " +
+        "QTc — if > 500 ms or > 60 ms above baseline, hold the QT-prolonging agent and consult cardiology. " +
+        "Continuous telemetry until electrolytes corrected.";
+      if (k !== undefined && k < 3.0) {
+        return (
+          base +
+          " Severe hypokalemia (K+ < 3.0): initiate IV potassium replacement with continuous telemetry " +
+          "monitoring and hold the QT-prolonging agent pending electrolyte correction and ECG review."
+        );
+      }
+      return base;
+    },
+    notify_specialties: ["cardiology"],
   },
 ];
 


### PR DESCRIPTION
## Summary

Scoped subset of issue #263. Adds two deterministic cross-specialty rules to the ai-oversight engine in `services/ai-oversight/src/rules/cross-specialty.ts`.

### Rules added

- **`CROSS-ACE-ARB-PREG-001`** (severity: **critical**)
  - Fires when a patient has a pregnancy diagnosis (ICD-10 Z33/Z34/O00-O9A or description) and is on an ACE inhibitor or ARB.
  - Reuses the existing `PREGNANCY_ICD10_PATTERN`, `PREGNANCY_DESCRIPTION_PATTERN`, and `ACE_ARB_PATTERN`.
  - Notifies: obstetrics, cardiology, pharmacology.
  - Complements (does NOT duplicate) the existing Category X/D rules which do not cover ACE/ARB.

- **`CROSS-QT-HYPOK-001`** (severity: **warning**; escalated to **critical** when K+ <3.0)
  - Fires when a patient is on any QT-prolonging agent (shared `QTC_PATTERN` imported from `drug-interactions.ts`) and has a recent potassium <3.5 mEq/L.
  - Severity stratified by potassium depth — aligned with the K+ <3.0 threshold in `critical-values.ts`.
  - Matches potassium labs by name `Potassium`, `K+`, or `K`.
  - Notifies: cardiology.

### Scope clarification vs. issue #263

The issue listed four rules. Two of them — **tramadol + SSRI/SNRI** and **linezolid + SSRI/SNRI** — are **already implemented** in `services/ai-oversight/src/rules/drug-interactions.ts` as `DI-SEROTONIN-TRAMADOL` and `DI-SEROTONIN-LINEZOLID`, both at **critical** severity with full test coverage in `drug-interactions.test.ts`. I did not duplicate them in the cross-specialty layer — doing so would produce two flags for the same condition and violate the de-duplication contract. This PR therefore adds the two rules from the issue list that were genuinely missing.

## PATIENT-SAFETY relevance

Both new rules target high-mortality, under-detected patterns that individual specialists routinely miss because the relevant data live in different parts of the chart:

- **ACE/ARB + pregnancy:** ACE inhibitor fetopathy (fetal renal failure, oligohydramnios, pulmonary hypoplasia, skull hypoplasia, neonatal death) in 2nd/3rd trimester, plus 1st-trimester cardiovascular/CNS malformations. Frequently caught too late when a woman on chronic hypertensive therapy becomes pregnant and the OB team never sees the cardiology med list.
- **QT drug + hypokalemia:** hypokalemia independently prolongs QTc by reducing outward IKr current, and the additive effect with QT-prolonging drugs is a leading driver of torsades de pointes. This pattern is missed by both `DI-QTC-COMBO` (requires two QT drugs) and the isolated critical-values potassium rule (no drug context).

## Test plan

- [x] 59 new tests (51 authored + 8 table-driven rows expanded) in `cross-specialty-rules.test.ts`.
  - `CROSS-ACE-ARB-PREG-001`: positive matches for 10 ACE inhibitors + 8 ARBs by generic name, 8 brand-name variants, 3 pregnancy-detection paths (Z33/Z34, O-code, description only), 3 negative cases.
  - `CROSS-QT-HYPOK-001`: positive matches across 11 QT drugs by generic, 6 brand names, boundary tests at K+ 3.0 and 3.5, severity escalation at K+ <3.0, 3 lab-name variants (`Potassium` / `K+` / `K`), negative cases for normal K+, no QT drug, and missing `recent_labs`.
- [x] `pnpm --filter @carebridge/ai-oversight test` — 602/602 pass (up from 543).
- [x] `pnpm typecheck` — 40/40 green.
- [x] `pnpm lint` — green (only pre-existing portal warnings unrelated to this PR).
- [x] No regressions on the existing 6 cross-specialty rules or the 30+ drug-interaction rules.

## References

References #263 but does **not** close it — two follow-up items from the issue list remain (additional cross-specialty combos beyond the four originally scoped here).