### PR TITLE
feat(portal): add role=alert to errors and aria-label to interactive elements

### DIFF
--- a/apps/clinician-portal/app/inbox/page.tsx
+++ b/apps/clinician-portal/app/inbox/page.tsx
@@ -240,6 +240,7 @@ function InboxContent() {
                     className="btn btn-success btn-sm"
                     onClick={() => openModal(flag, "acknowledge")}
                     disabled={isSubmitting}
+                    aria-label={`Acknowledge flag: ${flag.summary}`}
                   >
                     Acknowledge
                   </button>
@@ -247,6 +248,7 @@ function InboxContent() {
                     className="btn btn-primary btn-sm"
                     onClick={() => openModal(flag, "resolve")}
                     disabled={isSubmitting}
+                    aria-label={`Resolve flag: ${flag.summary}`}
                   >
                     Resolve
                   </button>
@@ -254,6 +256,7 @@ function InboxContent() {
                     className="btn btn-ghost btn-sm"
                     onClick={() => openModal(flag, "dismiss")}
                     disabled={isSubmitting}
+                    aria-label={`Dismiss flag: ${flag.summary}`}
                   >
                     Dismiss
                   </button>

--- a/apps/clinician-portal/app/login/page.tsx
+++ b/apps/clinician-portal/app/login/page.tsx
@@ -141,6 +141,8 @@ export default function LoginPage() {
 
               {error && (
                 <div
+                  role="alert"
+                  aria-live="assertive"
                   style={{
                     color: "var(--critical)",
                     fontSize: 13,
@@ -228,6 +230,8 @@ export default function LoginPage() {
 
               {error && (
                 <div
+                  role="alert"
+                  aria-live="assertive"
                   style={{
                     color: "var(--critical)",
                     fontSize: 13,

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -888,6 +888,7 @@ function PatientChartContent() {
               <button
                 key={tab.key}
                 className={`tab ${activeTab === tab.key ? "active" : ""}`}
+                aria-current={activeTab === tab.key ? "true" : undefined}
                 onClick={() => setTab(tab.key)}
               >
                 {tab.label}

--- a/apps/clinician-portal/app/patients/page.tsx
+++ b/apps/clinician-portal/app/patients/page.tsx
@@ -33,6 +33,7 @@ function PatientsContent() {
         <input
           type="text"
           placeholder="Search by name or MRN..."
+          aria-label="Search by patient name or MRN"
           className="search-input"
           style={{ maxWidth: 400 }}
           value={search}

--- a/apps/clinician-portal/src/__tests__/inbox-button-a11y.test.tsx
+++ b/apps/clinician-portal/src/__tests__/inbox-button-a11y.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA — 4.1.2 Name, Role, Value.
+ *
+ * The per-flag Acknowledge / Resolve / Dismiss buttons in the inbox list
+ * reuse the same visible label across many rows. Screen reader users need
+ * each button's accessible name to disambiguate which flag it acts on,
+ * so each button gets an `aria-label` that includes the flag summary.
+ * Issue #183.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+// Flatten the auth guard so InboxContent renders directly.
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+// FlagActionModal pulls in extra UI; stub it to a no-op for this test.
+vi.mock("@/components/flag-action-modal", () => ({
+  FlagActionModal: () => null,
+}));
+
+// Stub trpc with the query + mutation shapes used by InboxContent.
+const flags = [
+  {
+    id: "flag-1",
+    severity: "critical",
+    summary: "Potential stroke risk from combined VTE + anticoagulation gap",
+    suggested_action: "Order head CT",
+    patient_id: "patient-1",
+    created_at: "2026-04-17T10:00:00Z",
+  },
+  {
+    id: "flag-2",
+    severity: "warning",
+    summary: "Missing INR follow-up after warfarin start",
+    suggested_action: "Schedule INR draw",
+    patient_id: "patient-2",
+    created_at: "2026-04-17T09:00:00Z",
+  },
+];
+
+vi.mock("@/lib/trpc", () => {
+  const invalidate = vi.fn().mockResolvedValue(undefined);
+  const useMutation = () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  return {
+    trpc: {
+      useUtils: () => ({
+        aiOversight: {
+          flags: {
+            getAllOpen: { invalidate },
+            getByPatient: { invalidate },
+            getOpenCount: { invalidate },
+          },
+        },
+      }),
+      aiOversight: {
+        flags: {
+          getAllOpen: {
+            useQuery: () => ({ data: flags, isLoading: false, isError: false }),
+          },
+          acknowledge: { useMutation },
+          resolve: { useMutation },
+          dismiss: { useMutation },
+        },
+      },
+    },
+  };
+});
+
+import InboxPage from "../../app/inbox/page";
+
+describe("inbox flag action button a11y (WCAG 4.1.2)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("gives every Acknowledge button an aria-label referencing the flag summary", () => {
+    render(<InboxPage />);
+
+    for (const flag of flags) {
+      const btn = screen.getByLabelText(`Acknowledge flag: ${flag.summary}`);
+      expect(btn.getAttribute("aria-label")).toBe(
+        `Acknowledge flag: ${flag.summary}`,
+      );
+    }
+  });
+
+  it("gives every Resolve button an aria-label referencing the flag summary", () => {
+    render(<InboxPage />);
+
+    for (const flag of flags) {
+      const btn = screen.getByLabelText(`Resolve flag: ${flag.summary}`);
+      expect(btn.getAttribute("aria-label")).toBe(
+        `Resolve flag: ${flag.summary}`,
+      );
+    }
+  });
+
+  it("gives every Dismiss button an aria-label referencing the flag summary", () => {
+    render(<InboxPage />);
+
+    for (const flag of flags) {
+      const btn = screen.getByLabelText(`Dismiss flag: ${flag.summary}`);
+      expect(btn.getAttribute("aria-label")).toBe(
+        `Dismiss flag: ${flag.summary}`,
+      );
+    }
+  });
+});

--- a/apps/clinician-portal/src/__tests__/login-error-a11y.test.tsx
+++ b/apps/clinician-portal/src/__tests__/login-error-a11y.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA — 3.3.1 Error Identification.
+ *
+ * When the clinician-portal login form reports an error (failed
+ * credentials, failed MFA verification), the error container must be
+ * announced to assistive technology immediately. That requires both
+ * `role="alert"` and an explicit `aria-live="assertive"`.
+ *
+ * We stub the tRPC client so the submit handler rejects synchronously,
+ * then wait for the error element to render and assert its ARIA
+ * attributes. Issue #183.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+// Mock the trpc client so we can make login.mutate reject on demand.
+const loginMutate = vi.fn();
+const mfaCompleteMutate = vi.fn();
+vi.mock("@/lib/trpc", () => ({
+  trpcVanilla: {
+    auth: {
+      login: { mutate: (args: unknown) => loginMutate(args) },
+      mfaCompleteLogin: { mutate: (args: unknown) => mfaCompleteMutate(args) },
+    },
+  },
+}));
+
+import { AuthProvider } from "@carebridge/portal-shared/auth";
+import LoginPage from "../../app/login/page";
+
+describe("clinician-portal login error a11y (WCAG 3.3.1)", () => {
+  afterEach(() => {
+    cleanup();
+    loginMutate.mockReset();
+    mfaCompleteMutate.mockReset();
+    window.localStorage.removeItem("carebridge_user");
+    window.localStorage.removeItem("carebridge_has_session");
+  });
+
+  it("announces credential errors with role=alert and aria-live=assertive", async () => {
+    loginMutate.mockRejectedValueOnce(new Error("Invalid email or password"));
+
+    const { container } = render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>,
+    );
+
+    // Fill required inputs so the form is allowed to submit in jsdom, then
+    // submit the <form> directly (avoids HTMLFormElement.requestSubmit which
+    // jsdom does not fully implement).
+    const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
+    const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
+    fireEvent.change(emailInput, { target: { value: "x@example.com" } });
+    fireEvent.change(passwordInput, { target: { value: "nope" } });
+    const form = container.querySelector("form") as HTMLFormElement;
+    fireEvent.submit(form);
+
+    const alert = await waitFor(() => screen.getByRole("alert"));
+    expect(alert.getAttribute("role")).toBe("alert");
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+    expect(alert.textContent).toMatch(/invalid email or password/i);
+  });
+});

--- a/apps/clinician-portal/src/__tests__/patient-chart-tabs-a11y.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patient-chart-tabs-a11y.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA — 2.4.3 Focus Order / 4.1.2 Name, Role, Value.
+ *
+ * The patient-chart tab strip uses visual-only "active" styling. Screen
+ * readers have no way to know which tab is currently selected without an
+ * explicit `aria-current="page"` (or equivalent) on the active tab. Per
+ * issue #183 we expose `aria-current="true"` on the active tab only; all
+ * other tab buttons must omit the attribute entirely (not `"false"` —
+ * that is a common anti-pattern).
+ *
+ * The attribute value is the string `"true"`, not the boolean — DOM
+ * attributes always serialize to strings and aria-current specifically
+ * treats the token `"true"` as valid.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mutable holder so individual tests can set the active tab.
+let currentTab: string | null = null;
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "patient-1" }),
+  useSearchParams: () => ({ get: (k: string) => (k === "tab" ? currentTab : null) }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/components/vitals-trend-chart", () => ({
+  VitalsTrendChart: () => null,
+}));
+
+vi.mock("@/components/stale-data-banner", () => ({
+  StaleDataBanner: () => null,
+}));
+
+// Every child tab pulls tRPC queries. Stub a permissive mock so any
+// chained access returns a `useQuery`/`useMutation` that resolves to an
+// empty/loading shape. This keeps the test focused on the tab strip.
+const stubQuery = () => ({
+  data: undefined,
+  isLoading: true,
+  isError: false,
+});
+const stubMutation = () => ({ mutate: vi.fn(), isPending: false });
+
+const patient = {
+  id: "patient-1",
+  name: "Jane Doe",
+  mrn: "MRN-0001",
+  date_of_birth: "1970-01-01",
+  biological_sex: "F",
+};
+
+vi.mock("@/lib/trpc", () => {
+  // Flexible deep-getter — every leaf provides useQuery/useMutation.
+  const makeLeaf = (key: string) => {
+    const leaf: Record<string, unknown> = {
+      useQuery: (..._args: unknown[]) => {
+        if (key === "patients.getById") {
+          return { data: patient, isLoading: false, isError: false };
+        }
+        return stubQuery();
+      },
+      useMutation: () => stubMutation(),
+    };
+    return leaf;
+  };
+
+  // A thin shim for `trpc.useUtils()` — every invalidate is a resolved noop.
+  const utilsProxy = (): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === "invalidate") {
+            return () => Promise.resolve();
+          }
+          return utilsProxy();
+        },
+      },
+    );
+
+  const proxy = (path: string[]): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === "then") return undefined; // not a thenable
+          if (prop === "useUtils") return () => utilsProxy();
+          const nextPath = [...path, prop];
+          if (prop === "useQuery" || prop === "useMutation") {
+            return makeLeaf(path.join("."))[prop];
+          }
+          return proxy(nextPath);
+        },
+      },
+    );
+
+  return {
+    trpc: proxy([]) as unknown,
+  };
+});
+
+import PatientChartPage from "../../app/patients/[id]/page";
+
+describe("patient-chart tab a11y (WCAG 2.4.3)", () => {
+  afterEach(() => {
+    cleanup();
+    currentTab = null;
+  });
+
+  it("marks the Overview tab aria-current=true by default", () => {
+    currentTab = null;
+    render(<PatientChartPage />);
+
+    const overview = screen.getByRole("button", { name: "Overview" });
+    expect(overview.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("marks only one tab aria-current at a time (Vitals active)", () => {
+    currentTab = "vitals";
+    render(<PatientChartPage />);
+
+    const overview = screen.getByRole("button", { name: "Overview" });
+    const vitals = screen.getByRole("button", { name: "Vitals" });
+    const labs = screen.getByRole("button", { name: "Labs" });
+
+    expect(vitals.getAttribute("aria-current")).toBe("true");
+    expect(overview.getAttribute("aria-current")).toBeNull();
+    expect(labs.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("marks Labs aria-current when ?tab=labs", () => {
+    currentTab = "labs";
+    render(<PatientChartPage />);
+
+    const labs = screen.getByRole("button", { name: "Labs" });
+    expect(labs.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("marks AI Flags aria-current when ?tab=flags", () => {
+    currentTab = "flags";
+    render(<PatientChartPage />);
+
+    const flags = screen.getByRole("button", { name: "AI Flags" });
+    expect(flags.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("does not set aria-current=false on inactive tabs (must be absent)", () => {
+    currentTab = "overview";
+    render(<PatientChartPage />);
+
+    const vitals = screen.getByRole("button", { name: "Vitals" });
+    // ARIA spec: inactive tabs omit the attribute; "false" is the default.
+    expect(vitals.hasAttribute("aria-current")).toBe(false);
+  });
+});

--- a/apps/clinician-portal/src/__tests__/patients-search-a11y.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patients-search-a11y.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA — 2.4.4 / 4.1.2.
+ *
+ * The patients-list search input has only a placeholder. Placeholders are
+ * not an accessible name under the ARIA accessible-name algorithm, so a
+ * screen reader cannot announce the control's purpose. This test pins
+ * the contract that the input exposes `aria-label="Search by patient
+ * name or MRN"`. Issue #183.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    patients: {
+      list: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
+    },
+  },
+}));
+
+import PatientsPage from "../../app/patients/page";
+
+describe("patients list search input a11y (WCAG 2.4.4)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("exposes the search input with aria-label 'Search by patient name or MRN'", () => {
+    render(<PatientsPage />);
+
+    const input = screen.getByLabelText("Search by patient name or MRN");
+    expect(input).toBeDefined();
+    expect(input.getAttribute("aria-label")).toBe(
+      "Search by patient name or MRN",
+    );
+    expect(input.tagName).toBe("INPUT");
+  });
+});

--- a/apps/clinician-portal/src/test-setup.ts
+++ b/apps/clinician-portal/src/test-setup.ts
@@ -1,1 +1,35 @@
 import "@testing-library/jest-dom/vitest";
+
+// Node 25 exposes a built-in `localStorage` that lacks standard Web Storage
+// methods (getItem, setItem, removeItem, clear) when `--localstorage-file` is
+// not configured. This shadows the jsdom-provided `window.localStorage`,
+// causing "removeItem is not a function" errors. Replace it with a simple
+// in-memory implementation so tests behave like a real browser.
+const store = new Map<string, string>();
+
+const localStorageMock: Storage = {
+  getItem(key: string) {
+    return store.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    store.set(key, String(value));
+  },
+  removeItem(key: string) {
+    store.delete(key);
+  },
+  clear() {
+    store.clear();
+  },
+  get length() {
+    return store.size;
+  },
+  key(index: number) {
+    return [...store.keys()][index] ?? null;
+  },
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});

--- a/apps/clinician-portal/vitest.config.ts
+++ b/apps/clinician-portal/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   test: {
     globals: false,
+    environment: "jsdom",
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     setupFiles: ["./src/test-setup.ts"],
   },

--- a/apps/patient-portal/app/login/page.tsx
+++ b/apps/patient-portal/app/login/page.tsx
@@ -165,7 +165,11 @@ export default function LoginPage() {
               </div>
 
               {error && (
-                <div role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}
+                >
                   {error}
                 </div>
               )}
@@ -234,7 +238,11 @@ export default function LoginPage() {
               </div>
 
               {error && (
-                <div role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}>
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  style={{ color: "#ef4444", fontSize: "0.8rem", marginBottom: 12 }}
+                >
                   {error}
                 </div>
               )}

--- a/apps/patient-portal/src/__tests__/login-error-a11y.test.tsx
+++ b/apps/patient-portal/src/__tests__/login-error-a11y.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * WCAG 2.1 AA — 3.3.1 Error Identification.
+ *
+ * The patient-portal login form's error container must be announced to
+ * assistive technology as soon as it appears. That means both
+ * `role="alert"` and an explicit `aria-live="assertive"`. The existing
+ * markup sets role="alert" but omits aria-live; this test asserts the
+ * full contract required by issue #183.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+const loginMutate = vi.fn();
+const mfaCompleteMutate = vi.fn();
+vi.mock("@/lib/trpc", () => ({
+  trpcVanilla: {
+    auth: {
+      login: { mutate: (args: unknown) => loginMutate(args) },
+      mfaCompleteLogin: { mutate: (args: unknown) => mfaCompleteMutate(args) },
+    },
+  },
+}));
+
+import { AuthProvider } from "@carebridge/portal-shared/auth";
+import LoginPage from "../../app/login/page";
+
+describe("patient-portal login error a11y (WCAG 3.3.1)", () => {
+  afterEach(() => {
+    cleanup();
+    loginMutate.mockReset();
+    mfaCompleteMutate.mockReset();
+    window.localStorage.removeItem("carebridge_user");
+    window.localStorage.removeItem("carebridge_has_session");
+  });
+
+  it("announces credential errors with role=alert and aria-live=assertive", async () => {
+    loginMutate.mockRejectedValueOnce(new Error("Invalid email or password"));
+
+    const { container } = render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>,
+    );
+
+    const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
+    const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
+    fireEvent.change(emailInput, { target: { value: "x@example.com" } });
+    fireEvent.change(passwordInput, { target: { value: "nope" } });
+    const form = container.querySelector("form") as HTMLFormElement;
+    fireEvent.submit(form);
+
+    const alert = await waitFor(() => screen.getByRole("alert"));
+    expect(alert.getAttribute("role")).toBe("alert");
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+    expect(alert.textContent).toMatch(/invalid email or password/i);
+  });
+});


### PR DESCRIPTION
## Summary
WCAG 2.1 AA a11y fixes for the clinician- and patient-portal surfaces called out in issue #183.

- **3.3.1 Error Identification** — both login forms' error container is now `role="alert"` + `aria-live="assertive"`, so assistive tech announces failed credentials / MFA errors the moment they render.
- **4.1.2 Name, Role, Value** — the per-flag Acknowledge / Resolve / Dismiss buttons in the AI inbox get an `aria-label` that includes the flag summary, giving each a unique accessible name.
- **2.4.4 / 4.1.2** — the patients-list search input exposes `aria-label="Search by patient name or MRN"` (placeholders are not an accessible name under the ARIA accessible-name algorithm).
- **2.4.3 Focus Order** — the patient-chart tab strip sets `aria-current="true"` on the active tab (string value, not boolean) and omits the attribute on inactive tabs, so screen readers can identify the current section.

Closes #183.

## WCAG criteria addressed
- [x] 2.4.3 Focus Order — active tab has `aria-current="true"`; inactive tabs omit the attribute
- [x] 2.4.4 Link Purpose (In Context) — search input has a real accessible name
- [x] 3.3.1 Error Identification — login error containers are live regions
- [x] 4.1.2 Name, Role, Value — inbox action buttons have unique accessible names tied to their flag

## Test plan
- [x] `pnpm --filter @carebridge/clinician-portal test` — 186/186 pass, including 10 new a11y tests
- [x] `pnpm --filter @carebridge/patient-portal test` — 13/13 pass, including 1 new a11y test
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (only pre-existing warnings)

### New render-based tests (TDD red → green)
- `login-error-a11y.test.tsx` (clinician + patient): mount the login page, reject the login mutation, assert `role="alert"` and `aria-live="assertive"` on the error container.
- `inbox-button-a11y.test.tsx`: render the inbox with mocked flag data, assert every Acknowledge / Resolve / Dismiss button has the expected `aria-label` referencing the flag summary.
- `patients-search-a11y.test.tsx`: assert the search input is labelled "Search by patient name or MRN".
- `patient-chart-tabs-a11y.test.tsx`: render the patient chart, assert only the active tab has `aria-current="true"` (and inactive tabs omit the attribute, not `"false"`).

### Harness notes
The clinician-portal vitest config gained `environment: "jsdom"` and an in-memory `localStorage` polyfill in `test-setup.ts` to match patient-portal. Node 25's built-in `localStorage` lacks standard Web Storage methods, which shadows the jsdom-provided `window.localStorage` and breaks `removeItem` — this has been a known trap in the patient-portal setup and is now symmetric.