### PR TITLE
fix(ai): promote HL7v2 HH/LL to critical and flag no-flag/no-range labs (#849, #853, #835)

### DIFF
--- a/services/ai-oversight/src/__tests__/critical-values.test.ts
+++ b/services/ai-oversight/src/__tests__/critical-values.test.ts
@@ -313,13 +313,20 @@ describe("checkCriticalValues — lab heuristic fallback", () => {
     expect(flags[0]!.rule_id).toBe("CRITICAL-LAB-HEMOGLOBIN");
   });
 
-  it("does not flag unknown lab with no reference and no COMMON_LAB_TESTS entry", () => {
+  it("emits an info-severity 'unable-to-evaluate' signal for unknown lab with no reference and no COMMON_LAB_TESTS entry (issue #835)", () => {
+    // Issue #835: previously this result was silently dropped. The rule
+    // layer cannot assess the value against any threshold, but it also
+    // must not leave a totally silent lab result invisible to downstream
+    // LLM review. Emit info severity (not critical — we do not know the
+    // value is abnormal) to surface the result without over-alerting.
     const flags = checkCriticalValues(
       makeLabEvent([
         { test_name: "Obscure Marker X", value: 999, unit: "U/L" },
       ]),
     );
-    expect(flags).toHaveLength(0);
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("info");
+    expect(flags[0]!.rule_id).toBe("WARNING-LAB-UNEVALUATED-OBSCURE_MARKER_X");
   });
 });
 
@@ -713,10 +720,12 @@ describe("checkCriticalValues — unrecognized flag handling (issues #834, #837)
     expect(unrecognizedCalls).toHaveLength(0);
   });
 
-  it("maps HL7v2 'HH' (panic high) to a warning flag with direction='high'", () => {
-    // HL7v2 abnormal-flags: "HH" means panic/critical-high. Treat as warning
-    // (not critical) to avoid over-alerting pending principled mapping —
-    // see issue #834 discussion. Warning is the floor, not the ceiling.
+  it("maps HL7v2 'HH' (panic high) to a critical flag with direction='high' (issues #849, #853)", () => {
+    // HL7v2 abnormal-flags: "HH" means panic/critical-high. Promoting HH to
+    // critical matches HL7v2 semantics (panic > out-of-range) AND naturally
+    // resolves the severity-ceiling concern of issue #849: even though the
+    // numeric range-check branch is gated on `severity === null`, the
+    // HL7 mapping now emits the top severity so nothing is being suppressed.
     const flags = checkCriticalValues(
       makeLabEvent([
         {
@@ -728,14 +737,14 @@ describe("checkCriticalValues — unrecognized flag handling (issues #834, #837)
       ]),
     );
     expect(flags).toHaveLength(1);
-    expect(flags[0]!.severity).toBe("warning");
-    expect(flags[0]!.summary).toContain("High");
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("high");
     // This mapping should still emit the warn log so operators notice
     // non-enum flags arriving through FHIR/HL7 ingress paths.
     expect(mockWarn).toHaveBeenCalled();
   });
 
-  it("maps HL7v2 'LL' (panic low) to a warning flag with direction='low'", () => {
+  it("maps HL7v2 'LL' (panic low) to a critical flag with direction='low' (issues #849, #853)", () => {
     const flags = checkCriticalValues(
       makeLabEvent([
         {
@@ -747,8 +756,220 @@ describe("checkCriticalValues — unrecognized flag handling (issues #834, #837)
       ]),
     );
     expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("low");
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("emits critical severity for LL even when numeric range check would have agreed (issue #849 regression guard)", () => {
+    // The original #849 scenario: LL with value 0.1, reference_low 3.5,
+    // reference_high 5.0. Range-deviation check would fire critical
+    // (0.1 < 3.5 - 1.5 = 2.0), but the HL7 flag branch pre-empted with
+    // warning, suppressing the signal. Pinning critical severity ensures
+    // the panic-low lab is not silently compressed to warning.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Nonstandard Electrolyte",
+          value: 0.1,
+          unit: "mEq/L",
+          reference_low: 3.5,
+          reference_high: 5.0,
+          flag: "LL",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("low");
+  });
+
+  it("emits critical severity for HH even when value is far above reference_high (issue #849 regression guard)", () => {
+    // Symmetric counterpart: HH with value 999, reference_high 200.
+    // Single-letter 'H' remains warning (unchanged); 'HH' is the panic-level
+    // signal from the lab and must reach critical severity.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Nonstandard Electrolyte",
+          value: 999,
+          unit: "mEq/L",
+          reference_low: 100,
+          reference_high: 200,
+          flag: "HH",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.summary.toLowerCase()).toContain("high");
+  });
+
+  it("preserves single-letter 'H' → warning semantics (unchanged from PR #842)", () => {
+    // HL7v2 single-letter H is "out of reference range high" — not panic.
+    // It remains warning-severity; only HH/LL escalate to critical. This
+    // test guards against an accidental promotion of H/L alongside HH/LL.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Novel Biomarker",
+          value: 42,
+          unit: "pg/mL",
+          flag: "H",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.summary).toContain("High");
+  });
+
+  it("preserves single-letter 'L' → warning semantics (unchanged from PR #842)", () => {
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Novel Biomarker",
+          value: 0.1,
+          unit: "pg/mL",
+          flag: "L",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
     expect(flags[0]!.severity).toBe("warning");
     expect(flags[0]!.summary).toContain("Low");
-    expect(mockWarn).toHaveBeenCalled();
+  });
+});
+
+// ─── No-flag / no-range / unknown-name gap (issue #835) ──────────
+// A lab result with no `flag`, no `reference_low` / `reference_high`, and
+// no entry in `COMMON_LAB_TESTS` currently slips through the deterministic
+// layer entirely. Even a clinically catastrophic "Potassium Level" (non-
+// canonical name) with value 8.0 receives no signal. This is the no-flag
+// variant of the issue #244 silent-drop class.
+//
+// Fix: emit an info-severity "unable-to-evaluate" signal that gives the
+// downstream LLM review pipeline visibility into the result, and log a
+// structured `lab_unevaluated` warning so operators can quantify the gap.
+// Critical-severity is intentionally NOT used — we do not know whether the
+// value is abnormal. The info-severity flag exists specifically to surface
+// the result for LLM context assembly rather than to fire a clinical alert.
+describe("checkCriticalValues — no-flag/no-range gap (issue #835)", () => {
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
+  it("emits an info-severity 'lab-unevaluated' signal when a lab has no flag, no reference range, and no COMMON_LAB_TESTS entry", () => {
+    // Exact scenario from issue #835: non-canonical "Potassium Level" name
+    // with value 8.0 (clinically catastrophic) but no flag and no range.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Potassium Level",
+          value: 8.0,
+          unit: "mEq/L",
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("info");
+    expect(flags[0]!.category).toBe("critical-value");
+    expect(flags[0]!.rule_id).toBe("WARNING-LAB-UNEVALUATED-POTASSIUM_LEVEL");
+    // Summary should name the test so downstream LLM review has context.
+    expect(flags[0]!.summary).toContain("Potassium Level");
+    expect(flags[0]!.summary).toContain("8");
+  });
+
+  it("also emits a structured logger.warn('lab_unevaluated') for observability", () => {
+    checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Rare Obscure Analyte",
+          value: 42,
+          unit: "U/L",
+        },
+      ]),
+    );
+    const call = mockWarn.mock.calls.find(
+      ([msg]) => typeof msg === "string" && msg.includes("lab_unevaluated"),
+    );
+    expect(call).toBeDefined();
+    const meta = call![1] as Record<string, unknown>;
+    expect(meta.test_name).toBe("Rare Obscure Analyte");
+    expect(meta.value).toBe(42);
+    expect(meta.unit).toBe("U/L");
+  });
+
+  it("does NOT emit an unevaluated signal when the lab is in COMMON_LAB_TESTS", () => {
+    // Hemoglobin with a normal value 14.0 is in COMMON_LAB_TESTS and within
+    // the typical range; the existing fallback correctly returns nothing.
+    // The new unevaluated branch must NOT activate for labs the rule can
+    // evaluate (even when the evaluation concludes "normal").
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Hemoglobin", value: 14.0, unit: "g/dL" },
+      ]),
+    );
+    expect(flags).toHaveLength(0);
+  });
+
+  it("does NOT emit an unevaluated signal when reference_low/reference_high are provided", () => {
+    // A per-result reference range means the lab CAN be evaluated by the
+    // range-deviation branch. Value 10 is mid-range — no flag expected.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Rare Analyte",
+          value: 10,
+          unit: "U/L",
+          reference_low: 5,
+          reference_high: 15,
+        },
+      ]),
+    );
+    expect(flags).toHaveLength(0);
+  });
+
+  it("does NOT emit an unevaluated signal when the lab provides a flag", () => {
+    // Any flag value (even an unrecognized one) means the lab has expressed
+    // intent about the result. The unevaluated branch is only for totally
+    // silent results where we have no signal at all.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        {
+          test_name: "Rare Analyte",
+          value: 42,
+          unit: "U/L",
+          flag: "abnormal",
+        },
+      ]),
+    );
+    // 'abnormal' is a non-enum flag — logger.warn fires via the existing
+    // unrecognized-flag branch, but no flag is emitted (fall-through).
+    expect(flags).toHaveLength(0);
+  });
+
+  it("does NOT emit an unevaluated signal for explicit critical thresholds (Potassium canonical name)", () => {
+    // The canonical "Potassium" name matches CRITICAL_LAB_THRESHOLDS, so the
+    // explicit threshold fires and the unevaluated branch is unreachable.
+    // This confirms issue #835's observation — the gap is specifically for
+    // non-canonical names that slip past matching.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Potassium", value: 8.0, unit: "mEq/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("critical");
+    expect(flags[0]!.rule_id).toBe("CRITICAL-LAB-POTASSIUM");
+  });
+
+  it("does NOT emit an unevaluated signal for a canonical vital event", () => {
+    // The unevaluated branch should only apply to lab.resulted events. A
+    // vital.created event with a normal value must not trigger it.
+    const flags = checkCriticalValues(
+      makeVitalEvent({ type: "heart_rate", value_primary: 75 }),
+    );
+    expect(flags).toHaveLength(0);
   });
 });

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -20,15 +20,25 @@ import { createLogger } from "@carebridge/logger";
 const logger = createLogger("ai-oversight");
 
 /**
- * Common HL7v2 abnormal-flag values we promote to at-least-warning severity
- * pending a principled mapping (see issue #834). We keep these conservative
- * (warning rather than critical) to avoid over-alerting from ingress paths
- * that bypass the Zod validator. Callers who want critical severity should
- * normalize to `"critical"` upstream.
+ * Common HL7v2 abnormal-flag values we promote to deterministic severities.
  *
- *   - HH → panic/critical-high; mapped to warning direction=high
- *   - LL → panic/critical-low;  mapped to warning direction=low
+ * HL7v2 precedent: single-letter `H` / `L` means "out-of-reference-range
+ * high/low"; double-letter `HH` / `LL` means "panic high/low" — the lab's
+ * explicit panic-threshold signal, which is a strictly stronger claim than
+ * `H` / `L`. Issue #853 revisited the original PR #842 mapping (which
+ * compressed `HH` / `LL` to warning) and concluded that panic flags should
+ * map to `critical` to match HL7v2 semantics.
  *
+ *   - HH → critical, direction=high   (panic-high)
+ *   - LL → critical, direction=low    (panic-low)
+ *
+ * Promoting to `critical` also sidesteps the severity-ceiling concern
+ * flagged in issue #849: because the numeric range-check branch below is
+ * gated on `severity === null`, a lower-than-critical mapping here would
+ * pre-empt a potentially-critical range-deviation signal. Critical is the
+ * top severity, so no downstream suppression is possible.
+ *
+ * Single-letter `H` / `L` remain as warnings (unchanged from PR #842).
  * Other common HL7v2 values (A, AA, N, U, '' etc.) remain unmapped and fall
  * through to the range checks; a structured warn is emitted so operators can
  * observe silent drops.
@@ -37,8 +47,8 @@ const HL7_FLAG_MAPPINGS: Record<
   string,
   { severity: FlagSeverity; direction: "low" | "high" }
 > = {
-  HH: { severity: "warning", direction: "high" },
-  LL: { severity: "warning", direction: "low" },
+  HH: { severity: "critical", direction: "high" },
+  LL: { severity: "critical", direction: "low" },
 };
 
 // ─── Explicit Critical Lab Thresholds ────────────────────────────
@@ -532,8 +542,14 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
       for (const result of results) {
         // ── 1. Explicit critical thresholds (highest priority) ────────
         let matchedExplicit = false;
+        // Track whether the test name matched an explicit threshold
+        // definition at all (even when `evaluate` returned null for a normal
+        // value). Labs that match an explicit def were evaluated and must
+        // not trip the issue #835 "unable-to-evaluate" fallback below.
+        let matchedExplicitDef = false;
         for (const [ruleKey, def] of Object.entries(CRITICAL_LAB_THRESHOLDS)) {
           if (matchesCriticalLab(result.test_name, result.test_code, def)) {
+            matchedExplicitDef = true;
             const threshold = def.evaluate(result.value, { medications });
             if (threshold) {
               matchedExplicit = true;
@@ -686,6 +702,68 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
               notify_specialties: [],
               rule_id: `${severity === "critical" ? "CRITICAL" : "WARNING"}-LAB-${result.test_name.replace(/\s+/g, "_").toUpperCase()}`,
             });
+          } else if (
+            // ── 3. Unable-to-evaluate fallback (issue #835) ─────────
+            // A result with NO `flag`, NO `reference_low` / `reference_high`,
+            // and NOT in `COMMON_LAB_TESTS` currently has no signal at all.
+            // Example from issue #835: a non-canonical "Potassium Level"
+            // with value 8.0 slips past the deterministic layer entirely
+            // because the canonical matcher requires "Potassium".
+            //
+            // We do NOT know whether the value is abnormal — firing
+            // critical would be over-alerting. Instead, emit an
+            // info-severity signal so the downstream LLM review pipeline
+            // can assemble context around the result, and log a
+            // structured warning for operator observability.
+            //
+            // Preconditions (must all hold to reach this branch):
+            //   - severity is still null (no flag match, no range match,
+            //     not flagged as critical, not in COMMON_LAB_TESTS)
+            //   - result.flag is undefined / null (any flag would have
+            //     gone through branch 2 above, emitted a warn, and
+            //     possibly fallen through; we only want truly silent labs)
+            //   - no reference bounds at all
+            //   - not in COMMON_LAB_TESTS
+            result.flag === undefined ||
+            result.flag === null
+          ) {
+            const hasReferenceRange =
+              result.reference_low !== undefined ||
+              result.reference_high !== undefined;
+            const inCommonLabTests = COMMON_LAB_TESTS[result.test_name] !== undefined;
+
+            if (
+              !hasReferenceRange &&
+              !inCommonLabTests &&
+              !matchedExplicitDef
+            ) {
+              logger.warn("lab_unevaluated", {
+                metric: "lab_unevaluated_total",
+                test_name: result.test_name,
+                test_code: result.test_code,
+                value: result.value,
+                unit: result.unit,
+              });
+
+              flags.push({
+                severity: "info",
+                category: "critical-value",
+                summary:
+                  `Lab result not evaluable by deterministic rules: ` +
+                  `${result.test_name} = ${result.value} ${result.unit}`,
+                rationale:
+                  `Lab result for "${result.test_name}" arrived with no lab-provided ` +
+                  `flag, no reference range, and no entry in COMMON_LAB_TESTS. The ` +
+                  `deterministic rule layer cannot assess the value against a threshold; ` +
+                  `surfacing as an info signal so LLM review and clinicians have visibility.`,
+                suggested_action:
+                  `Clinician review recommended. Verify test name mapping and reference ` +
+                  `range metadata with the sending laboratory. Consider adding this test ` +
+                  `to COMMON_LAB_TESTS or CRITICAL_LAB_THRESHOLDS if clinically relevant.`,
+                notify_specialties: [],
+                rule_id: `WARNING-LAB-UNEVALUATED-${result.test_name.replace(/\s+/g, "_").toUpperCase()}`,
+              });
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Three interlocking clinical-safety follow-ups from PR #842, bundled because
they all touch `services/ai-oversight/src/rules/critical-values.ts` and
share a failure class: silent or under-severity lab signals at the
deterministic rule layer.

- **#849** — HH/LL mapping pre-empted the numeric range-check branch,
  creating a severity *ceiling* when the intent was a floor. Panic-low
  values that would otherwise fire critical (e.g. `LL` with value 0.1,
  ref_low 3.5, ref_high 5.0) were compressed to warning.
- **#853** — HL7v2 precedent: single-letter `H` / `L` = out-of-range;
  double-letter `HH` / `LL` = panic. Compressing `HH` / `LL` to the same
  severity as `H` / `L` silently flattens the lab's own stratification.
- **#835** — No-flag, no-range, unknown-name labs slip past the
  deterministic layer entirely. A non-canonical "Potassium Level" with
  value 8.0 receives no signal at all.

## What changed

### `services/ai-oversight/src/rules/critical-values.ts`

1. **HL7v2 mapping promoted (fixes #849 + #853 together).**
   `HH` → `{ severity: "critical", direction: "high" }`
   `LL` → `{ severity: "critical", direction: "low" }`
   Single-letter `H` / `L` remain `warning` (unchanged from PR #842).
   Because `critical` is the top severity in `FlagSeverity`, the
   numeric range-check gate (`if (severity === null)`) cannot suppress
   it — the severity-ceiling concern of #849 is resolved structurally,
   not by rewiring the gate.

2. **New "unable-to-evaluate" fallback (fixes #835).**
   When a lab result has no `flag`, no `reference_low` / `reference_high`,
   and no `COMMON_LAB_TESTS` entry, and did not match any
   `CRITICAL_LAB_THRESHOLDS` definition, we now:
   - Emit `logger.warn("lab_unevaluated", { metric, test_name, test_code, value, unit })`
     for operator observability.
   - Emit an `info`-severity `RuleFlag` so downstream LLM review has
     visibility into the silent result.

   **Severity choice — `info`.** The `FlagSeverity` enum already includes
   `"info"` (see `packages/shared-types/src/ai-flags.ts` and the Zod
   `flagSeveritySchema` in `packages/validators/src/ai-flags.ts`), so no
   schema churn. `info` is intentional — we do **not** know whether the
   value is abnormal; `critical` would be over-alerting, and `warning`
   implies a clinical judgment we cannot support from the data given.
   The signal exists to surface the result for LLM review, not to fire
   a clinical alert directly.

3. **Guard: `matchedExplicitDef`.** A new flag tracks whether the
   test name matched any `CRITICAL_LAB_THRESHOLDS` definition, even
   when `evaluate` returned `null` (normal value). This prevents the
   unevaluated fallback from re-surfacing benign canonical labs — e.g.
   `Lactate` with value 1.5 (no reference range, not in the test mock's
   `COMMON_LAB_TESTS`) now correctly stays silent.

### `services/ai-oversight/src/__tests__/critical-values.test.ts`

- Updated the two pre-existing `HH` / `LL` tests from PR #842 to
  assert `critical` severity (was `warning`).
- Added regression-guard tests for #849's concrete scenarios:
  - `LL`, value 0.1, ref_low 3.5, ref_high 5.0 → critical/low
  - `HH`, value 999, ref_low 100, ref_high 200 → critical/high
- Added regression guards pinning `H` → warning and `L` → warning
  (so a future refactor cannot accidentally promote them alongside HH/LL).
- Added a new `describe("... no-flag/no-range gap (issue #835)")` block
  with seven tests covering: the exact #835 "Potassium Level" scenario,
  the `logger.warn("lab_unevaluated")` observability signal, and four
  negative cases (lab in COMMON_LAB_TESTS, lab with reference range,
  lab with any flag, lab matching CRITICAL_LAB_THRESHOLDS, and a
  non-lab vital event) to ensure the fallback activates only for
  genuinely un-evaluable results.
- Updated the `"does not flag unknown lab with no reference..."` test
  from the heuristic-fallback describe block: it now asserts the new
  info-severity unevaluated signal (the old assertion was literally
  pinning the bug #835 was filed against).

## Clinical safety rigor

- `CRITICAL_LAB_THRESHOLDS` and every hard-coded numeric threshold are
  unchanged.
- `rule_id` naming follows existing conventions
  (`WARNING-LAB-UNEVALUATED-<name>`); rule-id harmonization is
  explicitly out of scope (tracked by #836).
- All Wave 1 (#244) and Wave 2 (#833 / #834 / #837) tests pass
  unchanged.
- Full `@carebridge/ai-oversight` suite: **622 passing** (611 baseline
  from Wave 2 + 11 new tests).
- `pnpm typecheck` green.
- `pnpm lint` green (only pre-existing portal warnings).

## Test plan

- [x] `pnpm --filter @carebridge/ai-oversight test` — 622 passed
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (pre-existing portal warnings only)
- [x] #849 regression guard: `LL` with value far below ref range → critical
- [x] #853 HL7v2 semantics: `HH` → critical/high, `LL` → critical/low
- [x] #835 regression guard: unknown lab with no flag/range/COMMON match → info flag
- [x] Negative cases: `H` / `L` still warning; canonical labs still critical;
      labs with reference range not re-surfaced; vitals not re-surfaced
- [ ] Reviewer to confirm `info` severity is acceptable for the
      unevaluated signal (alternative was metric-only `logger.warn`)
- [ ] Reviewer to confirm rule_id `WARNING-LAB-UNEVALUATED-*` is OK
      (could be `INFO-LAB-UNEVALUATED-*`; kept `WARNING-` prefix to
      follow the existing same-level naming in this file — #836 will
      harmonize)

Closes #849
Closes #853
Closes #835