### PR TITLE
refactor(gateway): drop lingering as User["role"] cast in audit-actor-context test

### DIFF
--- a/services/api-gateway/src/__tests__/audit-actor-context.test.ts
+++ b/services/api-gateway/src/__tests__/audit-actor-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { User } from "@carebridge/shared-types";
+import type { User, UserRole } from "@carebridge/shared-types";
 
 // ---------------------------------------------------------------------------
 // Mocks — covers @carebridge/db-schema and drizzle-orm so deriveActorContext
@@ -50,7 +50,7 @@ import { deriveActorContext, getFamilyRelationshipType } from "../middleware/aud
 // ---------------------------------------------------------------------------
 
 function makeUser(
-  role: string,
+  role: UserRole,
   id = "user-1",
   patient_id?: string,
 ): User {
@@ -58,7 +58,7 @@ function makeUser(
     id,
     email: `${role}@carebridge.dev`,
     name: `Test ${role}`,
-    role: role as User["role"],
+    role,
     is_active: true,
     patient_id,
     created_at: "2026-01-01T00:00:00.000Z",
@@ -113,7 +113,7 @@ describe("deriveActorContext", () => {
   });
 
   it("returns null for clinicians (physician, nurse, specialist)", async () => {
-    for (const role of ["physician", "nurse", "specialist"]) {
+    for (const role of ["physician", "nurse", "specialist"] as const) {
       expect(
         await deriveActorContext(makeUser(role), "pat-1"),
       ).toEqual({ actorRelationship: null, onBehalfOfPatientId: null });


### PR DESCRIPTION
## Summary
Wave 3 PR #862 (family_caregiver support) cleaned `as User["role"]` casts across test files but missed one in `services/api-gateway/src/__tests__/audit-actor-context.test.ts`. The `makeUser()` helper still typed its `role` parameter as `string` and cast with `role as User["role"]`. Since `family_caregiver` is now a first-class member of the `UserRole` union, the cast is unnecessary.

## Changes
- Import `UserRole` from `@carebridge/shared-types` alongside `User`.
- Change `makeUser()` `role` param type from `string` to `UserRole`.
- Drop the `as User["role"]` cast — `role` is now assignable directly.
- Add `as const` to the clinician-role loop array so element inference narrows to `UserRole`.

## Test plan
- [x] `pnpm --filter @carebridge/api-gateway exec vitest run src/__tests__/audit-actor-context.test.ts` — 12/12 pass
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (only unrelated pre-existing warnings)

Closes #868