### PR TITLE
feat(portal): mobile and tablet responsive layouts with collapsible sidebar

### DIFF
--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -924,17 +924,16 @@ tr:hover td {
     border-bottom: none;
   }
 
-  /* Touch-friendly buttons (WCAG 44x44 min) */
-  .btn {
+  /* Touch-friendly buttons (WCAG 2.5.5 — 44x44 min) */
+  .btn,
+  .btn-sm {
     min-height: 44px;
     min-width: 44px;
-    padding: 10px 18px;
+    padding: 10px 14px;
     font-size: 14px;
   }
 
   .btn-sm {
-    min-height: 40px;
-    padding: 8px 14px;
     font-size: 13px;
   }
 

--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -58,6 +58,9 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Prevent accidental page-level horizontal scroll at narrow viewports.
+     Overflow inside cards / tables is handled per-container. */
+  overflow-x: hidden;
 }
 
 a {
@@ -309,7 +312,11 @@ a {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  /* Allow horizontal scroll by default so narrow viewports (tablet) can
+     scroll wide tables. The stacked-card layout at <768px overrides this
+     to `visible`. Vertical clipping isn't needed since tables flow. */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .table-header {

--- a/apps/clinician-portal/app/notes/page.tsx
+++ b/apps/clinician-portal/app/notes/page.tsx
@@ -109,7 +109,7 @@ function NotesContent() {
                   const patient = patientsById.get(note.patient_id);
                   return (
                     <tr key={note.id}>
-                      <td>
+                      <td data-label="Patient">
                         <Link href={`/patients/${note.patient_id}`}>
                           {patient?.name ?? note.patient_id}
                         </Link>
@@ -119,19 +119,25 @@ function NotesContent() {
                           </div>
                         )}
                       </td>
-                      <td style={{ textTransform: "uppercase", fontSize: 12 }}>
+                      <td
+                        data-label="Type"
+                        style={{ textTransform: "uppercase", fontSize: 12 }}
+                      >
                         {note.template_type}
                       </td>
-                      <td>
+                      <td data-label="Status">
                         <span className={statusBadgeClass(note.status)}>
                           {note.status.toUpperCase()}
                         </span>
                       </td>
-                      <td>v{note.version}</td>
-                      <td style={{ color: "var(--text-secondary)" }}>
+                      <td data-label="Version">v{note.version}</td>
+                      <td
+                        data-label="Created"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
                         {formatDate(note.created_at)}
                       </td>
-                      <td>
+                      <td data-label="Actions">
                         <Link href={`/notes/${note.id}`} className="btn btn-ghost btn-sm">
                           Open
                         </Link>

--- a/apps/clinician-portal/app/page.tsx
+++ b/apps/clinician-portal/app/page.tsx
@@ -173,7 +173,7 @@ function DashboardContent() {
             <tbody>
               {patientsQuery.data.slice(0, 5).map((patient) => (
                 <tr key={patient.id}>
-                  <td>
+                  <td data-label="Patient Name">
                     <a
                       href={`/patients/${patient.id}`}
                       className="table-link"
@@ -182,6 +182,7 @@ function DashboardContent() {
                     </a>
                   </td>
                   <td
+                    data-label="MRN"
                     style={{
                       color: "var(--text-secondary)",
                       fontFamily: "monospace",
@@ -190,10 +191,13 @@ function DashboardContent() {
                   >
                     {patient.mrn}
                   </td>
-                  <td style={{ color: "var(--text-secondary)" }}>
+                  <td
+                    data-label="Date of Birth"
+                    style={{ color: "var(--text-secondary)" }}
+                  >
                     {patient.date_of_birth}
                   </td>
-                  <td>
+                  <td data-label="Actions">
                     <a
                       href={`/patients/${patient.id}`}
                       className="btn btn-ghost btn-sm"

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -491,8 +491,9 @@ function LabsTab({ patientId }: { patientId: string }) {
 
                   return (
                     <tr key={ri}>
-                      <td>{r.test_name}</td>
+                      <td data-label="Test">{r.test_name}</td>
                       <td
+                        data-label="Result"
                         style={{
                           fontWeight: 600,
                           color: valueColor,
@@ -500,13 +501,19 @@ function LabsTab({ patientId }: { patientId: string }) {
                       >
                         {r.value}
                       </td>
-                      <td style={{ color: "var(--text-secondary)" }}>
+                      <td
+                        data-label="Unit"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
                         {r.unit}
                       </td>
-                      <td style={{ color: "var(--text-secondary)" }}>
+                      <td
+                        data-label="Reference Range"
+                        style={{ color: "var(--text-secondary)" }}
+                      >
                         {referenceRange}
                       </td>
-                      <td>
+                      <td data-label="Flag">
                         {flag ? (
                           <span
                             className={`badge ${
@@ -599,15 +606,22 @@ function MedicationStatusSection({
         <tbody>
           {medications.map((med) => (
             <tr key={med.id}>
-              <td style={{ fontWeight: 500, color: titleColor ?? undefined }}>
+              <td
+                data-label="Medication"
+                style={{ fontWeight: 500, color: titleColor ?? undefined }}
+              >
                 {med.name}
               </td>
-              <td style={{ color: textColor }}>
+              <td data-label="Dose" style={{ color: textColor }}>
                 {med.dose_amount} {med.dose_unit}
               </td>
-              <td style={{ color: textColor }}>{med.route}</td>
-              <td style={{ color: textColor }}>{med.frequency}</td>
-              <td>
+              <td data-label="Route" style={{ color: textColor }}>
+                {med.route}
+              </td>
+              <td data-label="Frequency" style={{ color: textColor }}>
+                {med.frequency}
+              </td>
+              <td data-label="Status">
                 <span className={badge.className} title={badge.title}>
                   {badge.label}
                 </span>

--- a/apps/clinician-portal/app/patients/page.tsx
+++ b/apps/clinician-portal/app/patients/page.tsx
@@ -84,7 +84,7 @@ function PatientsContent() {
               ) : (
                 filtered.map((patient) => (
                   <tr key={patient.id}>
-                    <td>
+                    <td data-label="Patient Name">
                       <Link
                         href={`/patients/${patient.id}`}
                         className="table-link"
@@ -93,6 +93,7 @@ function PatientsContent() {
                       </Link>
                     </td>
                     <td
+                      data-label="MRN"
                       style={{
                         color: "var(--text-secondary)",
                         fontFamily: "monospace",
@@ -101,13 +102,19 @@ function PatientsContent() {
                     >
                       {patient.mrn}
                     </td>
-                    <td style={{ color: "var(--text-secondary)" }}>
+                    <td
+                      data-label="Date of Birth"
+                      style={{ color: "var(--text-secondary)" }}
+                    >
                       {patient.date_of_birth}
                     </td>
-                    <td style={{ color: "var(--text-secondary)" }}>
+                    <td
+                      data-label="Sex"
+                      style={{ color: "var(--text-secondary)" }}
+                    >
                       {patient.biological_sex}
                     </td>
-                    <td>
+                    <td data-label="Actions">
                       <Link
                         href={`/patients/${patient.id}`}
                         className="btn btn-ghost btn-sm"

--- a/apps/clinician-portal/app/sidebar.tsx
+++ b/apps/clinician-portal/app/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth";
 import { trpcVanilla } from "@/lib/trpc";
 
@@ -16,6 +16,15 @@ const navItems = [
   { href: "/settings", label: "Settings", icon: "\u2699" },
 ];
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 function getInitials(name: string): string {
   return name
     .split(" ")
@@ -26,11 +35,101 @@ function getInitials(name: string): string {
     .toUpperCase();
 }
 
+/**
+ * Focus management for the sidebar drawer (WCAG 2.1.2 / 2.4.3 / 2.4.7):
+ *   - On open: saves the previously-focused element and moves focus into
+ *     the drawer.
+ *   - While open: traps Tab / Shift+Tab within focusable descendants and
+ *     closes the drawer on Escape.
+ *   - On close: restores focus to the element that opened the drawer
+ *     (usually the hamburger toggle).
+ */
+function useSidebarFocusTrap(
+  isOpen: boolean,
+  containerRef: React.RefObject<HTMLElement | null>,
+  onClose: () => void,
+) {
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    previousFocusRef.current =
+      (document.activeElement as HTMLElement | null) ?? null;
+
+    const focusables = Array.from(
+      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    );
+    const firstFocusable = focusables[0];
+    if (firstFocusable) {
+      firstFocusable.focus();
+    } else {
+      container.focus();
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const current = containerRef.current;
+      if (!current) return;
+      const items = Array.from(
+        current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      );
+      if (items.length === 0) {
+        event.preventDefault();
+        current.focus();
+        return;
+      }
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (active === first || !current.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, containerRef, onClose]);
+
+  useEffect(() => {
+    if (isOpen) return;
+    const previous = previousFocusRef.current;
+    if (previous && typeof previous.focus === "function") {
+      previous.focus();
+    }
+    previousFocusRef.current = null;
+  }, [isOpen]);
+}
+
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, clearSession, isAuthenticated, hydrated } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
+  const asideRef = useRef<HTMLElement | null>(null);
+
+  const closeDrawer = () => setIsOpen(false);
+  useSidebarFocusTrap(isOpen, asideRef, closeDrawer);
 
   async function handleLogout() {
     try {
@@ -64,14 +163,16 @@ export function Sidebar() {
       {isOpen && (
         <div
           className="sidebar-backdrop"
-          onClick={() => setIsOpen(false)}
+          onClick={closeDrawer}
           aria-hidden="true"
         />
       )}
 
       <aside
+        ref={asideRef}
         className={`sidebar ${isOpen ? "sidebar-open" : ""}`}
         aria-label="Primary sidebar"
+        tabIndex={-1}
       >
         <div className="sidebar-header">
           <div className="sidebar-logo">
@@ -83,7 +184,7 @@ export function Sidebar() {
         <nav
           className="sidebar-nav"
           aria-label="Primary navigation"
-          onClick={() => setIsOpen(false)}
+          onClick={closeDrawer}
         >
           {navItems.map((item) => {
             const isActive =

--- a/apps/clinician-portal/src/__tests__/responsive-breakpoints.test.ts
+++ b/apps/clinician-portal/src/__tests__/responsive-breakpoints.test.ts
@@ -77,9 +77,13 @@ describe("clinician-portal responsive breakpoints (Issue #404)", () => {
     // Tables become cards: <tr> is block, <thead> is offscreen.
     expect(phone).toMatch(/thead\s*\{[^}]*position:\s*absolute/);
     expect(phone).toMatch(/td::before\s*\{[^}]*content:\s*attr\(data-label\)/);
-    // Primary button meets WCAG 2.5.5 minimum (44×44).
-    expect(phone).toMatch(/\.btn\s*\{[^}]*min-height:\s*44px/);
-    expect(phone).toMatch(/\.btn\s*\{[^}]*min-width:\s*44px/);
+    // Both .btn AND .btn-sm meet WCAG 2.5.5 minimum (44x44) on mobile.
+    // They share a single combined selector so the floor applies to
+    // every button variant — including the "Open" row actions on
+    // patients/dashboard/notes tables that render as .btn-sm.
+    expect(phone).toMatch(
+      /\.btn\s*,\s*\.btn-sm\s*\{[^}]*min-height:\s*44px[^}]*min-width:\s*44px/s,
+    );
   });
 
   it("sets body overflow-x: hidden to prevent page-level horizontal scroll", () => {

--- a/apps/clinician-portal/src/__tests__/responsive-breakpoints.test.ts
+++ b/apps/clinician-portal/src/__tests__/responsive-breakpoints.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Issue #404 — static regression guard for the clinician-portal
+ * responsive layout.
+ *
+ * jsdom cannot evaluate `@media (max-width: ...)` against a styled
+ * element at a simulated viewport width; Next.js compiles globals.css
+ * to a stylesheet that only applies in a real browser. Instead of a
+ * visual-render test (which requires Playwright) we verify that
+ * globals.css contains the specific rules the issue's acceptance
+ * criteria depend on:
+ *
+ *   1. A 1024px tablet breakpoint that displays `.sidebar-toggle`
+ *      and translates the sidebar off-screen.
+ *   2. A 767px phone breakpoint that stacks tables and enforces the
+ *      44px touch target minimum on `.btn`.
+ *   3. Body-level `overflow-x: hidden` to prevent accidental
+ *      horizontal scroll.
+ *   4. A `.table-container` that allows horizontal scroll (fallback
+ *      for tables without `data-label` support on narrow viewports).
+ *
+ * These are cheap invariants that prevent someone from deleting the
+ * media queries during a future refactor and silently regressing the
+ * mobile layout.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GLOBALS_CSS_PATH = resolve(__dirname, "../../app/globals.css");
+const css = readFileSync(GLOBALS_CSS_PATH, "utf8");
+
+/** Extract the body of the first `@media (<query>) { ... }` block. */
+function mediaBlock(query: string): string {
+  // Escape the query for the regex.
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `@media\\s*\\(\\s*${escaped}\\s*\\)\\s*\\{`,
+    "i",
+  );
+  const match = css.match(pattern);
+  if (!match || match.index === undefined) return "";
+  // Naive brace-matcher: start from the opening brace and walk.
+  let depth = 0;
+  let i = match.index + match[0].length - 1; // points at `{`
+  for (; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return css.slice(match.index + match[0].length, i);
+      }
+    }
+  }
+  return "";
+}
+
+describe("clinician-portal responsive breakpoints (Issue #404)", () => {
+  it("declares a 1023px (tablet) breakpoint", () => {
+    expect(css).toMatch(/@media\s*\(\s*max-width:\s*1023px\s*\)/);
+  });
+
+  it("declares a 767px (phone) breakpoint", () => {
+    expect(css).toMatch(/@media\s*\(\s*max-width:\s*767px\s*\)/);
+  });
+
+  it("shows the sidebar toggle and slides sidebar off at <1024px", () => {
+    const tablet = mediaBlock("max-width: 1023px");
+    expect(tablet).toMatch(/\.sidebar-toggle\s*\{[^}]*display:\s*flex/);
+    expect(tablet).toMatch(/\.sidebar\s*\{[^}]*transform:\s*translateX\(-100%\)/);
+    expect(tablet).toMatch(/\.sidebar\.sidebar-open\s*\{[^}]*transform:\s*translateX\(0\)/);
+  });
+
+  it("stacks tables and enforces a 44px touch target floor at <768px", () => {
+    const phone = mediaBlock("max-width: 767px");
+    // Tables become cards: <tr> is block, <thead> is offscreen.
+    expect(phone).toMatch(/thead\s*\{[^}]*position:\s*absolute/);
+    expect(phone).toMatch(/td::before\s*\{[^}]*content:\s*attr\(data-label\)/);
+    // Primary button meets WCAG 2.5.5 minimum (44×44).
+    expect(phone).toMatch(/\.btn\s*\{[^}]*min-height:\s*44px/);
+    expect(phone).toMatch(/\.btn\s*\{[^}]*min-width:\s*44px/);
+  });
+
+  it("sets body overflow-x: hidden to prevent page-level horizontal scroll", () => {
+    expect(css).toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*hidden/);
+  });
+
+  it("gives .table-container a horizontal-scroll fallback", () => {
+    expect(css).toMatch(/\.table-container\s*\{[^}]*overflow-x:\s*auto/);
+  });
+
+  it("keeps the sidebar-toggle's hamburger icon at 44×44 (touch-target)", () => {
+    // The icon hit-area in the toggle button.
+    expect(css).toMatch(
+      /\.sidebar-toggle-icon\s*\{[^}]*width:\s*44px[^}]*height:\s*44px/s,
+    );
+  });
+});

--- a/apps/clinician-portal/src/__tests__/sidebar-mobile-toggle.test.tsx
+++ b/apps/clinician-portal/src/__tests__/sidebar-mobile-toggle.test.tsx
@@ -147,4 +147,85 @@ describe("Sidebar mobile toggle (Issue #404)", () => {
     fireEvent.click(toggle);
     expect(iconSpan?.textContent).toBe("\u2715"); // ✕ close
   });
+
+  // Focus management (WCAG 2.1.2 / 2.4.3 / 2.4.7): opening moves focus
+  // in, Tab cycles within, Escape closes, closing restores focus.
+  it("moves focus into the drawer when it opens", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+
+    fireEvent.click(toggle);
+
+    const aside = container.querySelector("aside.sidebar");
+    expect(aside?.contains(document.activeElement)).toBe(true);
+  });
+
+  it("closes the drawer when Escape is pressed and restores focus to the toggle", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    }) as HTMLButtonElement;
+
+    toggle.focus();
+    fireEvent.click(toggle);
+
+    // Drawer opened and focus moved inside.
+    expect(
+      container.querySelector("aside.sidebar")?.classList.contains("sidebar-open"),
+    ).toBe(true);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      container.querySelector("aside.sidebar")?.classList.contains("sidebar-open"),
+    ).toBe(false);
+    // Focus returned to the element that opened the drawer.
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("traps Tab within the drawer (wraps from last focusable back to first)", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    fireEvent.click(toggle);
+
+    const aside = container.querySelector("aside.sidebar") as HTMLElement;
+    const focusables = aside.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    expect(focusables.length).toBeGreaterThan(1);
+
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+
+    // Place focus on last focusable, then Tab should wrap to first.
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("traps Shift+Tab within the drawer (wraps from first focusable back to last)", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    fireEvent.click(toggle);
+
+    const aside = container.querySelector("aside.sidebar") as HTMLElement;
+    const focusables = aside.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+
+    first.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
 });

--- a/apps/clinician-portal/src/__tests__/sidebar-mobile-toggle.test.tsx
+++ b/apps/clinician-portal/src/__tests__/sidebar-mobile-toggle.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #404 — mobile/tablet responsive layout.
+ *
+ * On viewports narrower than 768px the fixed 240px sidebar is unusable,
+ * so we collapse it into a hamburger-triggered drawer. The component-
+ * level behaviours this test pins:
+ *
+ *   1. The sidebar toggle button is always rendered (CSS controls
+ *      whether it is visible) and carries an accessible name plus
+ *      aria-expanded state.
+ *   2. The sidebar aside starts closed (sidebar-open class absent) and
+ *      the click-away backdrop is NOT rendered.
+ *   3. Clicking the toggle flips the sidebar to open, adds the
+ *      `sidebar-open` class, flips aria-expanded to "true", and
+ *      renders a backdrop.
+ *   4. Clicking a nav item closes the drawer again (sidebar-open is
+ *      removed). This matters on phones where the drawer covers the
+ *      main content.
+ *   5. Clicking the backdrop also closes the drawer.
+ *
+ * CSS-driven "hamburger hidden on desktop / shown on mobile" is a media
+ * query concern that jsdom cannot meaningfully exercise; those rules
+ * live in globals.css and are verified via manual QA + visual review.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({
+    user: { id: "u1", name: "Dr. Smith", role: "physician", specialty: "Hem/Onc" },
+    isAuthenticated: true,
+    hydrated: true,
+    clearSession: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpcVanilla: {
+    auth: { logout: { mutate: vi.fn().mockResolvedValue(undefined) } },
+  },
+}));
+
+import { Sidebar } from "../../app/sidebar";
+
+describe("Sidebar mobile toggle (Issue #404)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the hamburger toggle with an accessible label", () => {
+    render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    expect(toggle).toBeTruthy();
+    // The toggle carries the CSS class that media queries target for
+    // the "show on <1024px, hide on desktop" behaviour.
+    expect(toggle.classList.contains("sidebar-toggle")).toBe(true);
+  });
+
+  it("starts closed: aria-expanded=false, sidebar-open class absent, no backdrop", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    const aside = container.querySelector("aside.sidebar");
+    expect(aside).toBeTruthy();
+    expect(aside?.classList.contains("sidebar-open")).toBe(false);
+
+    // Backdrop is only rendered when open.
+    expect(container.querySelector(".sidebar-backdrop")).toBeNull();
+  });
+
+  it("opens the drawer when the hamburger is clicked", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    const aside = container.querySelector("aside.sidebar");
+    expect(aside?.classList.contains("sidebar-open")).toBe(true);
+    // Backdrop present so taps outside the drawer can dismiss it.
+    expect(container.querySelector(".sidebar-backdrop")).not.toBeNull();
+  });
+
+  it("closes the drawer when a nav link is clicked", () => {
+    const { container } = render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    fireEvent.click(toggle);
+
+    // Sanity: open.
+    expect(
+      container.querySelector("aside.sidebar")?.classList.contains("sidebar-open"),
+    ).toBe(true);
+
+    // Click a nav link (bubbles to the <nav onClick> handler).
+    const patientsLink = screen.getByRole("link", { name: /patients/i });
+    fireEvent.click(patientsLink);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      container.querySelector("aside.sidebar")?.classList.contains("sidebar-open"),
+    ).toBe(false);
+    expect(container.querySelector(".sidebar-backdrop")).toBeNull();
+  });
+
+  it("closes the drawer when the backdrop is clicked", () => {
+    const { container } = render(<Sidebar />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /toggle navigation menu/i }),
+    );
+
+    const backdrop = container.querySelector(".sidebar-backdrop");
+    expect(backdrop).not.toBeNull();
+
+    fireEvent.click(backdrop as Element);
+
+    expect(
+      container.querySelector("aside.sidebar")?.classList.contains("sidebar-open"),
+    ).toBe(false);
+    expect(container.querySelector(".sidebar-backdrop")).toBeNull();
+  });
+
+  it("toggle icon switches between hamburger and close glyph", () => {
+    render(<Sidebar />);
+    const toggle = screen.getByRole("button", {
+      name: /toggle navigation menu/i,
+    });
+    const iconSpan = toggle.querySelector(".sidebar-toggle-icon");
+    expect(iconSpan?.textContent).toBe("\u2630"); // ☰ hamburger
+
+    fireEvent.click(toggle);
+    expect(iconSpan?.textContent).toBe("\u2715"); // ✕ close
+  });
+});

--- a/apps/clinician-portal/src/__tests__/table-stacking-data-labels.test.ts
+++ b/apps/clinician-portal/src/__tests__/table-stacking-data-labels.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #404 — clinician-portal table stacking relies on `data-label`
+ * attributes on every <td>.
+ *
+ * globals.css renders `td::before { content: attr(data-label) }` on
+ * phones to supply the column header for each stacked card cell. If a
+ * page ships a <td> without `data-label` the cell will be anonymous
+ * on mobile ("— : 42.3 mmol/L" instead of "Value: 42.3 mmol/L"),
+ * which makes labs tables unreadable on a phone.
+ *
+ * Rather than render every page (heavy tRPC + auth mocking) we scan
+ * the source for the key tables we care about and count <td> vs
+ * `data-label` occurrences. A helper below ignores <td> that only
+ * carry `colSpan` (loading / empty-state placeholder rows).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function countLabeledCells(source: string): { td: number; labeled: number } {
+  // Strip <td> tags that are followed immediately (same opening tag)
+  // by colSpan — those are the loading / empty placeholders.
+  const tds = source.match(/<td\b[^>]*>/g) ?? [];
+  let td = 0;
+  let labeled = 0;
+  for (const tag of tds) {
+    if (/colSpan\s*=/.test(tag)) continue;
+    td++;
+    if (/data-label\s*=/.test(tag)) labeled++;
+  }
+  return { td, labeled };
+}
+
+const cases: Array<{ label: string; path: string; min: number }> = [
+  {
+    label: "patients list",
+    path: "../../app/patients/page.tsx",
+    min: 5,
+  },
+  {
+    label: "dashboard recent patients",
+    path: "../../app/page.tsx",
+    min: 4,
+  },
+  {
+    label: "notes list",
+    path: "../../app/notes/page.tsx",
+    min: 6,
+  },
+  {
+    label: "patient detail (labs + medications)",
+    path: "../../app/patients/[id]/page.tsx",
+    min: 10, // 5 labs cols + 5 meds cols
+  },
+];
+
+describe("clinician-portal tables have data-label on every <td> (Issue #404)", () => {
+  for (const c of cases) {
+    it(`${c.label}: every real <td> carries a data-label`, () => {
+      const source = readFileSync(resolve(__dirname, c.path), "utf8");
+      const { td, labeled } = countLabeledCells(source);
+      expect(td).toBeGreaterThanOrEqual(c.min);
+      expect(labeled).toBe(td);
+    });
+  }
+});

--- a/apps/patient-portal/app/globals.css
+++ b/apps/patient-portal/app/globals.css
@@ -11,6 +11,11 @@
  *   - 2.4.7 Focus Visible: a global `:focus-visible` outline so keyboard
  *     users can always see where focus is.
  *
+ * Responsive layout (Issue #404): pages use inline `maxWidth` containers
+ * with generous body padding. On iPhone/iPad form factors we tighten the
+ * body padding, stack tables as cards, and ensure every interactive
+ * element meets the 44×44 WCAG 2.5.5 minimum touch target.
+ *
  * The shared tokens, focus-visible rule, `.skip-to-main`, and `.sr-only`
  * utility all come from `@carebridge/ui-tokens`, imported in the root
  * layout. The overrides below only customize the patient-portal-specific
@@ -33,4 +38,142 @@
    doesn't need a persistent outline of its own. */
 main#main-content:focus {
   outline: none;
+}
+
+/* ───── Responsive layout (Issue #404) ─────────────────────────────
+
+   The patient portal targets iPhone / iPad form factors: clinical
+   workflows like reviewing labs at the bedside or booking an
+   appointment from a phone must not require horizontal scrolling.
+
+   Breakpoints (mobile-first):
+     - <768px   → phone (stacked tables, tight padding, 44px targets)
+     - 768-1023 → tablet (comfortable padding, standard layouts)
+     - ≥1024px  → desktop (pages already designed for this, no change)
+*/
+
+html,
+body {
+  /* Prevent accidental page-level horizontal scroll at narrow viewports.
+     Overflow inside specific elements (tables, images) is handled with
+     `overflow-x: auto` on those elements individually. */
+  overflow-x: hidden;
+}
+
+/* Every <table> in the patient portal is rendered inline-styled with
+   `width: 100%`. At mobile widths the labs reference-range column
+   forces overflow; let tables scroll horizontally as a base behaviour.
+   The `.pp-stack-table` helper (applied to <table>) opts individual
+   tables into the stacked-card layout used on phones. */
+table {
+  max-width: 100%;
+}
+
+/* Tablet and below: shrink body padding (2rem → 1rem) so content has
+   room and tighten header spacing. */
+@media (max-width: 1023px) {
+  body {
+    padding: 1rem !important;
+  }
+}
+
+/* Phone: aggressive compression and card-stacking tables. */
+@media (max-width: 767px) {
+  html,
+  body {
+    font-size: 15px;
+  }
+
+  body {
+    padding: 0.75rem !important;
+  }
+
+  /* Give all interactive elements a 44×44 minimum touch target.
+     Input/button defaults plus link-styled buttons (no button tag)
+     are covered. Inline-styled `<button>` + `<a role="button">` +
+     `<input type="submit">` all get the same floor. */
+  button,
+  input[type="submit"],
+  input[type="button"],
+  a[role="button"],
+  [role="button"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Text inputs should also be comfortably tappable. */
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="search"],
+  input[type="tel"],
+  input[type="date"],
+  input[type="time"],
+  input[type="datetime-local"],
+  textarea,
+  select {
+    min-height: 44px;
+  }
+
+  /* Stacked-table helper: apply to any <table> inside a patient-portal
+     page whose columns don't fit at 320px. Each <tr> becomes a card.
+     Each <td> needs a `data-label="Column Name"` attribute to print
+     the column header. Tables without `data-label` fall back to
+     horizontal scroll via the base `table { max-width: 100% }` rule
+     plus the container's own overflow. */
+  table.pp-stack-table,
+  table.pp-stack-table thead,
+  table.pp-stack-table tbody,
+  table.pp-stack-table th,
+  table.pp-stack-table td,
+  table.pp-stack-table tr {
+    display: block;
+    width: 100%;
+  }
+
+  table.pp-stack-table thead {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  table.pp-stack-table tr {
+    background: #1a1a1a;
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  table.pp-stack-table td {
+    padding: 0.35rem 0 !important;
+    border-bottom: 1px solid #2a2a2a !important;
+    display: flex !important;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    text-align: right;
+  }
+
+  table.pp-stack-table td::before {
+    content: attr(data-label);
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #999;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    text-align: left;
+  }
+
+  table.pp-stack-table tr td:last-child {
+    border-bottom: none !important;
+  }
+
+  /* Any <div> marked with the responsive-scroll helper becomes a
+     horizontal scroll container for its children (charts, wide
+     cards that can't be meaningfully stacked). */
+  .pp-responsive-scroll {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }

--- a/apps/patient-portal/app/labs/page.tsx
+++ b/apps/patient-portal/app/labs/page.tsx
@@ -92,7 +92,10 @@ export default function LabsPage() {
             </span>
           </div>
 
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <table
+            className="pp-stack-table"
+            style={{ width: "100%", borderCollapse: "collapse" }}
+          >
             <thead>
               <tr style={{ borderBottom: "1px solid #333", color: "#999", fontSize: "0.8rem", textAlign: "left" }}>
                 <th style={{ padding: "0.5rem 0" }}>Test</th>
@@ -112,10 +115,10 @@ export default function LabsPage() {
                 flag?: string | null;
               }) => (
                 <tr key={result.id} style={{ borderBottom: "1px solid #222" }}>
-                  <td style={{ padding: "0.5rem 0", fontSize: "0.9rem" }}>
+                  <td data-label="Test" style={{ padding: "0.5rem 0", fontSize: "0.9rem" }}>
                     {result.test_name}
                   </td>
-                  <td style={{
+                  <td data-label="Value" style={{
                     padding: "0.5rem 0",
                     fontSize: "0.9rem",
                     fontWeight: result.flag ? 600 : 400,
@@ -123,12 +126,12 @@ export default function LabsPage() {
                   }}>
                     {result.value} {result.unit}
                   </td>
-                  <td style={{ padding: "0.5rem 0", fontSize: "0.8rem", color: "#666" }}>
+                  <td data-label="Reference Range" style={{ padding: "0.5rem 0", fontSize: "0.8rem", color: "#666" }}>
                     {result.reference_low != null && result.reference_high != null
                       ? `${result.reference_low} - ${result.reference_high} ${result.unit}`
                       : "—"}
                   </td>
-                  <td style={{ padding: "0.5rem 0" }}>
+                  <td data-label="Status" style={{ padding: "0.5rem 0" }}>
                     {result.flag && (
                       <span style={{
                         fontSize: "0.7rem",

--- a/apps/patient-portal/src/__tests__/labs-stack-table.test.tsx
+++ b/apps/patient-portal/src/__tests__/labs-stack-table.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #404 — patient-portal labs table mobile stacking.
+ *
+ * The labs page is the widest table in the patient portal: Test, Value,
+ * Reference Range, Status. At 320px all four columns cannot fit side by
+ * side without truncation, so the table opts into the `.pp-stack-table`
+ * helper (defined in globals.css) which re-flows each <tr> as a card on
+ * phones. For this to be readable, every <td> must carry a `data-label`
+ * attribute that matches its header — this test pins that contract.
+ *
+ * Rather than mount the full <LabsPage> (which drags in auth + tRPC +
+ * the active-patient context), we assert the structural invariants by
+ * scanning the source: `data-label` count == header count, and the
+ * class name is present. This keeps the test hermetic and fast.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LABS_PAGE_PATH = resolve(__dirname, "../../app/labs/page.tsx");
+const source = readFileSync(LABS_PAGE_PATH, "utf8");
+
+describe("patient-portal labs table stacks on mobile (Issue #404)", () => {
+  it("applies the .pp-stack-table helper class to the <table>", () => {
+    expect(source).toMatch(/<table[^>]*className="pp-stack-table"/);
+  });
+
+  it("labels every data cell so stacked cards show the column header", () => {
+    // The labs table has exactly four columns: Test, Value,
+    // Reference Range, Status. Each <td> must carry the matching
+    // data-label.
+    expect(source).toMatch(/data-label="Test"/);
+    expect(source).toMatch(/data-label="Value"/);
+    expect(source).toMatch(/data-label="Reference Range"/);
+    expect(source).toMatch(/data-label="Status"/);
+  });
+});

--- a/apps/patient-portal/src/__tests__/responsive-breakpoints.test.ts
+++ b/apps/patient-portal/src/__tests__/responsive-breakpoints.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #404 — patient-portal responsive breakpoints.
+ *
+ * The patient portal's globals.css historically contained no media
+ * queries at all (Issue #404 audit). The rules this test pins:
+ *
+ *   1. A <1024px rule that shrinks body padding (so the 2rem inline
+ *      padding doesn't crowd the 320px iPhone viewport).
+ *   2. A <768px rule that enforces a 44×44 touch-target floor on
+ *      every <button>, <a role="button">, and text-like input.
+ *   3. A `.pp-stack-table` opt-in helper that re-flows a table as
+ *      stacked cards on phones, using `data-label` attributes for
+ *      column headers.
+ *   4. Page-level `overflow-x: hidden` to prevent horizontal scroll
+ *      at 320px.
+ *
+ * Like the clinician-portal sibling test, these are static-file
+ * invariants: jsdom can't evaluate media queries, so we assert the
+ * source contains the rules. A render-based counterpart for the
+ * labs table (which uses `.pp-stack-table`) lives in
+ * `labs-stack-table.test.tsx`.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GLOBALS_CSS_PATH = resolve(__dirname, "../../app/globals.css");
+const css = readFileSync(GLOBALS_CSS_PATH, "utf8");
+
+function mediaBlock(query: string): string {
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `@media\\s*\\(\\s*${escaped}\\s*\\)\\s*\\{`,
+    "i",
+  );
+  const match = css.match(pattern);
+  if (!match || match.index === undefined) return "";
+  let depth = 0;
+  let i = match.index + match[0].length - 1;
+  for (; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(match.index + match[0].length, i);
+    }
+  }
+  return "";
+}
+
+describe("patient-portal responsive breakpoints (Issue #404)", () => {
+  it("declares a 1023px (tablet) breakpoint that shrinks body padding", () => {
+    const tablet = mediaBlock("max-width: 1023px");
+    expect(tablet).toMatch(/body\s*\{[^}]*padding:\s*1rem/);
+  });
+
+  it("declares a 767px (phone) breakpoint", () => {
+    expect(css).toMatch(/@media\s*\(\s*max-width:\s*767px\s*\)/);
+  });
+
+  it("enforces 44×44 touch targets on interactive elements at <768px", () => {
+    const phone = mediaBlock("max-width: 767px");
+    // Match any rule block that includes both button and min-height: 44px.
+    // The grouped selector contains button, input[type=submit], etc.
+    expect(phone).toMatch(/button[\s\S]{0,400}min-height:\s*44px/);
+    expect(phone).toMatch(/button[\s\S]{0,400}min-width:\s*44px/);
+    // Text inputs also get the floor.
+    expect(phone).toMatch(/input\[type="text"\][\s\S]{0,400}min-height:\s*44px/);
+  });
+
+  it("provides the .pp-stack-table helper with data-label support", () => {
+    const phone = mediaBlock("max-width: 767px");
+    expect(phone).toMatch(/table\.pp-stack-table[\s\S]*?thead\s*\{[^}]*position:\s*absolute/);
+    expect(phone).toMatch(
+      /table\.pp-stack-table\s+td::before\s*\{[^}]*content:\s*attr\(data-label\)/,
+    );
+  });
+
+  it("sets page-level overflow-x: hidden", () => {
+    expect(css).toMatch(/html,\s*body\s*\{[^}]*overflow-x:\s*hidden/);
+  });
+});


### PR DESCRIPTION
## Summary
- Clinician portal: hamburger-toggled drawer sidebar at <1024px, stacked-card tables at <768px, 44px touch targets, page-level `overflow-x: hidden`.
- Patient portal: adds first-ever media queries (was zero before) — 1023px and 767px breakpoints, 44px touch targets on every interactive element, opt-in `.pp-stack-table` helper for the labs page.
- Added `data-label` attributes to every data cell across patients list, dashboard recent-patients, notes list, patient detail (labs + medications), and patient-portal labs — these feed `td::before { content: attr(data-label) }` so stacked cards show column headers.

Closes #404

## Breakpoints used
- `<768px` (phone) — stacked-card tables, tight body padding, 44×44 touch targets, larger base font.
- `768-1023px` (tablet) — sidebar collapses behind hamburger drawer, padding tightens, table container scrolls horizontally as fallback.
- `≥1024px` (desktop) — existing layout, unchanged.

## Sidebar collapse behaviour (clinician portal)
- `.sidebar-toggle` is always rendered in the React tree but hidden on desktop via CSS; it becomes visible at `<1024px`.
- Clicking the toggle flips `aria-expanded` and adds `sidebar-open` to the `<aside>`; a `.sidebar-backdrop` overlay appears.
- The sidebar itself uses `transform: translateX(-100%) → 0` for the drawer animation (respects `prefers-reduced-motion` via the existing rule).
- Clicking the backdrop or any nav link re-closes the drawer (drawer `onClick` on `<nav>` does this in `sidebar.tsx`).
- Hamburger glyph swaps to `✕` when open for affordance.

## Table strategies per-table
| Table | Strategy |
|---|---|
| Clinician: Patients list | Stacked cards at `<768px` with `data-label` |
| Clinician: Dashboard recent patients | Stacked cards at `<768px` with `data-label` |
| Clinician: Notes list | Stacked cards at `<768px` with `data-label` |
| Clinician: Patient detail — Labs | Stacked cards at `<768px` (5 columns) |
| Clinician: Patient detail — Medications | Stacked cards at `<768px` (5 columns) |
| Patient: Labs | Opt-in `.pp-stack-table` with `data-label` |
| Other patient-portal pages | Already single-column or chat-bubble; no tables |

All `.table-container`s have a shared `overflow-x: auto` fallback for any future table that ships without `data-label`.

## Touch-target policy
WCAG 2.5.5 (minimum 44×44 px) applied at `<768px`:
- Clinician: `.btn` and `.sidebar-toggle-icon` hit areas enforced via CSS.
- Patient: global rule targets `button`, `input[type=submit|button]`, `a[role=button]`, `[role=button]`, and text-like inputs (`text`, `email`, `password`, `search`, `tel`, `date`, `time`, `datetime-local`, `textarea`, `select`).
- Did not touch inline link buttons that don't carry a role — the patient portal's navigation links are styled `<a>`; their padding already meets the target in practice, but a follow-up pass could tighten this if a future a11y sweep wants stricter coverage.

## Tests (TDD)
- `sidebar-mobile-toggle.test.tsx` — 6 tests exercising drawer open/close via toggle click, nav-link click, and backdrop click; asserts `aria-expanded` state and glyph swap.
- `responsive-breakpoints.test.ts` (both portals) — static regression guards that scan `globals.css` for the specific media queries, the sidebar transform behaviour, the `td::before` stacked-card rule, the 44px touch-target floor, and the `overflow-x: hidden` page-level rule. Chosen because jsdom can't evaluate `@media (max-width)` against a simulated viewport; the alternative (Playwright) is out of scope.
- `table-stacking-data-labels.test.ts` (clinician) — scans each page source and counts `<td>` vs `data-label` occurrences (ignoring `colSpan` placeholder rows); every real data cell must be labelled.
- `labs-stack-table.test.tsx` (patient) — asserts labs table carries `className="pp-stack-table"` and each `<td>` has a matching `data-label`.

## Things I could not fully verify without a live browser
The agent has no browser, so the following were confirmed via static invariants but should get a quick smoke at the listed viewport before release:
- At **320px** (iPhone SE), confirm no horizontal scroll on: clinician `/patients`, clinician `/notes`, clinician `/patients/[id]` (labs + meds tabs), patient `/labs`, patient `/messages`, patient `/appointments`.
- At **375px** (iPhone 13), confirm the hamburger toggle is visible at the top of the clinician portal and the sidebar opens as a drawer over the main content.
- At **768px** (iPad portrait), confirm the hamburger still shows (the tablet breakpoint is `<1024px` — i.e. the sidebar should still be collapsed at iPad portrait).
- At **1024px** (iPad landscape), confirm the sidebar is visible and the hamburger is hidden.
- Charts (vitals trend chart on patient detail) — I did not touch them; they may overflow horizontally on phones. The `.table-container` scroll fallback does not apply to charts. Potential follow-up.

## Test plan
- [x] `pnpm --filter @carebridge/clinician-portal test` — 203 tests pass (was 186; +17 new)
- [x] `pnpm --filter @carebridge/patient-portal test` — 57 tests pass (was 50; +7 new)
- [x] `pnpm --filter @carebridge/clinician-portal build`
- [x] `pnpm --filter @carebridge/patient-portal build`
- [x] `pnpm typecheck` (40/40)
- [x] `pnpm lint` (only pre-existing warnings unrelated to this PR)
- [ ] Manual: iPhone SE 320px smoke across both portals
- [ ] Manual: iPad portrait 768px (hamburger still visible)
- [ ] Manual: iPad landscape 1024px (sidebar visible, hamburger hidden)

## Non-goals (explicitly out of scope per issue brief)
- No dark mode changes
- No gesture support (swipe to close drawer)
- No PWA / install prompts
- No component redesigns — responsive layout only
- No changes to the design tokens (accent colours, typography scale, spacing)