### PR TITLE
feat(portal): proxy/caregiver patient data visibility with audit

### DIFF
--- a/apps/patient-portal/app/layout.tsx
+++ b/apps/patient-portal/app/layout.tsx
@@ -4,6 +4,8 @@ import type { Metadata } from "next";
 import "@carebridge/ui-tokens/tokens.css";
 import "./globals.css";
 import { Providers } from "./providers";
+import { CaregiverIndicator } from "@/components/caregiver-indicator";
+import { PatientSelector } from "@/components/patient-selector";
 
 export const metadata: Metadata = {
   title: "CareBridge — Patient Portal",
@@ -32,6 +34,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <h1 style={{ margin: 0, fontSize: "1.5rem" }}>CareBridge</h1>
             <p style={{ margin: "0.25rem 0 0", color: "#999", fontSize: "0.875rem" }}>Patient Portal</p>
           </header>
+          <CaregiverIndicator />
+          <PatientSelector />
           <main id="main-content" tabIndex={-1}>
             {children}
           </main>

--- a/apps/patient-portal/app/providers.tsx
+++ b/apps/patient-portal/app/providers.tsx
@@ -1,3 +1,18 @@
 "use client";
 
-export { Providers } from "@carebridge/portal-shared/providers";
+import { Providers as SharedProviders } from "@carebridge/portal-shared/providers";
+import { ActivePatientProvider } from "@/lib/active-patient";
+
+/**
+ * Patient-portal providers:
+ *  - SharedProviders sets up tRPC, React Query, and AuthProvider.
+ *  - ActivePatientProvider adds the "which patient am I viewing" context on
+ *    top (depends on tRPC + auth, so it MUST be nested inside).
+ */
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SharedProviders>
+      <ActivePatientProvider>{children}</ActivePatientProvider>
+    </SharedProviders>
+  );
+}

--- a/apps/patient-portal/app/symptoms/page.tsx
+++ b/apps/patient-portal/app/symptoms/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
 import { useMyPatientRecord } from "@/lib/use-my-patient";
+import { useActivePatient } from "@/lib/active-patient";
 
 const OBSERVATION_TYPES = [
   { value: "pain", label: "Pain" },
@@ -31,6 +32,7 @@ export default function SymptomsPage() {
   const utils = trpc.useUtils();
 
   const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
+  const { isViewingAsCaregiver } = useActivePatient();
 
   const observationsQuery = trpc.patients.observations.getByPatient.useQuery(
     { patientId: myRecord?.id ?? "" },
@@ -112,6 +114,25 @@ export default function SymptomsPage() {
         <p style={{ color: "#ef4444" }}>
           Your account is not linked to a patient record. Please contact your care team.
         </p>
+      )}
+
+      {isViewingAsCaregiver && (
+        <div
+          role="note"
+          data-testid="symptoms-caregiver-readonly-notice"
+          style={{
+            backgroundColor: "#1e3a8a20",
+            border: "1px solid #3b82f6",
+            borderRadius: 8,
+            padding: "0.75rem",
+            marginBottom: "1rem",
+            color: "#bfdbfe",
+            fontSize: "0.85rem",
+          }}
+        >
+          Symptom observations must be entered by the patient. Caregivers can
+          view past entries but cannot submit on behalf of the patient.
+        </div>
       )}
 
       {submitted && (
@@ -239,15 +260,31 @@ export default function SymptomsPage() {
 
         <button
           onClick={handleSubmit}
-          disabled={!description.trim() || createMutation.isPending}
+          disabled={
+            !description.trim() ||
+            createMutation.isPending ||
+            isViewingAsCaregiver
+          }
+          aria-disabled={isViewingAsCaregiver || undefined}
+          title={
+            isViewingAsCaregiver
+              ? "Caregivers cannot submit symptom entries on the patient's behalf. The patient must sign in to add observations."
+              : undefined
+          }
+          data-testid="symptoms-submit"
           style={{
             width: "100%",
             padding: "0.75rem",
-            backgroundColor: description.trim() ? "#2563eb" : "#333",
+            backgroundColor:
+              description.trim() && !isViewingAsCaregiver ? "#2563eb" : "#333",
             border: "none",
             borderRadius: 6,
-            color: description.trim() ? "#fff" : "#666",
-            cursor: description.trim() ? "pointer" : "not-allowed",
+            color:
+              description.trim() && !isViewingAsCaregiver ? "#fff" : "#666",
+            cursor:
+              description.trim() && !isViewingAsCaregiver
+                ? "pointer"
+                : "not-allowed",
             fontSize: "0.9rem",
             fontWeight: 600,
           }}

--- a/apps/patient-portal/src/__tests__/active-patient.test.tsx
+++ b/apps/patient-portal/src/__tests__/active-patient.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { render, cleanup, screen, act } from "@testing-library/react";
+
+import {
+  ACTIVE_PATIENT_STORAGE_KEY,
+  resolveActivePatientId,
+} from "@/lib/active-patient";
+
+// ---------- Pure resolver ---------------------------------------------------
+
+describe("resolveActivePatientId", () => {
+  const P1 = { id: "p1" };
+  const P2 = { id: "p2" };
+
+  it("returns null when the list is empty", () => {
+    expect(resolveActivePatientId(null, [])).toBeNull();
+    expect(resolveActivePatientId("anything", [])).toBeNull();
+  });
+
+  it("returns the stored id when it matches a candidate", () => {
+    expect(resolveActivePatientId("p2", [P1, P2])).toBe("p2");
+  });
+
+  it("falls back to the first candidate when the stored id is absent", () => {
+    expect(resolveActivePatientId(null, [P1, P2])).toBe("p1");
+  });
+
+  it("falls back to the first candidate when the stored id is stale", () => {
+    // The caregiver's access was revoked for the previously-active patient.
+    expect(resolveActivePatientId("p-revoked", [P1, P2])).toBe("p1");
+  });
+});
+
+// ---------- React context hook ---------------------------------------------
+
+// Mocks must be set up before the component module is imported because the
+// hook captures `trpc.patients.getMyPatients.useQuery` at module load.
+
+const trpcState = {
+  getMyPatientsData: [] as Array<{
+    id: string;
+    name: string;
+    mrn: string | null;
+    relationship: string;
+  }>,
+};
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    patients: {
+      getMyPatients: {
+        useQuery: () => ({
+          data: trpcState.getMyPatientsData,
+          isLoading: false,
+        }),
+      },
+      getById: {
+        useQuery: () => ({ data: null, isLoading: false, isError: false }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "caregiver-1",
+      email: "c@c.dev",
+      name: "C",
+      role: "family_caregiver",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    isAuthenticated: true,
+    sessionId: "s-1",
+    setSession: vi.fn(),
+    clearSession: vi.fn(),
+    hydrated: true,
+    verifying: false,
+  }),
+}));
+
+// Import AFTER mocks have been registered.
+import {
+  ActivePatientProvider,
+  useActivePatient,
+} from "@/lib/active-patient";
+
+function Probe() {
+  const ctx = useActivePatient();
+  return (
+    <div>
+      <span data-testid="active-id">{ctx.activePatient?.id ?? "none"}</span>
+      <span data-testid="is-caregiver">
+        {String(ctx.isViewingAsCaregiver)}
+      </span>
+      <span data-testid="is-multi">{String(ctx.isMultiPatient)}</span>
+      <button onClick={() => ctx.setActivePatientId("p2")}>switch</button>
+    </div>
+  );
+}
+
+describe("ActivePatientProvider + useActivePatient", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    trpcState.getMyPatientsData = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("uses the localStorage-stored id when it is in the candidate list", async () => {
+    trpcState.getMyPatientsData = [
+      { id: "p1", name: "Alice", mrn: "M1", relationship: "parent" },
+      { id: "p2", name: "Bob", mrn: "M2", relationship: "child" },
+    ];
+    window.localStorage.setItem(ACTIVE_PATIENT_STORAGE_KEY, "p2");
+
+    render(
+      <ActivePatientProvider>
+        <Probe />
+      </ActivePatientProvider>,
+    );
+
+    // The hydration effect runs after first paint — findByText awaits it.
+    expect(await screen.findByTestId("active-id")).toHaveTextContent("p2");
+  });
+
+  it("falls back to the first patient when localStorage is empty", async () => {
+    trpcState.getMyPatientsData = [
+      { id: "p1", name: "Alice", mrn: "M1", relationship: "parent" },
+      { id: "p2", name: "Bob", mrn: "M2", relationship: "child" },
+    ];
+
+    render(
+      <ActivePatientProvider>
+        <Probe />
+      </ActivePatientProvider>,
+    );
+
+    expect(await screen.findByTestId("active-id")).toHaveTextContent("p1");
+  });
+
+  it("signals isViewingAsCaregiver when active relationship is not 'self'", async () => {
+    trpcState.getMyPatientsData = [
+      { id: "p1", name: "Alice", mrn: "M1", relationship: "spouse" },
+    ];
+
+    render(
+      <ActivePatientProvider>
+        <Probe />
+      </ActivePatientProvider>,
+    );
+
+    expect(await screen.findByTestId("is-caregiver")).toHaveTextContent(
+      "true",
+    );
+  });
+
+  it("signals isMultiPatient only when more than one patient is available", async () => {
+    trpcState.getMyPatientsData = [
+      { id: "p1", name: "Alice", mrn: "M1", relationship: "spouse" },
+      { id: "p2", name: "Bob", mrn: "M2", relationship: "child" },
+    ];
+
+    render(
+      <ActivePatientProvider>
+        <Probe />
+      </ActivePatientProvider>,
+    );
+
+    expect(await screen.findByTestId("is-multi")).toHaveTextContent("true");
+  });
+
+  it("switches active patient and persists the choice to localStorage", async () => {
+    trpcState.getMyPatientsData = [
+      { id: "p1", name: "Alice", mrn: "M1", relationship: "parent" },
+      { id: "p2", name: "Bob", mrn: "M2", relationship: "child" },
+    ];
+
+    render(
+      <ActivePatientProvider>
+        <Probe />
+      </ActivePatientProvider>,
+    );
+
+    // Initially the first patient is active.
+    expect(await screen.findByTestId("active-id")).toHaveTextContent("p1");
+
+    await act(async () => {
+      screen.getByRole("button", { name: /switch/i }).click();
+    });
+
+    expect(screen.getByTestId("active-id")).toHaveTextContent("p2");
+    expect(
+      window.localStorage.getItem(ACTIVE_PATIENT_STORAGE_KEY),
+    ).toBe("p2");
+  });
+});

--- a/apps/patient-portal/src/__tests__/caregiver-indicator.test.tsx
+++ b/apps/patient-portal/src/__tests__/caregiver-indicator.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+// Controllable `useActivePatient` mock. Each test swaps the return value.
+const activePatientState: {
+  value: {
+    patients: Array<{
+      id: string;
+      name: string;
+      mrn: string | null;
+      relationship: string;
+    }>;
+    activePatient: {
+      id: string;
+      name: string;
+      mrn: string | null;
+      relationship: string;
+    } | null;
+    setActivePatientId: (id: string) => void;
+    isLoading: boolean;
+    hasNoPatients: boolean;
+    isMultiPatient: boolean;
+    isViewingAsCaregiver: boolean;
+  };
+} = {
+  value: {
+    patients: [],
+    activePatient: null,
+    setActivePatientId: vi.fn(),
+    isLoading: false,
+    hasNoPatients: false,
+    isMultiPatient: false,
+    isViewingAsCaregiver: false,
+  },
+};
+
+vi.mock("@/lib/active-patient", () => ({
+  useActivePatient: () => activePatientState.value,
+}));
+
+import {
+  CaregiverIndicator,
+  humanizeRelationship,
+} from "@/components/caregiver-indicator";
+
+describe("CaregiverIndicator", () => {
+  afterEach(() => {
+    cleanup();
+    activePatientState.value = {
+      patients: [],
+      activePatient: null,
+      setActivePatientId: vi.fn(),
+      isLoading: false,
+      hasNoPatients: false,
+      isMultiPatient: false,
+      isViewingAsCaregiver: false,
+    };
+  });
+
+  it("renders nothing when the user is not viewing as a caregiver", () => {
+    const { container } = render(<CaregiverIndicator />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when isViewingAsCaregiver is true but activePatient is null", () => {
+    activePatientState.value = {
+      ...activePatientState.value,
+      isViewingAsCaregiver: true,
+      activePatient: null,
+    };
+    const { container } = render(<CaregiverIndicator />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner with the patient name when viewing as caregiver", () => {
+    activePatientState.value = {
+      ...activePatientState.value,
+      isViewingAsCaregiver: true,
+      activePatient: {
+        id: "p1",
+        name: "Jane Doe",
+        mrn: "MRN001",
+        relationship: "spouse",
+      },
+    };
+    render(<CaregiverIndicator />);
+    const banner = screen.getByTestId("caregiver-indicator");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/Viewing as spouse for Jane Doe/i);
+    expect(banner).toHaveAttribute("role", "status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("humanizes healthcare_poa to 'healthcare proxy'", () => {
+    expect(humanizeRelationship("healthcare_poa")).toBe("healthcare proxy");
+  });
+
+  it("falls back to 'caregiver' for unknown relationship types", () => {
+    expect(humanizeRelationship("bff")).toBe("caregiver");
+  });
+});

--- a/apps/patient-portal/src/__tests__/symptoms-caregiver-readonly.test.tsx
+++ b/apps/patient-portal/src/__tests__/symptoms-caregiver-readonly.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+// next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+// Auth — signed-in caregiver (role controls write-path toggling).
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "caregiver-1",
+      email: "c@carebridge.dev",
+      name: "C",
+      role: "family_caregiver",
+      is_active: true,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    isAuthenticated: true,
+    sessionId: "s-1",
+    setSession: vi.fn(),
+    clearSession: vi.fn(),
+    hydrated: true,
+    verifying: false,
+  }),
+}));
+
+vi.mock("@/lib/use-my-patient", () => ({
+  useMyPatientRecord: () => ({
+    patient: {
+      id: "linked-1",
+      name: "Jane Doe",
+      mrn: "MRN001",
+      date_of_birth: "1960-01-01",
+      biological_sex: "female",
+    },
+    isLoading: false,
+    isError: false,
+    isUnlinked: false,
+  }),
+}));
+
+// Controllable active-patient mock — flipped per test.
+const activePatientState = {
+  isViewingAsCaregiver: true,
+};
+
+vi.mock("@/lib/active-patient", () => ({
+  useActivePatient: () => ({
+    patients: [],
+    activePatient: {
+      id: "linked-1",
+      name: "Jane Doe",
+      mrn: "MRN001",
+      relationship: "spouse",
+    },
+    setActivePatientId: vi.fn(),
+    isLoading: false,
+    hasNoPatients: false,
+    isMultiPatient: false,
+    isViewingAsCaregiver: activePatientState.isViewingAsCaregiver,
+  }),
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    useUtils: () => ({
+      patients: {
+        observations: {
+          getByPatient: { invalidate: vi.fn() },
+        },
+      },
+    }),
+    patients: {
+      observations: {
+        getByPatient: {
+          useQuery: () => ({ data: [], isLoading: false, isError: false }),
+        },
+        create: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            isPending: false,
+            isError: false,
+          }),
+        },
+      },
+    },
+  },
+}));
+
+import SymptomsPage from "../../app/symptoms/page";
+
+describe("SymptomsPage — caregiver read-only state", () => {
+  beforeEach(() => {
+    activePatientState.isViewingAsCaregiver = true;
+  });
+
+  afterEach(() => cleanup());
+
+  it("shows the read-only notice when viewing as caregiver", () => {
+    render(<SymptomsPage />);
+    expect(
+      screen.getByTestId("symptoms-caregiver-readonly-notice"),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the submit button when viewing as caregiver", () => {
+    render(<SymptomsPage />);
+    const button = screen.getByTestId("symptoms-submit") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button).toHaveAttribute(
+      "title",
+      expect.stringMatching(/caregivers cannot submit/i),
+    );
+  });
+
+  it("does NOT show the read-only notice when the user is the patient", () => {
+    activePatientState.isViewingAsCaregiver = false;
+    render(<SymptomsPage />);
+    expect(
+      screen.queryByTestId("symptoms-caregiver-readonly-notice"),
+    ).toBeNull();
+  });
+});

--- a/apps/patient-portal/src/components/caregiver-indicator.tsx
+++ b/apps/patient-portal/src/components/caregiver-indicator.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useActivePatient } from "@/lib/active-patient";
+
+/**
+ * Banner rendered at the top of the portal whenever the signed-in user is
+ * viewing another person's chart (i.e. a family_caregiver with an active
+ * relationship, as opposed to a patient viewing themselves).
+ *
+ * Plain text — no icons / emojis — so screen readers announce it cleanly.
+ * `role="status"` + `aria-live="polite"` makes selection changes audible
+ * without interrupting the user mid-task.
+ */
+export function CaregiverIndicator() {
+  const { activePatient, isViewingAsCaregiver } = useActivePatient();
+
+  if (!isViewingAsCaregiver || !activePatient) return null;
+
+  const relationshipLabel = humanizeRelationship(activePatient.relationship);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="caregiver-indicator"
+      style={{
+        backgroundColor: "#1e3a8a",
+        border: "1px solid #3b82f6",
+        color: "#bfdbfe",
+        padding: "0.75rem 1rem",
+        borderRadius: 8,
+        marginBottom: "1rem",
+        fontSize: "0.875rem",
+      }}
+    >
+      <strong style={{ color: "#dbeafe" }}>
+        Viewing as {relationshipLabel} for {activePatient.name}.
+      </strong>{" "}
+      You have read-only access to this patient&apos;s record. Symptom entries
+      and clinical updates must be submitted by the patient.
+    </div>
+  );
+}
+
+/**
+ * Turn a `family_relationships.relationship_type` value into something
+ * readable. Exposed as a pure helper for unit tests.
+ */
+export function humanizeRelationship(relationship: string): string {
+  switch (relationship) {
+    case "spouse":
+      return "spouse";
+    case "parent":
+      return "parent";
+    case "child":
+      return "child";
+    case "sibling":
+      return "sibling";
+    case "healthcare_poa":
+      return "healthcare proxy";
+    case "other":
+    case "caregiver":
+      return "caregiver";
+    default:
+      return "caregiver";
+  }
+}

--- a/apps/patient-portal/src/components/patient-selector.tsx
+++ b/apps/patient-portal/src/components/patient-selector.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useActivePatient } from "@/lib/active-patient";
+
+/**
+ * Dropdown that lets a multi-patient caregiver switch which patient's
+ * records they are viewing.
+ *
+ * Hidden when the user can only view a single patient (a patient account, or
+ * a caregiver with exactly one linked patient) — the selector would be noise
+ * in that common case.
+ */
+export function PatientSelector() {
+  const { patients, activePatient, setActivePatientId, isMultiPatient } =
+    useActivePatient();
+
+  if (!isMultiPatient || !activePatient) return null;
+
+  return (
+    <div
+      data-testid="patient-selector"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        marginBottom: "1rem",
+      }}
+    >
+      <label
+        htmlFor="active-patient"
+        style={{ fontSize: "0.8rem", color: "#999" }}
+      >
+        Viewing:
+      </label>
+      <select
+        id="active-patient"
+        value={activePatient.id}
+        onChange={(e) => setActivePatientId(e.target.value)}
+        style={{
+          backgroundColor: "#1a1a1a",
+          color: "#ededed",
+          border: "1px solid #2a2a2a",
+          borderRadius: 6,
+          padding: "0.4rem 0.6rem",
+          fontSize: "0.875rem",
+        }}
+      >
+        {patients.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+            {p.mrn ? ` (${p.mrn})` : ""}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/patient-portal/src/lib/active-patient.tsx
+++ b/apps/patient-portal/src/lib/active-patient.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * Active-patient context for the patient portal.
+ *
+ * Resolves "which patient am I currently viewing" for the logged-in user:
+ *  - patient role  → themselves (the only option).
+ *  - family_caregiver → a selection from the patients they are linked to.
+ *
+ * The selection is persisted in localStorage under `ACTIVE_PATIENT_STORAGE_KEY`
+ * so it survives page reloads. This is UX convenience only — every server
+ * read re-checks access via the `enforcePatientAccess` middleware using the
+ * caller's session identity, NOT the localStorage value. A tampered
+ * localStorage key can at worst cause a FORBIDDEN from the server.
+ *
+ * When the stored id is no longer in the caregiver's active link set (for
+ * example after a patient revokes access), the hook silently falls back to
+ * the first patient returned by `patients.getMyPatients`. This keeps the UI
+ * from showing a blank dashboard after a stale id is picked up from storage.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import { trpc } from "./trpc";
+import { useAuth } from "./auth";
+
+export const ACTIVE_PATIENT_STORAGE_KEY = "carebridge:active-patient-id";
+
+export interface ViewablePatient {
+  id: string;
+  name: string;
+  mrn: string | null;
+  /** "self" for the patient role; a relationship_type token for caregivers. */
+  relationship: string;
+}
+
+export interface ActivePatientContextValue {
+  /** All patient records the signed-in user can view. */
+  patients: ViewablePatient[];
+  /** The one currently selected in the header / URL. */
+  activePatient: ViewablePatient | null;
+  /** Switches the active patient. Persists to localStorage. No-op for ids not in `patients`. */
+  setActivePatientId: (id: string) => void;
+  /** True on initial load before `getMyPatients` resolves. */
+  isLoading: boolean;
+  /** True when a caregiver has no active links — the portal should show an explanatory empty state. */
+  hasNoPatients: boolean;
+  /** True when the caregiver represents more than one patient (show the selector). */
+  isMultiPatient: boolean;
+  /** True when the active patient is NOT the logged-in user (banner should render). */
+  isViewingAsCaregiver: boolean;
+}
+
+const ActivePatientContext = createContext<ActivePatientContextValue | null>(
+  null,
+);
+
+/**
+ * Resolve the active-patient id from a stored value and the candidate list.
+ *
+ * Exported for unit testing. Pure — no DOM / storage side effects.
+ *
+ * Returns null only when `patients` is empty.
+ */
+export function resolveActivePatientId(
+  stored: string | null,
+  patients: ReadonlyArray<Pick<ViewablePatient, "id">>,
+): string | null {
+  if (patients.length === 0) return null;
+  if (stored) {
+    const match = patients.find((p) => p.id === stored);
+    if (match) return match.id;
+  }
+  return patients[0]!.id;
+}
+
+export function ActivePatientProvider({ children }: { children: ReactNode }) {
+  const { user, isAuthenticated } = useAuth();
+
+  const { data: patients = [], isLoading } =
+    trpc.patients.getMyPatients.useQuery(undefined, {
+      enabled: isAuthenticated,
+    });
+
+  const [storedId, setStoredId] = useState<string | null>(null);
+
+  // One-time hydrate from localStorage after mount (SSR-safe).
+  useEffect(() => {
+    try {
+      const value = window.localStorage.getItem(ACTIVE_PATIENT_STORAGE_KEY);
+      setStoredId(value);
+    } catch {
+      // localStorage may be blocked (private mode, sandboxed iframes); fall
+      // through to the "first patient wins" default.
+    }
+  }, []);
+
+  const activePatientId = useMemo(
+    () => resolveActivePatientId(storedId, patients),
+    [storedId, patients],
+  );
+
+  const activePatient = useMemo(
+    () => patients.find((p) => p.id === activePatientId) ?? null,
+    [patients, activePatientId],
+  );
+
+  const setActivePatientId = useCallback(
+    (id: string) => {
+      const match = patients.find((p) => p.id === id);
+      if (!match) return;
+      setStoredId(id);
+      try {
+        window.localStorage.setItem(ACTIVE_PATIENT_STORAGE_KEY, id);
+      } catch {
+        // Ignore — in-memory state still reflects the selection.
+      }
+    },
+    [patients],
+  );
+
+  const value = useMemo<ActivePatientContextValue>(() => {
+    const isViewingAsCaregiver = !!(
+      activePatient &&
+      user?.role === "family_caregiver" &&
+      activePatient.relationship !== "self"
+    );
+    return {
+      patients,
+      activePatient,
+      setActivePatientId,
+      isLoading,
+      hasNoPatients:
+        !isLoading && patients.length === 0 && user?.role === "family_caregiver",
+      isMultiPatient: patients.length > 1,
+      isViewingAsCaregiver,
+    };
+  }, [patients, activePatient, setActivePatientId, isLoading, user?.role]);
+
+  return (
+    <ActivePatientContext.Provider value={value}>
+      {children}
+    </ActivePatientContext.Provider>
+  );
+}
+
+export function useActivePatient(): ActivePatientContextValue {
+  const ctx = useContext(ActivePatientContext);
+  if (!ctx) {
+    throw new Error(
+      "useActivePatient must be used within an ActivePatientProvider",
+    );
+  }
+  return ctx;
+}

--- a/apps/patient-portal/src/lib/use-my-patient.ts
+++ b/apps/patient-portal/src/lib/use-my-patient.ts
@@ -1,30 +1,49 @@
 /**
- * Shared hook to resolve the current patient's record.
+ * Shared hook to resolve the currently-viewed patient's record.
  *
- * Uses user.patient_id (set on the users table) for a direct lookup via
- * patients.getById. If the user account has no patient_id linked, the hook
- * returns an explicit `isUnlinked` flag so pages can show an error state
- * instead of silently falling back to another patient's data.
+ * For a patient user this is always their own record (user.patient_id).
+ * For a family_caregiver user it is whichever linked patient is active in
+ * the ActivePatientContext (see src/lib/active-patient.tsx). The full
+ * patient record is fetched via patients.getById, which re-runs the server
+ * access check on every call — the localStorage-backed "active patient" is
+ * UX state only, never an authorisation primitive.
+ *
+ * `isUnlinked` is true only for patient users whose users.patient_id column
+ * has not been populated. Caregivers with zero active relationships surface
+ * via `useActivePatient().hasNoPatients` instead.
  */
 
 import { useAuth } from "./auth";
 import { trpc } from "./trpc";
+import { useActivePatient } from "./active-patient";
 
 export function useMyPatientRecord() {
   const { user } = useAuth();
+  const { activePatient } = useActivePatient();
 
-  const hasPatientId = !!user?.patient_id;
+  // For caregivers, the active patient (from the ActivePatient context)
+  // supplies the id. Patients fall back to users.patient_id.
+  const targetId =
+    user?.role === "family_caregiver"
+      ? (activePatient?.id ?? null)
+      : (user?.patient_id ?? null);
+
+  const hasTarget = !!targetId;
 
   const directQuery = trpc.patients.getById.useQuery(
-    { id: user?.patient_id ?? "" },
-    { enabled: hasPatientId },
+    { id: targetId ?? "" },
+    { enabled: hasTarget },
   );
 
   return {
-    patient: hasPatientId ? (directQuery.data ?? null) : null,
-    isLoading: hasPatientId ? directQuery.isLoading : false,
-    isError: hasPatientId ? directQuery.isError : false,
-    /** True when the user account is not linked to any patient record. */
-    isUnlinked: !!user && !user.patient_id,
+    patient: hasTarget ? (directQuery.data ?? null) : null,
+    isLoading: hasTarget ? directQuery.isLoading : false,
+    isError: hasTarget ? directQuery.isError : false,
+    /**
+     * True when a patient-role user has no linked patient record. Caregivers
+     * with no active relationships are NOT flagged here — that state is
+     * exposed via useActivePatient().hasNoPatients.
+     */
+    isUnlinked: !!user && user.role === "patient" && !user.patient_id,
   };
 }

--- a/services/api-gateway/src/__tests__/caregiver-access.test.ts
+++ b/services/api-gateway/src/__tests__/caregiver-access.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Server-side tests for family_caregiver read access (issue #329).
+ *
+ * Verifies that:
+ *  - enforcePatientAccess grants reads for a caregiver with an active
+ *    family_relationships row joined through users.patient_id.
+ *  - enforcePatientAccess rejects a caregiver with no active link.
+ *  - patients.getMyPatients returns the linked patient set (with
+ *    relationship_type) for caregivers and a single "self" row for patients.
+ *  - observations.create is denied for caregivers even when they otherwise
+ *    have access to the patient record.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+const CAREGIVER_USER_ID = "77777777-7777-4777-8777-777777777777";
+const LINKED_PATIENT_USER_ID = "11111111-1111-4111-8111-111111111111";
+const LINKED_PATIENT_RECORD_ID = "aaaa1111-1111-4111-8111-111111111111";
+const OTHER_PATIENT_RECORD_ID = "bbbb2222-2222-4222-8222-222222222222";
+
+const mocks = vi.hoisted(() => {
+  let queue: unknown[][] = [];
+
+  function makeChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain);
+    // where() returns a thenable so `await db.select().from().where()` works,
+    // but also still exposes .limit() for chains that terminate with a limit.
+    chain.where = vi.fn(() => {
+      const next = queue.shift() ?? [];
+      // Build a thenable wrapper that also carries a .limit() method.
+      const wrapper: Record<string, unknown> = {
+        then: (resolve: (v: unknown) => void) => {
+          resolve(next);
+          return wrapper;
+        },
+        limit: vi.fn(async () => next),
+      };
+      return wrapper;
+    });
+    chain.limit = vi.fn(async () => queue.shift() ?? []);
+    return chain;
+  }
+
+  const mockDb = {
+    select: vi.fn(() => makeChain()),
+    insert: vi.fn(() => ({ values: vi.fn() })),
+  };
+
+  return {
+    mockDb,
+    setQueue: (q: unknown[][]) => {
+      queue = [...q];
+    },
+  };
+});
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  hmacForIndex: (v: string) => `hmac:${v}`,
+  patients: {
+    id: "patients.id",
+    name: "patients.name",
+    mrn: "patients.mrn",
+    name_hmac: "patients.name_hmac",
+    date_of_birth: "patients.date_of_birth",
+    biological_sex: "patients.biological_sex",
+    diagnosis: "patients.diagnosis",
+    primary_provider_id: "patients.primary_provider_id",
+    allergy_status: "patients.allergy_status",
+    weight_kg: "patients.weight_kg",
+    mrn_hmac: "patients.mrn_hmac",
+    created_at: "patients.created_at",
+    updated_at: "patients.updated_at",
+  },
+  diagnoses: { id: "diagnoses.id", patient_id: "diagnoses.patient_id" },
+  allergies: { id: "allergies.id", patient_id: "allergies.patient_id" },
+  careTeamMembers: { patient_id: "care_team_members.patient_id" },
+  careTeamAssignments: {
+    id: "care_team_assignments.id",
+    user_id: "care_team_assignments.user_id",
+    patient_id: "care_team_assignments.patient_id",
+    removed_at: "care_team_assignments.removed_at",
+  },
+  familyRelationships: {
+    id: "family_relationships.id",
+    caregiver_id: "family_relationships.caregiver_id",
+    patient_id: "family_relationships.patient_id",
+    relationship_type: "family_relationships.relationship_type",
+    status: "family_relationships.status",
+  },
+  users: {
+    id: "users.id",
+    patient_id: "users.patient_id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  isNull: (col: unknown) => ({ op: "isNull", col }),
+  isNotNull: (col: unknown) => ({ op: "isNotNull", col }),
+  inArray: (col: unknown, vals: unknown) => ({ op: "inArray", col, vals }),
+  desc: (col: unknown) => ({ op: "desc", col }),
+}));
+
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: vi.fn(async () => false),
+}));
+
+vi.mock("@carebridge/patient-records", () => ({
+  listObservationsByPatient: vi.fn(async () => []),
+  createObservation: vi.fn(async (input: unknown) => ({
+    id: "obs-1",
+    ...(input as Record<string, unknown>),
+  })),
+  createDiagnosis: vi.fn(),
+  updateDiagnosis: vi.fn(),
+  createAllergy: vi.fn(),
+  updateAllergy: vi.fn(),
+}));
+
+vi.mock("@carebridge/validators", async () => {
+  const { z } = await import("zod");
+  return {
+    createPatientSchema: z.object({ mrn: z.string().optional() }),
+    updatePatientSchema: z.object({}),
+    createDiagnosisSchema: z.object({
+      patient_id: z.string().uuid(),
+      icd10_code: z.string(),
+      description: z.string(),
+      status: z.string().optional().default("active"),
+    }),
+    updateDiagnosisSchema: z.object({
+      status: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    createAllergySchema: z.object({
+      patient_id: z.string().uuid(),
+      allergen: z.string(),
+      reaction: z.string(),
+      severity: z.string(),
+    }),
+    updateAllergySchema: z.object({
+      severity: z.string().optional(),
+      reaction: z.string().optional(),
+    }),
+  };
+});
+
+import { patientRecordsRbacRouter } from "../routers/patient-records.js";
+import type { Context } from "../context.js";
+
+function makeUser(
+  role: User["role"],
+  id: string,
+  overrides: Partial<User> = {},
+): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function callerFor(user: User | null) {
+  const ctx: Context = {
+    db: mocks.mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+  return patientRecordsRbacRouter.createCaller(ctx);
+}
+
+describe("enforcePatientAccess — family_caregiver", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("grants observations.getByPatient to a caregiver with an active link", async () => {
+    // limit() for the family_relationships join => row found
+    // then createObservation / list runs without another DB call we care about
+    mocks.setQueue([
+      [{ id: "rel-1" }], // family link lookup
+    ]);
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    const caller = callerFor(caregiver);
+
+    await expect(
+      caller.observations.getByPatient({
+        patientId: LINKED_PATIENT_RECORD_ID,
+        limit: 20,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("denies observations.getByPatient to a caregiver with no active link", async () => {
+    mocks.setQueue([
+      [], // family link lookup => empty
+    ]);
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    const caller = callerFor(caregiver);
+
+    await expect(
+      caller.observations.getByPatient({
+        patientId: OTHER_PATIENT_RECORD_ID,
+        limit: 20,
+      }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("denies observations.create for family_caregiver even with active link", async () => {
+    // Server-side block is explicit for family_caregiver — must happen
+    // BEFORE the access check, so no DB lookups are expected.
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    const caller = callerFor(caregiver);
+
+    await expect(
+      caller.observations.create({
+        patientId: LINKED_PATIENT_RECORD_ID,
+        observationType: "pain",
+        description: "test",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: expect.stringMatching(/caregiver/i),
+    });
+  });
+});
+
+describe("patients.getMyPatients", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns a single self-relationship row for a patient user", async () => {
+    const patientUser = makeUser("patient", "patient-user-1", {
+      patient_id: LINKED_PATIENT_RECORD_ID,
+    });
+    mocks.setQueue([
+      [
+        {
+          id: LINKED_PATIENT_RECORD_ID,
+          name: "Jane Doe",
+          mrn: "MRN001",
+        },
+      ],
+    ]);
+    const caller = callerFor(patientUser);
+    const result = await caller.getMyPatients();
+
+    expect(result).toEqual([
+      {
+        id: LINKED_PATIENT_RECORD_ID,
+        name: "Jane Doe",
+        mrn: "MRN001",
+        relationship: "self",
+      },
+    ]);
+  });
+
+  it("returns empty list for a patient user with no patient_id link", async () => {
+    const patientUser = makeUser("patient", "patient-user-1");
+    const caller = callerFor(patientUser);
+    const result = await caller.getMyPatients();
+    expect(result).toEqual([]);
+  });
+
+  it("returns linked patients with relationship_type for a caregiver", async () => {
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    mocks.setQueue([
+      // 1) family_relationships rows
+      [
+        {
+          patient_user_id: LINKED_PATIENT_USER_ID,
+          relationship_type: "spouse",
+        },
+      ],
+      // 2) users rows with patient_id
+      [{ id: LINKED_PATIENT_USER_ID, patient_id: LINKED_PATIENT_RECORD_ID }],
+      // 3) patients rows (minimum-necessary projection: id, name, mrn)
+      [
+        {
+          id: LINKED_PATIENT_RECORD_ID,
+          name: "Jane Doe",
+          mrn: "MRN001",
+        },
+      ],
+    ]);
+
+    const caller = callerFor(caregiver);
+    const result = await caller.getMyPatients();
+
+    expect(result).toEqual([
+      {
+        id: LINKED_PATIENT_RECORD_ID,
+        name: "Jane Doe",
+        mrn: "MRN001",
+        relationship: "spouse",
+      },
+    ]);
+  });
+
+  it("returns multiple rows when a caregiver represents multiple patients", async () => {
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    const SECOND_PATIENT_USER_ID = "22222222-2222-4222-8222-222222222222";
+
+    mocks.setQueue([
+      [
+        {
+          patient_user_id: LINKED_PATIENT_USER_ID,
+          relationship_type: "parent",
+        },
+        {
+          patient_user_id: SECOND_PATIENT_USER_ID,
+          relationship_type: "child",
+        },
+      ],
+      [
+        { id: LINKED_PATIENT_USER_ID, patient_id: LINKED_PATIENT_RECORD_ID },
+        { id: SECOND_PATIENT_USER_ID, patient_id: OTHER_PATIENT_RECORD_ID },
+      ],
+      [
+        { id: LINKED_PATIENT_RECORD_ID, name: "Mom", mrn: "MRN001" },
+        { id: OTHER_PATIENT_RECORD_ID, name: "Kid", mrn: "MRN002" },
+      ],
+    ]);
+
+    const caller = callerFor(caregiver);
+    const result = await caller.getMyPatients();
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: LINKED_PATIENT_RECORD_ID,
+          relationship: "parent",
+        }),
+        expect.objectContaining({
+          id: OTHER_PATIENT_RECORD_ID,
+          relationship: "child",
+        }),
+      ]),
+    );
+  });
+
+  it("returns empty list when a caregiver has no active relationships", async () => {
+    const caregiver = makeUser("family_caregiver", CAREGIVER_USER_ID);
+    mocks.setQueue([[]]);
+    const caller = callerFor(caregiver);
+    const result = await caller.getMyPatients();
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty list for admins and clinicians (patient portal only)", async () => {
+    for (const role of ["admin", "nurse", "physician", "specialist"] as const) {
+      mocks.setQueue([]);
+      const caller = callerFor(makeUser(role, `${role}-id`));
+      const result = await caller.getMyPatients();
+      expect(result).toEqual([]);
+    }
+  });
+});

--- a/services/api-gateway/src/routers/clinical-data.ts
+++ b/services/api-gateway/src/routers/clinical-data.ts
@@ -26,8 +26,13 @@ import {
   procedureRepo,
   ConflictError,
 } from "@carebridge/clinical-data";
-import { getDb, medications } from "@carebridge/db-schema";
-import { eq } from "drizzle-orm";
+import {
+  getDb,
+  medications,
+  familyRelationships,
+  users,
+} from "@carebridge/db-schema";
+import { and, eq } from "drizzle-orm";
 import type { Context } from "../context.js";
 import { assertCareTeamAccess } from "../middleware/rbac.js";
 
@@ -45,6 +50,9 @@ const protectedProcedure = t.procedure.use(isAuthenticated);
 /**
  * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
  * Throws TRPCError(FORBIDDEN) on denial.
+ *
+ * Role semantics mirror patient-records.ts — family_caregiver resolves via
+ * an active family_relationships row joined through users.patient_id.
  */
 async function enforcePatientAccess(
   user: NonNullable<Context["user"]>,
@@ -53,10 +61,35 @@ async function enforcePatientAccess(
   if (user.role === "admin") return;
 
   if (user.role === "patient") {
-    if (user.id !== patientId) {
+    const ownRecord = user.patient_id ?? user.id;
+    if (ownRecord !== patientId) {
       throw new TRPCError({
         code: "FORBIDDEN",
         message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  if (user.role === "family_caregiver") {
+    const db = getDb();
+    const [row] = await db
+      .select({ id: familyRelationships.id })
+      .from(familyRelationships)
+      .innerJoin(users, eq(users.id, familyRelationships.patient_id))
+      .where(
+        and(
+          eq(familyRelationships.caregiver_id, user.id),
+          eq(users.patient_id, patientId),
+          eq(familyRelationships.status, "active"),
+        ),
+      )
+      .limit(1);
+    if (!row) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "Access denied: no active family relationship grants access to this patient",
       });
     }
     return;

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -53,6 +53,16 @@ const protectedProcedure = t.procedure.use(isAuthenticated);
 /**
  * Enforce HIPAA minimum-necessary access for a given user / patientId pair.
  * Throws TRPCError(FORBIDDEN) on denial.
+ *
+ * Role semantics:
+ *  - admin: unrestricted
+ *  - patient: own record only (user.patient_id === patientId; user.id fallback
+ *    preserved for test fixtures that do not set patient_id)
+ *  - family_caregiver: must have an active family_relationships row linking
+ *    the caller's user.id to a user whose users.patient_id matches the
+ *    requested patient record id. Caregivers never satisfy the clinician
+ *    care-team check, so they must be resolved via this path.
+ *  - clinicians (physician, specialist, nurse): active care-team assignment
  */
 async function enforcePatientAccess(
   user: NonNullable<Context["user"]>,
@@ -61,10 +71,23 @@ async function enforcePatientAccess(
   if (user.role === "admin") return;
 
   if (user.role === "patient") {
-    if (user.id !== patientId) {
+    const ownRecord = user.patient_id ?? user.id;
+    if (ownRecord !== patientId) {
       throw new TRPCError({
         code: "FORBIDDEN",
         message: "Access denied: patients may only access their own records",
+      });
+    }
+    return;
+  }
+
+  if (user.role === "family_caregiver") {
+    const hasLink = await hasActiveFamilyLink(user.id, patientId);
+    if (!hasLink) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "Access denied: no active family relationship grants access to this patient",
       });
     }
     return;
@@ -78,6 +101,35 @@ async function enforcePatientAccess(
       message: "Access denied: no active care-team assignment for this patient",
     });
   }
+}
+
+/**
+ * Resolve whether a family caregiver user currently has an active
+ * family_relationships row granting them read access to the given patient
+ * record id.
+ *
+ * family_relationships.patient_id references users.id (the patient's user
+ * account), but requests identify the subject by patients.id, so the query
+ * joins through users to close the mapping.
+ */
+async function hasActiveFamilyLink(
+  caregiverUserId: string,
+  patientRecordId: string,
+): Promise<boolean> {
+  const db = getDb();
+  const [row] = await db
+    .select({ id: familyRelationships.id })
+    .from(familyRelationships)
+    .innerJoin(users, eq(users.id, familyRelationships.patient_id))
+    .where(
+      and(
+        eq(familyRelationships.caregiver_id, caregiverUserId),
+        eq(users.patient_id, patientRecordId),
+        eq(familyRelationships.status, "active"),
+      ),
+    )
+    .limit(1);
+  return !!row;
 }
 
 /**
@@ -199,6 +251,97 @@ export const patientRecordsRbacRouter = t.router({
         .where(eq(patients.id, input.id));
       return patient ?? null;
     }),
+
+  /**
+   * Patients the current user is authorised to view in the patient portal.
+   *
+   * Returns a minimum-necessary summary (id, name, mrn, relationship) used
+   * to power the "which patient am I viewing" UI. Client-side code persists
+   * a selection in localStorage, but every downstream read still runs through
+   * enforcePatientAccess, so this endpoint is a UX helper — not the
+   * authorisation boundary.
+   *
+   * Role semantics:
+   *  - patient: returns exactly one entry (themselves), relationship "self".
+   *  - family_caregiver: returns every patient linked via an active
+   *    family_relationships row, keyed by patients.id. The relationship_type
+   *    (spouse/parent/child/sibling/...) is included so the UI can render
+   *    "Viewing as spouse for Jane Doe".
+   *  - clinicians (physician, specialist, nurse) and admins: returns an
+   *    empty list. The patient portal is not a clinician surface — these
+   *    roles use the clinician portal's dedicated patient selector.
+   */
+  getMyPatients: protectedProcedure.query(async ({ ctx }) => {
+    const db = getDb();
+
+    if (ctx.user.role === "patient") {
+      if (!ctx.user.patient_id) return [];
+      const [row] = await db
+        .select({ id: patients.id, name: patients.name, mrn: patients.mrn })
+        .from(patients)
+        .where(eq(patients.id, ctx.user.patient_id));
+      if (!row) return [];
+      return [{ ...row, relationship: "self" as const }];
+    }
+
+    if (ctx.user.role === "family_caregiver") {
+      const rels = await db
+        .select({
+          patient_user_id: familyRelationships.patient_id,
+          relationship_type: familyRelationships.relationship_type,
+        })
+        .from(familyRelationships)
+        .where(
+          and(
+            eq(familyRelationships.caregiver_id, ctx.user.id),
+            eq(familyRelationships.status, "active"),
+          ),
+        );
+      if (rels.length === 0) return [];
+
+      const userRows = await db
+        .select({ id: users.id, patient_id: users.patient_id })
+        .from(users)
+        .where(
+          and(
+            inArray(
+              users.id,
+              rels.map((r) => r.patient_user_id),
+            ),
+            isNotNull(users.patient_id),
+          ),
+        );
+      const patientIds = userRows
+        .map((u) => u.patient_id)
+        .filter((id): id is string => Boolean(id));
+      if (patientIds.length === 0) return [];
+
+      const patientRows = await db
+        .select({ id: patients.id, name: patients.name, mrn: patients.mrn })
+        .from(patients)
+        .where(inArray(patients.id, patientIds));
+
+      // Re-join in memory so the relationship_type travels with each row.
+      const patientIdByUserId = new Map<string, string>();
+      for (const u of userRows) {
+        if (u.patient_id) patientIdByUserId.set(u.id, u.patient_id);
+      }
+      const relationshipByPatientId = new Map<string, string>();
+      for (const r of rels) {
+        const pid = patientIdByUserId.get(r.patient_user_id);
+        if (pid) relationshipByPatientId.set(pid, r.relationship_type);
+      }
+      return patientRows.map((p) => ({
+        id: p.id,
+        name: p.name,
+        mrn: p.mrn,
+        relationship: relationshipByPatientId.get(p.id) ?? "caregiver",
+      }));
+    }
+
+    // Clinicians and admins use the clinician portal.
+    return [];
+  }),
 
   // HIPAA minimum-necessary: filter patient list by role.
   //   - patient: only their own record
@@ -445,6 +588,19 @@ export const patientRecordsRbacRouter = t.router({
         }),
       )
       .mutation(async ({ ctx, input }) => {
+        // Patient-reported observations are an act of first-person self-report.
+        // Family caregivers can *view* the symptom journal (via getByPatient +
+        // enforcePatientAccess) but must never submit entries on the patient's
+        // behalf — the clinical value of this feed depends on the patient
+        // being the author. Enforce server-side so a tampered client can't
+        // bypass the read-only UI.
+        if (ctx.user.role === "family_caregiver") {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "Family caregivers cannot submit symptom observations on behalf of a patient",
+          });
+        }
         await enforcePatientAccess(ctx.user, input.patientId);
         return createObservation(input);
       }),


### PR DESCRIPTION
Closes #329

## Summary

Lets a `family_caregiver` user sign into the patient portal and view the records of every patient who has granted them an active relationship. Reads are granted server-side via `family_relationships` joined through `users.patient_id`; writes to clinical data and first-person symptom observations remain denied. The UI surfaces who the caregiver is viewing, offers a selector when more than one patient is linked, and blocks the symptom-journal write path with both UI affordance and an enforced server-side denial.

## Acceptance criteria

- [x] Proxy users can view the represented patient's labs, medications, diagnoses, allergies, notes — reached via the existing per-resource `getByPatient` procedures, now allowed for caregivers with active links.
- [x] Every proxy data access creates an audit log entry identifying BOTH the proxy `user_id` AND the patient the caregiver is viewing — already provided by `auditMiddleware` + `deriveActorContext` (populates `on_behalf_of_patient_id` and `actor_relationship` on every request).
- [x] UI displays "Viewing as caregiver for [Patient Name]" indicator clearly (new `CaregiverIndicator` banner, `role=status`, `aria-live=polite`).
- [x] Proxy cannot submit symptom observations (read-only on symptom journal) — client-side disabled submit + server-side `FORBIDDEN` on `observations.create` for `family_caregiver`.
- [x] Multi-patient proxy switching when the caregiver represents multiple family members — `PatientSelector` dropdown rendered when `patients.length > 1`.

## Changes

**Server-side (api-gateway):**
- `patient-records.ts` / `clinical-data.ts`: `enforcePatientAccess` now grants `family_caregiver` via an active `family_relationships` row joined through `users.patient_id`.
- `patient-records.ts`: new `patients.getMyPatients` returning `{ id, name, mrn, relationship }[]` with minimum-necessary projection. Self for patient users, linked set for caregivers, empty for clinicians/admins (they use the clinician portal).
- `patient-records.ts`: `observations.create` now returns `FORBIDDEN` for `family_caregiver` before the access check, backing up the read-only UI.

**Client-side (patient-portal):**
- New `ActivePatientProvider` + `useActivePatient` hook (`src/lib/active-patient.tsx`). Resolves "which patient am I viewing". Persists selection in localStorage under `carebridge:active-patient-id` — UX only, server re-checks on every request.
- New `CaregiverIndicator` banner and `PatientSelector` dropdown, wired into `app/layout.tsx`.
- `useMyPatientRecord` now routes through the active patient for caregivers (patient-role behavior unchanged).
- `app/symptoms/page.tsx` shows a read-only notice and disables the submit button when viewing as caregiver.

## Security notes

- `localStorage` active-patient id is treated as advisory. The server-side `enforcePatientAccess` is the authorisation boundary; tampering can at worst yield a `FORBIDDEN`.
- `observations.create` is blocked server-side for `family_caregiver` as well as in the UI — a tampered client cannot bypass the read-only constraint.
- The existing `audit_log` migration (`0031`) already captures `on_behalf_of_patient_id` and `actor_relationship`; no new audit schema is required.

## Test plan

- [x] `pnpm --filter @carebridge/api-gateway test` — 270 tests, all green (includes new `caregiver-access.test.ts`).
- [x] `pnpm --filter @carebridge/patient-portal test` — 30 tests, all green (includes `active-patient.test.tsx`, `caregiver-indicator.test.tsx`, `symptoms-caregiver-readonly.test.tsx`).
- [x] `pnpm --filter @carebridge/auth test` — 97 tests, all green.
- [x] `pnpm typecheck` — green across 40 tasks.
- [x] `pnpm lint` — no warnings or errors in the patient portal. Pre-existing clinician-portal warnings are untouched.

## Non-goals

- No changes to caregiver invite/accept/revoke flows (already shipped in Phase B3).
- No per-field scope filtering — that's #305-313 territory; this PR only surfaces what the server already returns.
- No clinician-portal changes.