### PR TITLE
fix(gateway): resolve family_caregiver role type-hole (#847)

### DIFF
--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -6,7 +6,7 @@ export const users = pgTable("users", {
   email: text("email").notNull().unique(),
   password_hash: text("password_hash").notNull(),
   name: text("name").notNull(),
-  role: text("role").notNull(), // patient, nurse, physician, specialist, admin
+  role: text("role").notNull(), // patient, nurse, physician, specialist, admin, family_caregiver
   patient_id: text("patient_id"), // links patient users to their patient record
   specialty: text("specialty"),
   department: text("department"),

--- a/packages/shared-types/src/auth.ts
+++ b/packages/shared-types/src/auth.ts
@@ -1,6 +1,17 @@
 import type { MutableRecord } from "./base.js";
 
-export type UserRole = "patient" | "nurse" | "physician" | "specialist" | "admin";
+export type UserRole =
+  | "patient"
+  | "nurse"
+  | "physician"
+  | "specialist"
+  | "admin"
+  // Family caregivers are invited by a patient and gain scoped read access to
+  // that patient's record via the `family_relationships` table. Write access
+  // to clinical data (diagnoses, allergies, notes, orders) is always denied —
+  // the role is read-only by design. See services/auth/src/family-invite-flow.ts
+  // and the `list` projection in services/api-gateway/src/routers/patient-records.ts.
+  | "family_caregiver";
 
 export interface User extends MutableRecord {
   email: string;
@@ -67,6 +78,11 @@ export type Permission =
 
 export const ROLE_PERMISSIONS: Record<UserRole, Permission[]> = {
   patient: ["read:patients", "read:vitals", "read:labs", "read:medications", "read:notes", "read:flags"],
+  // Family caregivers inherit the patient read-set at the role level; granular
+  // filtering by active relationship and per-relationship access_scopes is
+  // enforced separately at the router layer. No write permissions are granted
+  // at the role level — clinical write-paths explicitly deny family_caregiver.
+  family_caregiver: ["read:patients", "read:vitals", "read:labs", "read:medications", "read:notes", "read:flags"],
   nurse: [
     "read:patients", "write:patients",
     "read:vitals", "write:vitals",

--- a/packages/validators/src/__tests__/auth.test.ts
+++ b/packages/validators/src/__tests__/auth.test.ts
@@ -120,6 +120,18 @@ describe("createUserSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("accepts family_caregiver role", () => {
+    // family_caregiver is a first-class role (see UserRole union) and must
+    // be creatable through the admin createUser flow that family-invite
+    // acceptance maps onto.
+    const result = createUserSchema.safeParse({
+      ...validUser,
+      email: "caregiver@carebridge.dev",
+      role: "family_caregiver",
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejects missing required fields", () => {
     expect(createUserSchema.safeParse({}).success).toBe(false);
   });

--- a/packages/validators/src/auth.ts
+++ b/packages/validators/src/auth.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-export const userRoleSchema = z.enum(["patient", "nurse", "physician", "specialist", "admin"]);
+export const userRoleSchema = z.enum([
+  "patient",
+  "nurse",
+  "physician",
+  "specialist",
+  "admin",
+  "family_caregiver",
+]);
 
 export const loginSchema = z.object({
   email: z.string().email(),

--- a/services/api-gateway/src/__tests__/family-access.test.ts
+++ b/services/api-gateway/src/__tests__/family-access.test.ts
@@ -49,19 +49,12 @@ vi.mock("@carebridge/auth/family-invite-flow", () => ({
 import { familyAccessRbacRouter } from "../routers/family-access.js";
 import type { Context } from "../context.js";
 
-/**
- * Test-only role union. `User["role"]` from `@carebridge/shared-types` does
- * not include "family_caregiver" yet; this alias keeps the `as User["role"]`
- * cast localized to `makeUser` so future union-expansion is a single edit.
- */
-type TestRole = User["role"] | "family_caregiver";
-
-function makeUser(role: TestRole, id = ROLE_IDS[role]!): User {
+function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
   return {
     id,
     email: `${role}@carebridge.dev`,
     name: `Test ${role}`,
-    role: role as User["role"],
+    role,
     is_active: true,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",

--- a/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-diagnosis-allergy-rbac.test.ts
@@ -172,7 +172,7 @@ describe("patientRecordsRbacRouter — diagnoses role restrictions", () => {
   });
 
   it("rejects family_caregiver from creating a diagnosis (FORBIDDEN)", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(caller.diagnoses.create(diagnosisInput)).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
@@ -188,7 +188,7 @@ describe("patientRecordsRbacRouter — diagnoses role restrictions", () => {
   });
 
   it("rejects family_caregiver from updating a diagnosis (FORBIDDEN)", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(
       caller.diagnoses.update({ id: DIAGNOSIS_ID, status: "resolved" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
@@ -232,7 +232,7 @@ describe("patientRecordsRbacRouter — allergies role restrictions", () => {
   });
 
   it("rejects family_caregiver from creating an allergy (FORBIDDEN)", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(caller.allergies.create(allergyInput)).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
@@ -248,7 +248,7 @@ describe("patientRecordsRbacRouter — allergies role restrictions", () => {
   });
 
   it("rejects family_caregiver from updating an allergy (FORBIDDEN)", async () => {
-    const caller = callerFor(makeUser("family_caregiver" as User["role"]));
+    const caller = callerFor(makeUser("family_caregiver"));
     await expect(
       caller.allergies.update({ id: ALLERGY_ID, severity: "severe" }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
@@ -466,4 +466,48 @@ describe("patientRecordsRbacRouter — care-team enforcement (allergies)", () =>
       }
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard for issue #847 — "family_caregiver" must be a first-class
+// member of the User["role"] union so the router deny-branches compile as
+// type-safe equality checks without `(ctx.user.role as string)` casts.
+// ---------------------------------------------------------------------------
+
+describe("family_caregiver role typing (issue #847)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("accepts family_caregiver as a literal User['role'] value without casts", () => {
+    // If this compiles, the union includes "family_caregiver". If it ever
+    // regresses back to the narrower union, tsc will fail at build time.
+    const caregiver: User = {
+      id: ROLE_IDS.family_caregiver!,
+      email: "caregiver@carebridge.dev",
+      name: "Test Caregiver",
+      role: "family_caregiver",
+      is_active: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    expect(caregiver.role).toBe("family_caregiver");
+  });
+
+  it("rejects family_caregiver through the type-safe deny branch on diagnoses.create", async () => {
+    // Before issue #847 the router relied on `(ctx.user.role as string) === "family_caregiver"`
+    // because the union was too narrow. With the union widened, the equality
+    // check is type-safe and this assertion protects the deny path.
+    const caller = callerFor(makeUser("family_caregiver"));
+    await expect(caller.diagnoses.create(diagnosisInput)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(mocks.createDiagnosis).not.toHaveBeenCalled();
+  });
+
+  it("rejects family_caregiver through the type-safe deny branch on allergies.update", async () => {
+    const caller = callerFor(makeUser("family_caregiver"));
+    await expect(
+      caller.allergies.update({ id: ALLERGY_ID, severity: "severe" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.updateAllergy).not.toHaveBeenCalled();
+  });
 });

--- a/services/api-gateway/src/__tests__/patient-records-list-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/patient-records-list-rbac.test.ts
@@ -347,7 +347,7 @@ describe("patientRecordsRbacRouter.list — HIPAA minimum-necessary filtering", 
       [{ patient_id: PATIENT_RECORD_1.id }],
       [PATIENT_RECORD_1],
     ]);
-    const caregiver = makeUser("family_caregiver" as User["role"], CAREGIVER_ID);
+    const caregiver = makeUser("family_caregiver", CAREGIVER_ID);
     const caller = callerFor(caregiver);
 
     const result = await caller.list();
@@ -366,7 +366,7 @@ describe("patientRecordsRbacRouter.list — HIPAA minimum-necessary filtering", 
     const CAREGIVER_ID = "77777777-7777-4777-8777-777777777777";
     // Queue: familyRelationships returns empty
     mocks.setResolvedDataQueue([[]]);
-    const caregiver = makeUser("family_caregiver" as User["role"], CAREGIVER_ID);
+    const caregiver = makeUser("family_caregiver", CAREGIVER_ID);
     const caller = callerFor(caregiver);
 
     const result = await caller.list();
@@ -395,7 +395,7 @@ describe("patientRecordsRbacRouter.list — HIPAA minimum-necessary filtering", 
           [{ patient_id: PATIENT_RECORD_1.id }],
           [PATIENT_RECORD_1],
         ]);
-        const user = makeUser("family_caregiver" as User["role"], CAREGIVER_ID);
+        const user = makeUser("family_caregiver", CAREGIVER_ID);
         const caller = callerFor(user);
 
         await caller.list();

--- a/services/api-gateway/src/middleware/audit.ts
+++ b/services/api-gateway/src/middleware/audit.ts
@@ -200,7 +200,7 @@ export async function deriveActorContext(
     return { actorRelationship: null, onBehalfOfPatientId: null };
   }
 
-  if ((user.role as string) === "family_caregiver") {
+  if (user.role === "family_caregiver") {
     if (!patientId) {
       return { actorRelationship: "caregiver", onBehalfOfPatientId: null };
     }

--- a/services/api-gateway/src/middleware/rbac.test.ts
+++ b/services/api-gateway/src/middleware/rbac.test.ts
@@ -237,6 +237,24 @@ describe("hasPermission", () => {
   it("returns false for unknown permission strings", () => {
     expect(hasPermission(makeUser("admin"), "launch:missiles")).toBe(false);
   });
+
+  it("grants family_caregiver the patient read-set but never write permissions (issue #847)", () => {
+    const caregiver = makeUser("family_caregiver");
+    // Read permissions match the patient role at the role layer — granular
+    // filtering happens via family_relationships.access_scopes in the router.
+    expect(hasPermission(caregiver, "read:patients")).toBe(true);
+    expect(hasPermission(caregiver, "read:vitals")).toBe(true);
+    expect(hasPermission(caregiver, "read:labs")).toBe(true);
+    expect(hasPermission(caregiver, "read:medications")).toBe(true);
+    expect(hasPermission(caregiver, "read:notes")).toBe(true);
+    expect(hasPermission(caregiver, "read:flags")).toBe(true);
+    // No write / admin / sign permissions at the role layer.
+    expect(hasPermission(caregiver, "write:patients")).toBe(false);
+    expect(hasPermission(caregiver, "write:vitals")).toBe(false);
+    expect(hasPermission(caregiver, "write:notes")).toBe(false);
+    expect(hasPermission(caregiver, "sign:notes")).toBe(false);
+    expect(hasPermission(caregiver, "admin:users")).toBe(false);
+  });
 });
 
 describe("assertPermission", () => {

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -225,7 +225,7 @@ export const patientRecordsRbacRouter = t.router({
     }
 
     // Family caregivers: only patients linked via an active family_relationships row.
-    if ((ctx.user.role as string) === "family_caregiver") {
+    if (ctx.user.role === "family_caregiver") {
       const activeRelationships = await db
         .select({ patient_user_id: familyRelationships.patient_id })
         .from(familyRelationships)
@@ -305,7 +305,7 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createDiagnosisSchema)
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot create clinical diagnoses",
@@ -318,7 +318,7 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateDiagnosisSchema))
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot update clinical diagnoses",
@@ -355,7 +355,7 @@ export const patientRecordsRbacRouter = t.router({
     create: protectedProcedure
       .input(createAllergySchema)
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot create clinical allergies",
@@ -368,7 +368,7 @@ export const patientRecordsRbacRouter = t.router({
     update: protectedProcedure
       .input(z.object({ id: z.string().uuid() }).merge(updateAllergySchema))
       .mutation(async ({ ctx, input }) => {
-        if (ctx.user.role === "patient" || (ctx.user.role as string) === "family_caregiver") {
+        if (ctx.user.role === "patient" || ctx.user.role === "family_caregiver") {
           throw new TRPCError({
             code: "FORBIDDEN",
             message: "Patients cannot update clinical allergies",


### PR DESCRIPTION
## Summary

- Adds `"family_caregiver"` to the `UserRole` union in `@carebridge/shared-types`, and to the `userRoleSchema` Zod enum in `@carebridge/validators`, closing the type-hole that PR #839 opened.
- Removes the five `(ctx.user.role as string) === "family_caregiver"` casts (4 in `services/api-gateway/src/routers/patient-records.ts` and 1 in `services/api-gateway/src/middleware/audit.ts`). Comparisons are now type-safe equality checks, so tsc will catch typos of this role.
- Grants the role the patient read-set in `ROLE_PERMISSIONS` (granular per-relationship filtering still lives in the router layer via `family_relationships.access_scopes`; no write permissions at the role level).
- Cleans up the `TestRole` shim and `as User["role"]` casts in three api-gateway test files.

## Option chosen: A (add to union)

Evidence gathered before deciding:
- `tooling/smoke-test.ts` inserts a real `family_caregiver` row into `users` to validate `patients.list`.
- `packages/db-schema/src/schema/family-access.ts` defines `family_relationships` + `family_invites` tables modelling the caregiver lifecycle.
- `services/auth/src/family-invite-flow.ts` implements the invite → accept → revoke flow (~35 service tests in `services/auth/src/__tests__/family-invite-flow.test.ts`).
- `services/api-gateway/src/routers/patient-records.ts` list path already has a real projection for caregivers (lines ~225-256).
- `services/api-gateway/src/middleware/audit.ts` derives `actor_relationship` from `family_relationships.relationship_type` for caregivers (covered by 12 tests in `audit-actor-context.test.ts`).
- Four gateway test files exercise the role via the RBAC suites.

Four of those tests had `type TestRole = User["role"] | "family_caregiver"` with an in-file comment calling out that the union was out of date. This PR removes that workaround.

## Non-goals

- No RBAC pattern refactor — `enforcePatientAccess` / `assertPatientAccess` keep their existing semantics.
- No expansion of UserRole beyond what is already evidenced at runtime.

## Test plan

- [x] `pnpm typecheck` — 40/40 workspace typechecks pass.
- [x] `pnpm lint` — 22/22 lint tasks pass.
- [x] `pnpm --filter @carebridge/api-gateway test` — 261/261 pass, including three new regression tests in `patient-records-diagnosis-allergy-rbac.test.ts` and a `hasPermission` coverage test in `rbac.test.ts`.
- [x] `pnpm --filter @carebridge/validators test` — 159/159 pass (new `family_caregiver` acceptance test added).
- [x] `pnpm --filter @carebridge/auth test` — 97/97 pass.
- [x] `pnpm --filter @carebridge/clinician-portal test` — 186/186 pass.
- [x] `pnpm --filter @carebridge/patient-portal test` — 13/13 pass.

Closes #847