### PR TITLE
feat(ai): add 3 cross-specialty rules and extract getRecentPotassium helper

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -1410,3 +1410,242 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
     expect(flag).toBeUndefined();
   });
 });
+
+describe("CROSS-METFORMIN-GFR-001 — Metformin + eGFR < 30 (contraindicated, lactic acidosis risk)", () => {
+  const metforminCtx = (
+    meds: string[],
+    egfr: number | null,
+    overrides: Partial<PatientContext> = {},
+  ): PatientContext => ({
+    active_diagnoses: ["Type 2 diabetes mellitus"],
+    active_diagnosis_codes: ["E11.9"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: [],
+    recent_labs: egfr === null ? [] : [{ name: "eGFR", value: egfr }],
+    ...overrides,
+  });
+
+  it("fires CRITICAL when metformin active and eGFR < 30 (positive case)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg BID"], 25),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+    expect(flag!.category).toBe("cross-specialty");
+    expect(flag!.notify_specialties).toContain("nephrology");
+    expect(flag!.notify_specialties).toContain("endocrinology");
+  });
+
+  it("does NOT fire when eGFR >= 45 (no dose adjustment concern for this rule)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 1000mg BID"], 45),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001"),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire at eGFR exactly 30 (threshold is strict < 30, matches FDA labeling)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg BID"], 30),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001"),
+    ).toBeUndefined();
+  });
+
+  it("fires at eGFR = 29 (just below threshold)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg BID"], 29),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it("does NOT fire when patient is not on metformin", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Lisinopril 10mg", "Amlodipine 5mg"], 20),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001"),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire when eGFR is unknown (no lab value)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg"], null),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001"),
+    ).toBeUndefined();
+  });
+
+  it("detects eGFR under the alternative lab name 'GFR'", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg"], null, {
+        recent_labs: [{ name: "GFR", value: 20 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("detects eGFR under the alternative lab name 'Estimated GFR'", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Metformin 500mg"], null, {
+        recent_labs: [{ name: "Estimated GFR", value: 18 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("fires for branded metformin combo (e.g. Janumet)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Janumet 50-1000mg"], 22),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("fires for Glucophage brand (generic metformin)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      metforminCtx(["Glucophage 1000mg"], 25),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-METFORMIN-GFR-001");
+    expect(flag).toBeDefined();
+  });
+});
+
+describe("CROSS-THIAZIDE-HYPOK-001 — Thiazide diuretic + hypokalemia (electrolyte worsening)", () => {
+  const thiazideCtx = (
+    meds: string[],
+    potassiumValue: number | null,
+    overrides: Partial<PatientContext> = {},
+  ): PatientContext => ({
+    active_diagnoses: ["Essential hypertension"],
+    active_diagnosis_codes: ["I10"],
+    active_medications: meds,
+    new_symptoms: [],
+    care_team_specialties: [],
+    recent_labs:
+      potassiumValue === null
+        ? []
+        : [{ name: "Potassium", value: potassiumValue }],
+    ...overrides,
+  });
+
+  it("fires WARNING for HCTZ + K+ = 3.2 (mild hypokalemia)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg daily"], 3.2),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+    expect(flag!.category).toBe("cross-specialty");
+  });
+
+  it("fires CRITICAL when K+ < 3.0 (escalation, mirrors CROSS-QT-HYPOK-001 pattern)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Chlorthalidone 25mg"], 2.9),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("critical");
+  });
+
+  it("fires WARNING at K+ boundary just below 3.5", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg"], 3.4),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("fires for indapamide", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Indapamide 2.5mg"], 3.1),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("fires for metolazone", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Metolazone 5mg"], 3.3),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("fires for HCTZ abbreviation", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["HCTZ 25mg"], 3.0),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("does NOT fire for thiazide alone with normal K+ (3.8)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg"], 3.8),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001"),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire at K+ exactly 3.5 (strict <3.5 threshold)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg"], 3.5),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001"),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire without a thiazide (loop diuretic only)", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Furosemide 40mg"], 3.0),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001"),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire when potassium lab is unknown", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg"], null),
+    );
+    expect(
+      flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001"),
+    ).toBeUndefined();
+  });
+
+  it("recognises potassium under 'K+' alias", () => {
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["HCTZ 25mg"], null, {
+        recent_labs: [{ name: "K+", value: 3.1 }],
+      }),
+    );
+    const flag = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    expect(flag).toBeDefined();
+  });
+
+  it("fires in parallel with CROSS-QT-HYPOK-001 when patient is on both a thiazide and a QT-prolonger", () => {
+    // Overlap case — different mechanisms (electrolyte worsening vs. torsades
+    // risk) and different downstream actions, so both rules are expected to fire.
+    const flags = checkCrossSpecialtyPatterns(
+      thiazideCtx(["Hydrochlorothiazide 25mg", "Azithromycin 500mg"], 3.0),
+    );
+    const thiazide = flags.find((f) => f.rule_id === "CROSS-THIAZIDE-HYPOK-001");
+    const qt = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+    expect(thiazide).toBeDefined();
+    expect(qt).toBeDefined();
+  });
+});

--- a/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/drug-interaction-rules.test.ts
@@ -136,3 +136,62 @@ describe("DI-QTC-COMBO brand/generic dedup", () => {
     });
   });
 });
+
+describe("DI-STATIN-GEMFIBROZIL — severity upgrade (issue #263)", () => {
+  // Rationale: gemfibrozil inhibits statin glucuronidation and raises plasma
+  // statin levels sharply, producing a rhabdomyolysis rate that led Pfizer to
+  // withdraw cerivastatin. Clinical consensus (FDA labeling, ACC/AHA, NLA) is
+  // that gemfibrozil + statin is contraindicated for most statins; fenofibrate
+  // is the preferred fibrate when combination therapy is necessary and
+  // remains at warning-level risk.
+  it("flags simvastatin + gemfibrozil as CRITICAL (rhabdomyolysis contraindication)", () => {
+    const flags = checkDrugInteractions(["Simvastatin 40mg", "Gemfibrozil 600mg"]);
+    const interaction = flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL");
+    expect(interaction).toBeDefined();
+    expect(interaction!.severity).toBe("critical");
+    expect(interaction!.category).toBe("drug-interaction");
+  });
+
+  it("flags atorvastatin + gemfibrozil as CRITICAL", () => {
+    const flags = checkDrugInteractions(["Atorvastatin 20mg", "Gemfibrozil 600mg"]);
+    const interaction = flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL");
+    expect(interaction).toBeDefined();
+    expect(interaction!.severity).toBe("critical");
+  });
+
+  it("flags rosuvastatin + gemfibrozil as CRITICAL", () => {
+    const flags = checkDrugInteractions(["Rosuvastatin 10mg", "Gemfibrozil 600mg"]);
+    const interaction = flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL");
+    expect(interaction).toBeDefined();
+    expect(interaction!.severity).toBe("critical");
+  });
+
+  it("keeps statin + fenofibrate at WARNING (separate rule DI-STATIN-FENOFIBRATE)", () => {
+    const flags = checkDrugInteractions(["Simvastatin 40mg", "Fenofibrate 145mg"]);
+    const fenoFlag = flags.find((f) => f.rule_id === "DI-STATIN-FENOFIBRATE");
+    expect(fenoFlag).toBeDefined();
+    expect(fenoFlag!.severity).toBe("warning");
+
+    const gemFlag = flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL");
+    expect(gemFlag).toBeUndefined();
+  });
+
+  it("tricor (fenofibrate brand) + statin also fires as WARNING", () => {
+    const flags = checkDrugInteractions(["Atorvastatin 40mg", "Tricor 145mg"]);
+    const fenoFlag = flags.find((f) => f.rule_id === "DI-STATIN-FENOFIBRATE");
+    expect(fenoFlag).toBeDefined();
+    expect(fenoFlag!.severity).toBe("warning");
+  });
+
+  it("does NOT fire gemfibrozil rule without a statin", () => {
+    const flags = checkDrugInteractions(["Gemfibrozil 600mg", "Aspirin 81mg"]);
+    expect(flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL")).toBeUndefined();
+  });
+
+  it("notifies cardiology for statin + gemfibrozil", () => {
+    const flags = checkDrugInteractions(["Simvastatin 40mg", "Gemfibrozil 600mg"]);
+    const interaction = flags.find((f) => f.rule_id === "DI-STATIN-GEMFIBROZIL");
+    expect(interaction).toBeDefined();
+    expect(interaction!.notify_specialties).toContain("cardiology");
+  });
+});

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -302,6 +302,64 @@ function classifyBleedingSeverity(symptoms: string[]): "critical" | "warning" | 
 const ANTICOAG_BLEED_ANY_PATTERN =
   /hemorrhage|haemorrhage|hematemesis|melena|hematochezia|hemoptysis|intracranial bleed|gi bleed|gastrointestinal bleed|retroperitoneal|blood in stool|hematuria|blood in urine|epistaxis|nosebleed|post.?procedural bleeding|bleeding|bruis|petechiae|ecchymosis/i;
 
+/**
+ * Lab-name pattern for serum potassium. Matches "potassium", "K", "K+" with
+ * optional surrounding whitespace. Shared by CROSS-QT-HYPOK-001 and
+ * CROSS-THIAZIDE-HYPOK-001 so the set of accepted aliases evolves in lockstep.
+ */
+const POTASSIUM_LAB_NAME_PATTERN = /^(potassium|k\+?)$/i;
+
+/**
+ * Look up the most recent serum potassium value in mEq/L from the patient's
+ * `recent_labs` context. Returns undefined when the lab is absent. K+ in mEq/L
+ * and mmol/L are numerically equivalent so no unit conversion is performed.
+ *
+ * Extracted per issue #855 to keep CROSS-QT-HYPOK-001's check / buildSeverity /
+ * buildSuggestedAction paths aligned, and re-used by CROSS-THIAZIDE-HYPOK-001.
+ */
+export function getRecentPotassium(ctx: PatientContext): number | undefined {
+  return ctx.recent_labs?.find((l) => POTASSIUM_LAB_NAME_PATTERN.test(l.name.trim()))
+    ?.value;
+}
+
+/**
+ * Lab-name pattern for estimated glomerular filtration rate (eGFR), reported
+ * in mL/min/1.73m². Accepts "eGFR", "GFR", and "Estimated GFR" (case-
+ * insensitive, tolerant of surrounding whitespace).
+ */
+const EGFR_LAB_NAME_PATTERN = /^(e?gfr|estimated\s*gfr)$/i;
+
+/**
+ * Look up the most recent eGFR value in mL/min/1.73m² from the patient's
+ * `recent_labs` context. Returns undefined when the lab is absent.
+ *
+ * Used by CROSS-METFORMIN-GFR-001 to detect metformin contraindication
+ * territory (eGFR < 30).
+ */
+export function getRecentEGFR(ctx: PatientContext): number | undefined {
+  return ctx.recent_labs?.find((l) => EGFR_LAB_NAME_PATTERN.test(l.name.trim()))
+    ?.value;
+}
+
+/**
+ * Thiazide diuretic name pattern. Distinct from LOOP_THIAZIDE_DIURETIC_PATTERN
+ * (which also includes loop diuretics for the triple-whammy rule) — this list
+ * is thiazide-only because only thiazides have the chronic-hypokalemia
+ * exacerbation profile targeted by CROSS-THIAZIDE-HYPOK-001. Loop diuretics
+ * cause hypokalemia too but have different kinetics and monitoring needs.
+ */
+const THIAZIDE_PATTERN =
+  /hydrochlorothiazide|hctz|chlorthalidone|thalitone|indapamide|lozol|metolazone|zaroxolyn|chlorothiazide|diuril/i;
+
+/**
+ * Metformin name pattern (generic + brand combinations). Includes fixed-dose
+ * combination brand names commonly prescribed in type 2 diabetes, so the rule
+ * fires regardless of whether the EHR records "metformin" plainly or the
+ * branded combo.
+ */
+const METFORMIN_PATTERN =
+  /\bmetformin\b|glucophage|glumetza|fortamet|riomet|janumet|jentadueto|kombiglyze|synjardy|xigduo|invokamet|kazano|prandimet/i;
+
 interface CrossSpecialtyRule {
   id: string;
   name: string;
@@ -847,16 +905,12 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     check: (ctx: PatientContext) => {
       const onQTDrug = ctx.active_medications.some((m) => QTC_PATTERN.test(m));
       if (!onQTDrug) return false;
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      const k = getRecentPotassium(ctx);
       if (k === undefined) return false;
       return k < 3.5;
     },
     buildSeverity: (ctx: PatientContext) => {
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      const k = getRecentPotassium(ctx);
       // Severe hypokalemia (K+ < 3.0) compounds torsades risk and is
       // independently critical per critical-values.ts. Escalate accordingly.
       if (k !== undefined && k < 3.0) return "critical";
@@ -880,9 +934,7 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       "QTc — if > 500 ms or > 60 ms above baseline, hold the QT-prolonging agent and consult cardiology. " +
       "Continuous telemetry until electrolytes corrected.",
     buildSuggestedAction: (ctx: PatientContext) => {
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      const k = getRecentPotassium(ctx);
       const base =
         "Replete potassium to > 4.0 mEq/L. Check magnesium concurrently and repeat if low (hypomagnesemia " +
         "impairs potassium correction and independently prolongs QT). Obtain baseline ECG and calculate " +
@@ -898,6 +950,117 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       return base;
     },
     notify_specialties: ["cardiology"],
+  },
+  {
+    // CROSS-METFORMIN-GFR-001 — Metformin is contraindicated at eGFR < 30
+    // mL/min/1.73m² per FDA labeling (2016 update) and ADA guidelines because
+    // impaired renal clearance allows metformin accumulation, raising the risk
+    // of life-threatening lactic acidosis (MALA — metformin-associated lactic
+    // acidosis). Between eGFR 30–45 metformin can be continued at reduced
+    // dose with monitoring, but below 30 it must be stopped. This rule is
+    // complementary to DI-METFORMIN-CONTRAST (which addresses transient AKI
+    // risk around contrast administration) and targets chronic/stable low
+    // eGFR that is a hard contraindication.
+    //
+    // Units: eGFR in mL/min/1.73m². Threshold is strictly < 30 to mirror FDA
+    // labeling exactly; eGFR = 30 does not fire.
+    id: "CROSS-METFORMIN-GFR-001",
+    name: "Metformin + eGFR < 30 (contraindicated, MALA risk)",
+    check: (ctx: PatientContext) => {
+      const onMetformin = ctx.active_medications.some((m) =>
+        METFORMIN_PATTERN.test(m),
+      );
+      if (!onMetformin) return false;
+      const egfr = getRecentEGFR(ctx);
+      if (egfr === undefined) return false;
+      return egfr < 30;
+    },
+    severity: "critical" as const,
+    category: "cross-specialty" as const,
+    summary:
+      "Patient on metformin with eGFR < 30 mL/min/1.73m² — contraindicated, risk of lactic acidosis",
+    rationale:
+      "Metformin is renally cleared unchanged; accumulation in advanced renal impairment drives mitochondrial " +
+      "inhibition of gluconeogenesis and lactate oxidation, producing metformin-associated lactic acidosis " +
+      "(MALA). MALA carries a mortality of 30–50%. FDA labeling (updated 2016) and ADA guidelines " +
+      "contraindicate metformin at eGFR < 30 mL/min/1.73m². Between 30 and 45, metformin may be continued at " +
+      "reduced dose with monitoring; below 30 it must be discontinued.",
+    suggested_action:
+      "Discontinue metformin. Switch to a renally-appropriate glycemic agent (e.g., DPP-4 inhibitor with " +
+      "renal dose adjustment, insulin, or GLP-1 agonist per current eGFR). Assess for signs of lactic acidosis " +
+      "(hyperventilation, malaise, nausea, non-specific abdominal pain); obtain venous blood gas and lactate " +
+      "if any concern. Nephrology and endocrinology consultation recommended.",
+    notify_specialties: ["nephrology", "endocrinology"],
+  },
+  {
+    // CROSS-THIAZIDE-HYPOK-001 — Thiazide diuretics induce potassium wasting
+    // at the distal convoluted tubule. Starting or continuing a thiazide in a
+    // patient who already has hypokalemia worsens the electrolyte deficit and
+    // increases the risk of cardiac arrhythmia, muscle weakness, and
+    // rhabdomyolysis. Loop diuretics also cause hypokalemia but have
+    // different kinetics, so this rule intentionally only matches thiazides.
+    //
+    // Overlap with CROSS-QT-HYPOK-001 is deliberate and left un-deduplicated:
+    // the two rules address different mechanisms (electrolyte worsening vs.
+    // torsades risk) and generate different actions (hold thiazide / replace
+    // K+ vs. QTc monitoring and cardiology review). Firing both gives the
+    // reviewer a complete picture.
+    //
+    // Units: K+ in mEq/L (numerically equivalent to mmol/L). Severity mirrors
+    // CROSS-QT-HYPOK-001: warning at K+ 3.0–3.4, critical when K+ < 3.0.
+    id: "CROSS-THIAZIDE-HYPOK-001",
+    name: "Thiazide diuretic + hypokalemia (electrolyte worsening)",
+    check: (ctx: PatientContext) => {
+      const onThiazide = ctx.active_medications.some((m) =>
+        THIAZIDE_PATTERN.test(m),
+      );
+      if (!onThiazide) return false;
+      const k = getRecentPotassium(ctx);
+      if (k === undefined) return false;
+      return k < 3.5;
+    },
+    buildSeverity: (ctx: PatientContext) => {
+      const k = getRecentPotassium(ctx);
+      // Severe hypokalemia (K+ < 3.0) is independently critical per
+      // critical-values.ts and mirrors the escalation pattern used by
+      // CROSS-QT-HYPOK-001.
+      if (k !== undefined && k < 3.0) return "critical";
+      return "warning";
+    },
+    severity: "warning" as const,
+    category: "cross-specialty" as const,
+    summary:
+      "Patient on thiazide diuretic with hypokalemia (K+ < 3.5) — elevated arrhythmia risk",
+    rationale:
+      "Thiazide diuretics (hydrochlorothiazide, chlorthalidone, indapamide, metolazone) increase urinary " +
+      "potassium excretion by delivering more sodium to the cortical collecting duct and stimulating " +
+      "aldosterone-mediated potassium secretion. Continuing a thiazide in an already hypokalemic patient " +
+      "exacerbates the deficit and raises the risk of ventricular arrhythmia, muscle weakness, leg cramps, " +
+      "rhabdomyolysis, and worsened glucose tolerance. Risk compounds with concurrent QT-prolonging drugs, " +
+      "heart failure, and hypomagnesemia.",
+    suggested_action:
+      "Replete potassium toward > 4.0 mEq/L. Consider holding the thiazide until K+ is corrected, or " +
+      "switching to a potassium-sparing regimen (ACE-I/ARB + aldosterone antagonist, or adding amiloride). " +
+      "Check serum magnesium concurrently and replete if low. Review other contributors (low dietary K+, " +
+      "concurrent corticosteroid, GI losses). Recheck electrolytes within 1–2 weeks.",
+    buildSuggestedAction: (ctx: PatientContext) => {
+      const k = getRecentPotassium(ctx);
+      const base =
+        "Replete potassium toward > 4.0 mEq/L. Consider holding the thiazide until K+ is corrected, or " +
+        "switching to a potassium-sparing regimen (ACE-I/ARB + aldosterone antagonist, or adding amiloride). " +
+        "Check serum magnesium concurrently and replete if low. Review other contributors (low dietary K+, " +
+        "concurrent corticosteroid, GI losses). Recheck electrolytes within 1–2 weeks.";
+      if (k !== undefined && k < 3.0) {
+        return (
+          base +
+          " Severe hypokalemia (K+ < 3.0): hold the thiazide, initiate urgent potassium replacement, " +
+          "obtain ECG to assess for arrhythmogenic changes, and consider continuous telemetry until " +
+          "electrolytes are corrected."
+        );
+      }
+      return base;
+    },
+    notify_specialties: ["nephrology", "cardiology"],
   },
 ];
 

--- a/services/ai-oversight/src/rules/drug-interactions.ts
+++ b/services/ai-oversight/src/rules/drug-interactions.ts
@@ -268,16 +268,51 @@ const INTERACTION_PAIRS: DrugInteractionPair[] = [
     notify_specialties: ["cardiology"],
   },
   {
-    id: "DI-STATIN-FIBRATE",
+    // Gemfibrozil + statin: upgraded to CRITICAL per issue #263.
+    // Gemfibrozil inhibits statin glucuronidation (OATP1B1 and UGT pathways),
+    // raising plasma statin levels several-fold. Rhabdomyolysis risk on this
+    // combination led Pfizer to withdraw cerivastatin (Baycol) from the market
+    // in 2001 after 52 deaths. FDA labeling now contraindicates gemfibrozil
+    // with simvastatin, lovastatin, pitavastatin, and rosuvastatin, and
+    // recommends avoidance with other statins.
+    id: "DI-STATIN-GEMFIBROZIL",
     drugA: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
-    drugB: /gemfibrozil|fenofibrate|tricor/i,
-    severity: "warning",
-    summary: "Statin + Fibrate: increased rhabdomyolysis risk",
+    drugB: /gemfibrozil|lopid/i,
+    severity: "critical",
+    summary: "Statin + Gemfibrozil: contraindicated — severe rhabdomyolysis risk",
     rationale:
-      "Concurrent use of statins and fibrates (especially gemfibrozil) increases the risk of myopathy " +
-      "and rhabdomyolysis. Gemfibrozil inhibits statin glucuronidation, raising statin levels significantly.",
+      "Gemfibrozil inhibits statin glucuronidation and OATP1B1-mediated hepatic uptake, markedly " +
+      "increasing plasma statin levels and producing a dramatically elevated risk of myopathy, " +
+      "rhabdomyolysis, and acute kidney injury. Pfizer withdrew cerivastatin in 2001 because of fatal " +
+      "rhabdomyolysis cases on this combination. FDA labeling contraindicates gemfibrozil with " +
+      "simvastatin, lovastatin, pitavastatin, and rosuvastatin and recommends avoidance with other " +
+      "statins; fenofibrate is the preferred fibrate when combination therapy is clinically necessary.",
     suggested_action:
-      "If combination needed, fenofibrate is preferred over gemfibrozil. Monitor CK levels and educate patient on muscle pain symptoms.",
+      "CONTRAINDICATED combination per FDA labeling. Switch gemfibrozil to fenofibrate, or discontinue " +
+      "fibrate therapy if LDL is the primary target. If the combination cannot be avoided, document " +
+      "indication, use the lowest effective statin dose, obtain baseline and follow-up CK, and counsel " +
+      "the patient to stop the statin immediately for muscle pain, weakness, or dark urine.",
+    notify_specialties: ["cardiology"],
+  },
+  {
+    // Fenofibrate + statin: warning-level risk. Fenofibrate does NOT inhibit
+    // statin glucuronidation, so the interaction is far less pronounced than
+    // with gemfibrozil. ACC/AHA and NLA guidelines support this combination
+    // for mixed dyslipidemia with appropriate monitoring.
+    id: "DI-STATIN-FENOFIBRATE",
+    drugA: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
+    drugB: /fenofibrate|tricor|antara|lipofen|lofibra|triglide|trilipix/i,
+    severity: "warning",
+    summary: "Statin + Fenofibrate: monitor for myopathy",
+    rationale:
+      "Fenofibrate added to a statin modestly increases the risk of myopathy and rhabdomyolysis, though " +
+      "substantially less than gemfibrozil because fenofibrate does not inhibit statin glucuronidation. " +
+      "This combination is clinically acceptable for mixed dyslipidemia when indicated, with CK monitoring " +
+      "and patient education on muscle symptoms.",
+    suggested_action:
+      "If combination is necessary, use the lowest effective doses, obtain baseline CK, and educate the " +
+      "patient to report muscle pain, weakness, or dark urine. Monitor renal function as fenofibrate " +
+      "may transiently elevate creatinine.",
     notify_specialties: ["cardiology"],
   },
   {


### PR DESCRIPTION
Builds on Wave 2 PR #843. Adds three high-value patient-safety rules from
issue #263, and extracts the helper requested in the #843 PR review (#855).

## New rules

### 1. `DI-STATIN-GEMFIBROZIL` (critical) — drug-interactions.ts
Upgrades the prior `DI-STATIN-FIBRATE` (warning) to two separate rules based
on fibrate identity:

- **`DI-STATIN-GEMFIBROZIL` — critical.** Gemfibrozil inhibits statin
  glucuronidation and OATP1B1-mediated hepatic uptake, raising plasma statin
  levels several-fold. This combination drove the fatal rhabdomyolysis cases
  behind Pfizer's 2001 withdrawal of cerivastatin (Baycol). FDA labeling
  now contraindicates gemfibrozil with simvastatin, lovastatin, pitavastatin,
  and rosuvastatin, and recommends avoidance with other statins.
- **`DI-STATIN-FENOFIBRATE` — warning** (retained severity). Fenofibrate
  does not inhibit statin glucuronidation, so the interaction is clinically
  manageable with CK monitoring — ACC/AHA and NLA support this combination
  for mixed dyslipidemia.

### 2. `CROSS-METFORMIN-GFR-001` (critical) — cross-specialty.ts
Fires when the patient is on metformin (or any metformin-containing combo
product) **and** a recent eGFR value is `< 30 mL/min/1.73m²`. This is a
hard contraindication per FDA 2016 labeling and ADA guidance — accumulation
in advanced renal impairment drives metformin-associated lactic acidosis
(MALA), mortality 30–50%.

- Threshold is strict `< 30` to mirror the published cutoff (eGFR = 30 does
  not fire).
- Recognises `eGFR`, `GFR`, and `Estimated GFR` lab names.
- Complementary to the existing `DI-METFORMIN-CONTRAST` (which covers
  transient peri-contrast AKI).

### 3. `CROSS-THIAZIDE-HYPOK-001` (warning, escalates to critical) — cross-specialty.ts
Fires when the patient is on a thiazide (HCTZ, chlorthalidone, indapamide,
metolazone, chlorothiazide) and K+ is `< 3.5 mEq/L`. Thiazides worsen
pre-existing hypokalemia via distal-tubule K+ wasting, increasing arrhythmia,
weakness, and rhabdomyolysis risk.

- Severity escalates to critical when K+ `< 3.0`, mirroring
  `CROSS-QT-HYPOK-001` and `critical-values.ts`.
- Deliberately overlaps with `CROSS-QT-HYPOK-001` when a patient is on both
  a thiazide and a QT-prolonger — different mechanisms (electrolyte worsening
  vs. torsades risk), different actions (hold thiazide / replace K+ vs. QTc
  monitoring + cardiology review). Both fire for a complete picture.

## Helper extraction (closes #855)

Extracts `getRecentPotassium(ctx)` and `getRecentEGFR(ctx)` at module scope
in `cross-specialty.ts`. Replaces the three duplicated potassium lookups in
`CROSS-QT-HYPOK-001` (check / buildSeverity / buildSuggestedAction) and is
reused by the new `CROSS-THIAZIDE-HYPOK-001`. Keeps the accepted lab-name
aliases (`potassium`, `K`, `K+`) in one place so they evolve in lockstep.

## Unit assumptions (documented in rule comments)

- K+ in mEq/L (numerically equivalent to mmol/L; no conversion).
- eGFR in mL/min/1.73m².
- No changes to `PatientContext` shape — reuses the existing `recent_labs`
  surface.

## Test plan

- [x] TDD per rule: positive, negative, boundary (exact threshold), and
      lab-name-alias tests written first, then implementation.
- [x] `pnpm --filter @carebridge/ai-oversight test` — 640 pass (baseline 611,
      +29 from this change).
- [x] All existing cross-specialty rules (including the two from #843) still
      green after the helper refactor — 216 cross-specialty tests pass.
- [x] `pnpm typecheck` — green.
- [x] `pnpm lint` — green (pre-existing warnings in other apps unchanged).
- [x] `pnpm test` root — 39/39 tasks pass.

## Non-goals for this PR

Refs #263 — more rules remain (chronic steroid + PCP prophylaxis needs
medication duration tracking; anticoag+GI-bleed+NSAID needs conditions data;
immunosuppressant+fever needs recent temp). Those require context-shape
changes and should land as separate PRs.

Closes #855.
Refs #263 (still open — remaining rules tracked there).