### PR TITLE
feat(ai): de-duplicate CROSS-QT-HYPOK flag when CRITICAL-LAB-POTASSIUM already fires

### DIFF
--- a/services/ai-oversight/src/__tests__/consolidate-rule-flags.test.ts
+++ b/services/ai-oversight/src/__tests__/consolidate-rule-flags.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for flag consolidation — specifically the narrow case where
+ * CRITICAL-LAB-POTASSIUM and CROSS-QT-HYPOK-001 both fire for the same
+ * underlying severe-hypokalemia signal. See issue #854.
+ *
+ * Policy: when both flags fire in the same review pass, suppress the
+ * CRITICAL-LAB-POTASSIUM flag. The cross-specialty flag is strictly more
+ * actionable because it names the QT-prolonging drug, and the two flags
+ * point clinicians at the same physiologic concern (hypokalemia → torsades /
+ * arrhythmia risk).
+ *
+ * Safety floor (non-goals, enforced by these tests):
+ *   - Do not suppress CRITICAL-LAB-POTASSIUM when firing alone.
+ *   - Do not suppress any other CRITICAL-LAB-* analyte.
+ *   - Do not suppress hyperkalemia critical flags (they share the
+ *     CRITICAL-LAB-POTASSIUM rule_id but describe a different mechanism;
+ *     QT-HYPOK cannot co-fire with a hyperkalemia flag, so we rely on
+ *     the rule source: only drop when CROSS-QT-HYPOK-001 is present).
+ */
+
+import { describe, it, expect } from "vitest";
+import type { RuleFlag } from "@carebridge/shared-types";
+import { consolidateRuleFlags } from "../services/review-service.js";
+
+function ruleFlag(overrides: Partial<RuleFlag> = {}): RuleFlag {
+  return {
+    rule_id: "TEST-RULE-001",
+    severity: "warning",
+    category: "cross-specialty",
+    summary: "test flag",
+    rationale: "",
+    suggested_action: "",
+    notify_specialties: [],
+    ...overrides,
+  };
+}
+
+function criticalPotassium(severity: RuleFlag["severity"] = "critical"): RuleFlag {
+  return ruleFlag({
+    rule_id: "CRITICAL-LAB-POTASSIUM",
+    severity,
+    category: "critical-value",
+    summary: "Critical hypokalemia: Potassium 2.8 mEq/L (<3.0 — cardiac arrest risk)",
+    notify_specialties: ["nephrology", "cardiology"],
+  });
+}
+
+function qtHypoK(severity: RuleFlag["severity"] = "critical"): RuleFlag {
+  return ruleFlag({
+    rule_id: "CROSS-QT-HYPOK-001",
+    severity,
+    category: "cross-specialty",
+    summary:
+      "Patient on QT-prolonging medication with hypokalemia (K+ < 3.5) — elevated risk of torsades de pointes",
+    notify_specialties: ["cardiology"],
+  });
+}
+
+describe("consolidateRuleFlags — CRITICAL-LAB-POTASSIUM / CROSS-QT-HYPOK-001 dedup (#854)", () => {
+  it("suppresses CRITICAL-LAB-POTASSIUM when CROSS-QT-HYPOK-001 also fires", () => {
+    // Patient with K+ 2.8 on ondansetron: both rules fire. Emit only the
+    // cross-specialty flag — it's more actionable (names the QT drug).
+    const flags = [criticalPotassium("critical"), qtHypoK("critical")];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.rule_id).toBe("CROSS-QT-HYPOK-001");
+  });
+
+  it("preserves CROSS-QT-HYPOK-001 ordering-independent: suppression works regardless of input order", () => {
+    const flags = [qtHypoK("critical"), criticalPotassium("critical")];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.rule_id).toBe("CROSS-QT-HYPOK-001");
+  });
+
+  it("preserves critical severity on the surviving CROSS-QT-HYPOK-001 flag", () => {
+    // When K+ < 3.0, CROSS-QT-HYPOK-001 escalates to critical on its own.
+    // The consolidated output must keep that critical severity — we must
+    // not lose the severity signal when suppressing the other flag.
+    const flags = [criticalPotassium("critical"), qtHypoK("critical")];
+    const out = consolidateRuleFlags(flags);
+    expect(out[0]!.severity).toBe("critical");
+  });
+
+  it("keeps CRITICAL-LAB-POTASSIUM when CROSS-QT-HYPOK-001 does NOT fire", () => {
+    // Patient with K+ 2.8, no QT drug: only CRITICAL-LAB-POTASSIUM fires.
+    // It must NOT be suppressed — that would silence a critical value.
+    const flags = [criticalPotassium("critical")];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.rule_id).toBe("CRITICAL-LAB-POTASSIUM");
+  });
+
+  it("is a no-op when CROSS-QT-HYPOK-001 fires alone (warning K+ 3.0-3.4)", () => {
+    // Patient with K+ 3.2 on ondansetron: only CROSS-QT-HYPOK-001 fires
+    // (K+ is not below the critical-values threshold of 3.0).
+    // CRITICAL-LAB-POTASSIUM isn't in the batch, so nothing to suppress.
+    const flags = [qtHypoK("warning")];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.rule_id).toBe("CROSS-QT-HYPOK-001");
+    expect(out[0]!.severity).toBe("warning");
+  });
+
+  it("preserves unrelated flags in the same batch", () => {
+    // Consolidation must be narrow. Other concurrent flags (drug-interactions,
+    // cross-specialty, etc.) must pass through untouched.
+    const unrelated = ruleFlag({
+      rule_id: "ONCO-VTE-NEURO-001",
+      category: "cross-specialty",
+      summary: "Cancer + VTE + new neuro symptom — stroke risk",
+    });
+    const flags = [criticalPotassium("critical"), qtHypoK("critical"), unrelated];
+    const out = consolidateRuleFlags(flags);
+    expect(out.map((f) => f.rule_id).sort()).toEqual(
+      ["CROSS-QT-HYPOK-001", "ONCO-VTE-NEURO-001"].sort(),
+    );
+  });
+
+  it("does NOT suppress other CRITICAL-LAB-* analytes when CROSS-QT-HYPOK-001 fires", () => {
+    // The suppression is specific to potassium. A critical troponin that
+    // happens to appear alongside a QT-HYPOK flag must still be emitted —
+    // they describe unrelated signals.
+    const troponin = ruleFlag({
+      rule_id: "CRITICAL-LAB-TROPONIN_I",
+      severity: "critical",
+      category: "critical-value",
+      summary: "Critical Troponin I: 0.8 ng/mL",
+    });
+    const flags = [troponin, qtHypoK("critical")];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.rule_id).sort()).toEqual(
+      ["CRITICAL-LAB-TROPONIN_I", "CROSS-QT-HYPOK-001"].sort(),
+    );
+  });
+
+  it("returns an empty array untouched", () => {
+    expect(consolidateRuleFlags([])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const flags = [criticalPotassium("critical"), qtHypoK("critical")];
+    const snapshot = flags.map((f) => ({ ...f }));
+    consolidateRuleFlags(flags);
+    expect(flags).toEqual(snapshot);
+  });
+
+  it("suppresses all CRITICAL-LAB-POTASSIUM duplicates when QT-HYPOK fires (defense in depth)", () => {
+    // Unlikely in practice — the rule only fires once per review pass —
+    // but the consolidation must not leave one behind if the upstream
+    // layer somehow emits two.
+    const flags = [
+      criticalPotassium("critical"),
+      criticalPotassium("critical"),
+      qtHypoK("critical"),
+    ];
+    const out = consolidateRuleFlags(flags);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.rule_id).toBe("CROSS-QT-HYPOK-001");
+  });
+});

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -263,6 +263,19 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
       }
     }
 
+    // Step 2z: Consolidate rule flags (#854)
+    //
+    // Narrow dedup: when CRITICAL-LAB-POTASSIUM and CROSS-QT-HYPOK-001 both
+    // fire for the same patient+review, suppress the critical-value flag in
+    // favor of the cross-specialty flag. Both describe the same underlying
+    // signal (severe hypokalemia → arrhythmia risk); the cross-specialty flag
+    // is strictly more actionable because it names the QT-prolonging drug.
+    // `allRuleFlags` is replaced with the consolidated list so downstream
+    // persistence, audit, and LLM-dedup all operate on the deduped set.
+    const consolidatedRuleFlags = consolidateRuleFlags(allRuleFlags);
+    allRuleFlags.length = 0;
+    allRuleFlags.push(...consolidatedRuleFlags);
+
     // Step 3: Create flags for rule matches
     for (const ruleFlag of allRuleFlags) {
       const flag = await createFlag({
@@ -876,6 +889,42 @@ function summaryOverlap(a: string, b: string): number {
   for (const w of setA) if (setB.has(w)) shared++;
   const union = new Set([...setA, ...setB]).size;
   return shared / union;
+}
+
+/**
+ * Consolidate the rule-flag array produced by the deterministic-rules step
+ * before it is persisted and fed to the LLM-dedup check. Applies narrow,
+ * clinically-motivated suppressions for flag pairs that describe the same
+ * underlying signal.
+ *
+ * Current policy (issue #854):
+ *   - If both `CRITICAL-LAB-POTASSIUM` and `CROSS-QT-HYPOK-001` fire in the
+ *     same pass, drop `CRITICAL-LAB-POTASSIUM`. The cross-specialty flag is
+ *     strictly more actionable because it names the QT-prolonging drug, and
+ *     both flags point clinicians at the same physiologic concern (severe
+ *     hypokalemia → torsades / arrhythmia risk). Severity on the surviving
+ *     flag is preserved as-is — CROSS-QT-HYPOK-001 already escalates to
+ *     `critical` when K+ < 3.0 (see cross-specialty.ts), so no info is lost.
+ *
+ * Safety posture:
+ *   - The dedup is keyed on rule_id pairs — no generic severity/category
+ *     suppression. This is deliberate: under-alerting on a critical lab is
+ *     far worse than minor UI duplication.
+ *   - When QT-HYPOK does NOT fire, CRITICAL-LAB-POTASSIUM passes through
+ *     unchanged (including hyperkalemia which never co-fires with QT-HYPOK).
+ *   - Unrelated flags in the same batch are untouched.
+ *   - Input is not mutated.
+ *
+ * Exported for unit testing.
+ */
+export function consolidateRuleFlags(flags: readonly RuleFlag[]): RuleFlag[] {
+  const hasQtHypoK = flags.some((f) => f.rule_id === "CROSS-QT-HYPOK-001");
+  if (!hasQtHypoK) {
+    // No dedup needed — shallow-copy so the caller cannot assume identity
+    // with the input reference.
+    return [...flags];
+  }
+  return flags.filter((f) => f.rule_id !== "CRITICAL-LAB-POTASSIUM");
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #854.

When a patient has severe hypokalemia (K+ < 3.0) AND is on a QT-prolonging drug (ondansetron, amiodarone, sotalol, haloperidol, methadone, citalopram, azithromycin, levofloxacin, quetiapine, etc.), two rules currently fire for the same underlying signal:

- `CRITICAL-LAB-POTASSIUM` (critical severity, `critical-value` category) from the `checkCriticalValues` threshold rule in `services/ai-oversight/src/rules/critical-values.ts`.
- `CROSS-QT-HYPOK-001` (critical after in-rule severity escalation when K+ < 3.0; warning at K+ 3.0-3.4) from the `checkCrossSpecialtyPatterns` rule in `services/ai-oversight/src/rules/cross-specialty.ts`.

Both flags point clinicians at the same physiologic concern (severe hypokalemia -> torsades / arrhythmia risk). The cross-specialty flag is strictly more actionable because it carries QT-specific guidance (ECG, QTc threshold, cardiology consult) layered on top of the K+ repletion recommendation.

## Policy

When both flags fire in the same review pass, suppress `CRITICAL-LAB-POTASSIUM` in favor of `CROSS-QT-HYPOK-001`. Severity is preserved — `CROSS-QT-HYPOK-001` already escalates to `critical` when K+ < 3.0, so no urgency signal is lost.

Truth table:

| Scenario | K+ value | QT drug? | `CRITICAL-LAB-POTASSIUM` | `CROSS-QT-HYPOK-001` | Consolidated |
| - | - | - | - | - | - |
| Severe hypoK on QT drug | 2.8 | yes | fires (critical) | fires (critical) | `CROSS-QT-HYPOK-001` only |
| Severe hypoK, no QT drug | 2.8 | no | fires (critical) | does not fire | `CRITICAL-LAB-POTASSIUM` (unchanged) |
| Mild hypoK on QT drug | 3.2 | yes | does not fire | fires (warning) | `CROSS-QT-HYPOK-001` (unchanged) |
| Hyperkalemia | 6.5 | either | fires (critical) | does not fire | `CRITICAL-LAB-POTASSIUM` (unchanged) |

## Implementation

- New pure function `consolidateRuleFlags(flags: RuleFlag[]): RuleFlag[]` exported from `services/ai-oversight/src/services/review-service.ts`.
- Called inside `processReviewJob` between the rules-firing step and flag persistence so that downstream DB writes, `review_jobs.rules_output` audit, and LLM dedup all operate on the consolidated set.
- The dedup is deliberately narrow — keyed on the two specific `rule_id`s — so it cannot silently mask unrelated flags.

## Design alternatives considered

- **Option B (link-and-suppress at UI)**: rejected — no existing flag-linking infrastructure and adding one would be significantly larger churn than a batch-level dedup.
- **Dedup at rule level** (have `CRITICAL-LAB-POTASSIUM` know about `CROSS-QT-HYPOK-001` or vice versa): rejected because the two rules have disjoint inputs (threshold rule takes a `ClinicalEvent`; cross-specialty takes a `PatientContext`). Consolidation at the batch level is simpler and co-located.
- **Dedup at DB insert time**: rejected — would be a post-emission cleanup and complicate the per-flag idempotency logic in `createFlag`.

## Safety

Under-alerting on hypokalemia is worse than minor UI duplication, so:

- Dedup fires only when `CROSS-QT-HYPOK-001` is definitively present in the same batch.
- `CRITICAL-LAB-POTASSIUM` passes through unchanged whenever `CROSS-QT-HYPOK-001` is absent (including all hyperkalemia cases — they do not co-fire).
- No generic severity / category suppression. The mechanism cannot accidentally mask unrelated flags.

## Test plan

- [x] New unit suite `services/ai-oversight/src/__tests__/consolidate-rule-flags.test.ts` (10 tests) covers: suppression when both fire, preservation of critical severity, no-op when either fires alone, no-op on mild-hypokalemia warning path, preservation of unrelated flags, preservation of other `CRITICAL-LAB-*` analytes, empty-array handling, input-immutability, order-independence, and duplicate-input defense.
- [x] `pnpm --filter @carebridge/ai-oversight test` — 661 tests pass (28 files).
- [x] `pnpm typecheck` — 40 tasks pass.
- [x] `pnpm lint` — 22 tasks pass.