### PR TITLE
chore(ui-tokens): declare sideEffects to prevent tree-shaking of tokens.css

### DIFF
--- a/packages/ui-tokens/package.json
+++ b/packages/ui-tokens/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "description": "Shared CSS design tokens and accessibility utilities for CareBridge portal apps.",
+  "sideEffects": ["*.css", "./tokens.css"],
   "exports": {
     "./tokens.css": "./tokens.css"
   },


### PR DESCRIPTION
## Summary
- Adds `"sideEffects": ["*.css", "./tokens.css"]` to `packages/ui-tokens/package.json`.
- Defensive one-line change: ensures any future bundler configuration with aggressive tree-shaking cannot silently drop the shared tokens CSS import.
- No behaviour change, no restructure, `tokens.css` content untouched.

## Why
`@carebridge/ui-tokens` exists solely to ship side-effectful CSS (a11y/design tokens) consumed by both portals. Next.js 15 + Turbopack/webpack currently handle the `import "@carebridge/ui-tokens/tokens.css"` correctly, but a silent drop due to tree-shaking would be a WCAG-critical regression invisible to type-checking and structural Vitest tests. Declaring `sideEffects` is the standard defensive practice for CSS-only packages.

## Test plan
- [x] `pnpm typecheck` green (40/40 tasks)
- [x] `pnpm lint` green (no new warnings)
- [x] `pnpm --filter @carebridge/clinician-portal build` succeeds; CSS still reaches the bundle (`/patients/[id]` route size unchanged)
- [x] `pnpm --filter @carebridge/clinician-portal test` — 186/186 tests pass, including skip-nav WCAG tests from #827
- [x] Verified the patient-portal `health-summary/page.tsx` implicit-any build error is pre-existing on `main` and unrelated to this change

Closes #846