### PR TITLE
refactor(clinical): care team idempotency, role CHECK, atomic RBAC audit

### DIFF
--- a/packages/db-schema/drizzle/0038_care_team_constraints.sql
+++ b/packages/db-schema/drizzle/0038_care_team_constraints.sql
@@ -1,0 +1,53 @@
+-- Care-team polish: idempotency indexes + role CHECK constraints.
+-- Closes issues #881 (idempotency) and #882 (role CHECK parity).
+--
+--  1. CHECK constraints mirror the Zod enums in
+--     `packages/validators/src/care-team.ts`. Zod is the source of truth
+--     (app layer); this DB guardrail catches direct SQL writes (seeds,
+--     manual fixes, future services) that could otherwise bypass it.
+--     The `packages/validators/src/__tests__/care-team.test.ts` tests
+--     break if either side drifts.
+--
+--  2. Partial UNIQUE indexes prevent duplicate ACTIVE rows for a given
+--     (patient, provider/user) pair — the DB-level enforcement of the
+--     idempotency semantics implemented in services/api-gateway/src/
+--     routers/care-team.ts. Soft-deleted rows are retained for HIPAA
+--     history and are explicitly excluded from the uniqueness check.
+--
+-- Non-destructive: existing rows already conform to both sets.
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1. CHECK constraints on role columns (#882)
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE "care_team_members"
+  DROP CONSTRAINT IF EXISTS "care_team_members_role_check";
+ALTER TABLE "care_team_members"
+  ADD CONSTRAINT "care_team_members_role_check"
+  CHECK (role IN ('primary', 'specialist', 'nurse', 'coordinator'));
+
+ALTER TABLE "care_team_assignments"
+  DROP CONSTRAINT IF EXISTS "care_team_assignments_role_check";
+ALTER TABLE "care_team_assignments"
+  ADD CONSTRAINT "care_team_assignments_role_check"
+  CHECK (role IN ('attending', 'consulting', 'nursing', 'covering'));
+
+-- ----------------------------------------------------------------------------
+-- 2. Partial UNIQUE indexes on active rows (#881)
+-- ----------------------------------------------------------------------------
+
+-- Clinical roster: one active row per (provider, patient). Soft-deleted
+-- rows (is_active = false) are excluded — we retain them for audit.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_care_team_members_active_unique"
+  ON "care_team_members" ("provider_id", "patient_id")
+  WHERE is_active = true;
+
+-- RBAC mapping: one active grant per (user, patient). Revoked rows
+-- (removed_at IS NOT NULL) are excluded.
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_care_team_assignments_active_unique"
+  ON "care_team_assignments" ("user_id", "patient_id")
+  WHERE removed_at IS NULL;
+
+COMMIT;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1746892800000,
       "tag": "0037_allergy_overrides",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1746979200000,
+      "tag": "0038_care_team_constraints",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
-import { pgTable, text, boolean, real, index } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { pgTable, text, boolean, real, index, uniqueIndex, check } from "drizzle-orm/pg-core";
 import { encryptedText } from "../encryption.js";
 
 export const patients = pgTable("patients", {
@@ -78,7 +79,9 @@ export const careTeamMembers = pgTable("care_team_members", {
   id: text("id").primaryKey(),
   patient_id: text("patient_id").notNull().references(() => patients.id),
   provider_id: text("provider_id").notNull(),
-  role: text("role").notNull(), // "primary", "specialist", "nurse", "coordinator"
+  // CHECK constraint mirrors `careTeamMemberRoleSchema` in
+  // packages/validators — see migration 0038_care_team_constraints.sql.
+  role: text("role").notNull(), // "primary" | "specialist" | "nurse" | "coordinator"
   specialty: text("specialty"),
   is_active: boolean("is_active").notNull().default(true),
   started_at: text("started_at").notNull(),
@@ -86,6 +89,16 @@ export const careTeamMembers = pgTable("care_team_members", {
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_care_team_patient").on(table.patient_id, table.is_active),
+  // Partial UNIQUE index — DB guardrail for #881 idempotency. App-layer
+  // check in care-team.ts short-circuits before we ever hit this, but
+  // the index defends against concurrent writers and direct SQL.
+  uniqueIndex("idx_care_team_members_active_unique")
+    .on(table.provider_id, table.patient_id)
+    .where(sql`${table.is_active} = true`),
+  check(
+    "care_team_members_role_check",
+    sql`${table.role} IN ('primary', 'specialist', 'nurse', 'coordinator')`,
+  ),
 ]);
 
 /**
@@ -108,10 +121,22 @@ export const careTeamAssignments = pgTable("care_team_assignments", {
   id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
   user_id: text("user_id").notNull(),
   patient_id: text("patient_id").notNull(),
-  role: text("role").notNull(), // "attending", "consulting", "nursing", etc.
+  // CHECK constraint mirrors `careTeamAssignmentRoleSchema` in
+  // packages/validators — see migration 0038_care_team_constraints.sql.
+  role: text("role").notNull(), // "attending" | "consulting" | "nursing" | "covering"
   assigned_at: text("assigned_at").notNull().$defaultFn(() => new Date().toISOString()),
   removed_at: text("removed_at"), // null = active
 }, (table) => [
   index("idx_care_team_assignments_user_patient").on(table.user_id, table.patient_id),
   index("idx_care_team_assignments_patient").on(table.patient_id),
+  // Partial UNIQUE index — DB guardrail for #881 idempotency on the
+  // RBAC table. Revoked rows (removed_at set) are excluded so the row
+  // is retained for audit history.
+  uniqueIndex("idx_care_team_assignments_active_unique")
+    .on(table.user_id, table.patient_id)
+    .where(sql`${table.removed_at} IS NULL`),
+  check(
+    "care_team_assignments_role_check",
+    sql`${table.role} IN ('attending', 'consulting', 'nursing', 'covering')`,
+  ),
 ]);

--- a/packages/validators/src/__tests__/care-team.test.ts
+++ b/packages/validators/src/__tests__/care-team.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  careTeamMemberRoleSchema,
+  careTeamAssignmentRoleSchema,
+  addCareTeamMemberSchema,
+  removeCareTeamMemberSchema,
+  updateCareTeamRoleSchema,
+  grantCareTeamAssignmentSchema,
+  revokeCareTeamAssignmentSchema,
+} from "../care-team.js";
+
+const PATIENT_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+const PROVIDER_ID = "a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5";
+
+// The DB CHECK constraint added in migration 0038 mirrors these enum
+// values one-to-one. If either side drifts, this test breaks and forces
+// the schema migration to catch up.
+describe("careTeamMemberRoleSchema (DB CHECK constraint parity)", () => {
+  const EXPECTED_ROLES = ["primary", "specialist", "nurse", "coordinator"] as const;
+
+  it.each(EXPECTED_ROLES)("accepts role=%s", (role) => {
+    expect(careTeamMemberRoleSchema.safeParse(role).success).toBe(true);
+  });
+
+  it("rejects unknown roles", () => {
+    expect(careTeamMemberRoleSchema.safeParse("surgeon").success).toBe(false);
+    expect(careTeamMemberRoleSchema.safeParse("").success).toBe(false);
+  });
+
+  it("enumerates exactly the DB CHECK-constraint set (no drift)", () => {
+    // `z.enum` exposes its values via `.options` — compare as sets so the
+    // ordering isn't load-bearing.
+    expect([...careTeamMemberRoleSchema.options].sort()).toEqual([...EXPECTED_ROLES].sort());
+  });
+});
+
+describe("careTeamAssignmentRoleSchema (DB CHECK constraint parity)", () => {
+  const EXPECTED_ROLES = ["attending", "consulting", "nursing", "covering"] as const;
+
+  it.each(EXPECTED_ROLES)("accepts role=%s", (role) => {
+    expect(careTeamAssignmentRoleSchema.safeParse(role).success).toBe(true);
+  });
+
+  it("rejects unknown roles", () => {
+    expect(careTeamAssignmentRoleSchema.safeParse("primary").success).toBe(false);
+    expect(careTeamAssignmentRoleSchema.safeParse("").success).toBe(false);
+  });
+
+  it("enumerates exactly the DB CHECK-constraint set (no drift)", () => {
+    expect([...careTeamAssignmentRoleSchema.options].sort()).toEqual([...EXPECTED_ROLES].sort());
+  });
+});
+
+describe("addCareTeamMemberSchema", () => {
+  const valid = {
+    patient_id: PATIENT_ID,
+    provider_id: PROVIDER_ID,
+    role: "nurse" as const,
+  };
+
+  it("accepts a minimal valid payload", () => {
+    expect(addCareTeamMemberSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts optional specialty + assignment_role", () => {
+    expect(
+      addCareTeamMemberSchema.safeParse({
+        ...valid,
+        specialty: "Oncology",
+        assignment_role: "nursing",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an invalid role (would fail DB CHECK too)", () => {
+    expect(addCareTeamMemberSchema.safeParse({ ...valid, role: "surgeon" }).success).toBe(false);
+  });
+
+  it("rejects mismatched assignment_role", () => {
+    expect(
+      addCareTeamMemberSchema.safeParse({ ...valid, assignment_role: "primary" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("removeCareTeamMemberSchema / updateCareTeamRoleSchema", () => {
+  it("removeCareTeamMemberSchema requires a UUID member_id", () => {
+    expect(removeCareTeamMemberSchema.safeParse({ member_id: PROVIDER_ID }).success).toBe(true);
+    expect(removeCareTeamMemberSchema.safeParse({ member_id: "not-a-uuid" }).success).toBe(false);
+  });
+
+  it("updateCareTeamRoleSchema enforces the member-role enum", () => {
+    expect(
+      updateCareTeamRoleSchema.safeParse({ member_id: PROVIDER_ID, role: "coordinator" }).success,
+    ).toBe(true);
+    expect(
+      updateCareTeamRoleSchema.safeParse({ member_id: PROVIDER_ID, role: "attending" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("grantCareTeamAssignmentSchema / revokeCareTeamAssignmentSchema", () => {
+  it("grantCareTeamAssignmentSchema accepts a valid assignment role", () => {
+    expect(
+      grantCareTeamAssignmentSchema.safeParse({
+        user_id: PROVIDER_ID,
+        patient_id: PATIENT_ID,
+        role: "attending",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("grantCareTeamAssignmentSchema rejects a clinical-roster role", () => {
+    expect(
+      grantCareTeamAssignmentSchema.safeParse({
+        user_id: PROVIDER_ID,
+        patient_id: PATIENT_ID,
+        role: "nurse",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("revokeCareTeamAssignmentSchema requires a UUID assignment_id", () => {
+    expect(revokeCareTeamAssignmentSchema.safeParse({ assignment_id: PROVIDER_ID }).success).toBe(
+      true,
+    );
+    expect(revokeCareTeamAssignmentSchema.safeParse({ assignment_id: "nope" }).success).toBe(false);
+  });
+});

--- a/services/api-gateway/src/__tests__/audit-client-ip.test.ts
+++ b/services/api-gateway/src/__tests__/audit-client-ip.test.ts
@@ -26,6 +26,8 @@ const hoisted = vi.hoisted(() => {
   const AUDIT_TABLE = { __tableName: "audit_log" };
   const captured: { values: Record<string, unknown>[] } = { values: [] };
   // Row returned by the DB mock's select().limit() — overridden per test.
+  // `null` means the SELECT returns `[]` (no row), which matters for
+  // procedures whose first SELECT is an idempotency pre-check.
   const state: { selectRow: unknown } = {
     selectRow: { patient_id: "placeholder" },
   };
@@ -34,7 +36,12 @@ const hoisted = vi.hoisted(() => {
     const chain: Record<string, unknown> = {};
     chain.from = vi.fn(() => chain);
     chain.where = vi.fn(() => chain);
-    chain.limit = vi.fn(async () => [state.selectRow]);
+    // `null` selectRow encodes "no match" so procedures whose first SELECT
+    // is an idempotency/existence pre-check (careTeam.addMember post-#881)
+    // fall through to the insert path.
+    chain.limit = vi.fn(async () =>
+      state.selectRow === null ? [] : [state.selectRow],
+    );
     return chain;
   }
 
@@ -217,6 +224,9 @@ describe("issue #885 — explicit audit_log rows carry ctx.clientIp", () => {
   });
 
   it("careTeam.addMember writes the caller IP into audit_log.ip_address", async () => {
+    // post-#881: addMember does an idempotency pre-check. `null` signals
+    // the SELECT returns no row so the insert path runs.
+    hoisted.state.selectRow = null;
     const caller = careTeamRbacRouter.createCaller(makeCtx(CLIENT_IP));
 
     await caller.addMember({

--- a/services/api-gateway/src/__tests__/care-team-rbac.test.ts
+++ b/services/api-gateway/src/__tests__/care-team-rbac.test.ts
@@ -101,10 +101,18 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@carebridge/db-schema", () => ({
   getDb: () => mocks.mockDb,
-  careTeamMembers: { __table: "care_team_members", id: "care_team_members.id" },
+  careTeamMembers: {
+    __table: "care_team_members",
+    id: "care_team_members.id",
+    patient_id: "care_team_members.patient_id",
+    provider_id: "care_team_members.provider_id",
+    is_active: "care_team_members.is_active",
+  },
   careTeamAssignments: {
     __table: "care_team_assignments",
     id: "care_team_assignments.id",
+    user_id: "care_team_assignments.user_id",
+    patient_id: "care_team_assignments.patient_id",
     removed_at: "care_team_assignments.removed_at",
   },
   auditLog: { __table: "audit_log" },
@@ -268,6 +276,74 @@ describe("careTeam.addMember", () => {
       role: "nursing",
     });
   });
+
+  // Issue #883 — capture the RBAC assignment_id in the audit row's
+  // structured details so auditors can correlate the team-member insert
+  // with the access-grant it triggered.
+  it("records the new assignment_id in audit details when RBAC grant is paired", async () => {
+    await callerFor(makeUser("physician")).addMember({
+      ...input,
+      assignment_role: "nursing",
+    });
+    const audit = auditRows();
+    expect(audit).toHaveLength(1);
+    const details = JSON.parse(audit[0]!.row.details as string);
+    expect(details.new_value.assignment_id).toEqual(expect.any(String));
+    // Must match the actual committed assignment row's id.
+    expect(details.new_value.assignment_id).toBe(assignmentRows()[0]!.row.id);
+    expect(details.new_value.assignment_role).toBe("nursing");
+  });
+
+  it("omits assignment_id from audit details when no RBAC grant is paired", async () => {
+    await callerFor(makeUser("physician")).addMember(input);
+    const details = JSON.parse(auditRows()[0]!.row.details as string);
+    // assignment_id must only be present when an assignment was actually
+    // inserted — a stray field would mislead auditors.
+    expect(details.new_value.assignment_id).toBeUndefined();
+  });
+
+  // Issue #881 — idempotency: a duplicate add for an already-active
+  // (provider_id, patient_id) pair returns the existing row and writes
+  // NO new state (no member insert, no audit row).
+  describe("idempotency (#881)", () => {
+    const existingMember = {
+      id: MEMBER_ID,
+      patient_id: PATIENT_ID,
+      provider_id: TARGET_PROVIDER_ID,
+      role: "nurse",
+      specialty: "Oncology",
+      is_active: true,
+      started_at: "2026-04-16T00:00:00.000Z",
+      created_at: "2026-04-16T00:00:00.000Z",
+    };
+
+    it("returns the existing active row and writes no new state", async () => {
+      mocks.state.limitResults = [[existingMember]];
+      const result = await callerFor(makeUser("physician")).addMember(input);
+      expect(result).toMatchObject({
+        id: MEMBER_ID,
+        provider_id: TARGET_PROVIDER_ID,
+        patient_id: PATIENT_ID,
+        is_active: true,
+      });
+      // No new member row, no new assignment row, no audit row.
+      expect(memberRows()).toHaveLength(0);
+      expect(assignmentRows()).toHaveLength(0);
+      expect(auditRows()).toHaveLength(0);
+    });
+
+    it("is idempotent even when an assignment_role is supplied", async () => {
+      mocks.state.limitResults = [[existingMember]];
+      const result = await callerFor(makeUser("physician")).addMember({
+        ...input,
+        assignment_role: "nursing",
+      });
+      expect(result).toMatchObject({ id: MEMBER_ID });
+      expect(memberRows()).toHaveLength(0);
+      expect(assignmentRows()).toHaveLength(0);
+      expect(auditRows()).toHaveLength(0);
+    });
+  });
 });
 
 describe("careTeam.removeMember (soft delete)", () => {
@@ -318,6 +394,34 @@ describe("careTeam.removeMember (soft delete)", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(mocks.state.updatedRows).toHaveLength(0);
     expect(auditRows()).toHaveLength(0);
+  });
+
+  // Issue #881 — REST idempotent DELETE: removing an already-inactive
+  // member is a 200 no-op, not an error. The original `ended_at` is
+  // preserved (not overwritten) so the audit trail of WHEN the member
+  // was removed remains trustworthy.
+  describe("idempotency (#881) — already inactive", () => {
+    const originalEndedAt = "2026-04-15T10:00:00.000Z";
+    const alreadyRemoved = {
+      id: MEMBER_ID,
+      patient_id: PATIENT_ID,
+      provider_id: TARGET_PROVIDER_ID,
+      role: "nurse",
+      specialty: "Oncology",
+      is_active: false,
+      ended_at: originalEndedAt,
+    };
+
+    it("no-ops when the member is already inactive (preserves ended_at, no audit row)", async () => {
+      mocks.state.limitResults = [[alreadyRemoved]];
+      const result = await callerFor(makeUser("physician")).removeMember({
+        member_id: MEMBER_ID,
+      });
+      expect(result).toMatchObject({ removed: true, member_id: MEMBER_ID });
+      // Critical: no UPDATE may run, so the original ended_at is preserved.
+      expect(mocks.state.updatedRows).toHaveLength(0);
+      expect(auditRows()).toHaveLength(0);
+    });
   });
 });
 
@@ -414,6 +518,32 @@ describe("careTeam.assignments.grant", () => {
     expect(assignmentRows()).toHaveLength(0);
     expect(auditRows()).toHaveLength(0);
   });
+
+  // Issue #881 — grant is idempotent on (user_id, patient_id). Second
+  // grant for an already-active assignment returns the existing row and
+  // writes no new state.
+  describe("idempotency (#881)", () => {
+    const existingAssignment = {
+      id: ASSIGNMENT_ID,
+      user_id: TARGET_PROVIDER_ID,
+      patient_id: PATIENT_ID,
+      role: "attending",
+      assigned_at: "2026-04-16T00:00:00.000Z",
+      removed_at: null,
+    };
+
+    it("returns the existing active assignment and writes no new state", async () => {
+      mocks.state.limitResults = [[existingAssignment]];
+      const result = await callerFor(makeUser("physician")).assignments.grant(input);
+      expect(result).toMatchObject({
+        id: ASSIGNMENT_ID,
+        user_id: TARGET_PROVIDER_ID,
+        patient_id: PATIENT_ID,
+      });
+      expect(assignmentRows()).toHaveLength(0);
+      expect(auditRows()).toHaveLength(0);
+    });
+  });
 });
 
 describe("careTeam.assignments.revoke", () => {
@@ -452,6 +582,28 @@ describe("careTeam.assignments.revoke", () => {
     await expect(
       callerFor(makeUser("physician")).assignments.revoke({ assignment_id: ASSIGNMENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  // Issue #881 — revoking an already-revoked assignment is a 200 no-op.
+  // Preserves the original `removed_at` (do NOT overwrite) so auditors
+  // can trust WHEN access was actually revoked.
+  it("no-ops when the assignment is already revoked (preserves removed_at)", async () => {
+    const originalRemovedAt = "2026-04-15T10:00:00.000Z";
+    mocks.state.limitResults = [[
+      {
+        id: ASSIGNMENT_ID,
+        user_id: TARGET_PROVIDER_ID,
+        patient_id: PATIENT_ID,
+        role: "attending",
+        removed_at: originalRemovedAt,
+      },
+    ]];
+    const result = await callerFor(makeUser("physician")).assignments.revoke({
+      assignment_id: ASSIGNMENT_ID,
+    });
+    expect(result).toMatchObject({ revoked: true, assignment_id: ASSIGNMENT_ID });
+    expect(mocks.state.updatedRows).toHaveLength(0);
+    expect(auditRows()).toHaveLength(0);
   });
 
   it("rejects unauthenticated callers (UNAUTHORIZED)", async () => {

--- a/services/api-gateway/src/routers/care-team.ts
+++ b/services/api-gateway/src/routers/care-team.ts
@@ -133,6 +133,14 @@ export const careTeamRbacRouter = t.router({
    * Add a provider to a patient's clinical care team. When `assignment_role`
    * is supplied, the RBAC grant is inserted in the same transaction so a
    * grant failure rolls the roster row back (prevents chart/access split-brain).
+   *
+   * Idempotency (#881): if an active roster row already exists for this
+   * (provider_id, patient_id) pair, return the existing row without writing
+   * ANY new state (no insert, no audit). A duplicate add is not an error —
+   * it aligns with the partial UNIQUE index in migration 0038 and keeps
+   * clients safe to retry on transient failures. The DB index is the hard
+   * guardrail; this app-level check avoids a needless round-trip + error
+   * serialisation on the common happy retry path.
    */
   addMember: protectedProcedure
     .input(addCareTeamMemberSchema)
@@ -140,6 +148,23 @@ export const careTeamRbacRouter = t.router({
       assertCanManageCareTeam(ctx.user);
       await enforcePatientAccess(ctx.user, input.patient_id, ctx.clientIp);
       const db = getDb();
+
+      // Idempotency check BEFORE the transaction: if an active row already
+      // exists, return it verbatim and write no audit row. No state change
+      // means no HIPAA-auditable event.
+      const [existingActive] = await db
+        .select()
+        .from(careTeamMembers)
+        .where(
+          and(
+            eq(careTeamMembers.provider_id, input.provider_id),
+            eq(careTeamMembers.patient_id, input.patient_id),
+            eq(careTeamMembers.is_active, true),
+          ),
+        )
+        .limit(1);
+      if (existingActive) return existingActive;
+
       const now = new Date().toISOString();
       const memberId = crypto.randomUUID();
       const memberRow = {
@@ -153,14 +178,19 @@ export const careTeamRbacRouter = t.router({
         created_at: now,
       };
 
+      // Track the assignment id so the audit row can record it (#883) —
+      // auditors need to correlate the roster insert with the access grant.
+      let assignmentId: string | undefined;
+
       await db.transaction(async (tx) => {
         await tx.insert(careTeamMembers).values(memberRow);
 
         if (input.assignment_role) {
+          assignmentId = crypto.randomUUID();
           // Atomic pair: if this grant throws (unique violation, DB outage),
           // the outer transaction rolls the member insert back.
           await tx.insert(careTeamAssignments).values({
-            id: crypto.randomUUID(),
+            id: assignmentId,
             user_id: input.provider_id,
             patient_id: input.patient_id,
             role: input.assignment_role,
@@ -181,6 +211,9 @@ export const careTeamRbacRouter = t.router({
               role: input.role,
               specialty: input.specialty,
               assignment_role: input.assignment_role,
+              // #883: record the RBAC assignment_id (when applicable) so an
+              // auditor can trace the team+grant pair back to a single row.
+              ...(assignmentId !== undefined && { assignment_id: assignmentId }),
             },
             procedure_name: "careTeam.addMember",
             client_ip: ctx.clientIp,
@@ -214,6 +247,14 @@ export const careTeamRbacRouter = t.router({
       // clinical-data.medications.update where the resource id is the only
       // input and patient_id is looked up before the access check.
       await enforcePatientAccess(ctx.user, existing.patient_id as string, ctx.clientIp);
+
+      // Idempotency (#881): if already inactive, treat as a 200 no-op per
+      // REST idempotent-DELETE semantics. Crucially we do NOT overwrite the
+      // original `ended_at` — auditors need to trust WHEN the member was
+      // actually removed, and a stale retry shouldn't rewrite that history.
+      if (!existing.is_active) {
+        return { removed: true, member_id: input.member_id };
+      }
 
       const now = new Date().toISOString();
       await db.transaction(async (tx) => {
@@ -312,6 +353,24 @@ export const careTeamRbacRouter = t.router({
         assertCanManageCareTeam(ctx.user);
         await enforcePatientAccess(ctx.user, input.patient_id, ctx.clientIp);
         const db = getDb();
+
+        // Idempotency (#881): if an active assignment exists for this
+        // (user_id, patient_id), return it and write no state. Matches the
+        // partial UNIQUE index added in migration 0038. No audit row —
+        // nothing actually changed.
+        const [existingActive] = await db
+          .select()
+          .from(careTeamAssignments)
+          .where(
+            and(
+              eq(careTeamAssignments.user_id, input.user_id),
+              eq(careTeamAssignments.patient_id, input.patient_id),
+              isNull(careTeamAssignments.removed_at),
+            ),
+          )
+          .limit(1);
+        if (existingActive) return existingActive;
+
         const now = new Date().toISOString();
         const assignmentId = crypto.randomUUID();
         const assignmentRow = {
@@ -348,24 +407,28 @@ export const careTeamRbacRouter = t.router({
       .mutation(async ({ ctx, input }) => {
         assertCanManageCareTeam(ctx.user);
         const db = getDb();
+        // Drop the `removed_at IS NULL` filter so we can distinguish
+        // "does not exist" (NOT_FOUND) from "already revoked" (no-op).
         const [existing] = await db
           .select()
           .from(careTeamAssignments)
-          .where(
-            and(
-              eq(careTeamAssignments.id, input.assignment_id),
-              isNull(careTeamAssignments.removed_at),
-            ),
-          )
+          .where(eq(careTeamAssignments.id, input.assignment_id))
           .limit(1);
         if (!existing) {
           throw new TRPCError({
             code: "NOT_FOUND",
-            message: `Care-team assignment ${input.assignment_id} not found or already revoked`,
+            message: `Care-team assignment ${input.assignment_id} not found`,
           });
         }
 
         await enforcePatientAccess(ctx.user, existing.patient_id as string, ctx.clientIp);
+
+        // Idempotency (#881): already revoked → 200 no-op. Preserve the
+        // original `removed_at` so the audit trail of WHEN access was
+        // actually revoked stays trustworthy.
+        if (existing.removed_at) {
+          return { revoked: true, assignment_id: input.assignment_id };
+        }
 
         const now = new Date().toISOString();
         await db.transaction(async (tx) => {


### PR DESCRIPTION
## Summary

Bundled polish for the Wave 5 care-team procedures. Each sub-change has a single motivating issue and is small enough to review on its own; they ship together to amortise one migration.

### #881 — Idempotency semantics

**Decision: return-existing on add/grant, 200-no-op on remove/revoke.**

Rationale:
- Clients retrying after a transient network failure shouldn't be punished with a 409 on the second call — they didn't cause the duplicate, the network did. Return-existing keeps retries safe-to-call.
- `removeMember` / `assignments.revoke` align with RFC 9110 idempotent DELETE — a second remove on a tombstoned resource is a 200 no-op, not an error.
- Critically, the remove/revoke paths now short-circuit BEFORE the UPDATE, so the original `ended_at` / `removed_at` is preserved. Auditors need to trust WHEN the event actually happened; a stale retry must not rewrite that history.
- A partial `UNIQUE ... WHERE is_active = true` index backs the semantic at the DB level — if two concurrent writers race past the app-level check, the second one gets a clean unique-violation rather than silent duplication.

Alternative considered (explicit 409 CONFLICT): rejected because idempotent retries are the common failure mode and a CONFLICT surfaces a "real" error to monitoring dashboards.

### #882 — Role CHECK constraint

`care_team_members.role` and `care_team_assignments.role` now carry DB CHECK constraints mirroring the Zod enums in `packages/validators/src/care-team.ts`. Zod remains the source of truth (app layer), the CHECK catches direct SQL writes (seeds, manual fixes, future services). A parity test in `packages/validators/src/__tests__/care-team.test.ts` fails if either side drifts.

Chose plain CHECK over `pgEnum` — simpler, additive, and the DROP/ADD migration pattern matches `0026_family_access_constraints.sql`.

### #883 — Audit RBAC assignment_id in atomic path

When `addMember` inserts both a `care_team_members` row and a `care_team_assignments` row in the same transaction, the audit row's `details.new_value` now includes the `assignment_id`. Without this, an auditor could see the roster change but had no way to correlate it with the access grant it triggered.

## Non-goals

- No RBAC middleware refactor.
- No role-enum expansion.
- No touches to allergy, appointments, or notes code.

## Test plan

- [x] `pnpm --filter @carebridge/api-gateway test` (492 passed — 35 care-team-rbac)
- [x] `pnpm --filter @carebridge/validators test` (199 passed — 21 new care-team parity)
- [x] `pnpm typecheck` (all packages green)
- [x] `pnpm lint` (no new warnings)
- [x] Full monorepo `pnpm test` passes
- [x] Migration `0038_care_team_constraints.sql` is additive; existing seed rows (primary / specialist / nurse / attending / consulting / nursing) conform to both CHECK sets
- [x] Partial UNIQUE indexes exclude soft-deleted / revoked rows so HIPAA history is retained

## Acceptance criteria

- [x] `addMember` returns the existing row on duplicate without writing a new audit entry
- [x] `assignments.grant` same
- [x] `removeMember` no-ops on already-inactive member (ended_at preserved)
- [x] `assignments.revoke` no-ops on already-revoked assignment (removed_at preserved)
- [x] `care_team_members.role` rejects out-of-enum values at the DB level
- [x] `care_team_assignments.role` rejects out-of-enum values at the DB level
- [x] `audit_log.details.new_value.assignment_id` present when the atomic path inserted one
- [x] Wave 5 transactional rollback contract preserved (covered by existing `rolls back the team insert when the atomic RBAC grant fails` test)

Closes #881
Closes #882
Closes #883