### PR TITLE
refactor(portal): extract createPermissiveTrpcMock for a11y render tests

### DIFF
--- a/apps/clinician-portal/src/__tests__/helpers/trpc-mock.ts
+++ b/apps/clinician-portal/src/__tests__/helpers/trpc-mock.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared tRPC mock helper for render / a11y tests.
+ *
+ * Many tests only care about one slice of the UI (e.g. a tab strip,
+ * a button, a layout shell) but the components they render pull
+ * dozens of tRPC queries and mutations. Re-implementing a permissive
+ * stub in every test file is noisy and fragile — any new call path
+ * added downstream breaks unrelated tests.
+ *
+ * `createPermissiveTrpcMock` returns a Proxy that answers any
+ * `trpc.<router>.<...>.<proc>.useQuery(...)` or `.useMutation()` call
+ * with a loading-but-quiet stub, plus a no-op `trpc.useUtils()` whose
+ * `.invalidate()` always resolves. Callers may pass per-route
+ * overrides keyed by the dot-separated procedure path (e.g.
+ * `"patients.getById"`) when they need a real-looking value for a
+ * single query.
+ *
+ * Scope is intentionally small: only what the current caller set
+ * needs. Expand deliberately, not speculatively.
+ */
+import { vi } from "vitest";
+
+/** Minimal shape of a React Query `useQuery` result our tests read. */
+export interface StubQueryResult<T = unknown> {
+  data: T | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  [key: string]: unknown;
+}
+
+/** Minimal shape of a React Query `useMutation` result our tests read. */
+export interface StubMutationResult {
+  mutate: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Per-route overrides. Keys are dot-separated procedure paths as
+ * they would appear on the tRPC client (e.g. `"patients.getById"`,
+ * `"clinicalFlags.listForPatient"`). The value is either a
+ * `useQuery`-shaped result or a factory that produces one.
+ */
+export type TrpcMockOverrides = Record<
+  string,
+  StubQueryResult | (() => StubQueryResult)
+>;
+
+export interface CreatePermissiveTrpcMockOptions {
+  /**
+   * Default shape returned by `useQuery` when no override matches.
+   * Defaults to `{ data: undefined, isLoading: true, isError: false }`.
+   */
+  defaultQuery?: StubQueryResult;
+  /**
+   * Default shape returned by `useMutation`.
+   * Defaults to `{ mutate: vi.fn(), isPending: false }`.
+   */
+  defaultMutation?: () => StubMutationResult;
+  /** Per-route `useQuery` overrides keyed by procedure path. */
+  overrides?: TrpcMockOverrides;
+}
+
+/**
+ * Build a `vi.mock("@/lib/trpc", ...)` factory return value.
+ *
+ * Usage:
+ *
+ * ```ts
+ * vi.mock("@/lib/trpc", () =>
+ *   createPermissiveTrpcMock({
+ *     overrides: {
+ *       "patients.getById": { data: patient, isLoading: false, isError: false },
+ *     },
+ *   })
+ * );
+ * ```
+ */
+export function createPermissiveTrpcMock(
+  options: CreatePermissiveTrpcMockOptions = {},
+): { trpc: unknown } {
+  const defaultQuery: StubQueryResult = options.defaultQuery ?? {
+    data: undefined,
+    isLoading: true,
+    isError: false,
+  };
+  const defaultMutation = options.defaultMutation ?? (() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }));
+  const overrides = options.overrides ?? {};
+
+  const resolveQuery = (path: string): StubQueryResult => {
+    const override = overrides[path];
+    if (override === undefined) return defaultQuery;
+    return typeof override === "function" ? override() : override;
+  };
+
+  // `trpc.useUtils()` returns a deeply-chainable proxy whose `invalidate`
+  // always resolves. Every other access keeps proxying so chains like
+  // `utils.patients.getById.invalidate()` just work.
+  const utilsProxy = (): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === "invalidate") {
+            return () => Promise.resolve();
+          }
+          return utilsProxy();
+        },
+      },
+    );
+
+  const proxy = (path: string[]): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          // Guard against accidental thenable detection by awaiters.
+          if (prop === "then") return undefined;
+          if (prop === "useUtils") return () => utilsProxy();
+          if (prop === "useQuery") {
+            return (..._args: unknown[]) => resolveQuery(path.join("."));
+          }
+          if (prop === "useMutation") {
+            return () => defaultMutation();
+          }
+          return proxy([...path, prop]);
+        },
+      },
+    );
+
+  return { trpc: proxy([]) };
+}

--- a/apps/clinician-portal/src/__tests__/patient-chart-tabs-a11y.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patient-chart-tabs-a11y.test.tsx
@@ -39,72 +39,29 @@ vi.mock("@/components/stale-data-banner", () => ({
   StaleDataBanner: () => null,
 }));
 
-// Every child tab pulls tRPC queries. Stub a permissive mock so any
-// chained access returns a `useQuery`/`useMutation` that resolves to an
-// empty/loading shape. This keeps the test focused on the tab strip.
-const stubQuery = () => ({
-  data: undefined,
-  isLoading: true,
-  isError: false,
-});
-const stubMutation = () => ({ mutate: vi.fn(), isPending: false });
+// `vi.mock` factories are hoisted above top-level imports, so any value
+// referenced inside must also be hoisted via `vi.hoisted`.
+const { patient } = vi.hoisted(() => ({
+  patient: {
+    id: "patient-1",
+    name: "Jane Doe",
+    mrn: "MRN-0001",
+    date_of_birth: "1970-01-01",
+    biological_sex: "F",
+  },
+}));
 
-const patient = {
-  id: "patient-1",
-  name: "Jane Doe",
-  mrn: "MRN-0001",
-  date_of_birth: "1970-01-01",
-  biological_sex: "F",
-};
-
-vi.mock("@/lib/trpc", () => {
-  // Flexible deep-getter — every leaf provides useQuery/useMutation.
-  const makeLeaf = (key: string) => {
-    const leaf: Record<string, unknown> = {
-      useQuery: (..._args: unknown[]) => {
-        if (key === "patients.getById") {
-          return { data: patient, isLoading: false, isError: false };
-        }
-        return stubQuery();
-      },
-      useMutation: () => stubMutation(),
-    };
-    return leaf;
-  };
-
-  // A thin shim for `trpc.useUtils()` — every invalidate is a resolved noop.
-  const utilsProxy = (): unknown =>
-    new Proxy(
-      {},
-      {
-        get(_t, prop: string) {
-          if (prop === "invalidate") {
-            return () => Promise.resolve();
-          }
-          return utilsProxy();
-        },
-      },
-    );
-
-  const proxy = (path: string[]): unknown =>
-    new Proxy(
-      {},
-      {
-        get(_t, prop: string) {
-          if (prop === "then") return undefined; // not a thenable
-          if (prop === "useUtils") return () => utilsProxy();
-          const nextPath = [...path, prop];
-          if (prop === "useQuery" || prop === "useMutation") {
-            return makeLeaf(path.join("."))[prop];
-          }
-          return proxy(nextPath);
-        },
-      },
-    );
-
-  return {
-    trpc: proxy([]) as unknown,
-  };
+// Every child tab pulls tRPC queries. The permissive mock answers any
+// `trpc.<router>.<proc>.useQuery/useMutation` with a loading-but-quiet
+// stub so the test stays focused on the tab strip; the single override
+// gives `patients.getById` a real patient so the header renders.
+vi.mock("@/lib/trpc", async () => {
+  const { createPermissiveTrpcMock } = await import("./helpers/trpc-mock");
+  return createPermissiveTrpcMock({
+    overrides: {
+      "patients.getById": { data: patient, isLoading: false, isError: false },
+    },
+  });
 });
 
 import PatientChartPage from "../../app/patients/[id]/page";


### PR DESCRIPTION
## Summary

Extracts the inline Proxy-based tRPC stub from
`apps/clinician-portal/src/__tests__/patient-chart-tabs-a11y.test.tsx`
(introduced in Wave 2 PR #844) into a reusable helper at
`apps/clinician-portal/src/__tests__/helpers/trpc-mock.ts`.

The helper exports `createPermissiveTrpcMock({ overrides })` — a
typed factory that returns a deep-proxy answering any
`trpc.<router>.<...>.<proc>.useQuery(...)` or `.useMutation()` call
with a loading-but-quiet stub, plus a no-op `trpc.useUtils()` whose
`.invalidate()` always resolves. Callers pass per-route overrides
keyed by dot-separated procedure path (e.g. `patients.getById`)
when they need a real-looking value for a single query.

## Location decision — Option 1 (portal-local)

Task offered two locations:

- Option 1: `apps/clinician-portal/src/__tests__/helpers/trpc-mock.ts`
- Option 2: `packages/test-utils/src/trpc-mock.ts` (shared)

Chose Option 1. Grepping `new Proxy(` across `apps/clinician-portal`
and `apps/patient-portal` test files shows only one call site today
(the one being refactored). Patient-portal has no analogous inline
Proxy stubs, so promoting to a shared package would be speculative
scope. If a second consumer appears later, relocation is a trivial
move.

## Scope discipline

Only the one Wave 2 test using the permissive deep-proxy pattern was
migrated. The other Wave 2 a11y tests use narrower, adequate mocks
and are intentionally left alone:

- `login-error-a11y.test.tsx` — mocks `trpcVanilla.auth.login.mutate`
  directly (simple reject-on-demand).
- `inbox-button-a11y.test.tsx` — explicit `clinicalFlags.*` query
  and mutation shape only.
- `patients-search-a11y.test.tsx` — one-line `patients.list.useQuery`
  stub.

## Implementation notes

- `vi.mock` factories are hoisted above top-level imports, so the
  factory uses dynamic `await import("./helpers/trpc-mock")` and
  the per-test `patient` fixture is wrapped in `vi.hoisted(...)`.
- Helper API intentionally minimal: `defaultQuery`, `defaultMutation`,
  `overrides`. No speculative expansion.

## Test plan

- [x] `pnpm --filter @carebridge/clinician-portal test` — 186 tests pass (16 files).
- [x] `pnpm lint` — 22 tasks successful, no new warnings introduced.
- [x] Clinician-portal `tsc --noEmit` — no new type errors (pre-existing
  `layout-skip-nav.test.tsx` errors unchanged).
- [x] Grepped `new Proxy(` in both portals to justify Option 1.

Closes #848