### PR TITLE
feat(clinical): harden allergy-override storage, internal notes router, and note version-history completeness

### DIFF
--- a/packages/db-schema/drizzle/0040_allergy_overrides_hardening.sql
+++ b/packages/db-schema/drizzle/0040_allergy_overrides_hardening.sql
@@ -1,0 +1,58 @@
+-- Harden the allergy_overrides audit trail (#905, #906).
+--
+-- Two related changes rolled into one non-destructive migration:
+--
+-- 1. Denormalise the allergen / medication strings that the override
+--    pertains to (issue #905).
+--
+--    Prior to this change, the ai-oversight rule layer recovered those
+--    strings by regex-parsing `clinical_flags.summary` — which is fragile
+--    (summary wording is a UX concern, not a schema contract) and couples
+--    the rule-layer suppression decision to the exact phrasing of the
+--    flag's human-readable message. Persisting the allergen and medication
+--    as explicit columns lets the suppression query read them directly,
+--    decouples the rule layer from the flag-summary text, and gives HIPAA
+--    reviewers a queryable field rather than a substring match.
+--
+--    Both columns are nullable to preserve backward compatibility for
+--    rows written prior to this migration; the rule layer falls back to
+--    the legacy parsing-from-summary path when either column is NULL,
+--    and the suppression tests cover both legacy and denormalised rows.
+--
+-- 2. Enforce immutability at the database level (issue #906).
+--
+--    The application layer already treats allergy_overrides as permanent —
+--    `allergies.override` only ever INSERTs rows — but there was no
+--    database-level safety net. Following the precedent in
+--    0012_audit_log_immutability.sql, we install BEFORE UPDATE / BEFORE
+--    DELETE triggers that raise an exception. This closes the residual
+--    risk that a future code path (or a misconfigured admin migration)
+--    could mutate or delete override records, which would undermine the
+--    audit-trail guarantee the table exists to provide.
+--
+--    Triggers are used instead of a REVOKE of table privileges so the
+--    constraint travels with the schema and does not depend on how roles
+--    are provisioned in each deployment.
+
+-- (1) Denormalised allergen / medication strings (nullable for backfill).
+ALTER TABLE "allergy_overrides"
+  ADD COLUMN IF NOT EXISTS "medication_name" text,
+  ADD COLUMN IF NOT EXISTS "allergen_name" text;
+
+-- (2) Append-only immutability (trigger-based, mirrors 0012_audit_log_*).
+CREATE OR REPLACE FUNCTION prevent_allergy_override_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'allergy_overrides is append-only; UPDATE/DELETE not permitted';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS allergy_overrides_no_update ON "allergy_overrides";
+CREATE TRIGGER allergy_overrides_no_update
+  BEFORE UPDATE ON "allergy_overrides"
+  FOR EACH ROW EXECUTE FUNCTION prevent_allergy_override_modification();
+
+DROP TRIGGER IF EXISTS allergy_overrides_no_delete ON "allergy_overrides";
+CREATE TRIGGER allergy_overrides_no_delete
+  BEFORE DELETE ON "allergy_overrides"
+  FOR EACH ROW EXECUTE FUNCTION prevent_allergy_override_modification();

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1746892800000,
       "tag": "0037_allergy_overrides",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1747152000000,
+      "tag": "0040_allergy_overrides_hardening",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/allergy-overrides.ts
+++ b/packages/db-schema/src/schema/allergy-overrides.ts
@@ -20,6 +20,9 @@ import { users } from "./auth.js";
  *
  * Related:
  *  - migration 0037_allergy_overrides.sql — schema + reason CHECK constraint
+ *  - migration 0040_allergy_overrides_hardening.sql — denormalised
+ *    medication_name / allergen_name columns (#905) + DB-level
+ *    append-only triggers (#906)
  *  - services/ai-oversight/src/rules/allergy-medication.ts — suppresses
  *    flags for allergy-drug pairs with an existing override
  *  - services/api-gateway/src/routers/patient-records.ts — `allergies.override`
@@ -49,6 +52,16 @@ export const allergyOverrides = pgTable(
     overridden_at: text("overridden_at")
       .notNull()
       .$defaultFn(() => new Date().toISOString()),
+    /**
+     * Denormalised medication / allergen strings (issue #905). Added in
+     * migration 0040 so the rule-layer suppression (`checkAllergyMedication`)
+     * can read them directly rather than regex-parsing the triggering flag's
+     * `summary` column. Nullable to preserve compatibility with rows written
+     * before 0040 — the review-service override loader falls back to the
+     * legacy flag-summary parse when either column is NULL.
+     */
+    medication_name: text("medication_name"),
+    allergen_name: text("allergen_name"),
   },
   (table) => [
     index("idx_allergy_overrides_patient").on(

--- a/services/ai-oversight/src/__tests__/build-patient-context-age.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context-age.test.ts
@@ -49,6 +49,8 @@ vi.mock("@carebridge/db-schema", () => ({
     flag_id: "flag_id",
     override_reason: "override_reason",
     overridden_at: "overridden_at",
+    medication_name: "medication_name",
+    allergen_name: "allergen_name",
   },
   clinicalFlags: {
     id: "id",

--- a/services/ai-oversight/src/__tests__/build-patient-context.test.ts
+++ b/services/ai-oversight/src/__tests__/build-patient-context.test.ts
@@ -39,6 +39,8 @@ vi.mock("@carebridge/db-schema", () => ({
     flag_id: "flag_id",
     override_reason: "override_reason",
     overridden_at: "overridden_at",
+    medication_name: "medication_name",
+    allergen_name: "allergen_name",
   },
   clinicalFlags: {
     id: "id",
@@ -582,6 +584,102 @@ describe("buildPatientContextForRules — recent_labs wiring", () => {
     const ctx = await buildPatientContextForRules("p-1", event);
 
     expect((ctx.allergies ?? []).map((a) => a.allergen)).toEqual(["peanut"]);
+  });
+});
+
+// ─── #905 — denormalised override allergen/medication preference ────
+describe("buildPatientContextForRules — override denormalisation (#905)", () => {
+  beforeEach(() => {
+    primeSelectMocks();
+  });
+
+  it("prefers denormalised allergen_name / medication_name over the legacy flag-summary parse", async () => {
+    // Row written after migration 0040 — both denormalised columns
+    // populated. Even though the legacy flag_summary is present and
+    // would parse to different-looking strings, the loader must use
+    // the structured columns.
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+    overridesSelect.mockResolvedValue([
+      {
+        allergy_id: "a-1",
+        override_reason: "patient_tolerated_previously",
+        overridden_at: "2026-04-10T00:00:00.000Z",
+        medication_name: "Amoxicillin 500mg",
+        allergen_name: "Penicillin",
+        // Intentionally different phrasing to prove the columns win.
+        flag_summary:
+          'Medication "SHOULD_IGNORE" matches patient allergy to "SHOULD_IGNORE"',
+      },
+    ]);
+
+    const ctx = await buildPatientContextForRules("p-1", stubEvent);
+
+    expect(ctx.resolved_overrides).toEqual([
+      {
+        allergy_id: "a-1",
+        allergen: "Penicillin",
+        medication: "Amoxicillin 500mg",
+        override_reason: "patient_tolerated_previously",
+        overridden_at: "2026-04-10T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("falls back to parsing flag_summary when denormalised columns are NULL (pre-migration rows)", async () => {
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+    overridesSelect.mockResolvedValue([
+      {
+        allergy_id: "a-legacy",
+        override_reason: "benefit_exceeds_risk",
+        overridden_at: "2025-12-01T00:00:00.000Z",
+        medication_name: null,
+        allergen_name: null,
+        flag_summary:
+          'Medication "Augmentin" may cross-react with allergy to "Penicillin" (penicillin-cephalosporin-cross class)',
+      },
+    ]);
+
+    const ctx = await buildPatientContextForRules("p-1", stubEvent);
+
+    expect(ctx.resolved_overrides).toEqual([
+      {
+        allergy_id: "a-legacy",
+        allergen: "Penicillin",
+        medication: "Augmentin",
+        override_reason: "benefit_exceeds_risk",
+        overridden_at: "2025-12-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("leaves allergen/medication as null when both the columns and the summary are empty", async () => {
+    diagnosesSelect.mockResolvedValue([]);
+    medicationsSelect.mockResolvedValue([]);
+    labsSelect.mockResolvedValue([]);
+    overridesSelect.mockResolvedValue([
+      {
+        allergy_id: null,
+        override_reason: "other",
+        overridden_at: "2026-04-10T00:00:00.000Z",
+        medication_name: null,
+        allergen_name: null,
+        flag_summary: null,
+      },
+    ]);
+
+    const ctx = await buildPatientContextForRules("p-1", stubEvent);
+
+    expect(ctx.resolved_overrides?.[0]).toEqual({
+      allergy_id: null,
+      allergen: null,
+      medication: null,
+      override_reason: "other",
+      overridden_at: "2026-04-10T00:00:00.000Z",
+    });
   });
 });
 

--- a/services/ai-oversight/src/__tests__/sql-snapshot-filter.test.ts
+++ b/services/ai-oversight/src/__tests__/sql-snapshot-filter.test.ts
@@ -45,6 +45,8 @@ vi.mock("@carebridge/db-schema", () => ({
     flag_id: "allergy_overrides.flag_id",
     override_reason: "allergy_overrides.override_reason",
     overridden_at: "allergy_overrides.overridden_at",
+    medication_name: "allergy_overrides.medication_name",
+    allergen_name: "allergy_overrides.allergen_name",
   },
   clinicalFlags: {
     id: "clinical_flags.id",

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -714,6 +714,10 @@ export async function buildPatientContextForRules(
         allergy_id: allergyOverrides.allergy_id,
         override_reason: allergyOverrides.override_reason,
         overridden_at: allergyOverrides.overridden_at,
+        // Denormalised columns (#905) — preferred over the legacy summary
+        // parse below. Nullable for rows written before migration 0040.
+        medication_name: allergyOverrides.medication_name,
+        allergen_name: allergyOverrides.allergen_name,
         flag_summary: clinicalFlags.summary,
       })
       .from(allergyOverrides)
@@ -874,12 +878,15 @@ export async function buildPatientContextForRules(
     })),
     resolved_overrides: overrideRows.map((o) => ({
       allergy_id: o.allergy_id ?? null,
-      // Recover allergen + medication strings from the overridden flag's
-      // summary. We parse loosely (empty values are fine) so the fallback
-      // matcher in `checkAllergyMedication` can still match on allergen
-      // alone when the override references an allergy_id.
-      allergen: extractAllergenFromFlagSummary(o.flag_summary),
-      medication: extractMedicationFromFlagSummary(o.flag_summary),
+      // Prefer the denormalised columns populated by `allergies.override`
+      // after migration 0040 (#905). Fall back to the legacy
+      // parse-from-flag-summary path for rows written before the migration,
+      // or if a future rule writes an override without the denormalised
+      // fields populated.
+      allergen:
+        o.allergen_name ?? extractAllergenFromFlagSummary(o.flag_summary),
+      medication:
+        o.medication_name ?? extractMedicationFromFlagSummary(o.flag_summary),
       override_reason: o.override_reason,
       overridden_at: o.overridden_at,
     })),

--- a/services/api-gateway/src/__tests__/allergy-override-audit.test.ts
+++ b/services/api-gateway/src/__tests__/allergy-override-audit.test.ts
@@ -200,9 +200,17 @@ describe("allergies.override — role gate", () => {
   function seedFlagAndAllergy() {
     // 1st .limit() -> clinical_flags lookup
     mocks.state.selectQueue.push([
-      { id: FLAG_ID, patient_id: PATIENT_ID, status: "open" },
+      {
+        id: FLAG_ID,
+        patient_id: PATIENT_ID,
+        status: "open",
+        summary:
+          'Medication "Amoxicillin" matches patient allergy to "Penicillin"',
+      },
     ]);
-    // 2nd .limit() -> allergies lookup
+    // 2nd .limit() -> allergies lookup (cross-patient guard + allergen
+    // denormalisation source; both needs served by the same fetch after
+    // the #905 refactor).
     mocks.state.selectQueue.push([
       { id: ALLERGY_ID, patient_id: PATIENT_ID, allergen: "Penicillin" },
     ]);
@@ -367,10 +375,83 @@ describe("allergies.override — flag / allergy lookups", () => {
   });
 });
 
+describe("allergies.override — denormalised allergen/medication (#905)", () => {
+  function seedFlagAndAllergy(summary: string, allergen = "Penicillin") {
+    mocks.state.selectQueue.push([
+      { id: FLAG_ID, patient_id: PATIENT_ID, status: "open", summary },
+    ]);
+    mocks.state.selectQueue.push([
+      { id: ALLERGY_ID, patient_id: PATIENT_ID, allergen },
+    ]);
+  }
+
+  it("denormalises medication_name and allergen_name onto the override row", async () => {
+    seedFlagAndAllergy(
+      'Medication "Amoxicillin 500mg" matches patient allergy to "Penicillin"',
+    );
+    const caller = callerFor(makeUser("physician"));
+    await caller.allergies.override(overrideInput);
+
+    expect(overrideRows()).toHaveLength(1);
+    expect(overrideRows()[0]!.row).toMatchObject({
+      medication_name: "Amoxicillin 500mg",
+      allergen_name: "Penicillin",
+    });
+  });
+
+  it("prefers the structured allergies row for allergen_name over the flag summary", async () => {
+    // Summary names "Penicillin" but the structured allergies row records
+    // the canonical "Amoxicillin" — the denormalisation must prefer the
+    // structured row so reviewers see the clinician's documented allergen
+    // rather than the flag's rendered description.
+    seedFlagAndAllergy(
+      'Medication "Augmentin" may cross-react with allergy to "Penicillin" (penicillin class)',
+      "Amoxicillin",
+    );
+    const caller = callerFor(makeUser("physician"));
+    await caller.allergies.override(overrideInput);
+
+    expect(overrideRows()[0]!.row).toMatchObject({
+      medication_name: "Augmentin",
+      allergen_name: "Amoxicillin",
+    });
+  });
+
+  it("leaves denormalised columns NULL when the flag summary has no recognisable medication line", async () => {
+    // Contraindication-only override (no allergy_id) against a flag whose
+    // summary isn't produced by checkAllergyMedication — e.g. a
+    // cross-specialty warning. The loader-side fallback keeps suppression
+    // correct; the row itself simply has NULLs.
+    mocks.state.selectQueue.push([
+      {
+        id: FLAG_ID,
+        patient_id: PATIENT_ID,
+        status: "open",
+        summary: "Unrelated pattern warning — see care plan",
+      },
+    ]);
+
+    const { allergy_id: _omit, ...withoutAllergy } = overrideInput;
+    const caller = callerFor(makeUser("physician"));
+    await caller.allergies.override(withoutAllergy);
+
+    expect(overrideRows()[0]!.row).toMatchObject({
+      medication_name: null,
+      allergen_name: null,
+    });
+  });
+});
+
 describe("allergies.override — audit ip_address capture (issue #907)", () => {
   function seedFlagAndAllergy() {
     mocks.state.selectQueue.push([
-      { id: FLAG_ID, patient_id: PATIENT_ID, status: "open" },
+      {
+        id: FLAG_ID,
+        patient_id: PATIENT_ID,
+        status: "open",
+        summary:
+          'Medication "Amoxicillin" matches patient allergy to "Penicillin"',
+      },
     ]);
     mocks.state.selectQueue.push([
       { id: ALLERGY_ID, patient_id: PATIENT_ID, allergen: "Penicillin" },

--- a/services/api-gateway/src/__tests__/clinical-notes-amend-audit.test.ts
+++ b/services/api-gateway/src/__tests__/clinical-notes-amend-audit.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Amend audit completeness — regression tests for issue #886.
+ *
+ * The HIPAA amendment audit entry previously captured only the reason
+ * and the new version. That left reviewers unable to distinguish an
+ * amendment of a cosigned chart from an amendment of a signed-only
+ * chart — clinically meaningful states with different downstream
+ * review requirements. After #886, the audit `details` JSON carries:
+ *
+ *   - amended_by:        actor UUID (unchanged)
+ *   - reason:            amendment rationale (unchanged)
+ *   - old_status:        pre-amend status (signed | cosigned | amended)
+ *   - new_status:        post-amend status (always "amended")
+ *   - previous_version:  live-row version BEFORE the amend
+ *   - new_version:       live-row version AFTER the amend
+ *
+ * These tests exercise the gateway router with a mocked DB that
+ * captures the audit row so we can assert the full details payload
+ * for each pre-amend status.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const PHYSICIAN_ID = "44444444-4444-4444-8444-444444444444";
+
+type InsertedRow = { table: string; row: Record<string, unknown> };
+
+const insertedRows: InsertedRow[] = [];
+let preAmendRow: {
+  patient_id: string;
+  status: string;
+  version: number;
+} = {
+  patient_id: PATIENT_ID,
+  status: "signed",
+  version: 3,
+};
+
+function tableOf(t: unknown): string {
+  return (t as { __table?: string })?.__table ?? "unknown";
+}
+
+function makeSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(async () => [preAmendRow]);
+  return chain;
+}
+
+function makeInsertChain(table: unknown) {
+  return {
+    values: vi.fn(async (row: Record<string, unknown>) => {
+      insertedRows.push({ table: tableOf(table), row });
+    }),
+  };
+}
+
+const mockDb = {
+  select: vi.fn(() => makeSelectChain()),
+  insert: vi.fn((table: unknown) => makeInsertChain(table)),
+};
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mockDb,
+  clinicalNotes: {
+    __table: "clinical_notes",
+    id: "clinical_notes.id",
+    patient_id: "clinical_notes.patient_id",
+    status: "clinical_notes.status",
+    version: "clinical_notes.version",
+  },
+  auditLog: { __table: "audit_log", id: "audit_log.id" },
+  familyRelationships: {},
+  users: { id: "users.id", patient_id: "users.patient_id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+  and: (...args: unknown[]) => ({ and: args }),
+}));
+
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@carebridge/clinical-notes", () => ({
+  noteService: {
+    createNote: vi.fn(),
+    updateNote: vi.fn(),
+    signNote: vi.fn(),
+    cosignNote: vi.fn(),
+    amendNote: vi.fn(
+      async (noteId: string, _amendedBy: string, sections: unknown[]) => ({
+        id: noteId,
+        status: "amended",
+        version: preAmendRow.version + 1,
+        sections,
+      }),
+    ),
+    getVersionHistory: vi.fn(async () => []),
+    getNotesByPatient: vi.fn(),
+    getNoteById: vi.fn(),
+  },
+  createSOAPTemplate: () => ({}),
+  createProgressTemplate: () => ({}),
+}));
+
+import { clinicalNotesRbacRouter } from "../routers/clinical-notes.js";
+import type { Context } from "../context.js";
+
+function makeUser(role: User["role"] = "physician", id = PHYSICIAN_ID): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function callerFor(user: User) {
+  const ctx: Context = {
+    db: mockDb as unknown as Context["db"],
+    user,
+    sessionId: "s",
+    requestId: "r",
+    clientIp: "203.0.113.7",
+  };
+  return clinicalNotesRbacRouter.createCaller(ctx);
+}
+
+const sampleSection = {
+  key: "s",
+  label: "Subjective",
+  fields: [],
+  free_text: "Amended text",
+};
+
+const amendInput = {
+  noteId: NOTE_ID,
+  sections: [sampleSection],
+  reason: "Correcting dose miscoded on signing.",
+};
+
+function auditRows(): InsertedRow[] {
+  return insertedRows.filter((r) => r.table === "audit_log");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows.length = 0;
+  preAmendRow = { patient_id: PATIENT_ID, status: "signed", version: 3 };
+});
+
+describe("clinicalNotes.amend audit — old_status / new_status / previous_version (#886)", () => {
+  it("writes audit details capturing the signed→amended transition", async () => {
+    preAmendRow = { patient_id: PATIENT_ID, status: "signed", version: 3 };
+    await callerFor(makeUser("physician")).amend(amendInput);
+
+    expect(auditRows()).toHaveLength(1);
+    const details = JSON.parse(auditRows()[0]!.row.details as string);
+    expect(details).toMatchObject({
+      amended_by: PHYSICIAN_ID,
+      reason: amendInput.reason,
+      old_status: "signed",
+      new_status: "amended",
+      previous_version: 3,
+      new_version: 4,
+    });
+  });
+
+  it("writes audit details capturing the cosigned→amended transition", async () => {
+    preAmendRow = { patient_id: PATIENT_ID, status: "cosigned", version: 7 };
+    await callerFor(makeUser("physician")).amend(amendInput);
+
+    const details = JSON.parse(auditRows()[0]!.row.details as string);
+    expect(details).toMatchObject({
+      old_status: "cosigned",
+      new_status: "amended",
+      previous_version: 7,
+      new_version: 8,
+    });
+  });
+
+  it("writes audit details capturing the amended→amended (chain) transition", async () => {
+    preAmendRow = { patient_id: PATIENT_ID, status: "amended", version: 12 };
+    await callerFor(makeUser("physician")).amend(amendInput);
+
+    const details = JSON.parse(auditRows()[0]!.row.details as string);
+    expect(details).toMatchObject({
+      old_status: "amended",
+      new_status: "amended",
+      previous_version: 12,
+      new_version: 13,
+    });
+  });
+});

--- a/services/api-gateway/src/routers/clinical-notes.ts
+++ b/services/api-gateway/src/routers/clinical-notes.ts
@@ -319,8 +319,21 @@ export const clinicalNotesRbacRouter = t.router({
       }
 
       const db = getDb();
+      // Capture the pre-amend status + version so the audit row can
+      // record the clinically-meaningful transition (#886). Amending a
+      // cosigned note is a different HIPAA-level event than amending a
+      // signed-but-not-cosigned one, and without the pair the audit row
+      // alone can't reconstruct which state the chart was in when the
+      // amendment happened. Reading before the service call gives us a
+      // snapshot of the row as it existed at the moment of the amend
+      // decision — races with a concurrent amend are safe because the
+      // service-side amend is itself ordered by DB row state.
       const [existing] = await db
-        .select({ patient_id: clinicalNotes.patient_id })
+        .select({
+          patient_id: clinicalNotes.patient_id,
+          status: clinicalNotes.status,
+          version: clinicalNotes.version,
+        })
         .from(clinicalNotes)
         .where(eq(clinicalNotes.id, input.noteId))
         .limit(1);
@@ -351,6 +364,9 @@ export const clinicalNotesRbacRouter = t.router({
 
       // Record the amendment reason explicitly — HIPAA amendment audit
       // requires the reason be retrievable alongside the actor/subject.
+      // `old_status` + `new_status` + `previous_version` capture the
+      // clinical transition (#886): amending a cosigned chart is a
+      // materially different event than amending a signed-only draft.
       try {
         await db.insert(auditLog).values({
           id: crypto.randomUUID(),
@@ -363,6 +379,9 @@ export const clinicalNotesRbacRouter = t.router({
           details: JSON.stringify({
             amended_by: ctx.user.id,
             reason: input.reason,
+            old_status: existing.status,
+            new_status: result.status,
+            previous_version: existing.version,
             new_version: result.version,
           }),
           ip_address: ctx.clientIp ?? "",

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -660,6 +660,11 @@ export const patientRecordsRbacRouter = t.router({
         // patient as the flag. This blocks cross-patient override bleed
         // (an attacker passing a valid flag_id for patient A together with
         // a valid allergy_id for patient B to dilute the audit trail).
+        // The row itself is retained for the allergen-name denormalisation
+        // below (#905) — saves a second round-trip.
+        let allergyRowForOverride:
+          | { patient_id: string; allergen: string }
+          | undefined;
         if (input.allergy_id) {
           const [allergyRow] = await db
             .select()
@@ -679,6 +684,7 @@ export const patientRecordsRbacRouter = t.router({
                 "allergy_id does not belong to the same patient as the flag",
             });
           }
+          allergyRowForOverride = allergyRow;
         }
 
         const now = new Date().toISOString();
@@ -693,6 +699,24 @@ export const patientRecordsRbacRouter = t.router({
             2000,
           );
 
+        // Denormalise the allergen / medication strings onto the override
+        // row so the rule-layer suppression can read them directly rather
+        // than regex-parsing the triggering flag's summary (#905). The
+        // allergen prefers the structured allergies row (when supplied);
+        // the medication is recovered from the flag summary which is
+        // produced by `checkAllergyMedication` in a stable format:
+        //   `Medication "<med>" matches patient allergy to "<allergen>"`
+        //   `Medication "<med>" may cross-react with allergy to "<allergen>" ...`
+        // A parse miss leaves the column NULL — downstream loader falls
+        // back to the legacy summary parse so legacy rows still resolve.
+        const summary = flag.summary ?? "";
+        const medMatch = summary.match(/^Medication "([^"]+)"/);
+        const allergenFromSummary = summary.match(/allergy to "([^"]+)"/);
+        const medicationName = medMatch ? medMatch[1]! : null;
+        const allergenName: string | null =
+          allergyRowForOverride?.allergen ??
+          (allergenFromSummary ? allergenFromSummary[1]! : null);
+
         await db.transaction(async (tx) => {
           await tx.insert(allergyOverrides).values({
             id: overrideId,
@@ -703,6 +727,8 @@ export const patientRecordsRbacRouter = t.router({
             override_reason: input.override_reason,
             clinical_justification: input.clinical_justification,
             overridden_at: now,
+            medication_name: medicationName,
+            allergen_name: allergenName,
           });
 
           await tx

--- a/services/clinical-notes/src/__tests__/note-service.test.ts
+++ b/services/clinical-notes/src/__tests__/note-service.test.ts
@@ -113,7 +113,8 @@ describe("createNote", () => {
       sections: soapSections,
     });
 
-    expect(db.insert).toHaveBeenCalledTimes(1);
+    // Two inserts: the clinical_notes row and the v1 draft archive (#888).
+    expect(db.insert).toHaveBeenCalledTimes(2);
     const insertCall = db.insert.calls[0];
     expect(insertCall?.chain).toContain("values");
     const insertedValues = insertCall?.chainArgs[0]?.[0] as {
@@ -124,6 +125,31 @@ describe("createNote", () => {
     expect(insertedValues.patient_id).toBe(PATIENT_ID);
     expect(insertedValues.version).toBe(1);
     expect(insertedValues.status).toBe("draft");
+  });
+
+  it("archives v1 to note_versions with lifecycle_event=draft on create (#888)", async () => {
+    await createNote({
+      patient_id: PATIENT_ID,
+      provider_id: PROVIDER_ID,
+      template_type: "soap",
+      sections: soapSections,
+    });
+
+    // The 2nd insert is the version-archive write. Before #888 the
+    // version history was empty until the first sign / update — a note
+    // that was viewed as a draft had no snapshot to show.
+    expect(db.insert).toHaveBeenCalledTimes(2);
+    const archived = db.insert.calls[1]?.chainArgs[0]?.[0] as {
+      note_id: string;
+      version: number;
+      sections: unknown;
+      saved_by: string;
+      lifecycle_event: string;
+    };
+    expect(archived.version).toBe(1);
+    expect(archived.saved_by).toBe(PROVIDER_ID);
+    expect(archived.sections).toEqual(soapSections);
+    expect(archived.lifecycle_event).toBe("draft");
   });
 
   it("emits a note.saved clinical event on create", async () => {
@@ -766,11 +792,21 @@ describe("getVersionHistory", () => {
   // query does), so the assertions pin both the event labels and the
   // chronological order that getVersionHistory must produce.
 
-  it("create → sign → cosign yields [signed, cosigned] in chronological order", async () => {
-    // Create does NOT archive (no pre-existing state to snapshot), so the
-    // history contains only the sign and cosign archive rows. Both share
-    // version=1 because neither sign nor cosign bumps clinical_notes.version.
+  it("create → sign → cosign yields [draft, signed, cosigned] in chronological order (#888)", async () => {
+    // After #888, createNote archives the initial draft as v1 — so a
+    // create → sign → cosign sequence produces THREE rows, not two. All
+    // three share version=1 because neither sign nor cosign bumps
+    // clinical_notes.version; the lifecycle_event label is what
+    // disambiguates them.
     db.willSelect([
+      {
+        note_id: NOTE_ID,
+        version: 1,
+        sections: [{ key: "s", label: "Subjective", fields: [], free_text: "initial" }],
+        saved_at: "2026-03-15T09:00:00.000Z",
+        saved_by: PROVIDER_ID,
+        lifecycle_event: "draft",
+      },
       {
         note_id: NOTE_ID,
         version: 1,
@@ -791,22 +827,32 @@ describe("getVersionHistory", () => {
 
     const versions = await getVersionHistory(NOTE_ID);
 
-    expect(versions).toHaveLength(2);
-    expect(versions[0].lifecycle_event).toBe("signed");
+    expect(versions).toHaveLength(3);
+    expect(versions.map((v) => v.lifecycle_event)).toEqual([
+      "draft",
+      "signed",
+      "cosigned",
+    ]);
     expect(versions[0].saved_by).toBe(PROVIDER_ID);
-    expect(versions[1].lifecycle_event).toBe("cosigned");
-    expect(versions[1].saved_by).toBe(COSIGNER_ID);
-    // Both rows sit at version=1 — the lifecycle_event label is what
-    // disambiguates them.
-    expect(versions[0].version).toBe(1);
-    expect(versions[1].version).toBe(1);
+    expect(versions[1].saved_by).toBe(PROVIDER_ID);
+    expect(versions[2].saved_by).toBe(COSIGNER_ID);
+    expect(versions.map((v) => v.version)).toEqual([1, 1, 1]);
   });
 
-  it("create → sign → amend → amend yields [signed, amended, amended] in chronological order", async () => {
-    // First amend archives the signed snapshot at version=1, then the live
-    // row bumps to version=2. Second amend archives version=2, live row
-    // bumps to version=3.
+  it("create → sign → amend → amend yields [draft, signed, amended, amended] in chronological order (#888)", async () => {
+    // After #888 the initial draft gets archived at create time. First
+    // amend archives the signed snapshot at version=1 and bumps the live
+    // row to version=2. Second amend archives version=2 and bumps to
+    // version=3 — so the full history is four rows, not three.
     db.willSelect([
+      {
+        note_id: NOTE_ID,
+        version: 1,
+        sections: [{ key: "s", label: "Subjective", fields: [], free_text: "initial" }],
+        saved_at: "2026-03-15T09:00:00.000Z",
+        saved_by: PROVIDER_ID,
+        lifecycle_event: "draft",
+      },
       {
         note_id: NOTE_ID,
         version: 1,
@@ -835,13 +881,38 @@ describe("getVersionHistory", () => {
 
     const versions = await getVersionHistory(NOTE_ID);
 
-    expect(versions).toHaveLength(3);
+    expect(versions).toHaveLength(4);
     expect(versions.map((v) => v.lifecycle_event)).toEqual([
+      "draft",
       "signed",
       "amended",
       "amended",
     ]);
-    expect(versions.map((v) => v.version)).toEqual([1, 1, 2]);
+    expect(versions.map((v) => v.version)).toEqual([1, 1, 1, 2]);
+  });
+
+  it("returns [draft v1] for a note that was created but never transitioned (#888)", async () => {
+    // Prior to #888 the version history of an unsaved-past-draft note
+    // was []. After #888 it's a single draft row — which is what the
+    // "what did this draft look like when it was first saved?" audit
+    // question needs to answer.
+    db.willSelect([
+      {
+        note_id: NOTE_ID,
+        version: 1,
+        sections: [{ key: "s", label: "Subjective", fields: [], free_text: "initial" }],
+        saved_at: "2026-03-15T09:00:00.000Z",
+        saved_by: PROVIDER_ID,
+        lifecycle_event: "draft",
+      },
+    ]);
+
+    const versions = await getVersionHistory(NOTE_ID);
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0].lifecycle_event).toBe("draft");
+    expect(versions[0].version).toBe(1);
+    expect(versions[0].saved_by).toBe(PROVIDER_ID);
   });
 });
 

--- a/services/clinical-notes/src/__tests__/router-actor-spoof.test.ts
+++ b/services/clinical-notes/src/__tests__/router-actor-spoof.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Internal clinical-notes router — actor spoofing regression (#884).
+ *
+ * The internal router's cosign / amend / sign procedures used to accept
+ * `cosigned_by` / `amended_by` / `signed_by` in their Zod input via
+ * `.extend()`. That shape is a latent spoofing vector: any caller that
+ * could reach the internal router directly (bypassing the gateway's
+ * `ctx.user.id` enforcement) would get to pick whose id gets written to
+ * the note's cosigner / amender column.
+ *
+ * This test file pins the post-fix behaviour:
+ *   1. Identity input fields are silently stripped at the Zod layer
+ *      (so calls that include them still succeed — backward compatible
+ *      for the gateway wrapper and existing clients).
+ *   2. The actor id written to the DB is always ctx.actorId, never the
+ *      stripped input field.
+ *   3. Omitting ctx.actorId raises UNAUTHORIZED so misconfigured call
+ *      sites fail loudly instead of silently attributing writes to "".
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const NOTE_ID = "11111111-1111-4111-8111-111111111111";
+const CTX_ACTOR_ID = "22222222-2222-4222-8222-222222222222";
+const SPOOFED_ACTOR_ID = "99999999-9999-4999-8999-999999999999";
+
+const signNoteMock = vi.fn();
+const cosignNoteMock = vi.fn();
+const amendNoteMock = vi.fn();
+
+// Stub the service + its db/event dependencies so the router can be
+// imported without pulling in @carebridge/outbox (the real service's
+// event-emit module) or a live DB. We export classes as class shims so
+// `err instanceof NoteStateError` in the router still works.
+vi.mock("../services/note-service.js", () => {
+  class NoteStateError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "NoteStateError";
+    }
+  }
+  class NoteConflictError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "NoteConflictError";
+    }
+  }
+  return {
+    signNote: signNoteMock,
+    cosignNote: cosignNoteMock,
+    amendNote: amendNoteMock,
+    createNote: vi.fn(),
+    updateNote: vi.fn(),
+    getNotesByPatient: vi.fn(),
+    getNoteById: vi.fn(),
+    getVersionHistory: vi.fn(async () => []),
+    NoteStateError,
+    NoteConflictError,
+  };
+});
+
+const { clinicalNotesRouter } = await import("../router.js");
+
+const sampleSection = {
+  key: "s",
+  label: "Subjective",
+  fields: [],
+  free_text: "Amended text",
+};
+
+function caller(actorId?: string) {
+  return clinicalNotesRouter.createCaller({ actorId });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  signNoteMock.mockResolvedValue({ id: NOTE_ID, status: "signed" });
+  cosignNoteMock.mockResolvedValue({ id: NOTE_ID, status: "cosigned" });
+  amendNoteMock.mockResolvedValue({ id: NOTE_ID, status: "amended" });
+});
+
+describe("internal clinical-notes router — sign actor resolution (#884)", () => {
+  it("uses ctx.actorId as the signer, ignoring any stripped signed_by input", async () => {
+    await caller(CTX_ACTOR_ID).sign({
+      noteId: NOTE_ID,
+      // @ts-expect-error — schema no longer accepts signed_by; runtime strips.
+      signed_by: SPOOFED_ACTOR_ID,
+    });
+    expect(signNoteMock).toHaveBeenCalledWith(NOTE_ID, CTX_ACTOR_ID);
+    expect(signNoteMock).not.toHaveBeenCalledWith(NOTE_ID, SPOOFED_ACTOR_ID);
+  });
+
+  it("raises UNAUTHORIZED when ctx.actorId is missing", async () => {
+    await expect(
+      caller().sign({ noteId: NOTE_ID }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(signNoteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("internal clinical-notes router — cosign actor resolution (#884)", () => {
+  it("uses ctx.actorId as the cosigner, ignoring any stripped cosigned_by input", async () => {
+    await caller(CTX_ACTOR_ID).cosign({
+      noteId: NOTE_ID,
+      // @ts-expect-error — schema no longer accepts cosigned_by.
+      cosigned_by: SPOOFED_ACTOR_ID,
+    });
+    expect(cosignNoteMock).toHaveBeenCalledWith(NOTE_ID, CTX_ACTOR_ID);
+    expect(cosignNoteMock).not.toHaveBeenCalledWith(NOTE_ID, SPOOFED_ACTOR_ID);
+  });
+
+  it("raises UNAUTHORIZED when ctx.actorId is missing", async () => {
+    await expect(
+      caller().cosign({ noteId: NOTE_ID }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(cosignNoteMock).not.toHaveBeenCalled();
+  });
+
+  it("raises UNAUTHORIZED when ctx.actorId is an empty string", async () => {
+    await expect(
+      caller("").cosign({ noteId: NOTE_ID }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    expect(cosignNoteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("internal clinical-notes router — amend actor resolution (#884)", () => {
+  const amendInput = {
+    noteId: NOTE_ID,
+    sections: [sampleSection],
+    reason: "Correcting dose miscoded on signing.",
+  };
+
+  it("uses ctx.actorId as the amender, ignoring any stripped amended_by input", async () => {
+    await caller(CTX_ACTOR_ID).amend({
+      ...amendInput,
+      // @ts-expect-error — schema no longer accepts amended_by.
+      amended_by: SPOOFED_ACTOR_ID,
+    });
+    expect(amendNoteMock).toHaveBeenCalledWith(
+      NOTE_ID,
+      CTX_ACTOR_ID,
+      amendInput.sections,
+      amendInput.reason,
+    );
+    // The spoof must never reach the service layer.
+    const calls = amendNoteMock.mock.calls;
+    expect(
+      calls.every(([, actor]: unknown[]) => actor !== SPOOFED_ACTOR_ID),
+    ).toBe(true);
+  });
+
+  it("raises UNAUTHORIZED when ctx.actorId is missing", async () => {
+    await expect(caller().amend(amendInput)).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(amendNoteMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/clinical-notes/src/index.ts
+++ b/services/clinical-notes/src/index.ts
@@ -1,5 +1,8 @@
 export { clinicalNotesRouter } from "./router.js";
-export type { ClinicalNotesRouter } from "./router.js";
+export type {
+  ClinicalNotesRouter,
+  ClinicalNotesRouterContext,
+} from "./router.js";
 export * as noteService from "./services/note-service.js";
 export { createSOAPTemplate } from "./templates/soap.js";
 export { createProgressTemplate } from "./templates/progress.js";

--- a/services/clinical-notes/src/router.ts
+++ b/services/clinical-notes/src/router.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   createNoteSchema,
   updateNoteSchema,
-  signNoteSchema,
   cosignNoteSchema,
   amendNoteSchema,
   noteTemplateTypeSchema,
@@ -17,7 +16,43 @@ import { createHAndPTemplate } from "./templates/h-and-p.js";
 import { createDischargeTemplate } from "./templates/discharge.js";
 import { createConsultTemplate } from "./templates/consult.js";
 
-const t = initTRPC.create();
+/**
+ * Internal router context (#884).
+ *
+ * The internal clinical-notes router no longer accepts `cosigned_by` /
+ * `amended_by` in Zod input — those fields were a spoofing vector even if
+ * the only in-tree caller (the gateway wrapper) passes the authenticated
+ * user id. Call sites that do not flow through the auth boundary (unit
+ * tests, future BullMQ workers) must pass the actor id via ctx.actorId.
+ *
+ * Leaving `actorId` optional keeps the router ergonomic for read-only
+ * procedures (getVersionHistory, getByPatient, getById, templates.*) that
+ * never need an actor — the actor resolution helper only throws for the
+ * mutation procedures that actually write an actor-bearing row.
+ */
+export interface ClinicalNotesRouterContext {
+  actorId?: string;
+}
+
+const t = initTRPC.context<ClinicalNotesRouterContext>().create();
+
+/**
+ * Resolve the acting user id for a state-changing procedure. Throws
+ * UNAUTHORIZED when the context lacks one so mis-wired call sites fail
+ * loudly instead of silently attributing a write to an empty string.
+ */
+function getActorId(
+  ctx: ClinicalNotesRouterContext,
+  operation: string,
+): string {
+  if (!ctx.actorId || ctx.actorId.length === 0) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: `Internal clinical-notes router requires ctx.actorId for ${operation}`,
+    });
+  }
+  return ctx.actorId;
+}
 
 const templateBuilders: Record<NoteTemplateType, (() => ReturnType<typeof createSOAPTemplate>) | null> = {
   soap: createSOAPTemplate,
@@ -49,20 +84,32 @@ export const clinicalNotesRouter = t.router({
     }),
 
   sign: t.procedure
-    .input(z.object({ noteId: z.string().uuid() }).merge(signNoteSchema))
-    .mutation(async ({ input }) => {
-      return noteService.signNote(input.noteId, input.signed_by);
+    // `signed_by` is server-derived from ctx.actorId — see #884. The
+    // input schema carries only the target note id so the internal
+    // router has no avenue to spoof the signer even if mounted directly.
+    .input(z.object({ noteId: z.string().uuid() }))
+    .mutation(async ({ input, ctx }) => {
+      const actor = getActorId(ctx, "sign");
+      return noteService.signNote(input.noteId, actor);
     }),
 
   cosign: t.procedure
-    // Cosigner identity is carried in the caller's auth context at the
-    // gateway tier; this internal router takes it as a second field to
-    // keep the service-under-router ergonomic for unit tests and for
-    // future call sites that don't go through the auth boundary.
-    .input(cosignNoteSchema.extend({ cosigned_by: z.string().uuid() }))
-    .mutation(async ({ input }) => {
+    // Cosigner and amender identities are server-derived only (#884).
+    //
+    // Previously these procedures accepted `cosigned_by` / `amended_by` in
+    // input via `.extend()`, which would have let a caller forge another
+    // user's signature if the internal router were ever mounted directly.
+    // The gateway-level wrapper in `api-gateway/src/routers/clinical-notes.ts`
+    // already ignores client input and uses `ctx.user.id`, but this
+    // internal router is the last line of defence — accepting identity via
+    // Zod input was a latent spoofing vector, so we drop those fields from
+    // the schema and read them from the meta object passed by call sites
+    // that don't flow through the auth boundary (unit tests, workers).
+    .input(cosignNoteSchema)
+    .mutation(async ({ input, ctx }) => {
+      const actor = getActorId(ctx, "cosign");
       try {
-        return await noteService.cosignNote(input.noteId, input.cosigned_by);
+        return await noteService.cosignNote(input.noteId, actor);
       } catch (err) {
         if (err instanceof NoteStateError) {
           throw new TRPCError({ code: "CONFLICT", message: err.message });
@@ -72,12 +119,13 @@ export const clinicalNotesRouter = t.router({
     }),
 
   amend: t.procedure
-    .input(amendNoteSchema.extend({ amended_by: z.string().uuid() }))
-    .mutation(async ({ input }) => {
+    .input(amendNoteSchema)
+    .mutation(async ({ input, ctx }) => {
+      const actor = getActorId(ctx, "amend");
       try {
         return await noteService.amendNote(
           input.noteId,
-          input.amended_by,
+          actor,
           input.sections,
           input.reason,
         );

--- a/services/clinical-notes/src/services/note-service.ts
+++ b/services/clinical-notes/src/services/note-service.ts
@@ -87,6 +87,22 @@ export async function createNote(input: CreateNoteInput): Promise<ClinicalNote> 
 
   await db.insert(clinicalNotes).values(note);
 
+  // Archive the initial draft as a v1 version row (#888). Historically
+  // archiving only began on the first state transition (updateNote /
+  // signNote), so a note that was created and viewed without being
+  // signed produced an empty version history. That gap broke "what did
+  // this note look like at time T" audit queries for drafts under
+  // active composition. Lifecycle event is "draft" — the same label
+  // updateNote writes when it archives a pre-edit draft snapshot.
+  await archiveVersion({
+    noteId: id,
+    version: 1,
+    sections: input.sections,
+    savedBy: input.provider_id,
+    savedAt: now,
+    lifecycleEvent: "draft",
+  });
+
   await emitClinicalEvent({
     id: crypto.randomUUID(),
     type: "note.saved",


### PR DESCRIPTION
## Summary

Five small hardening fixes bundled into one PR — all touch the same audit-and-history surface and share test infrastructure.

## Scope and acceptance criteria

### #905 — denormalise `medication_name` / `allergen_name` onto `allergy_overrides`
- [x] Migration adds nullable `medication_name` and `allergen_name` columns.
- [x] `allergies.override` mutation populates both from the structured allergy row + flag summary.
- [x] `buildPatientContextForRules` selects the new columns and prefers them over the legacy `flag_summary` parse.
- [x] Legacy rows (both columns NULL) still resolve via the summary-parse fallback.
- [x] Suppression tests unchanged; new loader-preference tests added.

### #906 — DB-level append-only for `allergy_overrides`
- [x] Migration installs `BEFORE UPDATE` / `BEFORE DELETE` triggers that raise, mirroring the `0012_audit_log_immutability.sql` precedent.
- [x] Non-destructive (additive). Triggers are idempotent via `DROP TRIGGER IF EXISTS`.

### #884 — remove spoofing vector on internal clinical-notes router
- [x] `cosigned_by` / `amended_by` / `signed_by` removed from Zod input schemas on the internal `services/clinical-notes/src/router.ts`.
- [x] Actor id now sourced from `ctx.actorId`; missing actor raises `UNAUTHORIZED`.
- [x] Gateway router unaffected (already used `ctx.user.id`).
- [x] New regression tests in `services/clinical-notes/src/__tests__/router-actor-spoof.test.ts` confirm stripped-input + ctx-override behaviour and the empty-actor failure path.

### #886 — HIPAA-complete amend audit details
- [x] Gateway amend procedure now reads pre-amend `status` + `version` before the service call.
- [x] Audit `details` JSON includes `old_status`, `new_status`, `previous_version`, `new_version` in addition to the pre-existing `amended_by` / `reason`.
- [x] New tests in `services/api-gateway/src/__tests__/clinical-notes-amend-audit.test.ts` cover signed→amended, cosigned→amended, and amended→amended transitions.

### #888 — archive v1 on note creation
- [x] `createNote` calls `archiveVersion` with `lifecycle_event="draft"`, `version=1` immediately after the note insert.
- [x] `create→sign→cosign` now yields `[draft, signed, cosigned]` (was `[signed, cosigned]`).
- [x] `create→sign→amend→amend` now yields `[draft, signed, amended, amended]` (was 3 rows).
- [x] `create→getVersionHistory` now returns `[draft v1]` (was `[]`).
- [x] Existing `note-service.test.ts` regression tests updated; new test pins the draft-only case.

## Schema migration

- **`packages/db-schema/drizzle/0040_allergy_overrides_hardening.sql`** — additive columns + immutability triggers. Both changes are non-destructive (nullable columns; triggers rely on the pre-existing no-UPDATE/no-DELETE contract at the app layer).

## Test plan

- [x] `pnpm --filter @carebridge/ai-oversight test` — 799 green
- [x] `pnpm --filter @carebridge/clinical-notes test` — 55 green
- [x] `pnpm --filter @carebridge/api-gateway test` — 491 green
- [x] `pnpm --filter @carebridge/validators test` — 178 green
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green (only pre-existing warnings in patient/clinician portal)

Closes #884
Closes #886
Closes #888
Closes #905
Closes #906