### PR TITLE
feat(clinical): care team management procedures with RBAC and audit

### DIFF
--- a/packages/validators/src/care-team.ts
+++ b/packages/validators/src/care-team.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+// Clinical roster role (what the chart displays). Mirrors seed data.
+export const careTeamMemberRoleSchema = z.enum([
+  "primary",
+  "specialist",
+  "nurse",
+  "coordinator",
+]);
+
+// RBAC-side assignment role — decoupled from the roster role so a provider
+// with clinical role "primary" can carry RBAC role "attending".
+export const careTeamAssignmentRoleSchema = z.enum([
+  "attending",
+  "consulting",
+  "nursing",
+  "covering",
+]);
+
+export const addCareTeamMemberSchema = z.object({
+  patient_id: z.string().uuid(),
+  provider_id: z.string().uuid(),
+  role: careTeamMemberRoleSchema,
+  specialty: z.string().max(100).optional(),
+  // When present, roster insert + RBAC grant run atomically in one tx.
+  assignment_role: careTeamAssignmentRoleSchema.optional(),
+});
+
+export const removeCareTeamMemberSchema = z.object({
+  member_id: z.string().uuid(),
+});
+
+export const updateCareTeamRoleSchema = z.object({
+  member_id: z.string().uuid(),
+  role: careTeamMemberRoleSchema,
+  specialty: z.string().max(100).optional(),
+});
+
+export const grantCareTeamAssignmentSchema = z.object({
+  user_id: z.string().uuid(),
+  patient_id: z.string().uuid(),
+  role: careTeamAssignmentRoleSchema,
+});
+
+export const revokeCareTeamAssignmentSchema = z.object({
+  assignment_id: z.string().uuid(),
+});
+
+export type AddCareTeamMemberInput = z.infer<typeof addCareTeamMemberSchema>;
+export type RemoveCareTeamMemberInput = z.infer<typeof removeCareTeamMemberSchema>;
+export type UpdateCareTeamRoleInput = z.infer<typeof updateCareTeamRoleSchema>;
+export type GrantCareTeamAssignmentInput = z.infer<typeof grantCareTeamAssignmentSchema>;
+export type RevokeCareTeamAssignmentInput = z.infer<typeof revokeCareTeamAssignmentSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -3,4 +3,5 @@ export * from "./clinical-data.js";
 export * from "./notes.js";
 export * from "./ai-flags.js";
 export * from "./auth.js";
+export * from "./care-team.js";
 

--- a/services/api-gateway/src/__tests__/care-team-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/care-team-rbac.test.ts
@@ -34,6 +34,13 @@ const mocks = vi.hoisted(() => {
     failTransactionAfterFirstInsert: false,
   };
 
+  // Default: acting clinician is on the patient's care team. Individual tests
+  // override via mockResolvedValueOnce(false) to exercise the FORBIDDEN path.
+  // Signature mirrors `middleware/rbac.ts#assertCareTeamAccess`.
+  const assertCareTeamAccess = fn(
+    async (_userId: string, _patientId: string): Promise<boolean> => true,
+  );
+
   function tableOf(t: unknown): string {
     return (t as { __table?: string })?.__table ?? "unknown";
   }
@@ -89,7 +96,7 @@ const mocks = vi.hoisted(() => {
     }),
   };
 
-  return { state, mockDb };
+  return { state, mockDb, assertCareTeamAccess };
 });
 
 vi.mock("@carebridge/db-schema", () => ({
@@ -107,6 +114,13 @@ vi.mock("drizzle-orm", () => ({
   eq: (col: unknown, val: unknown) => ({ eq: col, val }),
   and: (...args: unknown[]) => ({ and: args }),
   isNull: (col: unknown) => ({ isNull: col }),
+}));
+
+// Patient-access gate — mocked so individual tests can flip the acting
+// clinician's care-team membership on/off without touching the DB mock.
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: (userId: string, patientId: string) =>
+    mocks.assertCareTeamAccess(userId, patientId),
 }));
 
 import { careTeamRbacRouter } from "../routers/care-team.js";
@@ -148,6 +162,11 @@ function reset() {
 beforeEach(() => {
   vi.clearAllMocks();
   reset();
+  // Reset implementation AND drain any leftover `mockResolvedValueOnce`
+  // queue. Without this, an admin-bypass test (which never consumes its
+  // queued `false`) would poison the NEXT test's first access check.
+  mocks.assertCareTeamAccess.mockReset();
+  mocks.assertCareTeamAccess.mockImplementation(async () => true);
 });
 
 describe("careTeam.addMember", () => {
@@ -204,6 +223,24 @@ describe("careTeam.addMember", () => {
     await expect(callerFor(null).addMember(input)).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });
+  });
+
+  it("rejects physician NOT on the patient's care team (FORBIDDEN)", async () => {
+    // HIPAA minimum-necessary: role-gate alone isn't enough; the acting
+    // clinician must also be on this specific patient's care team.
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(
+      callerFor(makeUser("physician")).addMember(input),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(memberRows()).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
+  });
+
+  it("allows admin regardless of care-team membership (bypass)", async () => {
+    // Admin is unrestricted — assertCareTeamAccess must not even be called.
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(callerFor(makeUser("admin")).addMember(input)).resolves.toBeDefined();
+    expect(mocks.assertCareTeamAccess).not.toHaveBeenCalled();
   });
 
   it("rolls back the team insert when the atomic RBAC grant fails", async () => {
@@ -271,6 +308,16 @@ describe("careTeam.removeMember (soft delete)", () => {
       callerFor(makeUser("physician")).removeMember({ member_id: MEMBER_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
+
+  it("rejects physician NOT on the patient's care team (FORBIDDEN)", async () => {
+    mocks.state.limitResults = [[existing]];
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(
+      callerFor(makeUser("physician")).removeMember({ member_id: MEMBER_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
+  });
 });
 
 describe("careTeam.updateRole", () => {
@@ -321,6 +368,16 @@ describe("careTeam.updateRole", () => {
       callerFor(makeUser("physician")).updateRole({ member_id: MEMBER_ID, role: "coordinator" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
+
+  it("rejects physician NOT on the patient's care team (FORBIDDEN)", async () => {
+    mocks.state.limitResults = [[existing]];
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(
+      callerFor(makeUser("physician")).updateRole({ member_id: MEMBER_ID, role: "coordinator" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
+  });
 });
 
 describe("careTeam.assignments.grant", () => {
@@ -346,6 +403,15 @@ describe("careTeam.assignments.grant", () => {
       callerFor(makeUser(role)).assignments.grant(input),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(assignmentRows()).toHaveLength(0);
+  });
+
+  it("rejects physician NOT on the patient's care team (FORBIDDEN)", async () => {
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(
+      callerFor(makeUser("physician")).assignments.grant(input),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(assignmentRows()).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
   });
 });
 
@@ -391,5 +457,15 @@ describe("careTeam.assignments.revoke", () => {
     await expect(
       callerFor(null).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
     ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+
+  it("rejects physician NOT on the patient's care team (FORBIDDEN)", async () => {
+    mocks.state.limitResults = [[existing]];
+    mocks.assertCareTeamAccess.mockResolvedValueOnce(false);
+    await expect(
+      callerFor(makeUser("physician")).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
   });
 });

--- a/services/api-gateway/src/__tests__/care-team-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/care-team-rbac.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const MEMBER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ASSIGNMENT_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const TARGET_PROVIDER_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const ROLE_IDS: Record<string, string> = {
+  nurse: "33333333-3333-4333-8333-333333333333",
+  physician: "44444444-4444-4444-8444-444444444444",
+  specialist: "55555555-5555-4555-8555-555555555555",
+  admin: "66666666-6666-4666-8666-666666666666",
+  patient: PATIENT_ID,
+  family_caregiver: "77777777-7777-4777-8777-777777777777",
+};
+
+// Mock DB — `.limit()` returns arrays FIFO from `limitResults`; the tx mock
+// snapshots inserts/updates and rolls them back on throw so the atomicity
+// test can observe the rollback contract.
+
+const mocks = vi.hoisted(() => {
+  const fn = vi.fn;
+
+  const state: {
+    limitResults: unknown[][];
+    insertedRows: { table: string; row: Record<string, unknown> }[];
+    updatedRows: { table: string; set: Record<string, unknown> }[];
+    failTransactionAfterFirstInsert: boolean;
+  } = {
+    limitResults: [],
+    insertedRows: [],
+    updatedRows: [],
+    failTransactionAfterFirstInsert: false,
+  };
+
+  function tableOf(t: unknown): string {
+    return (t as { __table?: string })?.__table ?? "unknown";
+  }
+
+  function makeSelectChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = fn(() => chain);
+    chain.where = fn(() => chain);
+    chain.limit = fn(async () => state.limitResults.shift() ?? []);
+    return chain;
+  }
+
+  function buildHandle(opts: { trackRollback?: boolean } = {}) {
+    let firstInsertSeen = false;
+    return {
+      select: fn(() => makeSelectChain()),
+      insert: fn((table: unknown) => ({
+        values: fn(async (row: Record<string, unknown>) => {
+          state.insertedRows.push({ table: tableOf(table), row });
+          if (opts.trackRollback && state.failTransactionAfterFirstInsert) {
+            if (!firstInsertSeen) {
+              firstInsertSeen = true;
+              return;
+            }
+            throw new Error("simulated RBAC grant failure");
+          }
+        }),
+      })),
+      update: fn((table: unknown) => ({
+        set: fn((set: Record<string, unknown>) => ({
+          where: fn(async () => {
+            state.updatedRows.push({ table: tableOf(table), set });
+          }),
+        })),
+      })),
+    };
+  }
+
+  const mockDb = {
+    ...buildHandle(),
+    transaction: fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+      const preInsert = state.insertedRows.length;
+      const preUpdate = state.updatedRows.length;
+      try {
+        return await cb(buildHandle({ trackRollback: true }));
+      } catch (err) {
+        // Drizzle rolls back on throw — mirror that so tests can assert
+        // neither staged row remained committed.
+        state.insertedRows.length = preInsert;
+        state.updatedRows.length = preUpdate;
+        throw err;
+      }
+    }),
+  };
+
+  return { state, mockDb };
+});
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  careTeamMembers: { __table: "care_team_members", id: "care_team_members.id" },
+  careTeamAssignments: {
+    __table: "care_team_assignments",
+    id: "care_team_assignments.id",
+    removed_at: "care_team_assignments.removed_at",
+  },
+  auditLog: { __table: "audit_log" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ eq: col, val }),
+  and: (...args: unknown[]) => ({ and: args }),
+  isNull: (col: unknown) => ({ isNull: col }),
+}));
+
+import { careTeamRbacRouter } from "../routers/care-team.js";
+import type { Context } from "../context.js";
+
+function makeUser(role: User["role"], id = ROLE_IDS[role]!): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function callerFor(user: User | null) {
+  const ctx: Context = {
+    db: mocks.mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+  return careTeamRbacRouter.createCaller(ctx);
+}
+
+const auditRows = () => mocks.state.insertedRows.filter((r) => r.table === "audit_log");
+const memberRows = () => mocks.state.insertedRows.filter((r) => r.table === "care_team_members");
+const assignmentRows = () => mocks.state.insertedRows.filter((r) => r.table === "care_team_assignments");
+
+function reset() {
+  mocks.state.limitResults = [];
+  mocks.state.insertedRows = [];
+  mocks.state.updatedRows = [];
+  mocks.state.failTransactionAfterFirstInsert = false;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reset();
+});
+
+describe("careTeam.addMember", () => {
+  const input = {
+    patient_id: PATIENT_ID,
+    provider_id: TARGET_PROVIDER_ID,
+    role: "nurse" as const,
+    specialty: "Oncology",
+  };
+
+  it("allows physician to add a nurse and writes an audit entry", async () => {
+    const result = await callerFor(makeUser("physician")).addMember(input);
+    expect(result).toMatchObject({
+      patient_id: PATIENT_ID,
+      provider_id: TARGET_PROVIDER_ID,
+      role: "nurse",
+      specialty: "Oncology",
+      is_active: true,
+    });
+    expect(memberRows()).toHaveLength(1);
+    const audit = auditRows();
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.row).toMatchObject({
+      user_id: ROLE_IDS.physician,
+      action: "care_team_add_member",
+      resource_type: "care_team_member",
+      patient_id: PATIENT_ID,
+    });
+    const details = JSON.parse(audit[0]!.row.details as string);
+    expect(details.new_value).toMatchObject({
+      provider_id: TARGET_PROVIDER_ID,
+      role: "nurse",
+      specialty: "Oncology",
+    });
+  });
+
+  it.each([["specialist"], ["admin"]] as const)("allows %s to add a member", async (role) => {
+    await expect(callerFor(makeUser(role)).addMember(input)).resolves.toBeDefined();
+    expect(memberRows()).toHaveLength(1);
+  });
+
+  it.each([["nurse"], ["patient"], ["family_caregiver"]] as const)(
+    "rejects %s (FORBIDDEN)",
+    async (role) => {
+      await expect(callerFor(makeUser(role)).addMember(input)).rejects.toMatchObject({
+        code: "FORBIDDEN",
+      });
+      expect(memberRows()).toHaveLength(0);
+      expect(auditRows()).toHaveLength(0);
+    },
+  );
+
+  it("rejects unauthenticated callers (UNAUTHORIZED)", async () => {
+    await expect(callerFor(null).addMember(input)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+
+  it("rolls back the team insert when the atomic RBAC grant fails", async () => {
+    mocks.state.failTransactionAfterFirstInsert = true;
+    await expect(
+      callerFor(makeUser("physician")).addMember({ ...input, assignment_role: "nursing" }),
+    ).rejects.toThrow(/simulated RBAC grant failure/);
+
+    // Rollback contract: neither row committed, audit row also rolled back.
+    expect(memberRows()).toHaveLength(0);
+    expect(assignmentRows()).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
+  });
+
+  it("commits team-member and RBAC assignment atomically on success", async () => {
+    await expect(
+      callerFor(makeUser("physician")).addMember({ ...input, assignment_role: "nursing" }),
+    ).resolves.toBeDefined();
+    expect(memberRows()).toHaveLength(1);
+    expect(assignmentRows()).toHaveLength(1);
+    expect(assignmentRows()[0]!.row).toMatchObject({
+      user_id: TARGET_PROVIDER_ID,
+      patient_id: PATIENT_ID,
+      role: "nursing",
+    });
+  });
+});
+
+describe("careTeam.removeMember (soft delete)", () => {
+  const existing = {
+    id: MEMBER_ID,
+    patient_id: PATIENT_ID,
+    provider_id: TARGET_PROVIDER_ID,
+    role: "nurse",
+    specialty: "Oncology",
+    is_active: true,
+  };
+
+  it("soft-deletes the member (is_active=false, ended_at set) and audits", async () => {
+    mocks.state.limitResults = [[existing]];
+    const result = await callerFor(makeUser("physician")).removeMember({ member_id: MEMBER_ID });
+
+    expect(result).toMatchObject({ removed: true, member_id: MEMBER_ID });
+    expect(mocks.state.updatedRows).toHaveLength(1);
+    expect(mocks.state.updatedRows[0]!.table).toBe("care_team_members");
+    expect(mocks.state.updatedRows[0]!.set).toMatchObject({ is_active: false });
+    expect(mocks.state.updatedRows[0]!.set.ended_at).toEqual(expect.any(String));
+    expect(auditRows()[0]!.row).toMatchObject({
+      action: "care_team_remove_member",
+      resource_id: MEMBER_ID,
+      patient_id: PATIENT_ID,
+    });
+  });
+
+  it("rejects nurse (FORBIDDEN)", async () => {
+    await expect(
+      callerFor(makeUser("nurse")).removeMember({ member_id: MEMBER_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+  });
+
+  it("returns NOT_FOUND when the member does not exist", async () => {
+    mocks.state.limitResults = [[]];
+    await expect(
+      callerFor(makeUser("physician")).removeMember({ member_id: MEMBER_ID }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("careTeam.updateRole", () => {
+  const existing = {
+    id: MEMBER_ID,
+    patient_id: PATIENT_ID,
+    provider_id: TARGET_PROVIDER_ID,
+    role: "nurse",
+    specialty: "Oncology",
+    is_active: true,
+  };
+
+  it("updates role+specialty and captures old/new values in audit", async () => {
+    mocks.state.limitResults = [[existing]];
+    const result = await callerFor(makeUser("physician")).updateRole({
+      member_id: MEMBER_ID,
+      role: "coordinator",
+      specialty: "Care Coordination",
+    });
+
+    expect(result).toMatchObject({
+      member_id: MEMBER_ID,
+      role: "coordinator",
+      specialty: "Care Coordination",
+    });
+    expect(mocks.state.updatedRows[0]!.set).toMatchObject({
+      role: "coordinator",
+      specialty: "Care Coordination",
+    });
+    const details = JSON.parse(auditRows()[0]!.row.details as string);
+    expect(details.old_value).toMatchObject({ role: "nurse", specialty: "Oncology" });
+    expect(details.new_value).toMatchObject({
+      role: "coordinator",
+      specialty: "Care Coordination",
+    });
+  });
+
+  it("rejects nurse (FORBIDDEN)", async () => {
+    await expect(
+      callerFor(makeUser("nurse")).updateRole({ member_id: MEMBER_ID, role: "coordinator" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+  });
+
+  it("returns NOT_FOUND when the member does not exist", async () => {
+    mocks.state.limitResults = [[]];
+    await expect(
+      callerFor(makeUser("physician")).updateRole({ member_id: MEMBER_ID, role: "coordinator" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});
+
+describe("careTeam.assignments.grant", () => {
+  const input = {
+    user_id: TARGET_PROVIDER_ID,
+    patient_id: PATIENT_ID,
+    role: "attending" as const,
+  };
+
+  it("allows physician to grant an assignment and writes audit", async () => {
+    const result = await callerFor(makeUser("physician")).assignments.grant(input);
+    expect(result).toMatchObject(input);
+    expect(assignmentRows()).toHaveLength(1);
+    expect(auditRows()[0]!.row).toMatchObject({
+      action: "care_team_grant_assignment",
+      resource_type: "care_team_assignment",
+      patient_id: PATIENT_ID,
+    });
+  });
+
+  it.each([["nurse"], ["patient"]] as const)("rejects %s (FORBIDDEN)", async (role) => {
+    await expect(
+      callerFor(makeUser(role)).assignments.grant(input),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(assignmentRows()).toHaveLength(0);
+  });
+});
+
+describe("careTeam.assignments.revoke", () => {
+  const existing = {
+    id: ASSIGNMENT_ID,
+    user_id: TARGET_PROVIDER_ID,
+    patient_id: PATIENT_ID,
+    role: "attending",
+    removed_at: null,
+  };
+
+  it("soft-deletes the assignment (sets removed_at) and audits", async () => {
+    mocks.state.limitResults = [[existing]];
+    const result = await callerFor(makeUser("physician")).assignments.revoke({
+      assignment_id: ASSIGNMENT_ID,
+    });
+    expect(result).toMatchObject({ revoked: true, assignment_id: ASSIGNMENT_ID });
+    expect(mocks.state.updatedRows[0]!.table).toBe("care_team_assignments");
+    expect(mocks.state.updatedRows[0]!.set).toMatchObject({ removed_at: expect.any(String) });
+    expect(auditRows()[0]!.row).toMatchObject({
+      action: "care_team_revoke_assignment",
+      resource_id: ASSIGNMENT_ID,
+      patient_id: PATIENT_ID,
+    });
+  });
+
+  it("rejects nurse (FORBIDDEN)", async () => {
+    await expect(
+      callerFor(makeUser("nurse")).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+  });
+
+  it("returns NOT_FOUND when the assignment does not exist", async () => {
+    mocks.state.limitResults = [[]];
+    await expect(
+      callerFor(makeUser("physician")).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("rejects unauthenticated callers (UNAUTHORIZED)", async () => {
+    await expect(
+      callerFor(null).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -10,6 +10,7 @@ import { emergencyAccessRbacRouter } from "./routers/emergency-access.js";
 import { fhirRbacRouter } from "./routers/fhir.js";
 import { notificationsRbacRouter } from "./routers/notifications.js";
 import { familyAccessRbacRouter } from "./routers/family-access.js";
+import { careTeamRbacRouter } from "./routers/care-team.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -30,6 +31,7 @@ export const appRouter = router({
   scheduling: schedulingRbacRouter,
   fhir: fhirRbacRouter,
   familyAccess: familyAccessRbacRouter,
+  careTeam: careTeamRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/routers/care-team.ts
+++ b/services/api-gateway/src/routers/care-team.ts
@@ -1,0 +1,340 @@
+/**
+ * RBAC-enforced care-team management router (issue #397).
+ *
+ * Only `physician | specialist | admin` may mutate. Every mutation writes an
+ * audit entry (HIPAA §164.312(b)). Mutations that pair a roster change with
+ * an RBAC grant run inside one transaction so a grant failure rolls the team
+ * edit back — see `packages/db-schema/src/schema/patients.ts` for the
+ * careTeamMembers (clinical roster) vs careTeamAssignments (RBAC) split.
+ */
+import { TRPCError, initTRPC } from "@trpc/server";
+import {
+  getDb,
+  careTeamMembers,
+  careTeamAssignments,
+  auditLog,
+} from "@carebridge/db-schema";
+import {
+  addCareTeamMemberSchema,
+  removeCareTeamMemberSchema,
+  updateCareTeamRoleSchema,
+  grantCareTeamAssignmentSchema,
+  revokeCareTeamAssignmentSchema,
+} from "@carebridge/validators";
+import { and, eq, isNull } from "drizzle-orm";
+import crypto from "node:crypto";
+import type { Context } from "../context.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+// Nurses can READ the roster via `patients.careTeam.getByPatient` but cannot
+// mutate it — the triplet {physician, specialist, admin} mirrors issue #397.
+const CARE_TEAM_MANAGER_ROLES = new Set<string>(["physician", "specialist", "admin"]);
+
+function assertCanManageCareTeam(user: NonNullable<Context["user"]>): void {
+  if (!CARE_TEAM_MANAGER_ROLES.has(user.role)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only physicians, specialists, and admins can manage care teams",
+    });
+  }
+}
+
+/**
+ * Build a standard audit-log row. Returned as a plain value so callers can
+ * `.insert(auditLog).values(row)` on either the top-level db handle or an
+ * open transaction without fighting drizzle's `PgTransaction` generic.
+ * Captures actor, action, target patient / user, and old/new values so an
+ * auditor can reconstruct every change without replaying the DB.
+ */
+function buildAuditRow(params: {
+  actor_user_id: string;
+  action: string;
+  resource_type: "care_team_member" | "care_team_assignment";
+  resource_id: string;
+  patient_id: string;
+  target_user_id?: string;
+  old_value?: Record<string, unknown>;
+  new_value?: Record<string, unknown>;
+  procedure_name: string;
+}) {
+  return {
+    id: crypto.randomUUID(),
+    user_id: params.actor_user_id,
+    action: params.action,
+    resource_type: params.resource_type,
+    resource_id: params.resource_id,
+    patient_id: params.patient_id,
+    procedure_name: params.procedure_name,
+    details: JSON.stringify({
+      target_user_id: params.target_user_id,
+      old_value: params.old_value,
+      new_value: params.new_value,
+    }),
+    ip_address: "",
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export const careTeamRbacRouter = t.router({
+  /**
+   * Add a provider to a patient's clinical care team. When `assignment_role`
+   * is supplied, the RBAC grant is inserted in the same transaction so a
+   * grant failure rolls the roster row back (prevents chart/access split-brain).
+   */
+  addMember: protectedProcedure
+    .input(addCareTeamMemberSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertCanManageCareTeam(ctx.user);
+      const db = getDb();
+      const now = new Date().toISOString();
+      const memberId = crypto.randomUUID();
+      const memberRow = {
+        id: memberId,
+        patient_id: input.patient_id,
+        provider_id: input.provider_id,
+        role: input.role,
+        specialty: input.specialty,
+        is_active: true,
+        started_at: now,
+        created_at: now,
+      };
+
+      await db.transaction(async (tx) => {
+        await tx.insert(careTeamMembers).values(memberRow);
+
+        if (input.assignment_role) {
+          // Atomic pair: if this grant throws (unique violation, DB outage),
+          // the outer transaction rolls the member insert back.
+          await tx.insert(careTeamAssignments).values({
+            id: crypto.randomUUID(),
+            user_id: input.provider_id,
+            patient_id: input.patient_id,
+            role: input.assignment_role,
+            assigned_at: now,
+          });
+        }
+
+        await tx.insert(auditLog).values(
+          buildAuditRow({
+            actor_user_id: ctx.user.id,
+            action: "care_team_add_member",
+            resource_type: "care_team_member",
+            resource_id: memberId,
+            patient_id: input.patient_id,
+            target_user_id: input.provider_id,
+            new_value: {
+              provider_id: input.provider_id,
+              role: input.role,
+              specialty: input.specialty,
+              assignment_role: input.assignment_role,
+            },
+            procedure_name: "careTeam.addMember",
+          }),
+        );
+      });
+
+      return memberRow;
+    }),
+
+  // Soft-delete only — retaining the row preserves HIPAA-required history
+  // of who was on the patient's team and when.
+  removeMember: protectedProcedure
+    .input(removeCareTeamMemberSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertCanManageCareTeam(ctx.user);
+      const db = getDb();
+      const [existing] = await db
+        .select()
+        .from(careTeamMembers)
+        .where(eq(careTeamMembers.id, input.member_id))
+        .limit(1);
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Care-team member ${input.member_id} not found`,
+        });
+      }
+
+      const now = new Date().toISOString();
+      await db.transaction(async (tx) => {
+        await tx
+          .update(careTeamMembers)
+          .set({ is_active: false, ended_at: now })
+          .where(eq(careTeamMembers.id, input.member_id));
+
+        await tx.insert(auditLog).values(
+          buildAuditRow({
+            actor_user_id: ctx.user.id,
+            action: "care_team_remove_member",
+            resource_type: "care_team_member",
+            resource_id: input.member_id,
+            patient_id: existing.patient_id as string,
+            target_user_id: existing.provider_id as string,
+            old_value: {
+              role: existing.role,
+              specialty: existing.specialty,
+              is_active: existing.is_active,
+            },
+            new_value: { is_active: false, ended_at: now },
+            procedure_name: "careTeam.removeMember",
+          }),
+        );
+      });
+
+      return { removed: true, member_id: input.member_id };
+    }),
+
+  // Change role (and optionally specialty) for an existing care-team member.
+  updateRole: protectedProcedure
+    .input(updateCareTeamRoleSchema)
+    .mutation(async ({ ctx, input }) => {
+      assertCanManageCareTeam(ctx.user);
+      const db = getDb();
+      const [existing] = await db
+        .select()
+        .from(careTeamMembers)
+        .where(eq(careTeamMembers.id, input.member_id))
+        .limit(1);
+      if (!existing) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Care-team member ${input.member_id} not found`,
+        });
+      }
+
+      const patch: Record<string, unknown> = { role: input.role };
+      if (input.specialty !== undefined) patch.specialty = input.specialty;
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(careTeamMembers)
+          .set(patch)
+          .where(eq(careTeamMembers.id, input.member_id));
+
+        await tx.insert(auditLog).values(
+          buildAuditRow({
+            actor_user_id: ctx.user.id,
+            action: "care_team_update_role",
+            resource_type: "care_team_member",
+            resource_id: input.member_id,
+            patient_id: existing.patient_id as string,
+            target_user_id: existing.provider_id as string,
+            old_value: {
+              role: existing.role,
+              specialty: existing.specialty,
+            },
+            new_value: {
+              role: input.role,
+              specialty: input.specialty ?? existing.specialty,
+            },
+            procedure_name: "careTeam.updateRole",
+          }),
+        );
+      });
+
+      return {
+        member_id: input.member_id,
+        role: input.role,
+        specialty: input.specialty ?? existing.specialty,
+      };
+    }),
+
+  // RBAC sub-router — grant/revoke access without touching the clinical
+  // roster (e.g. covering physician needing temporary chart access).
+  assignments: t.router({
+    grant: protectedProcedure
+      .input(grantCareTeamAssignmentSchema)
+      .mutation(async ({ ctx, input }) => {
+        assertCanManageCareTeam(ctx.user);
+        const db = getDb();
+        const now = new Date().toISOString();
+        const assignmentId = crypto.randomUUID();
+        const assignmentRow = {
+          id: assignmentId,
+          user_id: input.user_id,
+          patient_id: input.patient_id,
+          role: input.role,
+          assigned_at: now,
+        };
+
+        await db.transaction(async (tx) => {
+          await tx.insert(careTeamAssignments).values(assignmentRow);
+
+          await tx.insert(auditLog).values(
+            buildAuditRow({
+              actor_user_id: ctx.user.id,
+              action: "care_team_grant_assignment",
+              resource_type: "care_team_assignment",
+              resource_id: assignmentId,
+              patient_id: input.patient_id,
+              target_user_id: input.user_id,
+              new_value: { role: input.role },
+              procedure_name: "careTeamAssignments.grant",
+            }),
+          );
+        });
+
+        return assignmentRow;
+      }),
+
+    revoke: protectedProcedure
+      .input(revokeCareTeamAssignmentSchema)
+      .mutation(async ({ ctx, input }) => {
+        assertCanManageCareTeam(ctx.user);
+        const db = getDb();
+        const [existing] = await db
+          .select()
+          .from(careTeamAssignments)
+          .where(
+            and(
+              eq(careTeamAssignments.id, input.assignment_id),
+              isNull(careTeamAssignments.removed_at),
+            ),
+          )
+          .limit(1);
+        if (!existing) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: `Care-team assignment ${input.assignment_id} not found or already revoked`,
+          });
+        }
+
+        const now = new Date().toISOString();
+        await db.transaction(async (tx) => {
+          await tx
+            .update(careTeamAssignments)
+            .set({ removed_at: now })
+            .where(eq(careTeamAssignments.id, input.assignment_id));
+
+          await tx.insert(auditLog).values(
+            buildAuditRow({
+              actor_user_id: ctx.user.id,
+              action: "care_team_revoke_assignment",
+              resource_type: "care_team_assignment",
+              resource_id: input.assignment_id,
+              patient_id: existing.patient_id as string,
+              target_user_id: existing.user_id as string,
+              old_value: { role: existing.role, removed_at: null },
+              new_value: { removed_at: now },
+              procedure_name: "careTeamAssignments.revoke",
+            }),
+          );
+        });
+
+        return { revoked: true, assignment_id: input.assignment_id };
+      }),
+  }),
+});

--- a/services/api-gateway/src/routers/care-team.ts
+++ b/services/api-gateway/src/routers/care-team.ts
@@ -24,6 +24,7 @@ import {
 import { and, eq, isNull } from "drizzle-orm";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
 
 const t = initTRPC.context<Context>().create();
 
@@ -48,6 +49,41 @@ function assertCanManageCareTeam(user: NonNullable<Context["user"]>): void {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Only physicians, specialists, and admins can manage care teams",
+    });
+  }
+}
+
+/**
+ * HIPAA minimum-necessary access check — mirrors the helper used by every
+ * other patient-scoped router (clinical-data, clinical-notes, patient-records,
+ * fhir, ai-oversight). Role gating (`assertCanManageCareTeam`) governs *what*
+ * a user can do; this gate governs *which patients* they can do it to.
+ *
+ * - admins bypass (unrestricted cross-patient access)
+ * - patients never reach here (role gate rejects first), but kept consistent
+ * - clinicians must have an active `careTeamAssignments` row for the patient
+ */
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+): Promise<void> {
+  if (user.role === "admin") return;
+
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  const hasAccess = await assertCareTeamAccess(user.id, patientId);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
     });
   }
 }
@@ -98,6 +134,7 @@ export const careTeamRbacRouter = t.router({
     .input(addCareTeamMemberSchema)
     .mutation(async ({ ctx, input }) => {
       assertCanManageCareTeam(ctx.user);
+      await enforcePatientAccess(ctx.user, input.patient_id);
       const db = getDb();
       const now = new Date().toISOString();
       const memberId = crypto.randomUUID();
@@ -168,6 +205,11 @@ export const careTeamRbacRouter = t.router({
         });
       }
 
+      // Patient is resolved from the member row — mirrors the pattern used in
+      // clinical-data.medications.update where the resource id is the only
+      // input and patient_id is looked up before the access check.
+      await enforcePatientAccess(ctx.user, existing.patient_id as string);
+
       const now = new Date().toISOString();
       await db.transaction(async (tx) => {
         await tx
@@ -215,6 +257,8 @@ export const careTeamRbacRouter = t.router({
         });
       }
 
+      await enforcePatientAccess(ctx.user, existing.patient_id as string);
+
       const patch: Record<string, unknown> = { role: input.role };
       if (input.specialty !== undefined) patch.specialty = input.specialty;
 
@@ -259,6 +303,7 @@ export const careTeamRbacRouter = t.router({
       .input(grantCareTeamAssignmentSchema)
       .mutation(async ({ ctx, input }) => {
         assertCanManageCareTeam(ctx.user);
+        await enforcePatientAccess(ctx.user, input.patient_id);
         const db = getDb();
         const now = new Date().toISOString();
         const assignmentId = crypto.randomUUID();
@@ -311,6 +356,8 @@ export const careTeamRbacRouter = t.router({
             message: `Care-team assignment ${input.assignment_id} not found or already revoked`,
           });
         }
+
+        await enforcePatientAccess(ctx.user, existing.patient_id as string);
 
         const now = new Date().toISOString();
         await db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary
Adds five tRPC mutation procedures for managing patient care teams. Only `physician | specialist | admin` can mutate. Every mutation writes a HIPAA audit row, and any mutation that pairs a roster change with an RBAC grant runs inside a single Drizzle transaction so a grant failure rolls the team edit back — preventing a chart/access split-brain.

No schema changes: the existing `careTeamMembers` / `careTeamAssignments` columns already support every field this router writes.

Closes #397

## Acceptance Criteria
- [x] `careTeam.addMember` — insert roster row; atomically grants RBAC when `assignment_role` is provided
- [x] `careTeam.removeMember` — soft delete (sets `is_active=false` + `ended_at`), never hard-delete
- [x] `careTeam.updateRole` — change role/specialty with old + new values in the audit trail
- [x] `careTeam.assignments.grant` — create RBAC assignment row (atomic-capable with team changes)
- [x] `careTeam.assignments.revoke` — soft-delete RBAC assignment (sets `removed_at`)
- [x] Only `physician | specialist | admin` can call these mutations (FORBIDDEN otherwise)
- [x] Every mutation writes an `audit_log` row capturing actor_user_id, action, target_patient_id, target_user_id, old_value, new_value
- [x] Care-team mutation + RBAC mutation are transactional (rollback on partial failure)
- [x] Soft delete preserves HIPAA-compliant history
- [x] TDD: 22 test cases (positive matrix, FORBIDDEN for nurse/patient/family_caregiver, UNAUTHORIZED, NOT_FOUND, atomic rollback contract)
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm --filter @carebridge/api-gateway test` green (283/283 passing, includes the 22 new cases)

## Files Changed
- `packages/validators/src/care-team.ts` (new) — Zod schemas for the five procedures
- `packages/validators/src/index.ts` — re-export
- `services/api-gateway/src/routers/care-team.ts` (new) — RBAC-enforced router
- `services/api-gateway/src/router.ts` — wired `careTeam` into `appRouter`
- `services/api-gateway/src/__tests__/care-team-rbac.test.ts` (new) — 22-case suite

Diff: +791 / -0 LOC.

## Test Plan
- [x] Unit: `pnpm --filter @carebridge/api-gateway test -- care-team-rbac` — 22 passing
- [x] Regression: full api-gateway suite (283 tests) — all passing
- [x] Typecheck: `pnpm typecheck` — green
- [x] Lint: `pnpm lint` — green
- [ ] Manual smoke: after merge, seed the DVT scenario (`pnpm db:seed`), log in as dr.smith, call `careTeam.addMember` + `careTeam.assignments.grant`, verify new provider gains chart access and can be removed via the soft-delete path
- [ ] Manual audit verification: query `audit_log` and confirm entries include `old_value`/`new_value` for update/remove actions

## Non-Goals
- Schema changes (out of scope per issue)
- Notification events on team changes (follow-up)
- RBAC middleware refactors (out of scope)