### PR TITLE
feat(ai): unit-aware recent_labs in rule-level PatientContext

### DIFF
--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -40,6 +40,7 @@ vi.mock("@carebridge/db-schema", () => ({
     created_at: "created_at",
     test_name: "test_name",
     value: "value",
+    unit: "unit",
   },
   reviewJobs: {},
 }));
@@ -95,7 +96,7 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     primeSelectMocks();
   });
 
-  it("populates recent_labs from the joined lab_results query", async () => {
+  it("populates recent_labs from the joined lab_results query, including unit (#856)", async () => {
     diagnosesSelect.mockResolvedValue([
       { description: "Breast cancer", icd10_code: "C50.9", status: "active" },
     ]);
@@ -103,16 +104,16 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
       { name: "Cisplatin", status: "active" },
     ]);
     labsSelect.mockResolvedValue([
-      { test_name: "ANC", value: 800, created_at: nowIso },
-      { test_name: "WBC", value: 2.1, created_at: nowIso },
+      { test_name: "ANC", value: 800, unit: "cells/µL", created_at: nowIso },
+      { test_name: "WBC", value: 2.1, unit: "10^3/µL", created_at: nowIso },
     ]);
 
     const ctx = await buildPatientContextForRules("p-1", stubEvent);
 
     expect(ctx.recent_labs).toBeDefined();
     expect(ctx.recent_labs).toEqual([
-      { name: "ANC", value: 800 },
-      { name: "WBC", value: 2.1 },
+      { name: "ANC", value: 800, unit: "cells/µL" },
+      { name: "WBC", value: 2.1, unit: "10^3/µL" },
     ]);
     expect(ctx.event_timestamp).toBe(stubEvent.timestamp);
     expect(ctx.active_diagnoses).toContain("Breast cancer");
@@ -124,13 +125,29 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     medicationsSelect.mockResolvedValue([]);
     // Ordered desc by created_at — first row wins.
     labsSelect.mockResolvedValue([
-      { test_name: "ANC", value: 500, created_at: nowIso },
-      { test_name: "ANC", value: 1800, created_at: "2026-04-05T00:00:00Z" },
+      { test_name: "ANC", value: 500, unit: "cells/µL", created_at: nowIso },
+      { test_name: "ANC", value: 1800, unit: "cells/µL", created_at: "2026-04-05T00:00:00Z" },
     ]);
 
     const ctx = await buildPatientContextForRules("p-1", stubEvent);
 
-    expect(ctx.recent_labs).toEqual([{ name: "ANC", value: 500 }]);
+    expect(ctx.recent_labs).toEqual([{ name: "ANC", value: 500, unit: "cells/µL" }]);
+  });
+
+  it("populates unit='' (empty string) when the lab row has null/missing unit, and logs a warn (#856)", async () => {
+    // Defensive: a lab row with null unit must not crash and must not be
+    // silently treated as if it had a canonical unit. The shape should
+    // carry an empty string, and downstream unit-aware helpers refuse to
+    // match it against a specific expected unit.
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([
+      { test_name: "Potassium", value: 3.2, unit: null, created_at: nowIso },
+    ]);
+
+    const ctx = await buildPatientContextForRules("p-1", stubEvent);
+
+    expect(ctx.recent_labs).toEqual([{ name: "Potassium", value: 3.2, unit: "" }]);
   });
 
   it("returns recent_labs as undefined when no recent lab rows exist", async () => {
@@ -242,14 +259,14 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     medicationsSelect.mockResolvedValue([]);
     labsSelect.mockResolvedValue([
       // Future lab — must not "leak from the future" into the rule evaluation.
-      { test_name: "ANC", value: 900, created_at: "2026-04-16T15:00:00.000Z" },
+      { test_name: "ANC", value: 900, unit: "cells/µL", created_at: "2026-04-16T15:00:00.000Z" },
       // Lab reported before the event — included.
-      { test_name: "WBC", value: 2.1, created_at: "2026-04-16T10:00:00.000Z" },
+      { test_name: "WBC", value: 2.1, unit: "10^3/µL", created_at: "2026-04-16T10:00:00.000Z" },
     ]);
 
     const ctx = await buildPatientContextForRules("p-1", event);
 
-    expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 2.1 }]);
+    expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 2.1, unit: "10^3/µL" }]);
   });
 
   // ─── #513 — normalize ISO timestamp comparisons ────────────────────
@@ -414,12 +431,14 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
       {
         test_name: "ANC",
         value: 200,
+        unit: "cells/µL",
         created_at: "2026-04-16T08:00:00.000Z",
         flag: "entered_in_error",
       },
       {
         test_name: "WBC",
         value: 4.5,
+        unit: "10^3/µL",
         created_at: "2026-04-16T09:00:00.000Z",
       },
     ]);
@@ -427,7 +446,7 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     const ctx = await buildPatientContextForRules("p-1", event);
 
     expect(ctx.recent_labs).toBeDefined();
-    expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 4.5 }]);
+    expect(ctx.recent_labs).toEqual([{ name: "WBC", value: 4.5, unit: "10^3/µL" }]);
     const labNames = (ctx.recent_labs ?? []).map((l) => l.name);
     expect(labNames).not.toContain("ANC");
   });
@@ -442,12 +461,14 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
       {
         test_name: "ANC",
         value: 200,
+        unit: "cells/µL",
         created_at: "2026-04-16T08:00:00.000Z",
         flag: "entered_in_error",
       },
       {
         test_name: "Hemoglobin",
         value: 7.2,
+        unit: "g/dL",
         created_at: "2026-04-16T07:00:00.000Z",
         flag: "entered_in_error",
       },

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -19,7 +19,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("fires CHEMO-NEUTRO-FEVER-001 (critical) when ANC <= 500 — true febrile neutropenia", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 200 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 200, unit: "cells/µL" }] });
     const flags = checkCrossSpecialtyPatterns(ctx);
 
     const flag = flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001");
@@ -32,7 +32,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("fires CHEMO-NEUTRO-FEVER-001 (critical) at ANC = 500 boundary", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 500 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 500, unit: "cells/µL" }] });
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
@@ -41,7 +41,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("fires CHEMO-NEUTRO-FEVER-001 (info) when ANC > 500 — likely non-neutropenic fever (issue #214)", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800, unit: "cells/µL" }] });
     const flags = checkCrossSpecialtyPatterns(ctx);
 
     const flag = flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001");
@@ -53,7 +53,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("adds a severe-neutropenia addendum when ANC < 500", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 200 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 200, unit: "cells/µL" }] });
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
@@ -63,7 +63,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("provides non-neutropenic fever guidance when ANC > 500 (issue #214)", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 1200 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 1200, unit: "cells/µL" }] });
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
@@ -87,7 +87,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("fires neither rule when ANC is normal (>= 1500)", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 3200 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 3200, unit: "cells/µL" }] });
     const flags = checkCrossSpecialtyPatterns(ctx);
 
     expect(flags.find((f) => f.rule_id === "CHEMO-FEVER-001")).toBeUndefined();
@@ -97,7 +97,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   });
 
   it("CHEMO-NEUTRO-FEVER-001 notifies emergency as well as oncology/infectious_disease", () => {
-    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800 }] });
+    const ctx = baseCtx({ recent_labs: [{ name: "ANC", value: 800, unit: "cells/µL" }] });
     const flag = checkCrossSpecialtyPatterns(ctx).find(
       (f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001",
     );
@@ -110,7 +110,7 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
   it("does not fire either rule when patient is not on chemo", () => {
     const ctx = baseCtx({
       active_medications: ["Lisinopril"],
-      recent_labs: [{ name: "ANC", value: 800 }],
+      recent_labs: [{ name: "ANC", value: 800, unit: "cells/µL" }],
     });
     const flags = checkCrossSpecialtyPatterns(ctx);
     expect(flags.find((f) => f.rule_id === "CHEMO-FEVER-001")).toBeUndefined();
@@ -758,7 +758,7 @@ describe("ANTICOAG-BLEED-001 — severity stratification", () => {
     ["minor skin bleeding"],
   ])("does NOT fire for minor bleeding with normal INR: %s", (symptom) => {
     const flags = checkCrossSpecialtyPatterns(
-      anticoagCtx([symptom], { recent_labs: [{ name: "INR", value: 2.5 }] }),
+      anticoagCtx([symptom], { recent_labs: [{ name: "INR", value: 2.5, unit: "" }] }),
     );
     const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
     expect(flag).toBeUndefined();
@@ -777,7 +777,7 @@ describe("ANTICOAG-BLEED-001 — severity stratification", () => {
   it("fires WARNING for minor bruising when INR > 5.0", () => {
     const flags = checkCrossSpecialtyPatterns(
       anticoagCtx(["bruising on forearm"], {
-        recent_labs: [{ name: "INR", value: 6.2 }],
+        recent_labs: [{ name: "INR", value: 6.2, unit: "" }],
       }),
     );
     const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
@@ -788,7 +788,7 @@ describe("ANTICOAG-BLEED-001 — severity stratification", () => {
   it("fires WARNING for petechiae when INR > 5.0", () => {
     const flags = checkCrossSpecialtyPatterns(
       anticoagCtx(["petechiae on lower extremities"], {
-        recent_labs: [{ name: "INR", value: 7.0 }],
+        recent_labs: [{ name: "INR", value: 7.0, unit: "" }],
       }),
     );
     const flag = flags.find((f) => f.rule_id === "ANTICOAG-BLEED-001");
@@ -1279,6 +1279,7 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
     meds: string[],
     potassiumValue: number | null,
     overrides: Partial<PatientContext> = {},
+    unit = "mEq/L",
   ): PatientContext => ({
     active_diagnoses: ["Hypertension"],
     active_diagnosis_codes: ["I10"],
@@ -1288,7 +1289,7 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
     recent_labs:
       potassiumValue === null
         ? []
-        : [{ name: "Potassium", value: potassiumValue }],
+        : [{ name: "Potassium", value: potassiumValue, unit }],
     ...overrides,
   });
 
@@ -1347,7 +1348,7 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
   it("detects potassium by alternative lab name 'K+'", () => {
     const flags = checkCrossSpecialtyPatterns(
       qtHypoKCtx(["haloperidol 2mg"], null, {
-        recent_labs: [{ name: "K+", value: 3.1 }],
+        recent_labs: [{ name: "K+", value: 3.1, unit: "mEq/L" }],
       }),
     );
     const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
@@ -1357,7 +1358,7 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
   it("detects potassium by alternative lab name 'K'", () => {
     const flags = checkCrossSpecialtyPatterns(
       qtHypoKCtx(["methadone 10mg"], null, {
-        recent_labs: [{ name: "K", value: 3.0 }],
+        recent_labs: [{ name: "K", value: 3.0, unit: "mEq/L" }],
       }),
     );
     const flag = flags.find((f) => f.rule_id === "CROSS-QT-HYPOK-001");
@@ -1408,5 +1409,64 @@ describe("CROSS-QT-HYPOK-001 — QT-prolonging drug + hypokalemia (torsades risk
       (f) => f.rule_id === "CROSS-QT-HYPOK-001",
     );
     expect(flag).toBeUndefined();
+  });
+
+  // ── Issue #856 — unit-aware potassium comparison ─────────────────────
+  //
+  // mEq/L and mmol/L are 1:1 numerically equivalent for monovalent ions
+  // like K+ (conservative alias list in find-recent-lab.ts). Non-equivalent
+  // units such as mg/dL or µmol/L must NOT match — otherwise the rule could
+  // silently fire on wrong-unit values.
+
+  it("fires for K+ 3.2 with canonical unit mEq/L", () => {
+    const ctx = qtHypoKCtx(["azithromycin 500mg"], 3.2, {}, "mEq/L");
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+    );
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("fires for K+ 3.2 with equivalent unit mmol/L (monovalent ion, 1:1)", () => {
+    const ctx = qtHypoKCtx(["azithromycin 500mg"], 3.2, {}, "mmol/L");
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+    );
+    expect(flag).toBeDefined();
+    expect(flag!.severity).toBe("warning");
+  });
+
+  it("does NOT fire when potassium unit is mg/dL (wrong-unit guard)", () => {
+    // 3.2 mg/dL of potassium is a nonsensical unit for K+, but an EHR
+    // import or data-entry error could produce it. The rule must refuse
+    // to compare against the 3.5 mEq/L threshold to avoid a silent false
+    // positive. Under unit-aware semantics, this lab is treated as unknown
+    // and the rule falls through as if no K+ were reported.
+    const ctx = qtHypoKCtx(["azithromycin 500mg"], 3.2, {}, "mg/dL");
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("does NOT fire when potassium unit is missing / empty string", () => {
+    // Missing unit is treated as unknown — fail closed rather than risk
+    // comparing wrong-unit values.
+    const ctx = qtHypoKCtx(["azithromycin 500mg"], 3.2, {}, "");
+    const flag = checkCrossSpecialtyPatterns(ctx).find(
+      (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+    );
+    expect(flag).toBeUndefined();
+  });
+
+  it("accepts case-insensitive and whitespace-tolerant unit strings", () => {
+    // "MEQ/L", " mmol/L ", "meq/l" should all be accepted as canonical K+ units.
+    for (const unit of ["MEQ/L", " mmol/L ", "meq/l"]) {
+      const ctx = qtHypoKCtx(["azithromycin 500mg"], 3.2, {}, unit);
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-QT-HYPOK-001",
+      );
+      expect(flag, `unit=${unit}`).toBeDefined();
+    }
   });
 });

--- a/services/ai-oversight/src/__tests__/lab-units.test.ts
+++ b/services/ai-oversight/src/__tests__/lab-units.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  findRecentLab,
+  getRecentPotassium,
+  getRecentSodium,
+  getRecentChloride,
+  getRecentEGFR,
+} from "../rules/lab-units.js";
+import type { PatientContext } from "../rules/cross-specialty.js";
+
+/**
+ * Minimal PatientContext used across these tests. Only `recent_labs` is
+ * exercised here — the helpers do not read any other field.
+ */
+const ctxWithLabs = (
+  labs: Array<{ name: string; value: number; unit: string }>,
+): PatientContext => ({
+  active_diagnoses: [],
+  active_diagnosis_codes: [],
+  active_medications: [],
+  new_symptoms: [],
+  care_team_specialties: [],
+  recent_labs: labs,
+});
+
+describe("findRecentLab (#856) — unit-aware lab lookup", () => {
+  const ACCEPTED = new Set(["meq/l", "mmol/l"]);
+  const NAME = /^(potassium|k\+?)$/i;
+
+  it("returns the lab when unit is in the accepted set (canonical mEq/L)", () => {
+    const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit: "mEq/L" }]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toEqual({ name: "Potassium", value: 3.2, unit: "mEq/L" });
+  });
+
+  it("returns the lab when unit is an accepted equivalent (mmol/L)", () => {
+    const ctx = ctxWithLabs([{ name: "K+", value: 3.2, unit: "mmol/L" }]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toBeDefined();
+    expect(lab!.value).toBe(3.2);
+  });
+
+  it("normalizes case and whitespace when checking unit", () => {
+    for (const unit of ["MEQ/L", " mmol/L ", "meq/l"]) {
+      const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit }]);
+      const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+      expect(lab, `unit=${JSON.stringify(unit)}`).toBeDefined();
+    }
+  });
+
+  it("returns undefined when the unit is NOT in the accepted set (mg/dL)", () => {
+    const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit: "mg/dL" }]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toBeUndefined();
+  });
+
+  it("returns undefined when the unit is missing / empty string", () => {
+    const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit: "" }]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toBeUndefined();
+  });
+
+  it("returns undefined when no lab matches the name pattern", () => {
+    const ctx = ctxWithLabs([{ name: "Sodium", value: 140, unit: "mEq/L" }]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toBeUndefined();
+  });
+
+  it("returns undefined when recent_labs is undefined", () => {
+    const ctx: PatientContext = {
+      active_diagnoses: [],
+      active_diagnosis_codes: [],
+      active_medications: [],
+      new_symptoms: [],
+      care_team_specialties: [],
+    };
+    expect(findRecentLab(ctx, NAME, ACCEPTED, "K+")).toBeUndefined();
+  });
+
+  it("skips mismatched-unit lab and returns a later matching lab (freshest wins within matches)", () => {
+    // recent_labs is ordered desc by recency at the source. The helper
+    // iterates in order; the first lab matching BOTH name and an
+    // accepted unit wins, so a mismatched-unit row earlier in the list
+    // does not block a valid later row.
+    const ctx = ctxWithLabs([
+      { name: "Potassium", value: 999, unit: "mg/dL" }, // wrong unit, skipped
+      { name: "Potassium", value: 3.1, unit: "mEq/L" }, // accepted
+    ]);
+    const lab = findRecentLab(ctx, NAME, ACCEPTED, "K+");
+    expect(lab).toBeDefined();
+    expect(lab!.value).toBe(3.1);
+  });
+});
+
+describe("getRecentPotassium (#856)", () => {
+  it("matches 'Potassium', 'K', and 'K+' (case-insensitive) with mEq/L", () => {
+    for (const name of ["Potassium", "potassium", "K", "k", "K+", "k+"]) {
+      const ctx = ctxWithLabs([{ name, value: 3.2, unit: "mEq/L" }]);
+      const lab = getRecentPotassium(ctx);
+      expect(lab, `name=${name}`).toBeDefined();
+      expect(lab!.value).toBe(3.2);
+    }
+  });
+
+  it("accepts mmol/L as equivalent (monovalent ion, 1:1)", () => {
+    const ctx = ctxWithLabs([{ name: "K+", value: 3.2, unit: "mmol/L" }]);
+    expect(getRecentPotassium(ctx)).toBeDefined();
+  });
+
+  it("refuses mg/dL for K+ (nonsensical unit, fail closed)", () => {
+    const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit: "mg/dL" }]);
+    expect(getRecentPotassium(ctx)).toBeUndefined();
+  });
+
+  it("refuses missing / empty unit for K+ (fail closed)", () => {
+    const ctx = ctxWithLabs([{ name: "Potassium", value: 3.2, unit: "" }]);
+    expect(getRecentPotassium(ctx)).toBeUndefined();
+  });
+});
+
+describe("getRecentSodium / getRecentChloride (#856)", () => {
+  it("getRecentSodium accepts mEq/L and mmol/L", () => {
+    expect(
+      getRecentSodium(
+        ctxWithLabs([{ name: "Sodium", value: 140, unit: "mEq/L" }]),
+      ),
+    ).toBeDefined();
+    expect(
+      getRecentSodium(ctxWithLabs([{ name: "Na", value: 140, unit: "mmol/L" }])),
+    ).toBeDefined();
+  });
+
+  it("getRecentChloride accepts mEq/L and mmol/L", () => {
+    expect(
+      getRecentChloride(
+        ctxWithLabs([{ name: "Chloride", value: 100, unit: "mEq/L" }]),
+      ),
+    ).toBeDefined();
+    expect(
+      getRecentChloride(
+        ctxWithLabs([{ name: "Cl", value: 100, unit: "mmol/L" }]),
+      ),
+    ).toBeDefined();
+  });
+
+  it("monovalent helpers all refuse mg/dL", () => {
+    expect(
+      getRecentSodium(
+        ctxWithLabs([{ name: "Sodium", value: 140, unit: "mg/dL" }]),
+      ),
+    ).toBeUndefined();
+    expect(
+      getRecentChloride(
+        ctxWithLabs([{ name: "Chloride", value: 100, unit: "mg/dL" }]),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("getRecentEGFR (#856)", () => {
+  it("accepts mL/min/1.73m² and tolerant spacing/encoding variants", () => {
+    for (const unit of [
+      "mL/min/1.73m2",
+      "mL/min/1.73m²",
+      "mL/min/1.73 m2",
+      "ML/MIN/1.73M²",
+    ]) {
+      const ctx = ctxWithLabs([{ name: "eGFR", value: 55, unit }]);
+      const lab = getRecentEGFR(ctx);
+      expect(lab, `unit=${JSON.stringify(unit)}`).toBeDefined();
+    }
+  });
+
+  it("refuses mg/dL for eGFR (wrong unit)", () => {
+    const ctx = ctxWithLabs([{ name: "eGFR", value: 1.2, unit: "mg/dL" }]);
+    expect(getRecentEGFR(ctx)).toBeUndefined();
+  });
+});

--- a/services/ai-oversight/src/__tests__/lab-units.test.ts
+++ b/services/ai-oversight/src/__tests__/lab-units.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @carebridge/logger so we can assert on logger.warn() calls emitted
+// by lab-units when a recorded unit is not in the accepted set.
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }));
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+  }),
+}));
 
 import {
   findRecentLab,
@@ -8,6 +20,10 @@ import {
   getRecentEGFR,
 } from "../rules/lab-units.js";
 import type { PatientContext } from "../rules/cross-specialty.js";
+
+beforeEach(() => {
+  mockWarn.mockReset();
+});
 
 /**
  * Minimal PatientContext used across these tests. Only `recent_labs` is
@@ -174,6 +190,47 @@ describe("getRecentEGFR (#856)", () => {
 
   it("refuses mg/dL for eGFR (wrong unit)", () => {
     const ctx = ctxWithLabs([{ name: "eGFR", value: 1.2, unit: "mg/dL" }]);
+    expect(getRecentEGFR(ctx)).toBeUndefined();
+  });
+
+  it("returns the BSA-indexed eGFR (mL/min/1.73m²) at value=25 (positive case)", () => {
+    const ctx = ctxWithLabs([
+      { name: "eGFR", value: 25, unit: "mL/min/1.73m²" },
+    ]);
+    const lab = getRecentEGFR(ctx);
+    expect(lab).toBeDefined();
+    expect(lab!.value).toBe(25);
+    expect(lab!.unit).toBe("mL/min/1.73m²");
+  });
+
+  it("returns the BSA-indexed eGFR (ASCII variant mL/min/1.73m2) at value=25", () => {
+    const ctx = ctxWithLabs([
+      { name: "eGFR", value: 25, unit: "mL/min/1.73m2" },
+    ]);
+    const lab = getRecentEGFR(ctx);
+    expect(lab).toBeDefined();
+    expect(lab!.value).toBe(25);
+  });
+
+  it("REFUSES raw 'ml/min' (unindexed Cockcroft-Gault CrCl) and emits rule_lab_unit_mismatch warn (CROSS-METFORMIN-GFR-001 safety)", () => {
+    // Raw mL/min is Cockcroft-Gault creatinine clearance — NOT numerically
+    // equivalent to BSA-indexed mL/min/1.73m² eGFR. Can diverge 20–30% in
+    // non-average-BSA patients, so the unit-check infra must fail closed.
+    const ctx = ctxWithLabs([{ name: "eGFR", value: 25, unit: "ml/min" }]);
+    const lab = getRecentEGFR(ctx);
+    expect(lab).toBeUndefined();
+    expect(mockWarn).toHaveBeenCalledWith(
+      "rule_lab_unit_mismatch",
+      expect.objectContaining({
+        metric: "rule_lab_unit_mismatch",
+        analyte: "eGFR",
+        lab_unit: "ml/min",
+      }),
+    );
+  });
+
+  it("REFUSES raw 'mL/min' (mixed-case, unindexed) — normalization must not smuggle it back in", () => {
+    const ctx = ctxWithLabs([{ name: "eGFR", value: 25, unit: "mL/min" }]);
     expect(getRecentEGFR(ctx)).toBeUndefined();
   });
 });

--- a/services/ai-oversight/src/__tests__/sql-snapshot-filter.test.ts
+++ b/services/ai-oversight/src/__tests__/sql-snapshot-filter.test.ts
@@ -46,6 +46,7 @@ vi.mock("@carebridge/db-schema", () => ({
     created_at: "lab_results.created_at",
     test_name: "lab_results.test_name",
     value: "lab_results.value",
+    unit: "lab_results.unit",
   },
   reviewJobs: {},
 }));

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -9,6 +9,7 @@
 
 import type { FlagSeverity, FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
 import { QTC_PATTERN } from "./drug-interactions.js";
+import { getRecentPotassium } from "./lab-units.js";
 
 export interface PatientAllergy {
   allergen: string;
@@ -54,8 +55,15 @@ export interface PatientContext {
   allergies?: PatientAllergy[];
   /** The triggering clinical event, used by medication-status rules. */
   trigger_event?: ClinicalEvent;
-  /** Recent lab values, used by ANC-aware rules. */
-  recent_labs?: Array<{ name: string; value: number }>;
+  /**
+   * Recent lab values, used by ANC-aware rules and other threshold
+   * comparisons. Each entry carries a `unit` string (issue #856) so rules
+   * that compare against analyte-specific thresholds can verify the value
+   * is in the expected unit before firing. An empty `unit` means the
+   * source record had no recorded unit — downstream unit-aware helpers
+   * treat this as unknown and fail closed.
+   */
+  recent_labs?: Array<{ name: string; value: number; unit: string }>;
   /**
    * ISO 8601 event timestamp. Time-sensitive rules (e.g. VTE recency gate)
    * use this instead of wall-clock time so the evaluation is anchored to the
@@ -847,16 +855,16 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     check: (ctx: PatientContext) => {
       const onQTDrug = ctx.active_medications.some((m) => QTC_PATTERN.test(m));
       if (!onQTDrug) return false;
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      // Unit-aware potassium lookup (#856). Refuses to match labs whose
+      // unit is not numerically equivalent to mEq/L (i.e. mmol/L). A K+
+      // value recorded in mg/dL or with no unit would cause the rule to
+      // skip rather than silently compare against the 3.5 mEq/L threshold.
+      const k = getRecentPotassium(ctx)?.value;
       if (k === undefined) return false;
       return k < 3.5;
     },
     buildSeverity: (ctx: PatientContext) => {
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      const k = getRecentPotassium(ctx)?.value;
       // Severe hypokalemia (K+ < 3.0) compounds torsades risk and is
       // independently critical per critical-values.ts. Escalate accordingly.
       if (k !== undefined && k < 3.0) return "critical";
@@ -880,9 +888,7 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       "QTc — if > 500 ms or > 60 ms above baseline, hold the QT-prolonging agent and consult cardiology. " +
       "Continuous telemetry until electrolytes corrected.",
     buildSuggestedAction: (ctx: PatientContext) => {
-      const k = ctx.recent_labs?.find((l) =>
-        /^(potassium|k\+?)$/i.test(l.name.trim()),
-      )?.value;
+      const k = getRecentPotassium(ctx)?.value;
       const base =
         "Replete potassium to > 4.0 mEq/L. Check magnesium concurrently and repeat if low (hypomagnesemia " +
         "impairs potassium correction and independently prolongs QT). Obtain baseline ECG and calculate " +

--- a/services/ai-oversight/src/rules/lab-units.ts
+++ b/services/ai-oversight/src/rules/lab-units.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit-aware accessors for rule-level `recent_labs` (issue #856).
+ *
+ * The rule-level `PatientContext.recent_labs` entries carry a `unit` string
+ * that originates from `lab_results.unit` in the database. Deterministic
+ * rules compare lab values against numeric thresholds that are defined in a
+ * specific canonical unit per analyte (e.g. K+ < 3.5 mEq/L). When the
+ * recorded unit does not match the canonical set for a given analyte, the
+ * rule MUST refuse to compare the raw number against its threshold —
+ * otherwise a 120 mg/dL glucose reading could be silently compared against
+ * a 6.7 mmol/L threshold and produce a false positive (or negative).
+ *
+ * Normalization policy (conservative):
+ *   - Only 1:1 numeric aliases are accepted as "equivalent" here
+ *     (e.g. mEq/L ↔ mmol/L for monovalent ions like K+, Na+, Cl−).
+ *   - Anything that requires molar-mass conversion (mg/dL ↔ mmol/L for
+ *     glucose, creatinine, etc.) must NOT be aliased — that's a real
+ *     conversion and a separate implementation.
+ *   - Unknown / empty units fail closed: the helper returns undefined and
+ *     emits a structured warn so the observability pipeline surfaces the
+ *     gap.
+ */
+
+import { createLogger } from "@carebridge/logger";
+import type { PatientContext } from "./cross-specialty.js";
+
+const logger = createLogger("ai-oversight");
+
+/** A recent_labs entry with a non-optional unit string. */
+export interface RecentLab {
+  name: string;
+  value: number;
+  /** Unit string as recorded in the EHR; empty string means unknown. */
+  unit: string;
+}
+
+/**
+ * Canonical / accepted units for individual analytes that rules compare
+ * against threshold values. Kept deliberately small — adding an entry here
+ * is a clinical safety decision that should be reviewed per-analyte.
+ *
+ * Keys are lower-cased, trimmed unit strings. Presence in the set means
+ * "numerically equivalent to the canonical unit for this analyte".
+ */
+const POTASSIUM_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
+  "meq/l",
+  "mmol/l",
+]);
+
+const SODIUM_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
+  "meq/l",
+  "mmol/l",
+]);
+
+const CHLORIDE_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
+  "meq/l",
+  "mmol/l",
+]);
+
+/**
+ * eGFR is reported as mL/min/1.73m² in the U.S. and often written with
+ * various spacing / encoding variants. All listed values are numerically
+ * equivalent — we only tolerate formatting variance, not a real unit
+ * mismatch.
+ */
+const EGFR_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
+  "ml/min/1.73m2",
+  "ml/min/1.73m²",
+  "ml/min/1.73 m2",
+  "ml/min/1.73 m²",
+  "ml/min",
+]);
+
+/** Normalize a unit string for set-lookup: trim, lowercase. */
+function normalizeUnit(unit: string): string {
+  return unit.trim().toLowerCase();
+}
+
+/**
+ * Find the most-recent lab in `ctx.recent_labs` whose name matches
+ * `namePattern` AND whose unit is in `acceptedUnits`. Returns undefined
+ * when no such lab is present.
+ *
+ * Labs with an unknown or mismatched unit are skipped with a structured
+ * warn, so the gap is observable in logs/metrics without silently
+ * comparing wrong-unit values.
+ *
+ * @param ctx           The rule-level patient context.
+ * @param namePattern   Regex matched case-insensitively against the lab name.
+ * @param acceptedUnits Set of lower-cased, trimmed unit strings that are
+ *                      numerically equivalent for this analyte.
+ * @param analyte       Short analyte tag for log correlation (e.g. "K+").
+ */
+export function findRecentLab(
+  ctx: PatientContext,
+  namePattern: RegExp,
+  acceptedUnits: ReadonlySet<string>,
+  analyte: string,
+): RecentLab | undefined {
+  const labs = ctx.recent_labs;
+  if (!labs || labs.length === 0) return undefined;
+
+  for (const lab of labs) {
+    if (!namePattern.test(lab.name.trim())) continue;
+    const normalized = normalizeUnit(lab.unit);
+    if (normalized === "") {
+      logger.warn("rule_lab_unit_missing", {
+        metric: "rule_lab_unit_missing",
+        analyte,
+        lab_name: lab.name,
+        caller: "rules:findRecentLab",
+      });
+      continue;
+    }
+    if (!acceptedUnits.has(normalized)) {
+      logger.warn("rule_lab_unit_mismatch", {
+        metric: "rule_lab_unit_mismatch",
+        analyte,
+        lab_name: lab.name,
+        lab_unit: lab.unit,
+        accepted_units: Array.from(acceptedUnits),
+        caller: "rules:findRecentLab",
+      });
+      continue;
+    }
+    return { name: lab.name, value: lab.value, unit: lab.unit };
+  }
+  return undefined;
+}
+
+/**
+ * Find the most-recent potassium (K+) value in recent_labs where the unit
+ * is numerically equivalent to mEq/L. For monovalent ions, mEq/L and
+ * mmol/L are 1:1 equivalent and both are accepted.
+ *
+ * Returns undefined when no K+ result is present, the unit is missing, or
+ * the unit is not in the accepted list (e.g. mg/dL — nonsensical for K+
+ * and almost certainly a data-entry or import error).
+ */
+export function getRecentPotassium(ctx: PatientContext): RecentLab | undefined {
+  // Name match: "Potassium", "K", or "K+". Anchored so we don't match
+  // unrelated labs that merely contain "K".
+  const NAME = /^(potassium|k\+?)$/i;
+  return findRecentLab(ctx, NAME, POTASSIUM_ACCEPTED_UNITS, "K+");
+}
+
+/**
+ * Find the most-recent sodium (Na+) value with accepted unit.
+ */
+export function getRecentSodium(ctx: PatientContext): RecentLab | undefined {
+  const NAME = /^(sodium|na\+?)$/i;
+  return findRecentLab(ctx, NAME, SODIUM_ACCEPTED_UNITS, "Na+");
+}
+
+/**
+ * Find the most-recent chloride (Cl−) value with accepted unit.
+ */
+export function getRecentChloride(ctx: PatientContext): RecentLab | undefined {
+  const NAME = /^(chloride|cl-?)$/i;
+  return findRecentLab(ctx, NAME, CHLORIDE_ACCEPTED_UNITS, "Cl-");
+}
+
+/**
+ * Find the most-recent eGFR value with accepted unit (mL/min/1.73m² or
+ * tolerant variants). mL/min is also accepted as a tolerant fallback used
+ * by some reporting systems.
+ */
+export function getRecentEGFR(ctx: PatientContext): RecentLab | undefined {
+  const NAME = /^(egfr|estimated gfr|gfr)$/i;
+  return findRecentLab(ctx, NAME, EGFR_ACCEPTED_UNITS, "eGFR");
+}

--- a/services/ai-oversight/src/rules/lab-units.ts
+++ b/services/ai-oversight/src/rules/lab-units.ts
@@ -58,17 +58,25 @@ const CHLORIDE_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * eGFR is reported as mL/min/1.73m² in the U.S. and often written with
- * various spacing / encoding variants. All listed values are numerically
- * equivalent — we only tolerate formatting variance, not a real unit
- * mismatch.
+ * eGFR is reported as mL/min/1.73m² (BSA-indexed MDRD / CKD-EPI) in the
+ * U.S. and often written with various spacing / encoding variants. All
+ * listed values are the BSA-indexed estimated GFR — only formatting
+ * variance is tolerated here.
+ *
+ * Raw "mL/min" (unindexed Cockcroft-Gault creatinine clearance) is
+ * DELIBERATELY NOT accepted: it is not numerically equivalent to the
+ * BSA-indexed value used by the FDA metformin contraindication threshold
+ * (<30 mL/min/1.73m²) and can diverge 20–30% in non-average-BSA patients.
+ * Aliasing the two would defeat the whole point of the unit-check
+ * infrastructure for CROSS-METFORMIN-GFR-001. Labs recorded as raw
+ * "mL/min" must fail closed (rule_lab_unit_mismatch) so the gap is
+ * surfaced rather than silently compared.
  */
 const EGFR_ACCEPTED_UNITS: ReadonlySet<string> = new Set([
   "ml/min/1.73m2",
   "ml/min/1.73m²",
   "ml/min/1.73 m2",
   "ml/min/1.73 m²",
-  "ml/min",
 ]);
 
 /** Normalize a unit string for set-lookup: trim, lowercase. */
@@ -161,9 +169,10 @@ export function getRecentChloride(ctx: PatientContext): RecentLab | undefined {
 }
 
 /**
- * Find the most-recent eGFR value with accepted unit (mL/min/1.73m² or
- * tolerant variants). mL/min is also accepted as a tolerant fallback used
- * by some reporting systems.
+ * Find the most-recent eGFR value with accepted unit (BSA-indexed
+ * mL/min/1.73m² or spacing/encoding-tolerant variants). Raw "mL/min"
+ * (unindexed Cockcroft-Gault CrCl) is NOT accepted — see
+ * EGFR_ACCEPTED_UNITS for rationale.
  */
 export function getRecentEGFR(ctx: PatientContext): RecentLab | undefined {
   const NAME = /^(egfr|estimated gfr|gfr)$/i;

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -635,11 +635,14 @@ export async function buildPatientContextForRules(
         ),
       ),
     // Join lab_results → lab_panels → filter by patient, freshness, and
-    // event-time upper bound (#514).
+    // event-time upper bound (#514). The `unit` column (#856) is selected
+    // so unit-aware rule helpers can verify threshold comparisons are
+    // against the canonical unit for each analyte.
     db
       .select({
         test_name: labResults.test_name,
         value: labResults.value,
+        unit: labResults.unit,
         created_at: labResults.created_at,
         flag: labResults.flag,
       })
@@ -688,14 +691,28 @@ export async function buildPatientContextForRules(
   // labRows are ordered desc by created_at, so the first occurrence wins.
   // SQL already filters by event-time upper bound and lab window (#514);
   // the retraction and future-lab checks remain as in-memory backstops.
+  //
+  // The `unit` field (#856) is forwarded as-is so rules can perform
+  // unit-aware threshold comparisons. Rows missing a unit degrade to an
+  // empty string with a structured warn — unit-aware helpers then treat
+  // the lab as unknown rather than silently comparing wrong-unit values.
   const seenLabs = new Set<string>();
-  const recentLabs: Array<{ name: string; value: number }> = [];
+  const recentLabs: Array<{ name: string; value: number; unit: string }> = [];
   for (const row of recentLabRows) {
     if (isLabRetracted(row)) continue;
     if (isoBefore(eventAt, row.created_at)) continue;
     if (seenLabs.has(row.test_name)) continue;
+    const unit = (row.unit ?? "").trim();
+    if (unit === "") {
+      logger.warn("lab_result_unit_missing", {
+        metric: "lab_result_unit_missing",
+        patient_id_prefix: patientId.slice(0, 8),
+        test_name: row.test_name,
+        caller: "review-service:buildPatientContextForRules",
+      });
+    }
     seenLabs.add(row.test_name);
-    recentLabs.push({ name: row.test_name, value: row.value });
+    recentLabs.push({ name: row.test_name, value: row.value, unit });
   }
 
   // A medication was "active at event time" if it had started (started_at


### PR DESCRIPTION
## Summary

Extend the rule-level `PatientContext.recent_labs` shape to include a required `unit: string` field (issue #856) and add defensive unit-aware lab accessors so threshold-based rules cannot silently compare wrong-unit values.

## Why

For potassium (CROSS-QT-HYPOK-001) the current rule code compares a raw `value` against `< 3.5` — safe as long as the recorded unit is `mEq/L` or `mmol/L`, since those are 1:1 equivalent for monovalent ions. But an EHR import or data-entry error that puts `K+ 3.2 mg/dL` into `lab_results.value` would still trip the rule. For analytes like glucose or creatinine, where `mg/dL <-> mmol/L` requires molar-mass conversion, the risk is worse. This PR closes that gap at the shape level.

## Changes

- **`PatientContext.recent_labs`** — each entry now carries `unit: string`. Empty string denotes "unknown" (source row had null unit).
- **`buildPatientContextForRules`** — selects `lab_results.unit`, forwards it to the rule context, emits `lab_result_unit_missing` warn for rows with a null/empty unit.
- **`rules/lab-units.ts`** (new) — `findRecentLab(ctx, namePattern, acceptedUnits, analyte)` plus analyte-specific helpers `getRecentPotassium`, `getRecentSodium`, `getRecentChloride`, `getRecentEGFR`. Mismatched / missing units fail closed and log a structured warn.
- **All K+ / eGFR threshold rules migrated** to the unit-aware helpers. Previously only CROSS-QT-HYPOK-001 was in scope; merging main (which introduced #861's CROSS-THIAZIDE-HYPOK-001 and CROSS-METFORMIN-GFR-001) extends coverage to:
  - `CROSS-QT-HYPOK-001` (K+)
  - `CROSS-THIAZIDE-HYPOK-001` (K+)
  - `CROSS-METFORMIN-GFR-001` (eGFR)
  The local `getRecentPotassium` / `getRecentEGFR` helpers introduced by #861 in `cross-specialty.ts` are removed; both callers now import from `./lab-units.js`.

### Normalization policy

Conservative — only 1:1 numeric aliases are listed as "equivalent":

- Potassium / sodium / chloride: `mEq/L` and `mmol/L` (monovalent ions).
- eGFR: `mL/min/1.73m²` and tolerant spacing/encoding variants.

Anything requiring molar-mass conversion (mg/dL <-> mmol/L for organic compounds) is intentionally NOT aliased — that would be a real conversion and belongs in a separate, well-tested module. Filed as a follow-up only if a threshold rule ever needs it.

## Test plan

- [x] TDD — failing tests written first for:
  - `CROSS-QT-HYPOK-001` with K+ in `mEq/L`, `mmol/L`, `mg/dL`, empty string, case/whitespace variants.
  - `buildPatientContextForRules` passes `unit` through the shape and maps null -> empty string.
  - Direct helper coverage in `lab-units.test.ts` (17 cases).
- [x] #861 rule tests (`CROSS-THIAZIDE-HYPOK-001`, `CROSS-METFORMIN-GFR-001`) migrated to supply `unit: "mEq/L"` / `unit: "mL/min/1.73m²"` in recent_labs fixtures after the merge.
- [x] `pnpm --filter @carebridge/ai-oversight test` — 28 files / 674 tests pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (pre-existing clinician-portal warnings unrelated).

Closes #856