### PR TITLE
feat(clinical): add per-drug max daily/single dose reference data (#238)

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -15,6 +15,10 @@ import {
   getPulsePressureThresholds,
   PEDIATRIC_PP_THRESHOLDS,
 } from "../medical-validation.js";
+import {
+  MEDICATION_MAX_DAILY_DOSES,
+  getMedicationDoseLimit,
+} from "../medication-max-doses.js";
 
 // ─── validateVital ──────────────────────────────────────────────
 
@@ -322,6 +326,158 @@ describe("validateMedicationDose", () => {
   it("errors on NaN dose", () => {
     const result = validateMedicationDose(NaN, "mg");
     expect(result.valid).toBe(false);
+  });
+});
+
+// ─── validateMedicationDose — per-drug limits (issue #238) ──────
+
+describe("validateMedicationDose — per-drug ceilings (#238)", () => {
+  it("accepts an acetaminophen 650 mg single dose", () => {
+    const result = validateMedicationDose(650, "mg", "acetaminophen");
+    expect(result.valid).toBe(true);
+    // 650 is not above warn threshold (650), so no warning either.
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("warns on acetaminophen 975 mg (above warn, below hard max)", () => {
+    const result = validateMedicationDose(975, "mg", "acetaminophen");
+    expect(result.valid).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toMatch(/Acetaminophen/);
+  });
+
+  it("errors on acetaminophen 1500 mg single dose (> 1000 mg max)", () => {
+    const result = validateMedicationDose(1500, "mg", "acetaminophen");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Acetaminophen max single dose/);
+    expect(result.errors[0]).toMatch(/1000 mg/);
+  });
+
+  it("errors on ibuprofen 1000 mg single dose (> 800 mg max)", () => {
+    const result = validateMedicationDose(1000, "mg", "ibuprofen");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Ibuprofen/);
+  });
+
+  it("errors on oxycodone 40 mg single dose (> 20 mg max)", () => {
+    const result = validateMedicationDose(40, "mg", "oxycodone");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Oxycodone/);
+  });
+
+  it("resolves brand alias Tylenol → acetaminophen ceiling", () => {
+    const result = validateMedicationDose(1500, "mg", "Tylenol");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Acetaminophen/);
+  });
+
+  it("resolves combo brand Percocet → oxycodone (stricter component)", () => {
+    // 30 mg oxycodone is above the 20 mg single-dose ceiling even though
+    // a 30 mg Percocet dose would be gross overdosing of APAP too.
+    const result = validateMedicationDose(30, "mg", "Percocet");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Oxycodone/);
+  });
+
+  it("is case-insensitive and trims whitespace in drug name", () => {
+    const result = validateMedicationDose(1500, "mg", "  ACETAMINOPHEN  ");
+    expect(result.valid).toBe(false);
+  });
+
+  it("falls back to generic 10,000-mg ceiling for unknown drugs", () => {
+    const result = validateMedicationDose(15000, "mg", "zolpidopride");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("exceeds 10,000"))).toBe(true);
+  });
+
+  it("suppresses the generic 'unusually high mg' warning when a drug limit matched", () => {
+    // Acetaminophen hard max is 1000; 900 mg is above warn but below hard max.
+    // The legacy generic "mg > 5000" warning path must not fire here because
+    // the drug-specific warn is the authoritative signal.
+    const result = validateMedicationDose(900, "mg", "acetaminophen");
+    expect(result.valid).toBe(true);
+    expect(
+      result.warnings.filter((w) => w.includes("unusually high")),
+    ).toHaveLength(0);
+  });
+
+  it("errors on ibuprofen with no drugName falls back to generic", () => {
+    // Without drugName, 6000 mg triggers the generic mg>5000 warn, not an
+    // ibuprofen-specific error. Backward compat for legacy callers.
+    const result = validateMedicationDose(6000, "mg");
+    expect(result.valid).toBe(true);
+    expect(result.warnings[0]).toMatch(/unusually high/);
+  });
+
+  it("skips per-drug error when unit is not mg (mg table isn't comparable)", () => {
+    const result = validateMedicationDose(100, "mcg", "acetaminophen");
+    expect(result.valid).toBe(true);
+    // No "exceeds Acetaminophen max" since unit isn't mg.
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ─── MEDICATION_MAX_DAILY_DOSES data sanity ─────────────────────
+
+describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
+  it("covers acetaminophen, ibuprofen, naproxen, aspirin", () => {
+    for (const name of ["acetaminophen", "ibuprofen", "naproxen", "aspirin"]) {
+      expect(MEDICATION_MAX_DAILY_DOSES[name]).toBeDefined();
+      expect(MEDICATION_MAX_DAILY_DOSES[name].max_daily_dose_mg).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers the major oral opioids with MME factors", () => {
+    for (const opioid of ["morphine", "oxycodone", "hydrocodone", "codeine", "tramadol"]) {
+      const limit = MEDICATION_MAX_DAILY_DOSES[opioid];
+      expect(limit).toBeDefined();
+      expect(limit.mme_factor).toBeGreaterThan(0);
+    }
+  });
+
+  it("every limit has a non-empty source", () => {
+    for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
+      expect(limit.source, `drug=${drug}`).toMatch(/\S/);
+    }
+  });
+
+  it("every limit's max_single_dose_mg <= max_daily_dose_mg (internal consistency)", () => {
+    for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
+      if (
+        limit.max_single_dose_mg !== undefined &&
+        limit.max_daily_dose_mg !== undefined
+      ) {
+        expect(
+          limit.max_single_dose_mg,
+          `drug=${drug} single=${limit.max_single_dose_mg} daily=${limit.max_daily_dose_mg}`,
+        ).toBeLessThanOrEqual(limit.max_daily_dose_mg);
+      }
+    }
+  });
+
+  it("every warn threshold is below its hard-max counterpart", () => {
+    for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
+      if (
+        limit.warn_single_dose_mg !== undefined &&
+        limit.max_single_dose_mg !== undefined
+      ) {
+        expect(
+          limit.warn_single_dose_mg,
+          `drug=${drug} warn=${limit.warn_single_dose_mg} max=${limit.max_single_dose_mg}`,
+        ).toBeLessThanOrEqual(limit.max_single_dose_mg);
+      }
+    }
+  });
+
+  it("getMedicationDoseLimit resolves aliases", () => {
+    expect(getMedicationDoseLimit("tylenol")?.display_name).toMatch(/Acetaminophen/);
+    expect(getMedicationDoseLimit("Advil")?.display_name).toMatch(/Ibuprofen/);
+    expect(getMedicationDoseLimit("OxyContin")?.display_name).toMatch(/Oxycodone/);
+    expect(getMedicationDoseLimit("norco")?.display_name).toMatch(/Hydrocodone/);
+  });
+
+  it("getMedicationDoseLimit returns undefined for unknown drugs", () => {
+    expect(getMedicationDoseLimit("unobtanium")).toBeUndefined();
   });
 });
 

--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -401,9 +401,10 @@ describe("validateMedicationDose — per-drug ceilings (#238)", () => {
     ).toHaveLength(0);
   });
 
-  it("errors on ibuprofen with no drugName falls back to generic", () => {
-    // Without drugName, 6000 mg triggers the generic mg>5000 warn, not an
-    // ibuprofen-specific error. Backward compat for legacy callers.
+  it("warns via the generic mg>5000 ceiling when drugName is omitted (backward compat)", () => {
+    // Without drugName the drug-specific branch is skipped, so 6000 mg
+    // triggers only the generic "unusually high" warning — no error and
+    // no drug-specific citation. Preserves behavior for pre-#238 callers.
     const result = validateMedicationDose(6000, "mg");
     expect(result.valid).toBe(true);
     expect(result.warnings[0]).toMatch(/unusually high/);
@@ -423,7 +424,7 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
   it("covers acetaminophen, ibuprofen, naproxen, aspirin", () => {
     for (const name of ["acetaminophen", "ibuprofen", "naproxen", "aspirin"]) {
       expect(MEDICATION_MAX_DAILY_DOSES[name]).toBeDefined();
-      expect(MEDICATION_MAX_DAILY_DOSES[name].max_daily_dose_mg).toBeGreaterThan(0);
+      expect(MEDICATION_MAX_DAILY_DOSES[name]!.maxDailyDoseMg).toBeGreaterThan(0);
     }
   });
 
@@ -431,7 +432,7 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
     for (const opioid of ["morphine", "oxycodone", "hydrocodone", "codeine", "tramadol"]) {
       const limit = MEDICATION_MAX_DAILY_DOSES[opioid];
       expect(limit).toBeDefined();
-      expect(limit.mme_factor).toBeGreaterThan(0);
+      expect(limit!.mmeFactor).toBeGreaterThan(0);
     }
   });
 
@@ -441,16 +442,16 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
     }
   });
 
-  it("every limit's max_single_dose_mg <= max_daily_dose_mg (internal consistency)", () => {
+  it("every limit's maxSingleDoseMg <= maxDailyDoseMg (internal consistency)", () => {
     for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
       if (
-        limit.max_single_dose_mg !== undefined &&
-        limit.max_daily_dose_mg !== undefined
+        limit.maxSingleDoseMg !== undefined &&
+        limit.maxDailyDoseMg !== undefined
       ) {
         expect(
-          limit.max_single_dose_mg,
-          `drug=${drug} single=${limit.max_single_dose_mg} daily=${limit.max_daily_dose_mg}`,
-        ).toBeLessThanOrEqual(limit.max_daily_dose_mg);
+          limit.maxSingleDoseMg,
+          `drug=${drug} single=${limit.maxSingleDoseMg} daily=${limit.maxDailyDoseMg}`,
+        ).toBeLessThanOrEqual(limit.maxDailyDoseMg);
       }
     }
   });
@@ -458,22 +459,34 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
   it("every warn threshold is below its hard-max counterpart", () => {
     for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
       if (
-        limit.warn_single_dose_mg !== undefined &&
-        limit.max_single_dose_mg !== undefined
+        limit.warnSingleDoseMg !== undefined &&
+        limit.maxSingleDoseMg !== undefined
       ) {
         expect(
-          limit.warn_single_dose_mg,
-          `drug=${drug} warn=${limit.warn_single_dose_mg} max=${limit.max_single_dose_mg}`,
-        ).toBeLessThanOrEqual(limit.max_single_dose_mg);
+          limit.warnSingleDoseMg,
+          `drug=${drug} warn=${limit.warnSingleDoseMg} max=${limit.maxSingleDoseMg}`,
+        ).toBeLessThanOrEqual(limit.maxSingleDoseMg);
       }
     }
   });
 
   it("getMedicationDoseLimit resolves aliases", () => {
-    expect(getMedicationDoseLimit("tylenol")?.display_name).toMatch(/Acetaminophen/);
-    expect(getMedicationDoseLimit("Advil")?.display_name).toMatch(/Ibuprofen/);
-    expect(getMedicationDoseLimit("OxyContin")?.display_name).toMatch(/Oxycodone/);
-    expect(getMedicationDoseLimit("norco")?.display_name).toMatch(/Hydrocodone/);
+    expect(getMedicationDoseLimit("tylenol")?.displayName).toMatch(/Acetaminophen/);
+    expect(getMedicationDoseLimit("Advil")?.displayName).toMatch(/Ibuprofen/);
+    expect(getMedicationDoseLimit("OxyContin")?.displayName).toMatch(/Oxycodone/);
+    expect(getMedicationDoseLimit("norco")?.displayName).toMatch(/Hydrocodone/);
+  });
+
+  it("getMedicationDoseLimit strips trailing strength/frequency tokens", () => {
+    expect(
+      getMedicationDoseLimit("Ibuprofen 600mg TID")?.displayName,
+    ).toMatch(/Ibuprofen/);
+    expect(
+      getMedicationDoseLimit("Acetaminophen 500mg PO q6h")?.displayName,
+    ).toMatch(/Acetaminophen/);
+    expect(
+      getMedicationDoseLimit("Morphine 10 mg q4h PRN")?.displayName,
+    ).toMatch(/Morphine/);
   });
 
   it("getMedicationDoseLimit returns undefined for unknown drugs", () => {

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -2,3 +2,4 @@ export * from "./trend-utils.js";
 export * from "./medical-validation.js";
 export * from "./weight-based-dosing.js";
 export * from "./vital-staleness-thresholds.js";
+export * from "./medication-max-doses.js";

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -5,6 +5,7 @@
 
 import type { VitalType } from "@carebridge/shared-types";
 import { COMMON_LAB_TESTS } from "@carebridge/shared-types";
+import { getMedicationDoseLimit } from "./medication-max-doses.js";
 
 export interface VitalRange {
   min: number;
@@ -270,9 +271,22 @@ export function validateVital(
   return { valid: errors.length === 0, warnings, errors };
 }
 
+/**
+ * Validate a single medication dose against drug-specific ceilings when a
+ * drug name is supplied, falling back to generic unit-based ceilings for
+ * unknown drugs.
+ *
+ * Issue #238: the prior generic 10,000-mg fall-through was 10–100× above
+ * real safe limits. When `drugName` matches {@link MEDICATION_MAX_DAILY_DOSES}
+ * (directly or via brand alias), the per-drug `max_single_dose_mg` is the
+ * authoritative ceiling. The generic 10,000 / 5,000-mg / 1,000-mcg / 500-mL
+ * checks remain as defence-in-depth for unknown drugs and gross
+ * decimal-point errors (e.g. "prednisone 10000 mg" typed instead of "10").
+ */
 export function validateMedicationDose(
   doseAmount: number | undefined,
-  doseUnit: string | undefined
+  doseUnit: string | undefined,
+  drugName?: string,
 ): ValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -285,12 +299,51 @@ export function validateMedicationDose(
   }
 
   if (doseAmount <= 0) errors.push("Dose must be a positive number");
-  if (doseAmount > 10000) errors.push("Dose exceeds 10,000 — verify this is correct");
 
   const unit = doseUnit?.toLowerCase();
-  if (unit === "mg" && doseAmount > 5000) warnings.push(`${doseAmount} mg is unusually high — verify`);
-  if (unit === "mcg" && doseAmount > 1000) warnings.push(`${doseAmount} mcg is unusually high — verify`);
-  if (unit === "ml" && doseAmount > 500) warnings.push(`${doseAmount} mL is unusually high — verify`);
+  const limit = drugName ? getMedicationDoseLimit(drugName) : undefined;
+
+  // Per-drug ceilings (issue #238). Only apply when the unit is mg — the
+  // table's limits are expressed in milligrams; cross-unit comparisons
+  // (mg vs mcg vs mL) can't be made safely without drug-specific density
+  // or concentration data, which is out of scope here.
+  if (limit && unit === "mg") {
+    if (
+      limit.max_single_dose_mg !== undefined &&
+      doseAmount > limit.max_single_dose_mg
+    ) {
+      errors.push(
+        `${doseAmount} mg exceeds ${limit.display_name} max single dose of ` +
+          `${limit.max_single_dose_mg} mg (${limit.source}) — verify prescription`,
+      );
+    } else if (
+      limit.warn_single_dose_mg !== undefined &&
+      doseAmount > limit.warn_single_dose_mg
+    ) {
+      warnings.push(
+        `${doseAmount} mg of ${limit.display_name} is above the typical ` +
+          `single-dose threshold (${limit.warn_single_dose_mg} mg); hard max ` +
+          `${limit.max_single_dose_mg ?? "unspecified"} mg`,
+      );
+    }
+  }
+
+  // Generic ceilings — defence-in-depth for unknown drugs, typos, and
+  // cross-unit sanity. These stay active even when a drug limit matched,
+  // so a grossly wrong number still trips a guard even if the drug's own
+  // hard max is higher than 10,000 mg (no such drug today, but future-proof).
+  if (doseAmount > 10000) {
+    errors.push("Dose exceeds 10,000 — verify this is correct");
+  }
+  if (unit === "mg" && doseAmount > 5000 && !limit) {
+    warnings.push(`${doseAmount} mg is unusually high — verify`);
+  }
+  if (unit === "mcg" && doseAmount > 1000) {
+    warnings.push(`${doseAmount} mcg is unusually high — verify`);
+  }
+  if (unit === "ml" && doseAmount > 500) {
+    warnings.push(`${doseAmount} mL is unusually high — verify`);
+  }
 
   return { valid: errors.length === 0, warnings, errors };
 }

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -309,21 +309,21 @@ export function validateMedicationDose(
   // or concentration data, which is out of scope here.
   if (limit && unit === "mg") {
     if (
-      limit.max_single_dose_mg !== undefined &&
-      doseAmount > limit.max_single_dose_mg
+      limit.maxSingleDoseMg !== undefined &&
+      doseAmount > limit.maxSingleDoseMg
     ) {
       errors.push(
-        `${doseAmount} mg exceeds ${limit.display_name} max single dose of ` +
-          `${limit.max_single_dose_mg} mg (${limit.source}) — verify prescription`,
+        `${doseAmount} mg exceeds ${limit.displayName} max single dose of ` +
+          `${limit.maxSingleDoseMg} mg (${limit.source}) — verify prescription`,
       );
     } else if (
-      limit.warn_single_dose_mg !== undefined &&
-      doseAmount > limit.warn_single_dose_mg
+      limit.warnSingleDoseMg !== undefined &&
+      doseAmount > limit.warnSingleDoseMg
     ) {
       warnings.push(
-        `${doseAmount} mg of ${limit.display_name} is above the typical ` +
-          `single-dose threshold (${limit.warn_single_dose_mg} mg); hard max ` +
-          `${limit.max_single_dose_mg ?? "unspecified"} mg`,
+        `${doseAmount} mg of ${limit.displayName} is above the typical ` +
+          `single-dose threshold (${limit.warnSingleDoseMg} mg); hard max ` +
+          `${limit.maxSingleDoseMg ?? "unspecified"} mg`,
       );
     }
   }

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -1,0 +1,204 @@
+/**
+ * Max single-dose and daily-cumulative-dose reference data (issue #238).
+ *
+ * Replaces the prior generic 10,000-mg fall-through in validateMedicationDose
+ * (10–100× above real safe limits) with drug-specific ceilings sourced from
+ * FDA labels and the CDC 2022 opioid prescribing guideline.
+ *
+ * Scope:
+ *  - Acetaminophen, ibuprofen, naproxen, aspirin, diclofenac, meloxicam,
+ *    celecoxib — NSAID / analgesic ceilings.
+ *  - Morphine, oxycodone, hydrocodone, codeine, tramadol — oral opioid
+ *    ceilings keyed off CDC MME guidance (90 MME/day is the elevated-risk
+ *    threshold; most per-day caps in this table are calibrated to that).
+ *
+ * Out of scope (handled in follow-ups):
+ *  - Route-specific caps (IV morphine vs PO morphine have very different
+ *    safe ceilings). All values here are PO unless noted.
+ *  - Transdermal fentanyl patches (expressed as mcg/hr, not mg) — the MME
+ *    conversion requires route-aware handling.
+ *  - Daily-cumulative summation across multiple prescriptions (issue #235).
+ *
+ * All values are adult dosing. Pediatric weight-based dosing is handled by
+ * weight-based-dosing.ts.
+ */
+
+export interface MedicationDoseLimit {
+  /** Human-readable canonical name used in validation messages. */
+  display_name: string;
+  /** Hard ceiling for a single administered dose, in mg (PO unless noted). */
+  max_single_dose_mg?: number;
+  /**
+   * Soft threshold for a single dose. Values above this warn ("verify")
+   * but below max_single_dose_mg do not error. Typical use: 650 mg for
+   * acetaminophen — legal but above the usual 325–500 mg prescribed dose.
+   */
+  warn_single_dose_mg?: number;
+  /** Max cumulative dose per 24 h in mg. Consumed by daily-sum rules (#235). */
+  max_daily_dose_mg?: number;
+  /**
+   * Morphine Milligram Equivalent factor (PO, oral). Opioid doses multiply
+   * by this to compare to the 90 MME/day elevated-risk threshold. Absent on
+   * non-opioids.
+   */
+  mme_factor?: number;
+  /** Authoritative source the limit is drawn from. */
+  source: string;
+}
+
+/**
+ * Canonical drug → dose limits. Keys are lowercase generic names; brand
+ * names are resolved via {@link DRUG_NAME_ALIASES}.
+ */
+export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
+  // ── NSAIDs / analgesics ─────────────────────────────────────────
+  acetaminophen: {
+    display_name: "Acetaminophen",
+    max_single_dose_mg: 1000,
+    warn_single_dose_mg: 650,
+    max_daily_dose_mg: 4000,
+    source: "FDA label (McNeil, 2011 max-daily reduction)",
+  },
+  ibuprofen: {
+    display_name: "Ibuprofen",
+    max_single_dose_mg: 800,
+    warn_single_dose_mg: 400,
+    max_daily_dose_mg: 3200,
+    source: "FDA label (prescription strength)",
+  },
+  naproxen: {
+    display_name: "Naproxen",
+    max_single_dose_mg: 1000,
+    warn_single_dose_mg: 500,
+    max_daily_dose_mg: 1500,
+    source: "FDA label (Naprosyn)",
+  },
+  aspirin: {
+    display_name: "Aspirin",
+    max_single_dose_mg: 1000,
+    warn_single_dose_mg: 650,
+    max_daily_dose_mg: 4000,
+    source: "FDA OTC monograph (analgesic dosing)",
+  },
+  diclofenac: {
+    display_name: "Diclofenac",
+    max_single_dose_mg: 50,
+    max_daily_dose_mg: 150,
+    source: "FDA label (Voltaren IR)",
+  },
+  meloxicam: {
+    display_name: "Meloxicam",
+    max_single_dose_mg: 15,
+    max_daily_dose_mg: 15,
+    source: "FDA label (Mobic)",
+  },
+  celecoxib: {
+    display_name: "Celecoxib",
+    max_single_dose_mg: 200,
+    max_daily_dose_mg: 400,
+    source: "FDA label (Celebrex)",
+  },
+
+  // ── Oral opioids (PO). Daily caps are calibrated to CDC 2022 90 MME/day.
+  morphine: {
+    display_name: "Morphine (PO)",
+    max_single_dose_mg: 30,
+    max_daily_dose_mg: 90,
+    mme_factor: 1.0,
+    source: "CDC 2022 opioid prescribing guideline",
+  },
+  oxycodone: {
+    display_name: "Oxycodone (PO)",
+    max_single_dose_mg: 20,
+    max_daily_dose_mg: 60,
+    mme_factor: 1.5,
+    source: "CDC 2022 opioid prescribing guideline",
+  },
+  hydrocodone: {
+    display_name: "Hydrocodone (PO)",
+    max_single_dose_mg: 10,
+    max_daily_dose_mg: 90,
+    mme_factor: 1.0,
+    source: "CDC 2022 opioid prescribing guideline",
+  },
+  codeine: {
+    display_name: "Codeine (PO)",
+    max_single_dose_mg: 60,
+    max_daily_dose_mg: 360,
+    mme_factor: 0.15,
+    source: "CDC 2022 opioid prescribing guideline",
+  },
+  tramadol: {
+    display_name: "Tramadol (PO)",
+    max_single_dose_mg: 100,
+    max_daily_dose_mg: 400,
+    mme_factor: 0.2,
+    source: "FDA label (Ultram) and CDC 2022",
+  },
+};
+
+/**
+ * Brand → generic aliases. Combo products (e.g. Percocet = oxycodone +
+ * acetaminophen) are aliased to the opioid component — the more tightly
+ * bounded drug — so the lookup returns the stricter of the two caps.
+ */
+const DRUG_NAME_ALIASES: Record<string, string> = {
+  // Acetaminophen
+  tylenol: "acetaminophen",
+  apap: "acetaminophen",
+  paracetamol: "acetaminophen",
+  panadol: "acetaminophen",
+  // Ibuprofen
+  advil: "ibuprofen",
+  motrin: "ibuprofen",
+  nuprin: "ibuprofen",
+  // Naproxen
+  aleve: "naproxen",
+  naprosyn: "naproxen",
+  anaprox: "naproxen",
+  // Aspirin
+  bayer: "aspirin",
+  asa: "aspirin",
+  bufferin: "aspirin",
+  ecotrin: "aspirin",
+  // Diclofenac
+  voltaren: "diclofenac",
+  cataflam: "diclofenac",
+  // Meloxicam
+  mobic: "meloxicam",
+  // Celecoxib
+  celebrex: "celecoxib",
+  // Opioids
+  "ms contin": "morphine",
+  ms_contin: "morphine",
+  mscontin: "morphine",
+  roxanol: "morphine",
+  kadian: "morphine",
+  oxycontin: "oxycodone",
+  percocet: "oxycodone", // oxycodone + APAP; opioid is the tighter guard
+  roxicodone: "oxycodone",
+  oxyir: "oxycodone",
+  norco: "hydrocodone",
+  vicodin: "hydrocodone", // hydrocodone + APAP
+  lortab: "hydrocodone",
+  zohydro: "hydrocodone",
+  ultram: "tramadol",
+  tylenol3: "codeine",
+  "tylenol 3": "codeine",
+};
+
+/**
+ * Look up per-drug dose limits by free-text drug name. Matches lowercase,
+ * trimmed name against the canonical table and the brand-name alias map.
+ * Returns undefined when the drug is unknown — callers should fall back
+ * to a generic ceiling.
+ */
+export function getMedicationDoseLimit(
+  drugName: string,
+): MedicationDoseLimit | undefined {
+  const key = drugName.trim().toLowerCase();
+  if (MEDICATION_MAX_DAILY_DOSES[key]) return MEDICATION_MAX_DAILY_DOSES[key];
+  const canonical = DRUG_NAME_ALIASES[key];
+  if (canonical) return MEDICATION_MAX_DAILY_DOSES[canonical];
+  return undefined;
+}

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -25,23 +25,23 @@
 
 export interface MedicationDoseLimit {
   /** Human-readable canonical name used in validation messages. */
-  display_name: string;
+  displayName: string;
   /** Hard ceiling for a single administered dose, in mg (PO unless noted). */
-  max_single_dose_mg?: number;
+  maxSingleDoseMg?: number;
   /**
    * Soft threshold for a single dose. Values above this warn ("verify")
-   * but below max_single_dose_mg do not error. Typical use: 650 mg for
+   * but below maxSingleDoseMg do not error. Typical use: 650 mg for
    * acetaminophen — legal but above the usual 325–500 mg prescribed dose.
    */
-  warn_single_dose_mg?: number;
+  warnSingleDoseMg?: number;
   /** Max cumulative dose per 24 h in mg. Consumed by daily-sum rules (#235). */
-  max_daily_dose_mg?: number;
+  maxDailyDoseMg?: number;
   /**
    * Morphine Milligram Equivalent factor (PO, oral). Opioid doses multiply
    * by this to compare to the 90 MME/day elevated-risk threshold. Absent on
    * non-opioids.
    */
-  mme_factor?: number;
+  mmeFactor?: number;
   /** Authoritative source the limit is drawn from. */
   source: string;
 }
@@ -53,86 +53,86 @@ export interface MedicationDoseLimit {
 export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
   // ── NSAIDs / analgesics ─────────────────────────────────────────
   acetaminophen: {
-    display_name: "Acetaminophen",
-    max_single_dose_mg: 1000,
-    warn_single_dose_mg: 650,
-    max_daily_dose_mg: 4000,
+    displayName: "Acetaminophen",
+    maxSingleDoseMg: 1000,
+    warnSingleDoseMg: 650,
+    maxDailyDoseMg: 4000,
     source: "FDA label (McNeil, 2011 max-daily reduction)",
   },
   ibuprofen: {
-    display_name: "Ibuprofen",
-    max_single_dose_mg: 800,
-    warn_single_dose_mg: 400,
-    max_daily_dose_mg: 3200,
+    displayName: "Ibuprofen",
+    maxSingleDoseMg: 800,
+    warnSingleDoseMg: 400,
+    maxDailyDoseMg: 3200,
     source: "FDA label (prescription strength)",
   },
   naproxen: {
-    display_name: "Naproxen",
-    max_single_dose_mg: 1000,
-    warn_single_dose_mg: 500,
-    max_daily_dose_mg: 1500,
+    displayName: "Naproxen",
+    maxSingleDoseMg: 1000,
+    warnSingleDoseMg: 500,
+    maxDailyDoseMg: 1500,
     source: "FDA label (Naprosyn)",
   },
   aspirin: {
-    display_name: "Aspirin",
-    max_single_dose_mg: 1000,
-    warn_single_dose_mg: 650,
-    max_daily_dose_mg: 4000,
+    displayName: "Aspirin",
+    maxSingleDoseMg: 1000,
+    warnSingleDoseMg: 650,
+    maxDailyDoseMg: 4000,
     source: "FDA OTC monograph (analgesic dosing)",
   },
   diclofenac: {
-    display_name: "Diclofenac",
-    max_single_dose_mg: 50,
-    max_daily_dose_mg: 150,
+    displayName: "Diclofenac",
+    maxSingleDoseMg: 50,
+    maxDailyDoseMg: 150,
     source: "FDA label (Voltaren IR)",
   },
   meloxicam: {
-    display_name: "Meloxicam",
-    max_single_dose_mg: 15,
-    max_daily_dose_mg: 15,
+    displayName: "Meloxicam",
+    maxSingleDoseMg: 15,
+    maxDailyDoseMg: 15,
     source: "FDA label (Mobic)",
   },
   celecoxib: {
-    display_name: "Celecoxib",
-    max_single_dose_mg: 200,
-    max_daily_dose_mg: 400,
+    displayName: "Celecoxib",
+    maxSingleDoseMg: 200,
+    maxDailyDoseMg: 400,
     source: "FDA label (Celebrex)",
   },
 
   // ── Oral opioids (PO). Daily caps are calibrated to CDC 2022 90 MME/day.
   morphine: {
-    display_name: "Morphine (PO)",
-    max_single_dose_mg: 30,
-    max_daily_dose_mg: 90,
-    mme_factor: 1.0,
+    displayName: "Morphine (PO)",
+    maxSingleDoseMg: 30,
+    maxDailyDoseMg: 90,
+    mmeFactor: 1.0,
     source: "CDC 2022 opioid prescribing guideline",
   },
   oxycodone: {
-    display_name: "Oxycodone (PO)",
-    max_single_dose_mg: 20,
-    max_daily_dose_mg: 60,
-    mme_factor: 1.5,
+    displayName: "Oxycodone (PO)",
+    maxSingleDoseMg: 20,
+    maxDailyDoseMg: 60,
+    mmeFactor: 1.5,
     source: "CDC 2022 opioid prescribing guideline",
   },
   hydrocodone: {
-    display_name: "Hydrocodone (PO)",
-    max_single_dose_mg: 10,
-    max_daily_dose_mg: 90,
-    mme_factor: 1.0,
+    displayName: "Hydrocodone (PO)",
+    maxSingleDoseMg: 10,
+    maxDailyDoseMg: 90,
+    mmeFactor: 1.0,
     source: "CDC 2022 opioid prescribing guideline",
   },
   codeine: {
-    display_name: "Codeine (PO)",
-    max_single_dose_mg: 60,
-    max_daily_dose_mg: 360,
-    mme_factor: 0.15,
+    displayName: "Codeine (PO)",
+    maxSingleDoseMg: 60,
+    maxDailyDoseMg: 360,
+    mmeFactor: 0.15,
     source: "CDC 2022 opioid prescribing guideline",
   },
   tramadol: {
-    display_name: "Tramadol (PO)",
-    max_single_dose_mg: 100,
-    max_daily_dose_mg: 400,
-    mme_factor: 0.2,
+    displayName: "Tramadol (PO)",
+    maxSingleDoseMg: 100,
+    maxDailyDoseMg: 400,
+    mmeFactor: 0.2,
     source: "FDA label (Ultram) and CDC 2022",
   },
 };
@@ -188,17 +188,39 @@ const DRUG_NAME_ALIASES: Record<string, string> = {
 };
 
 /**
- * Look up per-drug dose limits by free-text drug name. Matches lowercase,
- * trimmed name against the canonical table and the brand-name alias map.
- * Returns undefined when the drug is unknown — callers should fall back
- * to a generic ceiling.
+ * Strip trailing strength / route / frequency tokens from a free-text
+ * drug name so entries like "Ibuprofen 600mg TID" or "Acetaminophen
+ * 500mg PO q6h" still resolve to their canonical entry.
+ *
+ * Heuristic: everything from the first digit onward is clinical-form
+ * decoration (strength, frequency, duration), not drug-identity. Drop
+ * it, then collapse whitespace. The raw input is also tried so pure-name
+ * lookups keep working for inputs like "Tylenol 3" that encode strength
+ * as part of the aliased brand key.
+ */
+function candidatesFor(drugName: string): string[] {
+  const raw = drugName.trim().toLowerCase();
+  const stripped = raw.replace(/\s*\d.*$/, "").trim().replace(/\s+/g, " ");
+  // raw wins first so alias keys that happen to contain digits ("tylenol 3")
+  // keep resolving; stripped handles "ibuprofen 600mg tid" style input.
+  if (!stripped || stripped === raw) return [raw];
+  return [raw, stripped];
+}
+
+/**
+ * Look up per-drug dose limits by free-text drug name. Accepts
+ * generics, brand aliases (case-insensitive), and names with trailing
+ * strength / frequency tokens stripped. Returns undefined when the
+ * drug is unknown — callers should fall back to a generic ceiling.
  */
 export function getMedicationDoseLimit(
   drugName: string,
 ): MedicationDoseLimit | undefined {
-  const key = drugName.trim().toLowerCase();
-  if (MEDICATION_MAX_DAILY_DOSES[key]) return MEDICATION_MAX_DAILY_DOSES[key];
-  const canonical = DRUG_NAME_ALIASES[key];
-  if (canonical) return MEDICATION_MAX_DAILY_DOSES[canonical];
+  for (const key of candidatesFor(drugName)) {
+    const direct = MEDICATION_MAX_DAILY_DOSES[key];
+    if (direct) return direct;
+    const canonical = DRUG_NAME_ALIASES[key];
+    if (canonical) return MEDICATION_MAX_DAILY_DOSES[canonical];
+  }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- New `packages/medical-logic/src/medication-max-doses.ts` with `MEDICATION_MAX_DAILY_DOSES` reference table covering acetaminophen, ibuprofen, naproxen, aspirin, diclofenac, meloxicam, celecoxib, and oral opioids (morphine, oxycodone, hydrocodone, codeine, tramadol) with MME factors
- `getMedicationDoseLimit(name)` resolves generics + brand aliases (Tylenol → acetaminophen, Percocet → oxycodone). Combo brands resolve to the stricter component
- `validateMedicationDose` now takes an optional `drugName`; when matched and unit is mg, per-drug single-dose ceiling is the authoritative guard. Generic 10 000-mg / 5 000-mg / 1 000-mcg / 500-mL ceilings stay on for unknown drugs and decimal-point errors
- 18 new tests + 6 data-sanity invariants (single ≤ daily, warn ≤ hard max, every limit has a source, alias resolution, unit/case-insensitivity)

## Why

`packages/medical-logic/src/medical-validation.ts:288` had a generic `doseAmount > 10000` fallback — 10–100× above acetaminophen's 1 g single-dose cap, 500× above meloxicam's 15 mg cap. A mis-keyed `40` for oxycodone (max 20 mg) would pass without complaint. This PR gives `validateMedicationDose` the drug-aware ceiling it was missing and unblocks the daily-sum rule tracked as #235.

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 237/237 pass
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — 22/22, no new warnings
- [x] Data invariants locked in tests (max_single ≤ max_daily, warn ≤ hard max, every drug has a source)
- [x] Backward compat: legacy `validateMedicationDose(amount, unit)` callers unchanged

Closes #238