### PR TITLE
test(services): migrate remaining DB mock chains to @carebridge/test-utils

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@carebridge/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -576,6 +579,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@carebridge/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -736,6 +742,9 @@ importers:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@carebridge/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -36,6 +36,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@carebridge/test-utils": "workspace:*",
     "@types/node": "^22.0.0",
     "@types/qrcode": "^1.5.6",
     "typescript": "^5.7.0",

--- a/services/auth/src/__tests__/mfa-enumeration.test.ts
+++ b/services/auth/src/__tests__/mfa-enumeration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { TRPCError } from "@trpc/server";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 // ---------------------------------------------------------------------------
 // Mocks — set up before importing the module under test
@@ -75,23 +76,10 @@ vi.mock("@carebridge/redis-config", () => ({
   }),
 }));
 
-// Controllable user-row result for the router's db lookup.
-let mockUserRows: unknown[] = [];
-
-const mockLimit = vi.fn(async () => mockUserRows);
-const mockWhere = vi.fn(() => ({ limit: mockLimit }));
-const mockFrom = vi.fn(() => ({ where: mockWhere }));
-const mockSelect = vi.fn(() => ({ from: mockFrom }));
+let db: MockDb;
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({
-    select: mockSelect,
-    insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
-    update: vi.fn(() => ({
-      set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
-    })),
-    delete: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
-  }),
+  getDb: () => db,
   users: {
     id: "users.id",
     email: "users.email",
@@ -154,8 +142,8 @@ function createCaller() {
 describe("mfaCompleteLogin — user enumeration hardening (issue #278)", () => {
   beforeEach(() => {
     redisStore.clear();
-    mockUserRows = [];
     vi.clearAllMocks();
+    db = createMockDb();
   });
 
   async function callAndCaptureError(): Promise<TRPCError> {
@@ -183,7 +171,7 @@ describe("mfaCompleteLogin — user enumeration hardening (issue #278)", () => {
   it("returns the SAME generic error when the pending session references a deleted user", async () => {
     // Pending session exists, but the user row has been deleted.
     setPendingSessionInRedis(VALID_UUID, "deleted-user-id");
-    mockUserRows = []; // db returns no rows
+    db.willSelect([]); // db returns no rows
 
     const err = await callAndCaptureError();
     expect(err.code).toBe("UNAUTHORIZED");
@@ -198,7 +186,7 @@ describe("mfaCompleteLogin — user enumeration hardening (issue #278)", () => {
 
     // Branch 2: valid MFA session but deleted user.
     setPendingSessionInRedis(VALID_UUID, "deleted-user-id");
-    mockUserRows = [];
+    db.willSelect([]);
     const deletedUserErr = await callAndCaptureError();
 
     expect(deletedUserErr.code).toBe(expiredErr.code);

--- a/services/auth/src/__tests__/session-cleanup.test.ts
+++ b/services/auth/src/__tests__/session-cleanup.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 // ---------------------------------------------------------------------------
 // Mocks — set up before importing the module under test
@@ -12,19 +13,14 @@ interface DeletedSessionRow {
   created_at: string;
 }
 
-const deletedRows: DeletedSessionRow[] = [];
-const mockReturning = vi.fn(() => deletedRows);
-const mockWhere = vi.fn(() => ({ returning: mockReturning }));
-const mockDeleteFn = vi.fn(() => ({ where: mockWhere }));
+let db: MockDb;
 
+// Tracks records inserted via `db.insert(auditLog).values({...})`. Populated
+// in `beforeEach` by wiring up a spy on the helper's insert chain.
 const insertedAuditEntries: Array<Record<string, unknown>> = [];
-const mockInsertValues = vi.fn(async (values: Record<string, unknown>) => {
-  insertedAuditEntries.push(values);
-});
-const mockInsertFn = vi.fn(() => ({ values: mockInsertValues }));
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({ delete: mockDeleteFn, insert: mockInsertFn }),
+  getDb: () => db,
   sessions: {
     id: "sessions.id",
     user_id: "sessions.user_id",
@@ -45,7 +41,7 @@ vi.mock("drizzle-orm", () => ({
   sql: () => ({}),
 }));
 
-import { cleanupExpiredSessions } from "../session-cleanup.js";
+const { cleanupExpiredSessions } = await import("../session-cleanup.js");
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -63,28 +59,46 @@ function seedDeletedRow(
   };
 }
 
+/**
+ * Extract the argument passed to the `where()` chain call on the delete
+ * operation (equivalent to the legacy `mockWhere.mock.calls[0][0]` check).
+ */
+function getDeleteWhereArg(): { op: string; args: unknown[] } {
+  const call = db.delete.calls[0];
+  if (!call) throw new Error("expected db.delete to have been called");
+  const whereIdx = call.chain.indexOf("where");
+  return call.chainArgs[whereIdx]?.[0] as { op: string; args: unknown[] };
+}
+
 describe("cleanupExpiredSessions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    deletedRows.length = 0;
+    db = createMockDb();
     insertedAuditEntries.length = 0;
+
+    // The helper's insert chain does not retain what was passed to
+    // `.values(...)` except inside chainArgs. Each test seeds its own
+    // deleted-row fixture via `db.willDelete`; audit-log assertions read
+    // the `values(...)` args directly from `db.insert.calls[i].chainArgs`.
   });
 
   it("calls db.delete on the sessions table", async () => {
+    db.willDelete([]);
     const count = await cleanupExpiredSessions();
 
-    expect(mockDeleteFn).toHaveBeenCalledTimes(1);
-    expect(mockWhere).toHaveBeenCalledTimes(1);
-    expect(mockReturning).toHaveBeenCalledTimes(1);
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    const deleteChain = db.delete.calls[0]?.chain ?? [];
+    expect(deleteChain).toContain("where");
+    expect(deleteChain).toContain("returning");
     expect(count).toBe(0);
   });
 
   it("returns the number of deleted rows", async () => {
-    deletedRows.push(
+    db.willDelete([
       seedDeletedRow({ id: "s1" }),
       seedDeletedRow({ id: "s2" }),
       seedDeletedRow({ id: "s3" }),
-    );
+    ]);
 
     const count = await cleanupExpiredSessions();
 
@@ -92,12 +106,10 @@ describe("cleanupExpiredSessions", () => {
   });
 
   it("builds an OR condition covering expiry, idle, and hard-cap", async () => {
+    db.willDelete([]);
     await cleanupExpiredSessions();
 
-    const whereArg = (mockWhere.mock.calls[0] as unknown[])[0] as {
-      op: string;
-      args: unknown[];
-    };
+    const whereArg = getDeleteWhereArg();
 
     // Top-level should be an OR with three branches.
     expect(whereArg.op).toBe("or");
@@ -123,14 +135,12 @@ describe("cleanupExpiredSessions", () => {
   });
 
   it("uses correct idle timeout of 15 minutes", async () => {
+    db.willDelete([]);
     const before = Date.now();
     await cleanupExpiredSessions();
     const after = Date.now();
 
-    const whereArg = (mockWhere.mock.calls[0] as unknown[])[0] as {
-      op: string;
-      args: unknown[];
-    };
+    const whereArg = getDeleteWhereArg();
 
     const idleCondition = whereArg.args[1] as {
       op: string;
@@ -145,11 +155,12 @@ describe("cleanupExpiredSessions", () => {
   });
 
   it("uses correct hard cap of 48 hours", async () => {
+    db.willDelete([]);
     const before = Date.now();
     await cleanupExpiredSessions();
     const after = Date.now();
 
-    const whereArg = (mockWhere.mock.calls[0] as unknown[])[0] as {
+    const whereArg = getDeleteWhereArg() as {
       op: string;
       args: { op: string; val: string }[];
     };
@@ -163,7 +174,7 @@ describe("cleanupExpiredSessions", () => {
 
   it("logs when sessions are deleted", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    deletedRows.push(seedDeletedRow({ id: "s1" }));
+    db.willDelete([seedDeletedRow({ id: "s1" })]);
 
     await cleanupExpiredSessions();
 
@@ -179,7 +190,7 @@ describe("cleanupExpiredSessions", () => {
     const idlePast = new Date(Date.now() - 20 * 60 * 1000).toISOString();
     const oldCreated = new Date(Date.now() - 50 * 60 * 60 * 1000).toISOString();
 
-    deletedRows.push(
+    db.willDelete([
       seedDeletedRow({
         id: "expired-1",
         user_id: "user-a",
@@ -195,12 +206,19 @@ describe("cleanupExpiredSessions", () => {
         user_id: "user-c",
         created_at: oldCreated,
       }),
-    );
+    ]);
 
     await cleanupExpiredSessions();
 
-    expect(insertedAuditEntries).toHaveLength(3);
-    for (const entry of insertedAuditEntries) {
+    // Each `db.insert(auditLog).values({...})` is recorded on the helper.
+    // Extract the values argument of each call.
+    const entries = db.insert.calls.map((call) => {
+      const valuesIdx = call.chain.indexOf("values");
+      return call.chainArgs[valuesIdx]?.[0] as Record<string, unknown>;
+    });
+
+    expect(entries).toHaveLength(3);
+    for (const entry of entries) {
       expect(entry.action).toBe("session_idle_expired");
       expect(entry.resource_type).toBe("session");
       expect(typeof entry.resource_id).toBe("string");
@@ -210,9 +228,7 @@ describe("cleanupExpiredSessions", () => {
       expect(details.reason.length).toBeGreaterThan(0);
     }
 
-    const byId = Object.fromEntries(
-      insertedAuditEntries.map((e) => [e.resource_id, e]),
-    );
+    const byId = Object.fromEntries(entries.map((e) => [e.resource_id, e]));
     expect(JSON.parse(byId["expired-1"].details as string).reason).toContain(
       "Absolute",
     );
@@ -228,6 +244,7 @@ describe("cleanupExpiredSessions", () => {
 
   it("does not log when no sessions are deleted", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    db.willDelete([]);
 
     await cleanupExpiredSessions();
 

--- a/services/auth/vitest.config.ts
+++ b/services/auth/vitest.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
         __dirname,
         "../../packages/db-schema/src/index.ts",
       ),
+      "@carebridge/test-utils": path.resolve(
+        __dirname,
+        "../../packages/test-utils/src/index.ts",
+      ),
     },
   },
 });

--- a/services/clinical-data/package.json
+++ b/services/clinical-data/package.json
@@ -30,6 +30,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@carebridge/test-utils": "workspace:*",
     "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
     "vitest": "^3.0.0"

--- a/services/clinical-data/src/__tests__/lab-repo.test.ts
+++ b/services/clinical-data/src/__tests__/lab-repo.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 // ── Mock DB ──────────────────────────────────────────────────────
-const insertValuesMock = vi.fn().mockResolvedValue(undefined);
-const insertMock = vi.fn(() => ({ values: insertValuesMock }));
-
-const selectFromWhereMock = vi.fn().mockResolvedValue([]);
-const selectFromMock = vi.fn(() => ({
-  where: selectFromWhereMock,
-  orderBy: vi.fn().mockReturnValue({
-    where: selectFromWhereMock,
-  }),
-}));
-const selectMock = vi.fn(() => ({ from: selectFromMock }));
+// Non-transactional operations (select, insert) flow through the shared
+// MockDb helper. The `transaction` hook is kept as a standalone mock
+// because the helper does not model Drizzle's transactional callback API.
+let db: MockDb;
 
 const txInsertValuesMock = vi.fn().mockResolvedValue(undefined);
 const txInsertMock = vi.fn(() => ({ values: txInsertValuesMock }));
@@ -21,8 +15,8 @@ const transactionMock = vi.fn(async (cb: (tx: unknown) => Promise<void>) => {
 
 vi.mock("@carebridge/db-schema", () => ({
   getDb: () => ({
-    insert: insertMock,
-    select: selectMock,
+    select: db.select,
+    insert: db.insert,
     transaction: transactionMock,
   }),
   labPanels: { patient_id: "patient_id", collected_at: "collected_at" },
@@ -67,6 +61,7 @@ const sampleLabInput = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  db = createMockDb();
 });
 
 describe("createLabPanel", () => {
@@ -225,18 +220,10 @@ describe("getLabPanelsByPatient", () => {
       created_at: "2026-03-15T08:00:00.000Z",
     };
 
-    // First call: select panels (with orderBy)
-    selectFromMock.mockReturnValueOnce({
-      where: vi.fn().mockReturnValue({
-        orderBy: vi.fn().mockResolvedValue([mockPanelRow]),
-      }),
-      orderBy: vi.fn(),
-    });
-    // Second call: select results for panel-1
-    selectFromMock.mockReturnValueOnce({
-      where: vi.fn().mockResolvedValue([mockResultRow]),
-      orderBy: vi.fn(),
-    });
+    // First call: select panels (with orderBy).
+    db.willSelect([mockPanelRow]);
+    // Second call: select results for panel-1.
+    db.willSelect([mockResultRow]);
 
     const results = await getLabPanelsByPatient(PATIENT_ID);
 

--- a/services/clinical-data/src/__tests__/medication-repo.test.ts
+++ b/services/clinical-data/src/__tests__/medication-repo.test.ts
@@ -1,38 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 // ── Mock DB ──────────────────────────────────────────────────────
-const insertValuesMock = vi.fn().mockResolvedValue(undefined);
-const insertMock = vi.fn(() => ({ values: insertValuesMock }));
-
-const updateReturningMock = vi.fn();
-const updateSetWhereMock = vi.fn(() => ({ returning: updateReturningMock }));
-const updateSetMock = vi.fn(() => ({ where: updateSetWhereMock }));
-const updateMock = vi.fn(() => ({ set: updateSetMock }));
-
-const selectFromWhereLimitMock = vi.fn();
-/** Where mock returns a thenable with .limit() support.
- * Allergy queries await where() directly; other queries chain .limit(). */
-let allergyResults: unknown[] = [];
-const selectFromWhereMock = vi.fn(() => {
-  const obj = {
-    limit: selectFromWhereLimitMock,
-    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
-      Promise.resolve(allergyResults).then(resolve, reject),
-  };
-  return obj;
-});
-const selectFromMock = vi.fn(() => ({
-  where: selectFromWhereMock,
-  orderBy: vi.fn().mockReturnValue({ where: selectFromWhereMock }),
-}));
-const selectMock = vi.fn(() => ({ from: selectFromMock }));
+let db: MockDb;
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({
-    insert: insertMock,
-    select: selectMock,
-    update: updateMock,
-  }),
+  getDb: () => db,
   medications: {
     id: "id",
     patient_id: "patient_id",
@@ -71,14 +44,18 @@ const sampleMedInput = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  db = createMockDb();
 });
 
 describe("createMedication", () => {
   it("inserts a medication and returns it with all fields", async () => {
+    // createMedication first selects allergies — return none so the insert path runs.
+    db.willSelect([]);
+
     const result = await createMedication(sampleMedInput);
 
-    expect(insertMock).toHaveBeenCalledOnce();
-    expect(insertValuesMock).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
+    expect(db.insert.calls[0]?.chain).toContain("values");
 
     expect(result).toMatchObject({
       patient_id: PATIENT_ID,
@@ -95,6 +72,8 @@ describe("createMedication", () => {
   });
 
   it("emits medication.created event", async () => {
+    db.willSelect([]); // no allergy conflicts
+
     const result = await createMedication(sampleMedInput);
 
     expect(emitClinicalEvent).toHaveBeenCalledOnce();
@@ -135,12 +114,12 @@ describe("updateMedication", () => {
       updated_at: "2026-03-15T10:00:00.000Z",
     };
 
-    // First select: find existing record
-    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
-    // Update returning: row was updated
-    updateReturningMock.mockResolvedValueOnce([{ id: MED_ID }]);
-    // Second select: re-fetch updated record
-    selectFromWhereLimitMock.mockResolvedValueOnce([
+    // First select: find existing record.
+    db.willSelect([existingRow]);
+    // Update returning: row was updated.
+    db.willUpdate([{ id: MED_ID }]);
+    // Second select: re-fetch updated record.
+    db.willSelect([
       { ...existingRow, status: "discontinued", updated_at: "2026-03-16T10:00:00.000Z" },
     ]);
 
@@ -161,7 +140,7 @@ describe("updateMedication", () => {
   });
 
   it("throws when medication is not found", async () => {
-    selectFromWhereLimitMock.mockResolvedValueOnce([]);
+    db.willSelect([]);
 
     await expect(updateMedication("nonexistent", { status: "discontinued" }))
       .rejects.toThrow("Medication nonexistent not found");
@@ -190,9 +169,9 @@ describe("updateMedication", () => {
       updated_at: "2026-03-15T10:00:00.000Z",
     };
 
-    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
-    updateReturningMock.mockResolvedValueOnce([{ id: MED_ID }]);
-    selectFromWhereLimitMock.mockResolvedValueOnce([
+    db.willSelect([existingRow]);
+    db.willUpdate([{ id: MED_ID }]);
+    db.willSelect([
       { ...existingRow, status: "discontinued", updated_at: "2026-03-16T10:00:00.000Z" },
     ]);
 
@@ -202,7 +181,9 @@ describe("updateMedication", () => {
     });
 
     expect(result.status).toBe("discontinued");
-    expect(updateSetWhereMock).toHaveBeenCalledOnce();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(db.update.calls[0]?.chain).toContain("set");
+    expect(db.update.calls[0]?.chain).toContain("where");
   });
 
   it("throws ConflictError when expectedUpdatedAt does not match (concurrent modification)", async () => {
@@ -228,9 +209,9 @@ describe("updateMedication", () => {
       updated_at: "2026-03-16T12:00:00.000Z", // already modified by another user
     };
 
-    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
-    // Update returns 0 rows because updated_at doesn't match
-    updateReturningMock.mockResolvedValueOnce([]);
+    db.willSelect([existingRow]);
+    // Update returns 0 rows because updated_at doesn't match.
+    db.willUpdate([]);
 
     const error = await updateMedication(MED_ID, {
       status: "discontinued",
@@ -268,9 +249,9 @@ describe("updateMedication", () => {
       updated_at: "2026-03-15T10:00:00.000Z",
     };
 
-    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
-    updateReturningMock.mockResolvedValueOnce([{ id: MED_ID }]);
-    selectFromWhereLimitMock.mockResolvedValueOnce([
+    db.willSelect([existingRow]);
+    db.willUpdate([{ id: MED_ID }]);
+    db.willSelect([
       { ...existingRow, status: "held", updated_at: "2026-03-16T10:00:00.000Z" },
     ]);
 
@@ -314,9 +295,9 @@ describe("updateMedication", () => {
       updated_at: "2026-03-15T10:00:00.000Z",
     };
 
-    selectFromWhereLimitMock.mockResolvedValueOnce([existingRow]);
-    updateReturningMock.mockResolvedValueOnce([{ id: MED_ID }]);
-    selectFromWhereLimitMock.mockResolvedValueOnce([
+    db.willSelect([existingRow]);
+    db.willUpdate([{ id: MED_ID }]);
+    db.willSelect([
       { ...existingRow, frequency: "TID", updated_at: "2026-03-16T10:00:00.000Z" },
     ]);
 
@@ -328,7 +309,7 @@ describe("updateMedication", () => {
 
 describe("allergy safety check", () => {
   it("blocks medication that directly matches a patient allergy", async () => {
-    allergyResults = [
+    db.willSelect([
       {
         id: "allergy-1",
         patient_id: PATIENT_ID,
@@ -339,18 +320,18 @@ describe("allergy safety check", () => {
         snomed_code: null,
         created_at: "2026-01-01T00:00:00.000Z",
       },
-    ];
+    ]);
 
     await expect(
       createMedication({ ...sampleMedInput, name: "Penicillin V" }),
     ).rejects.toThrow(/ALLERGY_CONFLICT.*Penicillin/);
 
     // Must NOT have inserted into the database
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it("blocks medication that cross-reacts with a patient allergy (penicillin → amoxicillin)", async () => {
-    allergyResults = [
+    db.willSelect([
       {
         id: "allergy-2",
         patient_id: PATIENT_ID,
@@ -361,17 +342,17 @@ describe("allergy safety check", () => {
         snomed_code: null,
         created_at: "2026-01-01T00:00:00.000Z",
       },
-    ];
+    ]);
 
     await expect(
       createMedication({ ...sampleMedInput, name: "Amoxicillin 500mg" }),
     ).rejects.toThrow(/ALLERGY_CONFLICT.*Amoxicillin.*Penicillin.*penicillin/);
 
-    expect(insertMock).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
   });
 
   it("allows medication when no allergy conflicts exist", async () => {
-    allergyResults = [
+    db.willSelect([
       {
         id: "allergy-3",
         patient_id: PATIENT_ID,
@@ -382,20 +363,20 @@ describe("allergy safety check", () => {
         snomed_code: null,
         created_at: "2026-01-01T00:00:00.000Z",
       },
-    ];
+    ]);
 
     const result = await createMedication(sampleMedInput); // Enoxaparin — no penicillin cross-reactivity
 
     expect(result.name).toBe("Enoxaparin");
-    expect(insertMock).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
   });
 
   it("allows medication when patient has no allergies", async () => {
-    allergyResults = [];
+    db.willSelect([]);
 
     const result = await createMedication(sampleMedInput);
 
     expect(result.name).toBe("Enoxaparin");
-    expect(insertMock).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
   });
 });

--- a/services/clinical-data/src/__tests__/vital-repo.test.ts
+++ b/services/clinical-data/src/__tests__/vital-repo.test.ts
@@ -1,22 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 // ── Mock DB ──────────────────────────────────────────────────────
-const insertValuesMock = vi.fn().mockResolvedValue(undefined);
-const insertMock = vi.fn(() => ({ values: insertValuesMock }));
-
-const selectFromWhereMock = vi.fn().mockReturnValue({
-  orderBy: vi.fn().mockResolvedValue([]),
-});
-const selectFromMock = vi.fn((table: unknown) => ({
-  where: selectFromWhereMock,
-}));
-const selectMock = vi.fn(() => ({ from: selectFromMock }));
+let db: MockDb;
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => ({
-    insert: insertMock,
-    select: selectMock,
-  }),
+  getDb: () => db,
   vitals: { patient_id: "patient_id", type: "type", recorded_at: "recorded_at" },
 }));
 
@@ -41,14 +30,15 @@ const sampleVitalInput = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  db = createMockDb();
 });
 
 describe("createVital", () => {
   it("inserts a vital record and returns it with all fields", async () => {
     const result = await createVital(sampleVitalInput);
 
-    expect(insertMock).toHaveBeenCalledOnce();
-    expect(insertValuesMock).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
+    expect(db.insert.calls[0]?.chain).toContain("values");
 
     expect(result).toMatchObject({
       patient_id: PATIENT_ID,
@@ -100,13 +90,11 @@ describe("getVitalsByPatient", () => {
       },
     ];
 
-    selectFromWhereMock.mockReturnValueOnce({
-      orderBy: vi.fn().mockResolvedValue(mockRows),
-    });
+    db.willSelect(mockRows);
 
     const results = await getVitalsByPatient(PATIENT_ID);
 
-    expect(selectMock).toHaveBeenCalled();
+    expect(db.select).toHaveBeenCalled();
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({
       id: "v1",
@@ -118,9 +106,7 @@ describe("getVitalsByPatient", () => {
   });
 
   it("returns empty array when no vitals exist for patient", async () => {
-    selectFromWhereMock.mockReturnValueOnce({
-      orderBy: vi.fn().mockResolvedValue([]),
-    });
+    db.willSelect([]);
 
     const results = await getVitalsByPatient("nonexistent-id");
     expect(results).toEqual([]);

--- a/services/clinical-data/vitest.config.ts
+++ b/services/clinical-data/vitest.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
         __dirname,
         "../../packages/redis-config/src/index.ts",
       ),
+      "@carebridge/test-utils": path.resolve(
+        __dirname,
+        "../../packages/test-utils/src/index.ts",
+      ),
     },
   },
 });

--- a/services/notifications/package.json
+++ b/services/notifications/package.json
@@ -27,6 +27,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@carebridge/test-utils": "workspace:*",
     "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",

--- a/services/notifications/src/__tests__/dispatch-worker.test.ts
+++ b/services/notifications/src/__tests__/dispatch-worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
 
 /**
  * Unit tests for dispatch worker notification creation logic.
@@ -12,28 +13,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ── DB mocks ────────────────────────────────────────────────────────
 
-const mockSelectResult: Array<Record<string, unknown>> = [];
-const mockSelectResult2: Array<Record<string, unknown>> = [];
-let selectCallCount = 0;
-
-const mockInsertValues = vi.fn().mockResolvedValue(undefined);
-const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
-
-const mockDb = {
-  select: vi.fn().mockImplementation(() => {
-    const currentCall = selectCallCount++;
-    const resultSet = currentCall === 0 ? mockSelectResult : mockSelectResult2;
-    return {
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue(resultSet),
-      }),
-    };
-  }),
-  insert: mockInsert,
-};
+let db: MockDb;
 
 vi.mock("@carebridge/db-schema", () => ({
-  getDb: () => mockDb,
+  getDb: () => db,
   notifications: { user_id: "user_id" },
   users: {
     id: "id",
@@ -84,18 +67,7 @@ vi.mock("../publish.js", () => ({
 
 // ── Import module under test (after mocks) ──────────────────────────
 
-// The dispatch worker exports `startDispatchWorker` which instantiates
-// a BullMQ Worker. We need to access `processNotificationJob` which is
-// internal. Instead we re-test the exported helpers indirectly by
-// invoking the worker callback captured from the Worker constructor mock.
-
 import type { NotificationEvent } from "../queue.js";
-
-// Since processNotificationJob is not exported, we'll test through the
-// worker callback. But actually the Worker constructor is mocked, so we
-// need a different approach. Let's test the logic by importing and
-// calling startDispatchWorker, then extracting the processor callback.
-
 import { startDispatchWorker } from "../workers/dispatch-worker.js";
 import { Worker } from "bullmq";
 
@@ -114,14 +86,40 @@ function makeEvent(overrides: Partial<NotificationEvent> = {}): NotificationEven
   };
 }
 
+/**
+ * Prime the `db` mock for a full dispatch-worker job:
+ *  1. care_team_assignments select
+ *  2. users select
+ *  3. per-recipient notification_preferences select (one per recipient;
+ *     empty → opt-out default).
+ */
+function primeDispatch(
+  assignments: Array<Record<string, unknown>>,
+  providers: Array<Record<string, unknown>>,
+): void {
+  db.willSelect(assignments);
+  db.willSelect(providers);
+  for (let i = 0; i < providers.length; i++) {
+    db.willSelect([]);
+  }
+}
+
+/**
+ * Extract the records array passed to `db.insert(notifications).values(...)`.
+ */
+function getInsertedRecords(): Array<Record<string, unknown>> {
+  const call = db.insert.calls[0];
+  if (!call) throw new Error("expected db.insert to have been called");
+  const valuesIdx = call.chain.indexOf("values");
+  return call.chainArgs[valuesIdx]?.[0] as Array<Record<string, unknown>>;
+}
+
 describe("dispatch-worker", () => {
   let processorFn: (job: { data: NotificationEvent; id: string }) => Promise<void>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    selectCallCount = 0;
-    mockSelectResult.length = 0;
-    mockSelectResult2.length = 0;
+    db = createMockDb();
 
     // Extract the processor function passed to the Worker constructor
     const WorkerMock = Worker as unknown as ReturnType<typeof vi.fn>;
@@ -134,20 +132,16 @@ describe("dispatch-worker", () => {
   });
 
   it("creates urgent notifications for critical severity flags", async () => {
-    // First select: care_team_assignments returns one user
-    mockSelectResult.push({ user_id: "user-neuro" });
-    // Second select: users table returns the provider
-    mockSelectResult2.push({
-      id: "user-neuro",
-      specialty: "Neurology",
-      role: "physician",
-    });
+    primeDispatch(
+      [{ user_id: "user-neuro" }],
+      [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+    );
 
     const event = makeEvent({ severity: "critical" });
     await processorFn({ data: event, id: "job-1" });
 
-    expect(mockInsertValues).toHaveBeenCalledTimes(1);
-    const insertedRecords = mockInsertValues.mock.calls[0][0];
+    expect(db.insert).toHaveBeenCalledOnce();
+    const insertedRecords = getInsertedRecords();
     expect(insertedRecords).toHaveLength(1);
     expect(insertedRecords[0].is_urgent).toBe(true);
     expect(insertedRecords[0].type).toBe("ai-flag");
@@ -155,68 +149,62 @@ describe("dispatch-worker", () => {
   });
 
   it("creates urgent notifications for high severity flags", async () => {
-    mockSelectResult.push({ user_id: "user-onco" });
-    mockSelectResult2.push({
-      id: "user-onco",
-      specialty: "Hematology/Oncology",
-      role: "physician",
-    });
+    primeDispatch(
+      [{ user_id: "user-onco" }],
+      [{ id: "user-onco", specialty: "Hematology/Oncology", role: "physician" }],
+    );
 
     const event = makeEvent({ severity: "high" });
     await processorFn({ data: event, id: "job-2" });
 
-    const insertedRecords = mockInsertValues.mock.calls[0][0];
+    const insertedRecords = getInsertedRecords();
     expect(insertedRecords[0].is_urgent).toBe(true);
   });
 
   it("creates non-urgent notifications for warning severity flags", async () => {
-    mockSelectResult.push({ user_id: "user-onco" });
-    mockSelectResult2.push({
-      id: "user-onco",
-      specialty: "Hematology/Oncology",
-      role: "physician",
-    });
+    primeDispatch(
+      [{ user_id: "user-onco" }],
+      [{ id: "user-onco", specialty: "Hematology/Oncology", role: "physician" }],
+    );
 
     const event = makeEvent({ severity: "warning" });
     await processorFn({ data: event, id: "job-3" });
 
-    const insertedRecords = mockInsertValues.mock.calls[0][0];
+    const insertedRecords = getInsertedRecords();
     expect(insertedRecords[0].is_urgent).toBe(false);
   });
 
   it("creates non-urgent notifications for info severity flags", async () => {
-    mockSelectResult.push({ user_id: "user-onco" });
-    mockSelectResult2.push({
-      id: "user-onco",
-      specialty: "Hematology/Oncology",
-      role: "physician",
-    });
+    primeDispatch(
+      [{ user_id: "user-onco" }],
+      [{ id: "user-onco", specialty: "Hematology/Oncology", role: "physician" }],
+    );
 
     const event = makeEvent({ severity: "info" });
     await processorFn({ data: event, id: "job-4" });
 
-    const insertedRecords = mockInsertValues.mock.calls[0][0];
+    const insertedRecords = getInsertedRecords();
     expect(insertedRecords[0].is_urgent).toBe(false);
   });
 
   it("creates no notifications when no care team assignments exist", async () => {
-    // First select returns empty (no assignments)
-    // mockSelectResult is already empty
+    // First select returns empty (no assignments) — subsequent selects
+    // are never reached because the early-return in
+    // `findNotificationRecipients` fires on the empty result.
+    db.willSelect([]);
 
     const event = makeEvent();
     await processorFn({ data: event, id: "job-5" });
 
-    expect(mockInsertValues).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
     expect(mockPublishNotification).not.toHaveBeenCalled();
   });
 
   it("publishes real-time SSE notification with is_urgent flag", async () => {
-    mockSelectResult.push({ user_id: "user-neuro" });
-    mockSelectResult2.push({
-      id: "user-neuro",
-      specialty: "Neurology",
-      role: "physician",
-    });
+    primeDispatch(
+      [{ user_id: "user-neuro" }],
+      [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+    );
 
     const event = makeEvent({ severity: "critical" });
     await processorFn({ data: event, id: "job-6" });
@@ -229,19 +217,18 @@ describe("dispatch-worker", () => {
   });
 
   it("creates notifications for multiple care team members", async () => {
-    mockSelectResult.push(
-      { user_id: "user-neuro" },
-      { user_id: "user-onco" },
-    );
-    mockSelectResult2.push(
-      { id: "user-neuro", specialty: "Neurology", role: "physician" },
-      { id: "user-onco", specialty: "Hematology/Oncology", role: "physician" },
+    primeDispatch(
+      [{ user_id: "user-neuro" }, { user_id: "user-onco" }],
+      [
+        { id: "user-neuro", specialty: "Neurology", role: "physician" },
+        { id: "user-onco", specialty: "Hematology/Oncology", role: "physician" },
+      ],
     );
 
     const event = makeEvent();
     await processorFn({ data: event, id: "job-7" });
 
-    const insertedRecords = mockInsertValues.mock.calls[0][0];
+    const insertedRecords = getInsertedRecords();
     expect(insertedRecords).toHaveLength(2);
     expect(mockPublishNotification).toHaveBeenCalledTimes(2);
   });
@@ -262,12 +249,10 @@ describe("dispatch-worker", () => {
       });
 
     it("published body contains no numeric values", async () => {
-      mockSelectResult.push({ user_id: "user-neuro" });
-      mockSelectResult2.push({
-        id: "user-neuro",
-        specialty: "Neurology",
-        role: "physician",
-      });
+      primeDispatch(
+        [{ user_id: "user-neuro" }],
+        [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+      );
 
       const event = phiEvent();
       await processorFn({ data: event, id: "job-phi-1" });
@@ -278,12 +263,10 @@ describe("dispatch-worker", () => {
     });
 
     it("published body does not contain the raw event.summary text", async () => {
-      mockSelectResult.push({ user_id: "user-neuro" });
-      mockSelectResult2.push({
-        id: "user-neuro",
-        specialty: "Neurology",
-        role: "physician",
-      });
+      primeDispatch(
+        [{ user_id: "user-neuro" }],
+        [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+      );
 
       const event = phiEvent();
       await processorFn({ data: event, id: "job-phi-2" });
@@ -298,12 +281,10 @@ describe("dispatch-worker", () => {
     });
 
     it("persisted record.summary_safe equals the buildSafeSummary output", async () => {
-      mockSelectResult.push({ user_id: "user-neuro" });
-      mockSelectResult2.push({
-        id: "user-neuro",
-        specialty: "Neurology",
-        role: "physician",
-      });
+      primeDispatch(
+        [{ user_id: "user-neuro" }],
+        [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+      );
 
       const event = phiEvent();
       await processorFn({ data: event, id: "job-phi-3" });
@@ -315,7 +296,7 @@ describe("dispatch-worker", () => {
       const expectedSafe =
         "Clinical flag — Critical value. Open the portal to view details.";
 
-      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      const insertedRecords = getInsertedRecords();
       expect(insertedRecords).toHaveLength(1);
       expect(insertedRecords[0].summary_safe).toBe(expectedSafe);
 
@@ -325,17 +306,15 @@ describe("dispatch-worker", () => {
     });
 
     it("persisted record.body still equals event.summary (full, for authenticated fetch)", async () => {
-      mockSelectResult.push({ user_id: "user-neuro" });
-      mockSelectResult2.push({
-        id: "user-neuro",
-        specialty: "Neurology",
-        role: "physician",
-      });
+      primeDispatch(
+        [{ user_id: "user-neuro" }],
+        [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+      );
 
       const event = phiEvent();
       await processorFn({ data: event, id: "job-phi-4" });
 
-      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      const insertedRecords = getInsertedRecords();
       expect(insertedRecords[0].body).toBe(event.summary);
     });
   });
@@ -347,12 +326,10 @@ describe("dispatch-worker", () => {
   // lock in the whitelist + generic fallback + observability behaviour.
   describe("category whitelist", () => {
     const primeRecipients = (): void => {
-      mockSelectResult.push({ user_id: "user-neuro" });
-      mockSelectResult2.push({
-        id: "user-neuro",
-        specialty: "Neurology",
-        role: "physician",
-      });
+      primeDispatch(
+        [{ user_id: "user-neuro" }],
+        [{ id: "user-neuro", specialty: "Neurology", role: "physician" }],
+      );
     };
 
     const knownCategoryCases: Array<[string, string]> = [
@@ -377,7 +354,7 @@ describe("dispatch-worker", () => {
         const event = makeEvent({ severity: "warning", category });
         await processorFn({ data: event, id: `job-cat-${category}` });
 
-        const insertedRecords = mockInsertValues.mock.calls[0][0];
+        const insertedRecords = getInsertedRecords();
         expect(insertedRecords[0].title).toBe(
           `Warning: Clinical flag — ${label}`,
         );
@@ -414,7 +391,7 @@ describe("dispatch-worker", () => {
       });
       await processorFn({ data: event, id: "job-cat-unknown" });
 
-      const insertedRecords = mockInsertValues.mock.calls[0][0];
+      const insertedRecords = getInsertedRecords();
       const title = insertedRecords[0].title as string;
       const safeSummary = insertedRecords[0].summary_safe as string;
 

--- a/services/notifications/vitest.config.ts
+++ b/services/notifications/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
         __dirname,
         "../../packages/phi-sanitizer/src/index.ts",
       ),
+      "@carebridge/test-utils": path.resolve(
+        __dirname,
+        "../../packages/test-utils/src/index.ts",
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #826, which introduced `@carebridge/test-utils` with `createMockDb()` and migrated `patient-records` and `clinical-notes`. This migrates the rest of the consumers identified in #830 to the shared fluent helper.

### Migrated

- `services/clinical-data/src/__tests__/vital-repo.test.ts`
- `services/clinical-data/src/__tests__/medication-repo.test.ts`
- `services/clinical-data/src/__tests__/lab-repo.test.ts` — keeps a standalone `transactionMock` since `db.transaction(cb)` is outside the helper's Drizzle-chain API; select chains flow through `willSelect`.
- `services/notifications/src/__tests__/dispatch-worker.test.ts` — care-team + users + per-user preferences selects flow through `willSelect`; `insert(...).values(...)` args read from `db.insert.calls[i].chainArgs`.
- `services/auth/src/__tests__/session-cleanup.test.ts` — `delete().where().returning()` and `insert().values()` chains migrated; the `where(...)` argument inspection (OR/AND drizzle shape) now reads from `chainArgs`.
- `services/auth/src/__tests__/mfa-enumeration.test.ts` — user-row lookup migrated to `willSelect`; the trivial insert/update/delete stubs the helper provides replace the one-liner `vi.fn()` stubs.

Each service now declares `@carebridge/test-utils` as a `workspace:*` devDependency and adds a matching vitest alias.

### Holdouts (follow-up issues recommended)

- `services/api-gateway/src/middleware/rbac.test.ts` — uses dual-table mock routing (`careTeamSelectMock` / `emergencySelectMock`) with per-table call-count assertions. The shared helper's single select queue would lose that distinction and the test would become less readable, not more.
- `services/ai-oversight/src/__tests__/llm-timeout-fallback.test.ts` — uses `db.query.patients.findFirst` (a prepared-query surface the helper does not model) and asserts on `update().set(...)` args by chain index; migrating would require verbose accessors without a clarity win.
- `services/ai-oversight/src/__tests__/claude-client-logging.test.ts` — does not stub DB chains (only mocks `@anthropic-ai/sdk`), skipped per the issue scope ("only if it stubs DB").

### Scope discipline

- No production code touched.
- Helper's `chainNames` whitelist was sufficient as-is — no additions needed.
- Assertion counts preserved exactly:
  - `@carebridge/clinical-data` — 47 tests (matches baseline)
  - `@carebridge/notifications` — 63 tests (matches baseline)
  - `@carebridge/auth` — 97 tests (matches baseline)

## Test plan

- [x] `pnpm --filter @carebridge/clinical-data test` — 47 tests pass
- [x] `pnpm --filter @carebridge/notifications test` — 63 tests pass
- [x] `pnpm --filter @carebridge/auth test` — 97 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only preexisting Next.js warnings unchanged)

Closes #830