### PR TITLE
feat(ai): escalate info-severity unevaluable labs with numerically extreme values

### DIFF
--- a/services/ai-oversight/src/__tests__/critical-values.test.ts
+++ b/services/ai-oversight/src/__tests__/critical-values.test.ts
@@ -1068,3 +1068,125 @@ describe("checkCriticalValues — no-flag/no-range gap (issue #835)", () => {
     expect(flags).toHaveLength(0);
   });
 });
+
+// ─── Numerically-extreme-value escalation (issue #867) ─────────────
+// PR #860 introduced the info-severity unevaluated fallback (issue #835)
+// for labs with no flag, no reference range, and no COMMON_LAB_TESTS
+// entry. The reviewer on that PR raised #867: when the value itself is
+// numerically extreme (e.g., 99999 or 0.001 for any analyte), info is
+// plausibly under-alerting — the magnitude is suggestive of abnormality
+// even though we cannot map the result to a threshold.
+//
+// Escalation window: values with abs() > 10000 or abs() < 0.01 (including
+// zero and negatives) escalate from info to warning. These are coarse
+// signal-over-noise hints to catch data-entry errors (misordered
+// magnitudes, decimal misplacement, sign-flipped values); they are NOT
+// clinical thresholds, and the rule does NOT escalate to critical
+// because no analyte-specific judgement is justified without a
+// reference.
+describe("checkCriticalValues — extreme-value escalation on unevaluated fallback (issue #867)", () => {
+  beforeEach(() => {
+    mockWarn.mockClear();
+  });
+
+  it("escalates to warning when an unevaluable lab has a very large positive value (>10000)", () => {
+    // Hypothetical scenario from issue #867: "Potassium Levl" (typo) with
+    // value 99999 slips past canonical matching. Today this emits info;
+    // issue #867 escalates to warning because 99999 is physiologically
+    // implausible for essentially any analyte.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Obscure Marker Y", value: 99999, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.rule_id).toBe("WARNING-LAB-UNEVALUATED-OBSCURE_MARKER_Y");
+    expect(flags[0]!.summary).toContain("Obscure Marker Y");
+    expect(flags[0]!.summary).toContain("99999");
+  });
+
+  it("escalates to warning when an unevaluable lab has a very small positive value (<0.01)", () => {
+    // Decimal-misplacement scenario: 0.001 instead of 1.0. Escalates to
+    // warning so the result surfaces as clinician-review-worthy.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Obscure Marker Z", value: 0.001, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.rule_id).toBe("WARNING-LAB-UNEVALUATED-OBSCURE_MARKER_Z");
+  });
+
+  it("escalates to warning when an unevaluable lab has a negative value", () => {
+    // Negative values are almost always data errors for concentration/
+    // count analytes. Escalate conservatively to warning (not critical —
+    // the signal is "this is bad data" not "this is a clinical emergency").
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Obscure Marker N", value: -5, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("warning");
+    expect(flags[0]!.rule_id).toBe("WARNING-LAB-UNEVALUATED-OBSCURE_MARKER_N");
+  });
+
+  it("stays info-severity when an unevaluable lab has an ordinary magnitude (in [0.01, 10000])", () => {
+    // Baseline case: value 10.5 is within the "any-analyte-plausible"
+    // window. We genuinely do not know if it is abnormal — stay info.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Obscure Marker M", value: 10.5, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("info");
+    expect(flags[0]!.rule_id).toBe("INFO-LAB-UNEVALUATED-OBSCURE_MARKER_M");
+  });
+
+  it("preserves the lab_unevaluated_total logger warn and metric shape for escalated flags", () => {
+    // The escalation is additive — the structured observability event
+    // MUST still fire with the same event name and metric field so
+    // downstream aggregation stays consistent across info and warning
+    // escalations.
+    checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Extreme Analyte", value: 50000, unit: "U/L" },
+      ]),
+    );
+    const call = mockWarn.mock.calls.find(
+      ([msg]) => msg === "lab_unevaluated_total",
+    );
+    expect(call).toBeDefined();
+    const meta = call![1] as Record<string, unknown>;
+    expect(meta.metric).toBe("lab_unevaluated_total");
+    expect(meta.test_name).toBe("Extreme Analyte");
+    expect(meta.value).toBe(50000);
+    expect(meta.unit).toBe("U/L");
+  });
+
+  it("keeps value exactly at 10000 as info (inclusive upper bound stays evaluable)", () => {
+    // Boundary: the escalation window is strictly outside [0.01, 10000].
+    // value === 10000 is the boundary and remains info.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Boundary Marker A", value: 10000, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("info");
+  });
+
+  it("keeps value exactly at 0.01 as info (inclusive lower bound stays evaluable)", () => {
+    // Boundary: value === 0.01 remains info.
+    const flags = checkCriticalValues(
+      makeLabEvent([
+        { test_name: "Boundary Marker B", value: 0.01, unit: "U/L" },
+      ]),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.severity).toBe("info");
+  });
+});

--- a/services/ai-oversight/src/rules/critical-values.ts
+++ b/services/ai-oversight/src/rules/critical-values.ts
@@ -366,6 +366,43 @@ function buildLabRuleId(severity: FlagSeverity, ruleKey: string): string {
 }
 
 /**
+ * Coarse "any-analyte-implausible" numeric sanity window for the issue
+ * #835 unevaluated-lab fallback.
+ *
+ * Issue #867 (reviewer follow-up on PR #860): when the unevaluable
+ * fallback fires, the info-severity default is plausibly under-alerting
+ * for values whose magnitude alone suggests data corruption or a
+ * decimal / sign / unit error. Without a reference range or canonical
+ * mapping we cannot claim a clinical threshold, but we CAN observe that
+ * common human-scale analyte results almost never fall outside
+ * (0.01, 10000) in their own units. Values outside that window are much
+ * more likely to be clinician-review-worthy than values inside it.
+ *
+ * Chosen thresholds (signal-over-noise hints, NOT clinical thresholds):
+ *   - value > 10000  → extreme magnitude (misordered units / order-of-
+ *     magnitude error). Most physiological analytes rarely exceed a few
+ *     thousand in their reported units.
+ *   - value < 0.01   → near-zero or sub-thresholdable (decimal misplacement
+ *     or lost precision). For positive analytes this usually means the
+ *     reading is either missing or encoded with the wrong multiplier.
+ *   - value < 0      → negative concentrations / counts are almost always
+ *     data errors; captured by `value < 0.01` above (negatives satisfy
+ *     the same predicate).
+ *
+ * Escalation stays at `warning` (not `critical`) because the signal is
+ * magnitude-based, not analyte-specific: `critical` requires a clinical
+ * claim we cannot make without a reference. The escalation is additive —
+ * the base case (value in the window) continues to emit info.
+ */
+const EXTREME_VALUE_HIGH = 10000;
+const EXTREME_VALUE_LOW = 0.01;
+
+function isExtremeNumericValue(value: number): boolean {
+  if (!Number.isFinite(value)) return false;
+  return value > EXTREME_VALUE_HIGH || value < EXTREME_VALUE_LOW;
+}
+
+/**
  * Infer the direction ("low" | "high") of a laboratory-flagged critical
  * result when the lab itself did not encode direction in the flag string.
  *
@@ -775,24 +812,41 @@ export function checkCriticalValues(event: ClinicalEvent): RuleFlag[] {
                 unit: result.unit,
               });
 
+              // Issue #867: escalate info → warning when the raw magnitude
+              // of the value is outside the coarse any-analyte-plausible
+              // window. See `isExtremeNumericValue` for rationale and
+              // threshold choice. This is additive — values in the window
+              // continue to emit info as introduced by PR #860.
+              const escalate = isExtremeNumericValue(result.value);
+              const severity: FlagSeverity = escalate ? "warning" : "info";
+              const rationale = escalate
+                ? `Lab result for "${result.test_name}" arrived with no lab-provided ` +
+                  `flag, no reference range, and no entry in COMMON_LAB_TESTS. The ` +
+                  `deterministic rule layer cannot map the value to an analyte-specific ` +
+                  `threshold, but the raw magnitude (${result.value} ${result.unit}) ` +
+                  `falls outside the coarse any-analyte-plausible window ` +
+                  `(${EXTREME_VALUE_LOW}–${EXTREME_VALUE_HIGH}). Escalating to warning ` +
+                  `as a signal-over-noise hint: values of this magnitude usually ` +
+                  `indicate a data-entry or unit/decimal error worth clinician review.`
+                : `Lab result for "${result.test_name}" arrived with no lab-provided ` +
+                  `flag, no reference range, and no entry in COMMON_LAB_TESTS. The ` +
+                  `deterministic rule layer cannot assess the value against a threshold; ` +
+                  `surfacing as an info signal so LLM review and clinicians have visibility.`;
+
               flags.push({
-                severity: "info",
+                severity,
                 category: "critical-value",
                 summary:
                   `Lab result not evaluable by deterministic rules: ` +
                   `${result.test_name} = ${result.value} ${result.unit}`,
-                rationale:
-                  `Lab result for "${result.test_name}" arrived with no lab-provided ` +
-                  `flag, no reference range, and no entry in COMMON_LAB_TESTS. The ` +
-                  `deterministic rule layer cannot assess the value against a threshold; ` +
-                  `surfacing as an info signal so LLM review and clinicians have visibility.`,
+                rationale,
                 suggested_action:
                   `Clinician review recommended. Verify test name mapping and reference ` +
                   `range metadata with the sending laboratory. Consider adding this test ` +
                   `to COMMON_LAB_TESTS or CRITICAL_LAB_THRESHOLDS if clinically relevant.`,
                 notify_specialties: [],
                 rule_id: buildLabRuleId(
-                  "info",
+                  severity,
                   `UNEVALUATED-${result.test_name.replace(/\s+/g, "_").toUpperCase()}`,
                 ),
               });


### PR DESCRIPTION
## Summary

PR #860 introduced the info-severity "unable-to-evaluate" fallback (issue #835) for labs with no flag, no reference range, and no entry in `COMMON_LAB_TESTS`. The reviewer raised issue #867: when the value itself is numerically extreme (e.g., 99999 or 0.001 for any analyte), `info` is plausibly under-alerting — the raw magnitude alone suggests data corruption, a decimal/unit error, or a genuine out-of-range reading worth clinician review.

This PR adds a coarse magnitude-based escalation so extreme unevaluable values surface at `warning` instead of `info`.

## Chosen thresholds (signal-over-noise hints, NOT clinical thresholds)

| Condition | Severity | Rationale |
| --- | --- | --- |
| `value > 10000` | `warning` | Extreme magnitude; covers misordered units / order-of-magnitude errors. Most physiological analytes rarely exceed a few thousand in their reported units. |
| `value < 0.01` (includes negatives and zero) | `warning` | Near-zero or sub-thresholdable; covers decimal misplacement and lost precision. Negatives are almost always data errors for concentration/count analytes, so the same predicate covers them. |
| `value` in `[0.01, 10000]` | `info` (unchanged) | Genuinely unevaluable; base case from PR #860. |

**Why not `critical`?** Magnitude alone does not justify an analyte-specific clinical claim without a reference. `warning` is the ceiling here.

**Why not analyte-specific?** That is what `CRITICAL_LAB_THRESHOLDS` is for. This escalation is strictly a magnitude heuristic for the unevaluable branch.

The escalation is **additive**: values in the plausible window continue to emit `info` exactly as introduced by PR #860.

## Changes

- `services/ai-oversight/src/rules/critical-values.ts`
  - Added `isExtremeNumericValue(value)` helper with `EXTREME_VALUE_HIGH` (10000) / `EXTREME_VALUE_LOW` (0.01) constants and a docstring explaining the chosen thresholds and why escalation stays at `warning`.
  - Unevaluated-fallback emission site now branches severity on the helper and threads `severity` through `buildLabRuleId`, so the rule_id prefix flips `INFO-LAB-UNEVALUATED-*` → `WARNING-LAB-UNEVALUATED-*` in lockstep with the severity (consistent with #836 harmonization landed in #869).
  - Rationale text now explains the magnitude escalation when it fires; the plain "info" rationale is unchanged for the in-window case.
  - `logger.warn("lab_unevaluated_total", ...)` event name and metric shape are unchanged (#863 rename preserved). Observability is additive.
- `services/ai-oversight/src/__tests__/critical-values.test.ts`
  - New `describe` block "extreme-value escalation on unevaluated fallback (issue #867)" with 7 tests:
    - value 99999 → warning, `WARNING-LAB-UNEVALUATED-OBSCURE_MARKER_Y`.
    - value 0.001 → warning.
    - value -5 → warning (negative is data error; captured by `value < 0.01`).
    - value 10.5 → info (baseline unchanged).
    - Escalated flag still emits `lab_unevaluated_total` logger warn with the correct metric / test_name / value / unit fields.
    - Boundary cases `value === 10000` and `value === 0.01` remain info (strict inequality in the predicate).

## Non-goals (explicitly out of scope)

- No changes to `CRITICAL_LAB_THRESHOLDS` numeric values.
- No changes to HL7v2 flag handling (`HH` / `LL` → critical, `H` / `L` → warning).
- No changes to per-result reference range handling.
- No changes to the explicit-threshold path (#836 `buildLabRuleId` harmonization from #869 is preserved).
- No escalation to `critical`.
- No analyte-specific escalation.
- No change to the `logger.warn` event name (#863 has already landed the rename).

## Test plan

- [x] `pnpm --filter @carebridge/ai-oversight test` — 690 passed, 0 failed (+7 new tests for #867).
- [x] `pnpm typecheck` — green.
- [x] `pnpm lint` — green (pre-existing portal warnings unrelated to this change).
- [x] TDD — wrote failing tests first, confirmed 3 expected-escalation tests failed with `info`, then implemented and verified all 7 new tests pass.

Closes #867