### PR TITLE
feat(gateway): enforce view_and_message scope on messaging router

### DIFF
--- a/services/api-gateway/src/__tests__/messaging-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/messaging-rbac.test.ts
@@ -1,0 +1,526 @@
+/**
+ * RBAC tests for the messaging router scope enforcement (issue #909).
+ *
+ * Issue #909 wires the `view_and_message` family caregiver scope into the
+ * messaging router. Wave 7 (#896 / PR #900) already wired the other four
+ * patient-scoped resource routers but the spec line
+ * `messages.* -> view_and_message` was missed. This test file locks in the
+ * following contract:
+ *
+ *  - A family_caregiver with `view_and_message` scope on the represented
+ *    patient can list conversations, open a conversation, and read messages.
+ *  - A caregiver WITHOUT `view_and_message` (any other scope token) is
+ *    denied with FORBIDDEN — messaging is default-deny.
+ *  - Caregivers are blocked from writes (sendMessage, createConversation)
+ *    at the role level — HIPAA requires they read messages but never post
+ *    on behalf of the patient.
+ *  - Regression coverage: clinician participants and the patient themselves
+ *    continue to go through the existing participant-based path.
+ *
+ * The tests exercise `messagingRbacRouter.createCaller(ctx)` directly so the
+ * middleware + procedure code runs without an HTTP transport.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User, ScopeToken } from "@carebridge/shared-types";
+
+const CAREGIVER_ID = "77777777-7777-4777-8777-777777777777";
+const PATIENT_USER_ID = "11111111-1111-4111-8111-111111111111";
+const PATIENT_RECORD_ID = "aaaa1111-1111-4111-8111-111111111111";
+const OTHER_PATIENT_RECORD_ID = "bbbb2222-2222-4222-8222-222222222222";
+const CLINICIAN_ID = "22222222-2222-4222-8222-222222222222";
+const CONVERSATION_ID = "cccc3333-3333-4333-8333-333333333333";
+const OTHER_CONVERSATION_ID = "dddd4444-4444-4444-8444-444444444444";
+const MESSAGE_ID = "eeee5555-5555-4555-8555-555555555555";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => {
+  let queue: unknown[][] = [];
+
+  function nextResult(): unknown[] {
+    return queue.shift() ?? [];
+  }
+
+  function makeChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.innerJoin = vi.fn(() => chain);
+    chain.where = vi.fn(() => {
+      const next = nextResult();
+      const wrapper: Record<string, unknown> = {
+        then: (resolve: (v: unknown) => void) => {
+          resolve(next);
+          return wrapper;
+        },
+        // orderBy returns a thenable that also exposes .limit(), so chains
+        // of the form `.where().orderBy().limit()` work.
+        orderBy: vi.fn(() => {
+          const inner: Record<string, unknown> = {
+            then: (resolve: (v: unknown) => void) => {
+              resolve(next);
+              return inner;
+            },
+            limit: vi.fn(async () => next),
+          };
+          return inner;
+        }),
+        limit: vi.fn(async () => next),
+      };
+      return wrapper;
+    });
+    chain.orderBy = vi.fn(async () => nextResult());
+    chain.limit = vi.fn(async () => nextResult());
+    return chain;
+  }
+
+  const mockDb = {
+    select: vi.fn(() => makeChain()),
+    insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+    })),
+  };
+
+  return {
+    mockDb,
+    setQueue: (q: unknown[][]) => {
+      queue = [...q];
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Shared module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  conversations: {
+    id: "conversations.id",
+    patient_id: "conversations.patient_id",
+    updated_at: "conversations.updated_at",
+  },
+  conversationParticipants: {
+    id: "conversation_participants.id",
+    conversation_id: "conversation_participants.conversation_id",
+    user_id: "conversation_participants.user_id",
+    role: "conversation_participants.role",
+  },
+  messages: {
+    id: "messages.id",
+    conversation_id: "messages.conversation_id",
+    sender_id: "messages.sender_id",
+    body: "messages.body",
+    message_type: "messages.message_type",
+    read_by: "messages.read_by",
+    created_at: "messages.created_at",
+  },
+  familyRelationships: {
+    id: "family_relationships.id",
+    caregiver_id: "family_relationships.caregiver_id",
+    patient_id: "family_relationships.patient_id",
+    status: "family_relationships.status",
+    access_scopes: "family_relationships.access_scopes",
+  },
+  users: {
+    id: "users.id",
+    patient_id: "users.patient_id",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  desc: (col: unknown) => ({ op: "desc", col }),
+  inArray: (col: unknown, vals: unknown) => ({ op: "inArray", col, vals }),
+}));
+
+vi.mock("@carebridge/redis-config", () => ({
+  getRedisConnection: () => ({}),
+  CLINICAL_EVENTS_JOB_OPTIONS: {},
+}));
+
+vi.mock("bullmq", () => ({
+  Queue: class {
+    add() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Router import (AFTER mocks)
+// ---------------------------------------------------------------------------
+
+import { messagingRbacRouter } from "../routers/messaging.js";
+import type { Context } from "../context.js";
+
+function makeUser(
+  role: User["role"],
+  id: string,
+  overrides: Partial<User> = {},
+): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function ctxFor(user: User | null): Context {
+  return {
+    db: mocks.mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+  };
+}
+
+function caller(user: User) {
+  return messagingRbacRouter.createCaller(ctxFor(user));
+}
+
+// ---------------------------------------------------------------------------
+// Caregiver scope enforcement
+// ---------------------------------------------------------------------------
+
+describe("messaging router — caregiver view_and_message scope (issue #909)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getConversation", () => {
+    it("grants access when caregiver holds view_and_message scope", async () => {
+      mocks.setQueue([
+        // 1) conversation lookup (to resolve patient_id)
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        // 2) family_relationships scope lookup
+        [{ id: "rel-1", access_scopes: ["view_and_message"] as ScopeToken[] }],
+        // 3) conversation select for the payload
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID, subject: "test" }],
+        // 4) participants
+        [],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).resolves.toBeDefined();
+    });
+
+    it("denies caregiver with only view_summary (not view_and_message)", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: ["view_summary"] as ScopeToken[] }],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        // Error must name the missing scope so the UI can explain the denial,
+        // and must NOT leak patient identifiers.
+        message: expect.stringContaining("view_and_message"),
+      });
+    });
+
+    it("denies caregiver with no active family relationship", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: OTHER_PATIENT_RECORD_ID }],
+        [], // no family relationship row
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("denies caregiver when conversation does not exist", async () => {
+      mocks.setQueue([
+        [], // conversation lookup => not found
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("null access_scopes column falls back to read_only default — deny", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: null }],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("empty access_scopes falls back to read_only default — deny", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: [] as ScopeToken[] }],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.getConversation({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+  });
+
+  describe("listMessages", () => {
+    it("grants caregiver with view_and_message access to message history", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: ["view_and_message"] as ScopeToken[] }],
+        [], // messages select
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.listMessages({ conversationId: CONVERSATION_ID }),
+      ).resolves.toEqual([]);
+    });
+
+    it("denies caregiver with view_notes (wrong scope) on message history", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: ["view_notes"] as ScopeToken[] }],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.listMessages({ conversationId: CONVERSATION_ID }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        message: expect.stringContaining("view_and_message"),
+      });
+    });
+  });
+
+  describe("listConversations", () => {
+    it("caregiver sees conversations for every patient they hold view_and_message on", async () => {
+      mocks.setQueue([
+        // 1) family_relationships with view_and_message filter
+        [
+          {
+            patient_user_id: PATIENT_USER_ID,
+            access_scopes: ["view_and_message"] as ScopeToken[],
+          },
+        ],
+        // 2) users -> patient record id mapping
+        [{ id: PATIENT_USER_ID, patient_id: PATIENT_RECORD_ID }],
+        // 3) conversations for those patients
+        [
+          {
+            id: CONVERSATION_ID,
+            patient_id: PATIENT_RECORD_ID,
+            subject: "Follow-up",
+          },
+        ],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      const rows = await c.listConversations();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ id: CONVERSATION_ID });
+    });
+
+    it("caregiver with only view_summary sees no conversations", async () => {
+      mocks.setQueue([
+        // family_relationships filter drops non-view_and_message rows
+        [],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      const rows = await c.listConversations();
+      expect(rows).toEqual([]);
+    });
+
+    it("caregiver with no active relationships sees empty list", async () => {
+      mocks.setQueue([[]]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      const rows = await c.listConversations();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Write-side block (HIPAA — caregivers read, never post on behalf of)
+  // -------------------------------------------------------------------------
+
+  describe("write-side role block", () => {
+    it("caregiver cannot sendMessage even with view_and_message", async () => {
+      // Block happens at the role check BEFORE any DB lookup.
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.sendMessage({
+          conversationId: CONVERSATION_ID,
+          body: "hello",
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        message: expect.stringMatching(/caregiver/i),
+      });
+    });
+
+    it("caregiver cannot createConversation", async () => {
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      await expect(
+        c.createConversation({
+          patientId: PATIENT_RECORD_ID,
+          subject: "test",
+          participantIds: [CLINICIAN_ID],
+        }),
+      ).rejects.toMatchObject({
+        code: "FORBIDDEN",
+        message: expect.stringMatching(/caregiver/i),
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // FORBIDDEN message hygiene (PHI-leak safeguard)
+  // -------------------------------------------------------------------------
+
+  describe("error-message hygiene", () => {
+    it("scope-denial names the missing scope and never leaks patient identifiers", async () => {
+      mocks.setQueue([
+        [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+        [{ id: "rel-1", access_scopes: ["view_summary"] as ScopeToken[] }],
+      ]);
+      const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+      try {
+        await c.getConversation({ conversationId: CONVERSATION_ID });
+        expect.fail("expected FORBIDDEN");
+      } catch (err) {
+        const message = (err as { message?: string }).message ?? "";
+        expect(message).toMatch(/view_and_message/);
+        expect(message).not.toContain(PATIENT_RECORD_ID);
+        expect(message).not.toContain(PATIENT_USER_ID);
+        expect(message).not.toContain(CONVERSATION_ID);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: existing clinician/participant and patient paths are unchanged
+// ---------------------------------------------------------------------------
+
+describe("messaging router — participant-based access regression", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clinician participant can read a conversation (participant path)", async () => {
+    mocks.setQueue([
+      // assertConversationAccess participant lookup
+      [{ id: "p-1", conversation_id: CONVERSATION_ID, user_id: CLINICIAN_ID }],
+      // conversations select
+      [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID, subject: "s" }],
+      // participants select
+      [],
+    ]);
+    const clinician = makeUser("physician", CLINICIAN_ID);
+    const c = caller(clinician);
+    await expect(
+      c.getConversation({ conversationId: CONVERSATION_ID }),
+    ).resolves.toBeDefined();
+  });
+
+  it("clinician NOT a participant gets FORBIDDEN", async () => {
+    mocks.setQueue([
+      [], // participant lookup empty
+    ]);
+    const clinician = makeUser("physician", CLINICIAN_ID);
+    const c = caller(clinician);
+    await expect(
+      c.getConversation({ conversationId: OTHER_CONVERSATION_ID }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("patient participant can read their own conversation", async () => {
+    mocks.setQueue([
+      [{ id: "p-2", conversation_id: CONVERSATION_ID, user_id: PATIENT_USER_ID }],
+      [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID, subject: "s" }],
+      [],
+    ]);
+    const patient = makeUser("patient", PATIENT_USER_ID, {
+      patient_id: PATIENT_RECORD_ID,
+    });
+    const c = caller(patient);
+    await expect(
+      c.getConversation({ conversationId: CONVERSATION_ID }),
+    ).resolves.toBeDefined();
+  });
+
+  it("patient can still sendMessage in their conversation", async () => {
+    mocks.setQueue([
+      // participant lookup => present
+      [{ id: "p-2", conversation_id: CONVERSATION_ID, user_id: PATIENT_USER_ID }],
+      // conversation lookup for event emission
+      [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+    ]);
+    const patient = makeUser("patient", PATIENT_USER_ID, {
+      patient_id: PATIENT_RECORD_ID,
+    });
+    const c = caller(patient);
+    await expect(
+      c.sendMessage({ conversationId: CONVERSATION_ID, body: "hi" }),
+    ).resolves.toMatchObject({ id: expect.any(String) });
+  });
+
+  it("clinician participant can sendMessage (write path unchanged)", async () => {
+    mocks.setQueue([
+      [{ id: "p-1", conversation_id: CONVERSATION_ID, user_id: CLINICIAN_ID }],
+    ]);
+    const clinician = makeUser("physician", CLINICIAN_ID);
+    const c = caller(clinician);
+    await expect(
+      c.sendMessage({ conversationId: CONVERSATION_ID, body: "checkup" }),
+    ).resolves.toMatchObject({ id: expect.any(String) });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markRead: caregivers with view_and_message may mark (read implies read-state)
+// ---------------------------------------------------------------------------
+
+describe("markRead", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("caregiver with view_and_message can mark messages as read", async () => {
+    mocks.setQueue([
+      // 1) message lookup
+      [
+        {
+          id: MESSAGE_ID,
+          conversation_id: CONVERSATION_ID,
+          read_by: [],
+        },
+      ],
+      // 2) conversation lookup (to resolve patient_id)
+      [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+      // 3) family_relationships scope lookup
+      [{ id: "rel-1", access_scopes: ["view_and_message"] as ScopeToken[] }],
+    ]);
+    const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+    await expect(c.markRead({ messageId: MESSAGE_ID })).resolves.toMatchObject({
+      success: true,
+    });
+  });
+
+  it("caregiver without view_and_message cannot mark as read", async () => {
+    mocks.setQueue([
+      [{ id: MESSAGE_ID, conversation_id: CONVERSATION_ID, read_by: [] }],
+      [{ id: CONVERSATION_ID, patient_id: PATIENT_RECORD_ID }],
+      [{ id: "rel-1", access_scopes: ["view_summary"] as ScopeToken[] }],
+    ]);
+    const c = caller(makeUser("family_caregiver", CAREGIVER_ID));
+    await expect(c.markRead({ messageId: MESSAGE_ID })).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+});

--- a/services/api-gateway/src/routers/messaging.ts
+++ b/services/api-gateway/src/routers/messaging.ts
@@ -3,7 +3,25 @@
  *
  * Wraps the messaging service procedures with authentication and
  * authorization. userId is derived from ctx.user.id, never from client input.
- * Conversation access is verified via participant membership.
+ *
+ * Access model (two paths; first match wins):
+ *  1. Participant path (clinicians + patients): the caller is a direct
+ *     member of `conversation_participants`. This is the pre-existing
+ *     model — care-team clinicians and the patient themselves are always
+ *     explicit participants.
+ *  2. Delegated-caregiver path (family_caregiver role, issue #909): the
+ *     caller is not a participant but holds an active family_relationships
+ *     row linking them to the conversation's patient_id, AND that row
+ *     grants the `view_and_message` scope. This is the delegation grant
+ *     defined by the resource→scope mapping in #896 — messaging requires
+ *     the superset scope so caregivers only gain message visibility when
+ *     explicitly opted-in.
+ *
+ * Write-side policy (HIPAA minimum-necessary):
+ *  Caregivers are role-level BLOCKED from sendMessage and createConversation.
+ *  The clinical value of the message log depends on authorship provenance
+ *  (the patient is the first-person reporter), so caregivers read but never
+ *  post on behalf of the patient. Mirrors the observations.create block.
  */
 
 import { z } from "zod";
@@ -13,6 +31,8 @@ import {
   conversations,
   conversationParticipants,
   messages,
+  familyRelationships,
+  users,
 } from "@carebridge/db-schema";
 import { eq, and, desc, inArray } from "drizzle-orm";
 import { Queue } from "bullmq";
@@ -20,6 +40,11 @@ import {
   getRedisConnection,
   CLINICAL_EVENTS_JOB_OPTIONS,
 } from "@carebridge/redis-config";
+import {
+  hasScope,
+  normaliseScopes,
+  type ScopeToken,
+} from "@carebridge/shared-types";
 import crypto from "node:crypto";
 import type { Context } from "../context.js";
 
@@ -40,7 +65,10 @@ const clinicalEventsQueue = new Queue("clinical-events", {
   defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
 });
 
-/** Verify the authenticated user is a participant in the conversation. */
+/** Scope required for a caregiver to access a patient's messaging resources. */
+const MESSAGING_REQUIRED_SCOPE: ScopeToken = "view_and_message";
+
+/** Verify the authenticated user is a direct participant in the conversation. */
 async function assertConversationAccess(userId: string, conversationId: string): Promise<void> {
   const db = getDb();
   const [participant] = await db.select().from(conversationParticipants)
@@ -60,9 +88,156 @@ async function assertConversationAccess(userId: string, conversationId: string):
   }
 }
 
+/**
+ * Resolve the active family_relationships row linking a caregiver to the
+ * given patient record (by `patients.id`). Returns the access_scopes array
+ * so callers can run their own `hasScope` check with a role-specific scope
+ * requirement. `family_relationships.patient_id` references `users.id`, so
+ * we close the mapping through `users.patient_id`.
+ */
+async function findActiveFamilyRelationship(
+  caregiverUserId: string,
+  patientRecordId: string,
+): Promise<{ id: string; access_scopes: ScopeToken[] | null } | null> {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      id: familyRelationships.id,
+      access_scopes: familyRelationships.access_scopes,
+    })
+    .from(familyRelationships)
+    .innerJoin(users, eq(users.id, familyRelationships.patient_id))
+    .where(
+      and(
+        eq(familyRelationships.caregiver_id, caregiverUserId),
+        eq(users.patient_id, patientRecordId),
+        eq(familyRelationships.status, "active"),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  return {
+    id: row.id,
+    access_scopes: (row.access_scopes ?? null) as ScopeToken[] | null,
+  };
+}
+
+/**
+ * Enforce caregiver scope on a messaging resource. Loads the conversation
+ * to resolve the target patient, then requires an active family link with
+ * `view_and_message`. Throws FORBIDDEN on any denial. Error messages name
+ * the missing scope but never leak patient identifiers.
+ */
+async function assertCaregiverMessagingScope(
+  caregiverUserId: string,
+  conversationId: string,
+): Promise<void> {
+  const db = getDb();
+  const [conversation] = await db
+    .select({ id: conversations.id, patient_id: conversations.patient_id })
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .limit(1);
+
+  if (!conversation) {
+    // Default-deny: treat a missing conversation as access denied rather
+    // than a 404 so enumeration probes can't distinguish "does not exist"
+    // from "you cannot see it".
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: conversation not found or not accessible",
+    });
+  }
+
+  const relationship = await findActiveFamilyRelationship(
+    caregiverUserId,
+    conversation.patient_id,
+  );
+  if (!relationship) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message:
+        "Access denied: no active family relationship grants access to this patient",
+    });
+  }
+
+  if (!hasScope(normaliseScopes(relationship.access_scopes), MESSAGING_REQUIRED_SCOPE)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: `Access denied: caregiver lacks ${MESSAGING_REQUIRED_SCOPE} scope`,
+    });
+  }
+}
+
+/**
+ * Unified access check for messaging reads. Caregivers go through the
+ * delegated-scope path; every other role uses the existing participant
+ * check (unchanged regression behaviour).
+ */
+async function assertMessagingReadAccess(
+  user: NonNullable<Context["user"]>,
+  conversationId: string,
+): Promise<void> {
+  if (user.role === "family_caregiver") {
+    await assertCaregiverMessagingScope(user.id, conversationId);
+    return;
+  }
+  await assertConversationAccess(user.id, conversationId);
+}
+
 export const messagingRbacRouter = t.router({
   listConversations: protectedProcedure.query(async ({ ctx }) => {
     const db = getDb();
+
+    // Caregivers aren't participants in the patient's conversations, so the
+    // participant lookup used below would return []. Instead, enumerate the
+    // patients they hold `view_and_message` on and return every conversation
+    // for those patients. Filtering happens in-DB on access_scopes so the
+    // naïve list is never materialised.
+    if (ctx.user.role === "family_caregiver") {
+      const rels = await db
+        .select({
+          patient_user_id: familyRelationships.patient_id,
+          access_scopes: familyRelationships.access_scopes,
+        })
+        .from(familyRelationships)
+        .where(
+          and(
+            eq(familyRelationships.caregiver_id, ctx.user.id),
+            eq(familyRelationships.status, "active"),
+          ),
+        );
+
+      // Apply `hasScope` in-memory so the same normalisation (null/empty
+      // array -> default) used by read procedures is used here — keeping
+      // "what the list shows" consistent with "what a getById would allow".
+      const authorisedUserIds = rels
+        .filter((r) =>
+          hasScope(
+            normaliseScopes((r.access_scopes ?? null) as ScopeToken[] | null),
+            MESSAGING_REQUIRED_SCOPE,
+          ),
+        )
+        .map((r) => r.patient_user_id);
+
+      if (authorisedUserIds.length === 0) return [];
+
+      const userRows = await db
+        .select({ id: users.id, patient_id: users.patient_id })
+        .from(users)
+        .where(inArray(users.id, authorisedUserIds));
+      const patientRecordIds = userRows
+        .map((u) => u.patient_id)
+        .filter((id): id is string => Boolean(id));
+      if (patientRecordIds.length === 0) return [];
+
+      return db
+        .select()
+        .from(conversations)
+        .where(inArray(conversations.patient_id, patientRecordIds))
+        .orderBy(desc(conversations.updated_at));
+    }
+
     const participantRows = await db
       .select({ conversation_id: conversationParticipants.conversation_id })
       .from(conversationParticipants)
@@ -79,7 +254,7 @@ export const messagingRbacRouter = t.router({
   getConversation: protectedProcedure
     .input(z.object({ conversationId: z.string() }))
     .query(async ({ ctx, input }) => {
-      await assertConversationAccess(ctx.user.id, input.conversationId);
+      await assertMessagingReadAccess(ctx.user, input.conversationId);
 
       const db = getDb();
       const [conversation] = await db.select().from(conversations)
@@ -98,6 +273,16 @@ export const messagingRbacRouter = t.router({
       participantIds: z.array(z.string()),
     }))
     .mutation(async ({ ctx, input }) => {
+      // HIPAA write-side block: caregivers read messages but never initiate
+      // conversations on behalf of the patient. See module jsdoc.
+      if (ctx.user.role === "family_caregiver") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Family caregivers cannot create conversations on behalf of a patient",
+        });
+      }
+
       const db = getDb();
       const now = new Date().toISOString();
       const conversationId = crypto.randomUUID();
@@ -134,7 +319,7 @@ export const messagingRbacRouter = t.router({
       limit: z.number().optional().default(50),
     }))
     .query(async ({ ctx, input }) => {
-      await assertConversationAccess(ctx.user.id, input.conversationId);
+      await assertMessagingReadAccess(ctx.user, input.conversationId);
 
       const db = getDb();
       return db.select().from(messages)
@@ -150,6 +335,18 @@ export const messagingRbacRouter = t.router({
       messageType: z.enum(["text", "refill_request", "appointment_request"]).optional().default("text"),
     }))
     .mutation(async ({ ctx, input }) => {
+      // HIPAA write-side block: caregivers are read-only for messaging even
+      // when their scope grants `view_and_message`. Authorship provenance
+      // matters clinically — the patient is the first-person reporter and
+      // the UI surfaces the sender identity as such. See module jsdoc.
+      if (ctx.user.role === "family_caregiver") {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Family caregivers cannot send messages on behalf of a patient",
+        });
+      }
+
       await assertConversationAccess(ctx.user.id, input.conversationId);
 
       const db = getDb();
@@ -203,8 +400,9 @@ export const messagingRbacRouter = t.router({
 
       if (!message) return { success: false };
 
-      // Verify access via conversation
-      await assertConversationAccess(ctx.user.id, message.conversation_id);
+      // Verify access via conversation — caregivers go through the scope
+      // path, everyone else through the existing participant path.
+      await assertMessagingReadAccess(ctx.user, message.conversation_id);
 
       const readBy = (message.read_by ?? []) as string[];
       if (!readBy.includes(ctx.user.id)) {


### PR DESCRIPTION
## Summary

Wave 7 (#896 / PR #900) wired per-resource `access_scopes` enforcement into patient-records, clinical-data, clinical-notes, and scheduling, but the `messages.* -> view_and_message` line from the spec wasn't actually wired into `messaging.ts`. Caregiver access to conversations relied only on participant membership — and caregivers are never direct participants — so scope-granted caregivers were silently denied regardless of `view_and_message`.

This PR wires the messaging router to match the other four routers.

## Changes

`services/api-gateway/src/routers/messaging.ts`
- Added `findActiveFamilyRelationship` (same join-through-users pattern as patient-records/scheduling).
- Added `assertCaregiverMessagingScope` that loads the conversation to resolve `patient_id`, verifies an active family_relationship, and requires `view_and_message` via `hasScope`/`normaliseScopes`.
- Added `assertMessagingReadAccess` dispatcher: caregivers go through the scope path, every other role stays on `assertConversationAccess` (unchanged regression behaviour).
- Applied to read procedures: `listConversations`, `getConversation`, `listMessages`, `markRead`.
- `listConversations` for caregivers enumerates patients they hold `view_and_message` on (via `family_relationships` + `users.patient_id` join) and returns every conversation for those patients.

Write-side role block (HIPAA minimum-necessary):
- `sendMessage` and `createConversation` return FORBIDDEN for `family_caregiver` regardless of scope. Mirrors the `observations.create` block — caregivers read messages but never post on behalf of the patient (authorship provenance is clinically load-bearing).

## Acceptance criteria

- [x] Caregiver with `view_and_message` can list represented patient's conversations, open a conversation, and read messages.
- [x] Caregiver without `view_and_message` (including `view_summary`, `view_notes`, `read_only`, null, empty array) gets FORBIDDEN on every read procedure.
- [x] Caregiver cannot `sendMessage` or `createConversation` — FORBIDDEN at the role check before any DB lookup.
- [x] Regression: clinician on care team (participant) still reads + writes conversations as before.
- [x] Regression: patient (participant) still reads + writes their own conversations.
- [x] FORBIDDEN messages name the missing scope and do NOT leak patient, user, or conversation identifiers.
- [x] Default-deny: missing conversation -> FORBIDDEN (not NOT_FOUND), null/empty access_scopes -> read_only default -> deny.
- [x] Diff under 500 LOC (router +204/-6; test file +526 new).

## Test plan
- [x] New `messaging-rbac.test.ts`: 21 tests covering scope grant/deny, write-side block, error-message hygiene, markRead, and participant-path regression.
- [x] `pnpm --filter @carebridge/api-gateway test` — all 447 tests pass.
- [x] `pnpm typecheck` — green.
- [x] `pnpm lint` — green.

Closes #909