### PR TITLE
feat(ai): medication frequency parsing + daily-dose cap enforcement (#235)

### DIFF
--- a/packages/medical-logic/src/__tests__/medication-frequency.test.ts
+++ b/packages/medical-logic/src/__tests__/medication-frequency.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFrequencyText,
+  estimateDailyDose,
+  FREQUENCY_DOSES_PER_DAY,
+  type MedFrequency,
+} from "../medication-frequency.js";
+
+describe("parseFrequencyText (#235)", () => {
+  const cases: Array<[string, MedFrequency | null]> = [
+    // Q-N-hour shorthand
+    ["q2h", "q2h"],
+    ["Q2H", "q2h"],
+    ["q 2 h", "q2h"],
+    ["q2hr", "q2h"],
+    ["q2hrs", "q2h"],
+    ["every 2 hours", "q2h"],
+    ["q4h", "q4h"],
+    ["Q4H PRN", "q4h"], // paired PRN → keep interval
+    ["q6h", "q6h"],
+    ["q8h", "q8h"],
+    ["q12h", "q12h"],
+    ["q24h", "daily"],
+    // bid/tid/qid
+    ["BID", "bid"],
+    ["b.i.d.", "bid"],
+    ["twice daily", "bid"],
+    ["tid", "tid"],
+    ["three times daily", "tid"],
+    ["qid", "qid"],
+    ["4x/day", "qid"],
+    // daily
+    ["qd", "daily"],
+    ["once daily", "daily"],
+    ["once a day", "daily"],
+    ["daily", "daily"],
+    // PRN standalone
+    ["PRN", "prn"],
+    ["as needed", "prn"],
+    // stat / once
+    ["stat", "once"],
+    ["once", "once"],
+    ["one-time", "once"],
+    ["x1", "once"],
+    // weekly / monthly
+    ["weekly", "weekly"],
+    ["q7d", "weekly"],
+    ["monthly", "monthly"],
+    // uninterpretable
+    ["when sleepy", null],
+    ["", null],
+    ["every 5 hours", null], // non-canonical interval → fail open
+    [" ", null],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`"${input}" → ${String(expected)}`, () => {
+      expect(parseFrequencyText(input)).toBe(expected);
+    });
+  }
+
+  it("returns null for null/undefined", () => {
+    expect(parseFrequencyText(null)).toBeNull();
+    expect(parseFrequencyText(undefined)).toBeNull();
+  });
+});
+
+describe("FREQUENCY_DOSES_PER_DAY invariants", () => {
+  it("q2h gives 12/day, bid 2, tid 3, qid 4", () => {
+    expect(FREQUENCY_DOSES_PER_DAY.q2h).toBe(12);
+    expect(FREQUENCY_DOSES_PER_DAY.bid).toBe(2);
+    expect(FREQUENCY_DOSES_PER_DAY.tid).toBe(3);
+    expect(FREQUENCY_DOSES_PER_DAY.qid).toBe(4);
+  });
+
+  it("prn contributes 0 by default (caller must supply cap)", () => {
+    expect(FREQUENCY_DOSES_PER_DAY.prn).toBe(0);
+  });
+
+  it("once contributes 0 (stat isn't a recurring daily load)", () => {
+    expect(FREQUENCY_DOSES_PER_DAY.once).toBe(0);
+  });
+
+  it("weekly is 1/7, monthly is ~1/30", () => {
+    expect(FREQUENCY_DOSES_PER_DAY.weekly).toBeCloseTo(1 / 7);
+    expect(FREQUENCY_DOSES_PER_DAY.monthly).toBeCloseTo(1 / 30);
+  });
+});
+
+describe("estimateDailyDose (#235)", () => {
+  it("10 mg morphine q2h → 120 mg/day (respiratory-depression territory)", () => {
+    expect(estimateDailyDose(10, "q2h")).toBe(120);
+  });
+
+  it("10 mg morphine q4h PRN max 4/day → 40 mg/day (within CDC 90-MME)", () => {
+    expect(estimateDailyDose(10, "q4h", 4)).toBe(40);
+  });
+
+  it("10 mg morphine q4h (no PRN cap) → 60 mg/day", () => {
+    expect(estimateDailyDose(10, "q4h")).toBe(60);
+  });
+
+  it("5 mg oxycodone qid → 20 mg/day", () => {
+    expect(estimateDailyDose(5, "qid")).toBe(20);
+  });
+
+  it("500 mg acetaminophen q6h → 2000 mg/day (half of 4000 mg daily max)", () => {
+    expect(estimateDailyDose(500, "q6h")).toBe(2000);
+  });
+
+  it("1000 mg acetaminophen q4h → 6000 mg/day (above 4000 mg daily max)", () => {
+    expect(estimateDailyDose(1000, "q4h")).toBe(6000);
+  });
+
+  it("PRN without max_doses_per_day → null (caller fails open)", () => {
+    expect(estimateDailyDose(10, "prn")).toBeNull();
+  });
+
+  it("PRN with max_doses_per_day=6 → 6 × dose", () => {
+    expect(estimateDailyDose(10, "prn", 6)).toBe(60);
+  });
+
+  it("stat / once → null (not a recurring daily load)", () => {
+    expect(estimateDailyDose(30, "once")).toBeNull();
+  });
+
+  it("null frequency → null", () => {
+    expect(estimateDailyDose(10, null)).toBeNull();
+  });
+
+  it("zero or negative dose → null", () => {
+    expect(estimateDailyDose(0, "q4h")).toBeNull();
+    expect(estimateDailyDose(-5, "q4h")).toBeNull();
+  });
+
+  it("explicit cap tighter than scheduled frequency wins", () => {
+    // q4h is 6/day; cap of 3 overrides.
+    expect(estimateDailyDose(10, "q4h", 3)).toBe(30);
+  });
+
+  it("explicit cap looser than scheduled frequency is ignored (frequency wins)", () => {
+    // q4h is 6/day; cap of 10 doesn't expand the scheduled dose.
+    expect(estimateDailyDose(10, "q4h", 10)).toBe(60);
+  });
+});

--- a/packages/medical-logic/src/__tests__/medication-frequency.test.ts
+++ b/packages/medical-logic/src/__tests__/medication-frequency.test.ts
@@ -42,10 +42,18 @@ describe("parseFrequencyText (#235)", () => {
     ["once", "once"],
     ["one-time", "once"],
     ["x1", "once"],
-    // weekly / monthly
+    // weekly / monthly, spaced + longhand variants (every N days → weekly/monthly)
     ["weekly", "weekly"],
     ["q7d", "weekly"],
+    ["q 7 d", "weekly"],
+    ["q 7 day", "weekly"],
+    ["q14d", "weekly"],
+    ["every 7 days", "weekly"],
     ["monthly", "monthly"],
+    ["q30d", "monthly"],
+    ["q 30 d", "monthly"],
+    ["every 28 days", "monthly"],
+    ["q10d", null], // non-canonical day interval — fail open
     // uninterpretable
     ["when sleepy", null],
     ["", null],

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -3,3 +3,4 @@ export * from "./medical-validation.js";
 export * from "./weight-based-dosing.js";
 export * from "./vital-staleness-thresholds.js";
 export * from "./medication-max-doses.js";
+export * from "./medication-frequency.js";

--- a/packages/medical-logic/src/medication-frequency.ts
+++ b/packages/medical-logic/src/medication-frequency.ts
@@ -1,0 +1,179 @@
+/**
+ * Structured medication frequency parsing (issue #235).
+ *
+ * The medications table stores `frequency` as free-text. That's adequate
+ * for display but useless for daily-cumulative-dose enforcement: "Q2H PRN"
+ * as a string can't be compared against MEDICATION_MAX_DAILY_DOSES.
+ *
+ * This module parses the common clinical shorthand clinicians actually
+ * write (q2h, bid, tid, qid, q4h, prn, daily, etc.) into a doses-per-24h
+ * multiplier. The caller multiplies `dose_amount × dosesPerDay` to get an
+ * implied daily-cumulative dose that can be checked against the per-drug
+ * cap from `MEDICATION_MAX_DAILY_DOSES`.
+ *
+ * Unparseable strings return `null` so the calling rule can fail-open
+ * (don't flag what we don't understand). High-risk drugs still get the
+ * per-dose check from `validateMedicationDose`.
+ */
+
+/**
+ * Canonical structured frequency values. Kept as a string union rather than
+ * an enum so we can serialise/compare without runtime wrapping.
+ */
+export type MedFrequency =
+  | "once" // one-time / stat — effectively not a daily drug
+  | "daily" // qd, once a day
+  | "bid" // twice daily
+  | "tid" // three times daily
+  | "qid" // four times daily
+  | "q2h"
+  | "q3h"
+  | "q4h"
+  | "q6h"
+  | "q8h"
+  | "q12h"
+  | "weekly"
+  | "monthly"
+  | "prn"; // as-needed — no implicit daily count; caller must supply max_doses_per_day
+
+/**
+ * Doses-per-24h multiplier for each structured frequency. `prn` is zero
+ * here — PRN prescriptions must carry an explicit `max_doses_per_day`
+ * for daily-sum estimation; otherwise the rule cannot bound the dose.
+ *
+ * `once` uses a very small fraction so a stat order doesn't blow up the
+ * daily sum. Weekly/monthly are fractional so rules that aggregate over
+ * shorter windows don't trigger false positives.
+ */
+export const FREQUENCY_DOSES_PER_DAY: Record<MedFrequency, number> = {
+  once: 0, // a stat dose contributes nothing to a recurring daily total
+  daily: 1,
+  bid: 2,
+  tid: 3,
+  qid: 4,
+  q2h: 12,
+  q3h: 8,
+  q4h: 6,
+  q6h: 4,
+  q8h: 3,
+  q12h: 2,
+  weekly: 1 / 7,
+  monthly: 1 / 30,
+  prn: 0, // caller provides max_doses_per_day explicitly
+};
+
+/**
+ * Parse a free-text frequency string into a {@link MedFrequency}.
+ *
+ * Handles: q2h / q 2 h / q2hr / q2hrs / every 2 hours / every 2h, bid, tid,
+ * qid, qd / once daily / daily / once a day, weekly / q7d, monthly, stat /
+ * once / one-time, prn / as needed.
+ *
+ * Intentionally lenient on whitespace and punctuation. Returns null for
+ * strings it cannot classify — callers treat that as "unknown, don't flag".
+ */
+export function parseFrequencyText(
+  text: string | null | undefined,
+): MedFrequency | null {
+  if (!text) return null;
+  // Normalise: lowercase, collapse whitespace, drop punctuation that
+  // shorthand forms commonly sprinkle in.
+  const s = text
+    .toLowerCase()
+    .replace(/[.,()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!s) return null;
+
+  // Every-N-hours patterns: q2h, q2hr, q2hrs, q 2 h, q2, every 2 hours.
+  // Try this first so "q24h" resolves to `daily` rather than `once`.
+  const qH =
+    s.match(/\bq\s*(\d+)\s*(h|hr|hrs|hour|hours)?\b/) ??
+    s.match(/\bevery\s+(\d+)\s*(h|hr|hrs|hour|hours)\b/);
+  if (qH) {
+    const n = Number(qH[1]);
+    if (n === 2) return "q2h";
+    if (n === 3) return "q3h";
+    if (n === 4) return "q4h";
+    if (n === 6) return "q6h";
+    if (n === 8) return "q8h";
+    if (n === 12) return "q12h";
+    if (n === 24) return "daily";
+    // Non-canonical intervals (e.g. q5h) — we could compute 24/n but
+    // clinicians rarely write these and being strict avoids false daily
+    // sums for odd values. Return null to fail open.
+    return null;
+  }
+
+  // PRN often appears in combination (e.g. "q4h prn"). The qH branch above
+  // has already resolved paired-interval cases; by this point PRN means
+  // the prescription has no fixed schedule — caller must supply
+  // max_doses_per_day to make it boundable.
+  const prnOnly = /\b(prn|as needed|as required)\b/.test(s);
+
+  // Compound phrases BEFORE single-word generics: "once daily" must
+  // resolve to `daily`, not match the `once` stat-shorthand below.
+  if (/\b(twice daily|twice a day|2x daily|2x\s*\/\s*day)\b/.test(s)) return "bid";
+  if (/\b(three times daily|3x daily|3x\s*\/\s*day)\b/.test(s)) return "tid";
+  if (/\b(four times daily|4x daily|4x\s*\/\s*day)\b/.test(s)) return "qid";
+  if (/\b(qd|q d|every day|once daily|once a day|daily|every 24 hours)\b/.test(s))
+    return "daily";
+
+  // Abbreviations AFTER the compound forms so "b i d" doesn't eat "bid in
+  // evening" etc.
+  if (/\b(bid|b i d)\b/.test(s)) return "bid";
+  if (/\b(tid|t i d)\b/.test(s)) return "tid";
+  if (/\b(qid|q i d)\b/.test(s)) return "qid";
+
+  // Every-N-days → weekly/monthly approximations
+  if (/\bq\s*7\s*d\b|\bweekly\b|\bevery week\b/.test(s)) return "weekly";
+  if (/\bmonthly\b|\bevery month\b|\bq\s*30\s*d\b/.test(s)) return "monthly";
+
+  // Stat / one-time shorthand. Kept AFTER the compound `once daily` check so
+  // daily-recurring prescriptions that happen to contain the word "once" do
+  // not collapse to a stat order.
+  if (/\b(stat|one.?time|single dose|x1)\b/.test(s)) return "once";
+  if (/\bonce\b/.test(s)) return "once"; // bare "once" — a stat order
+
+  // PRN with no paired interval.
+  if (prnOnly) return "prn";
+
+  return null;
+}
+
+/**
+ * Estimate the implied daily-cumulative dose (mg-equivalent units the
+ * caller passes in). Returns null when the frequency can't be parsed or
+ * when PRN is the frequency and no max_doses_per_day is supplied — the
+ * caller should fail-open rather than flag.
+ *
+ * `maxDosesPerDay` caps whatever the frequency would imply. For example,
+ * "morphine 10 mg q4h PRN, max 4 doses/day": frequency q4h gives 6/day,
+ * but cap is 4 → 40 mg/day not 60 mg/day.
+ */
+export function estimateDailyDose(
+  doseAmount: number | null | undefined,
+  frequency: MedFrequency | null,
+  maxDosesPerDay?: number | null,
+): number | null {
+  if (doseAmount == null || doseAmount <= 0) return null;
+  if (frequency === null) return null;
+
+  let dosesPerDay = FREQUENCY_DOSES_PER_DAY[frequency];
+
+  // PRN-only prescriptions must have an explicit cap to be boundable.
+  if (frequency === "prn") {
+    if (maxDosesPerDay == null || maxDosesPerDay <= 0) return null;
+    dosesPerDay = maxDosesPerDay;
+  } else if (maxDosesPerDay != null && maxDosesPerDay > 0) {
+    // Non-PRN with an explicit cap: take whichever is stricter. A scheduled
+    // q4h prescription with max 3/day is unusual but explicit caps always
+    // win.
+    dosesPerDay = Math.min(dosesPerDay, maxDosesPerDay);
+  }
+
+  if (dosesPerDay === 0) return null; // `once` / unparseable PRN
+
+  return doseAmount * dosesPerDay;
+}

--- a/packages/medical-logic/src/medication-frequency.ts
+++ b/packages/medical-logic/src/medication-frequency.ts
@@ -41,12 +41,13 @@ export type MedFrequency =
  * here — PRN prescriptions must carry an explicit `max_doses_per_day`
  * for daily-sum estimation; otherwise the rule cannot bound the dose.
  *
- * `once` uses a very small fraction so a stat order doesn't blow up the
- * daily sum. Weekly/monthly are fractional so rules that aggregate over
- * shorter windows don't trigger false positives.
+ * `once` maps to 0 — a stat order is not a recurring daily load, so
+ * `estimateDailyDose` returns null for it (same semantics as an
+ * unboundable PRN). Weekly/monthly are fractional so rules that
+ * aggregate over shorter windows don't trigger false positives.
  */
 export const FREQUENCY_DOSES_PER_DAY: Record<MedFrequency, number> = {
-  once: 0, // a stat dose contributes nothing to a recurring daily total
+  once: 0, // stat / one-time — estimateDailyDose returns null
   daily: 1,
   bid: 2,
   tid: 3,
@@ -86,10 +87,27 @@ export function parseFrequencyText(
 
   if (!s) return null;
 
+  // Every-N-days patterns run BEFORE every-N-hours so "q 7 d" / "q 30 d"
+  // aren't swallowed by the hours branch when it tolerates a missing
+  // hour token. Handles q7d, q14d, q30d plus the longhand "every 7 days".
+  const qD =
+    s.match(/\bq\s*(\d+)\s*d(?:ay|ays)?\b/) ??
+    s.match(/\bevery\s+(\d+)\s*(d|day|days)\b/);
+  if (qD) {
+    const n = Number(qD[1]);
+    if (n === 7 || n === 14) return "weekly";
+    if (n >= 28 && n <= 31) return "monthly";
+    // Non-canonical intervals (q10d etc.) — fail open rather than
+    // inventing a daily fraction.
+    return null;
+  }
+
   // Every-N-hours patterns: q2h, q2hr, q2hrs, q 2 h, q2, every 2 hours.
-  // Try this first so "q24h" resolves to `daily` rather than `once`.
+  // Hour unit is required here (unit regex is non-optional) because an
+  // unqualified "q 7" is ambiguous — days vs hours vs generic — so we
+  // require the `h/hr/hrs/hour/hours` marker to commit to hours.
   const qH =
-    s.match(/\bq\s*(\d+)\s*(h|hr|hrs|hour|hours)?\b/) ??
+    s.match(/\bq\s*(\d+)\s*(h|hr|hrs|hour|hours)\b/) ??
     s.match(/\bevery\s+(\d+)\s*(h|hr|hrs|hour|hours)\b/);
   if (qH) {
     const n = Number(qH[1]);

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -69,6 +69,25 @@ export interface PatientDiagnosis {
   resolved_date: string | null;
 }
 
+/**
+ * Structured medication row consumed by dose/frequency-aware rules
+ * (issue #235). Carries the fields needed to compute an implied daily
+ * cumulative dose: id for cross-referencing `trigger_event.data.resourceId`,
+ * dose_amount + dose_unit + frequency for the estimate, and route so
+ * future route-specific caps can fold in.
+ */
+export interface PatientMedication {
+  id: string;
+  name: string;
+  dose_amount: number | null;
+  dose_unit: string | null;
+  route: string | null;
+  frequency: string | null;
+  /** Optional PRN / hard-cap dose count per 24 h (not yet stored in DB). */
+  max_doses_per_day?: number | null;
+  rxnorm_code: string | null;
+}
+
 export interface PatientContext {
   active_diagnoses: string[];
   /** ICD-10 codes for active diagnoses (parallel to active_diagnoses). */
@@ -83,6 +102,15 @@ export interface PatientContext {
   active_medications: string[];
   /** RxNorm codes for active medications (parallel to active_medications). */
   active_medication_rxnorm_codes?: (string | null)[];
+  /**
+   * Optional structured medication list (#235). Populated by
+   * `buildPatientContextForRules` with dose_amount / dose_unit / frequency so
+   * rules can compute implied daily cumulative doses and compare against
+   * per-drug caps (see `medication-daily-dose.ts`). Parallel to
+   * `active_medications` — the flat name array remains the canonical input
+   * for older rules that only need name matching.
+   */
+  active_medications_detail?: PatientMedication[];
   new_symptoms: string[];
   care_team_specialties: string[];
   /** Patient allergies for cross-checking against medications. */

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -77,8 +77,10 @@ describe("checkMedicationDailyDose (#235)", () => {
       expect(daily).toBeUndefined();
     });
 
-    it("10 mg Q4H (no PRN cap) → flag warning (60 mg/day between 1× and 1.5×)", () => {
-      // 60 mg/day isn't over 90 mg/day cap → should NOT flag daily
+    it("10 mg Q4H (60 mg/day) stays within the 90 mg cap → no daily flag", () => {
+      // 60 mg morphine/day is under the 90 mg cap (1× threshold), so the
+      // daily-over rule must NOT fire. Locks the lower-edge behaviour so a
+      // future severity tweak doesn't silently start warning here.
       const flags = checkMedicationDailyDose(
         makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q4h" })),
       );

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+import { checkMedicationDailyDose } from "./medication-daily-dose.js";
+import type { PatientContext, PatientMedication } from "./cross-specialty.js";
+
+function makeMed(
+  overrides: Partial<PatientMedication> & { id?: string; name?: string } = {},
+): PatientMedication {
+  return {
+    id: overrides.id ?? "med-1",
+    name: overrides.name ?? "Morphine",
+    // Explicit has-key check so callers can override with null (e.g. for the
+    // "missing dose_amount" fail-open case) without `??` defaulting it away.
+    dose_amount: "dose_amount" in overrides ? (overrides.dose_amount as number | null) : 10,
+    dose_unit: overrides.dose_unit ?? "mg",
+    route: overrides.route ?? "oral",
+    frequency: overrides.frequency ?? "q2h",
+    max_doses_per_day: overrides.max_doses_per_day ?? null,
+    rxnorm_code: overrides.rxnorm_code ?? null,
+  };
+}
+
+function makeCtx(
+  triggerMed: PatientMedication,
+  eventType:
+    | "medication.created"
+    | "medication.updated"
+    | "lab.resulted" = "medication.created",
+): PatientContext {
+  const event: ClinicalEvent = {
+    id: "evt-1",
+    type: eventType,
+    patient_id: "p-1",
+    timestamp: "2026-04-18T12:00:00.000Z",
+    data: {
+      resourceId: triggerMed.id,
+      name: triggerMed.name,
+      status: "active",
+    },
+  };
+  return {
+    active_diagnoses: [],
+    active_diagnosis_codes: [],
+    active_medications: [triggerMed.name],
+    active_medications_detail: [triggerMed],
+    new_symptoms: [],
+    care_team_specialties: [],
+    trigger_event: event,
+  };
+}
+
+describe("checkMedicationDailyDose (#235)", () => {
+  describe("Morphine", () => {
+    it("10 mg Q2H → flag critical (120 mg/day, >1.5× 90 mg cap)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q2h" })),
+      );
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.severity).toBe("critical");
+      expect(daily!.summary).toMatch(/120/);
+      expect(daily!.summary).toMatch(/90/);
+    });
+
+    it("10 mg Q4H PRN cap 4/day → no flag (40 mg/day < 90)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine",
+            dose_amount: 10,
+            frequency: "q4h prn",
+            max_doses_per_day: 4,
+          }),
+        ),
+      );
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeUndefined();
+    });
+
+    it("10 mg Q4H (no PRN cap) → flag warning (60 mg/day between 1× and 1.5×)", () => {
+      // 60 mg/day isn't over 90 mg/day cap → should NOT flag daily
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q4h" })),
+      );
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeUndefined();
+    });
+
+    it("30 mg Q2H → flag critical for both single-dose and daily", () => {
+      // Single-dose ceiling is 30 mg; 30 mg is AT the ceiling, not above.
+      // 30 mg q2h → 360 mg/day, 4× the 90 mg cap.
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 30, frequency: "q2h" })),
+      );
+      const single = flags.find((f) => f.rule_id.startsWith("MED-SINGLE-OVER"));
+      expect(single).toBeUndefined(); // 30 is at ceiling, not above
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.severity).toBe("critical");
+    });
+
+    it("31 mg Q2H → flag single-dose (>30 mg) and daily (critical)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 31, frequency: "q2h" })),
+      );
+      expect(flags.some((f) => f.rule_id.startsWith("MED-SINGLE-OVER"))).toBe(true);
+      expect(flags.some((f) => f.rule_id.startsWith("MED-DAILY-OVER"))).toBe(true);
+    });
+  });
+
+  describe("Acetaminophen", () => {
+    it("1000 mg Q4H → flag daily (6000 mg/day > 4000 cap, 1.5× → warning)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Acetaminophen",
+            dose_amount: 1000,
+            frequency: "q4h",
+          }),
+        ),
+      );
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.severity).toBe("warning");
+    });
+
+    it("500 mg Q6H → no daily flag (2000 mg/day within 4000 cap)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Acetaminophen",
+            dose_amount: 500,
+            frequency: "q6h",
+          }),
+        ),
+      );
+      expect(flags.some((f) => f.rule_id.startsWith("MED-DAILY-OVER"))).toBe(false);
+    });
+
+    it("1500 mg single dose → flag single-dose (over 1000 mg ceiling)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Acetaminophen",
+            dose_amount: 1500,
+            frequency: "q8h",
+          }),
+        ),
+      );
+      expect(flags.some((f) => f.rule_id.startsWith("MED-SINGLE-OVER"))).toBe(true);
+    });
+  });
+
+  describe("brand-name alias (Percocet → oxycodone)", () => {
+    it("resolves Percocet and flags over-daily (40 mg q4h → 240 mg oxycodone/day)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Percocet",
+            dose_amount: 40,
+            frequency: "q4h",
+          }),
+        ),
+      );
+      expect(flags.some((f) => f.rule_id.includes("OXYCODONE"))).toBe(true);
+    });
+  });
+
+  describe("fail-open cases", () => {
+    it("unparseable frequency → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine",
+            dose_amount: 10,
+            frequency: "when needed on weekends",
+          }),
+        ),
+      );
+      expect(flags.some((f) => f.rule_id.startsWith("MED-DAILY-OVER"))).toBe(false);
+    });
+
+    it("unknown drug → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Zolpidopride",
+            dose_amount: 500,
+            frequency: "q2h",
+          }),
+        ),
+      );
+      expect(flags).toHaveLength(0);
+    });
+
+    it("non-mg unit → no flag (future issue adds conversion)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine",
+            dose_amount: 100,
+            dose_unit: "mcg",
+            frequency: "q2h",
+          }),
+        ),
+      );
+      expect(flags).toHaveLength(0);
+    });
+
+    it("missing dose_amount → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine",
+            dose_amount: null,
+            frequency: "q2h",
+          }),
+        ),
+      );
+      expect(flags).toHaveLength(0);
+    });
+
+    it("non-medication trigger event → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({ name: "Morphine", dose_amount: 10, frequency: "q2h" }),
+          "lab.resulted",
+        ),
+      );
+      expect(flags).toHaveLength(0);
+    });
+
+    it("PRN without max_doses_per_day → no daily flag (unboundable)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine",
+            dose_amount: 10,
+            frequency: "prn",
+          }),
+        ),
+      );
+      expect(flags.some((f) => f.rule_id.startsWith("MED-DAILY-OVER"))).toBe(false);
+    });
+
+    it("medication not in active_medications_detail → no flag", () => {
+      const ctx = makeCtx(
+        makeMed({ id: "med-1", name: "Morphine", dose_amount: 10, frequency: "q2h" }),
+      );
+      // The trigger references resourceId=med-1, but the detail list is empty.
+      ctx.active_medications_detail = [];
+      const flags = checkMedicationDailyDose(ctx);
+      expect(flags).toHaveLength(0);
+    });
+  });
+
+  describe("rule_id conventions", () => {
+    it("daily flag rule_id starts with MED-DAILY-OVER-<DRUG>", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q2h" })),
+      );
+      const daily = flags.find((f) => f.rule_id.startsWith("MED-DAILY-OVER"));
+      expect(daily?.rule_id).toBe("MED-DAILY-OVER-MORPHINE");
+    });
+
+    it("single-dose flag rule_id starts with MED-SINGLE-OVER-<DRUG>", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 50, frequency: "q12h" })),
+      );
+      const single = flags.find((f) => f.rule_id.startsWith("MED-SINGLE-OVER"));
+      expect(single?.rule_id).toBe("MED-SINGLE-OVER-MORPHINE");
+    });
+  });
+});

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -117,26 +117,26 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
     med.max_doses_per_day ?? null,
   );
 
-  const isOpioid = limit.mme_factor !== undefined;
-  const slug = slugForRuleId(limit.display_name);
+  const isOpioid = limit.mmeFactor !== undefined;
+  const slug = slugForRuleId(limit.displayName);
 
   // ── Per-dose over-max check ───────────────────────────────────
   // validateMedicationDose covers this when the writer supplies drugName;
   // mirror the check here so the AI layer catches the case even when the
   // writer didn't thread drugName through (most callers today).
   if (
-    limit.max_single_dose_mg !== undefined &&
-    med.dose_amount > limit.max_single_dose_mg
+    limit.maxSingleDoseMg !== undefined &&
+    med.dose_amount > limit.maxSingleDoseMg
   ) {
     flags.push({
       severity: "critical",
       category: "medication-safety" as FlagCategory,
       summary:
         `"${med.name}" ${med.dose_amount} ${med.dose_unit ?? ""} single dose ` +
-        `exceeds the ${limit.max_single_dose_mg} mg maximum for ${limit.display_name}`,
+        `exceeds the ${limit.maxSingleDoseMg} mg maximum for ${limit.displayName}`,
       rationale:
-        `Per ${limit.source}, the maximum single oral dose of ${limit.display_name} ` +
-        `is ${limit.max_single_dose_mg} mg. The prescribed single dose of ` +
+        `Per ${limit.source}, the maximum single oral dose of ${limit.displayName} ` +
+        `is ${limit.maxSingleDoseMg} mg. The prescribed single dose of ` +
         `${med.dose_amount} ${med.dose_unit ?? ""} exceeds this ceiling` +
         (isOpioid
           ? ". For opioids this raises the risk of respiratory depression."
@@ -144,7 +144,7 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
       suggested_action:
         `Verify the prescribed dose. If the order is intentional (e.g. titrated ` +
         `for opioid-tolerant patient), document the justification. Otherwise ` +
-        `reduce to ${limit.max_single_dose_mg} mg or below.`,
+        `reduce to ${limit.maxSingleDoseMg} mg or below.`,
       notify_specialties: ["pharmacy"],
       rule_id: `MED-SINGLE-OVER-${slug.toUpperCase()}`,
     });
@@ -153,23 +153,23 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
   // ── Daily-cumulative over-max check ───────────────────────────
   if (
     daily !== null &&
-    limit.max_daily_dose_mg !== undefined &&
-    daily > limit.max_daily_dose_mg
+    limit.maxDailyDoseMg !== undefined &&
+    daily > limit.maxDailyDoseMg
   ) {
-    const ratio = daily / limit.max_daily_dose_mg;
+    const ratio = daily / limit.maxDailyDoseMg;
     const severity = severityForDailyOver(ratio, isOpioid);
     const mmeNote = isOpioid
-      ? ` (implied ${Math.round(daily * (limit.mme_factor ?? 1))} MME/day; CDC elevated-risk threshold is 90 MME/day)`
+      ? ` (implied ${Math.round(daily * (limit.mmeFactor ?? 1))} MME/day; CDC elevated-risk threshold is 90 MME/day)`
       : "";
     flags.push({
       severity,
       category: "medication-safety" as FlagCategory,
       summary:
         `"${med.name}" at ${med.dose_amount} ${med.dose_unit ?? ""} ${med.frequency ?? ""} ` +
-        `implies ~${Math.round(daily)} mg/day — exceeds ${limit.display_name} max ` +
-        `(${limit.max_daily_dose_mg} mg/day)${mmeNote}`,
+        `implies ~${Math.round(daily)} mg/day — exceeds ${limit.displayName} max ` +
+        `(${limit.maxDailyDoseMg} mg/day)${mmeNote}`,
       rationale:
-        `${limit.display_name} daily cap is ${limit.max_daily_dose_mg} mg ` +
+        `${limit.displayName} daily cap is ${limit.maxDailyDoseMg} mg ` +
         `(${limit.source}). The prescribed ${med.dose_amount} ${med.dose_unit ?? ""} ` +
         `${med.frequency ?? ""} translates to approximately ${Math.round(daily)} mg/day, ` +
         `which is ${ratio.toFixed(1)}× the ceiling. ` +
@@ -182,7 +182,7 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
         `Review frequency and dose. Typical options: reduce per-dose amount, ` +
         `widen dosing interval (e.g. q6h → q8h), or impose a PRN cap ` +
         `(max_doses_per_day) that bounds the daily total below ` +
-        `${limit.max_daily_dose_mg} mg.`,
+        `${limit.maxDailyDoseMg} mg.`,
       notify_specialties: isOpioid ? ["pharmacy", "pain"] : ["pharmacy"],
       rule_id: `MED-DAILY-OVER-${slug.toUpperCase()}`,
     });

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -1,0 +1,192 @@
+/**
+ * Medication daily-cumulative dose rule (issue #235).
+ *
+ * Fires on medication.created / medication.updated events. Parses the
+ * newly-prescribed medication's frequency string, computes the implied
+ * doses-per-24h, multiplies by dose_amount, and compares the result to
+ * the per-drug max from `MEDICATION_MAX_DAILY_DOSES` (issue #238).
+ *
+ * The canonical example this prevents: "Morphine 10 mg Q2H PRN" — a
+ * clinician writes the frequency as unstructured text, the prescription
+ * writer enforces only single-dose limits, and the implied 120 mg/day
+ * (well above the 90 mg/day MME-calibrated cap) sails through. This rule
+ * closes that gap.
+ *
+ * Rule ID prefix scheme (aligned with existing lab/contraindication rules):
+ *   - `MED-DAILY-OVER-*`   — estimated daily > drug's max_daily_dose_mg
+ *   - `MED-SINGLE-OVER-*`  — per-dose exceeds drug's max_single_dose_mg
+ *                            (covers the case validateMedicationDose missed
+ *                             because the writer never supplied drugName)
+ *
+ * Fail-open: unparseable frequency strings, unknown drugs, and missing
+ * dose_amount produce no flag. High-risk inputs still get the per-dose
+ * check from validateMedicationDose upstream.
+ */
+
+import type {
+  FlagSeverity,
+  FlagCategory,
+  RuleFlag,
+} from "@carebridge/shared-types";
+import {
+  parseFrequencyText,
+  estimateDailyDose,
+  getMedicationDoseLimit,
+} from "@carebridge/medical-logic";
+import type { PatientContext, PatientMedication } from "./cross-specialty.js";
+
+/**
+ * Canonicalise a drug name into a rule_id slug: lowercase, replace
+ * non-alphanumerics with underscore, collapse repeats. Keeps rule_ids
+ * stable across alias variants (Tylenol vs acetaminophen both resolve to
+ * the same generic name via getMedicationDoseLimit, but we use the
+ * resolved display name to build the slug so both produce the same id).
+ */
+function slugForRuleId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s*\([^)]+\)\s*/g, "") // drop "(PO)" etc.
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Map the excess-ratio of estimated-over-max into a flag severity.
+ *
+ * Opioids: the CDC 2022 guidance calibrates the per-drug daily caps in
+ * MEDICATION_MAX_DAILY_DOSES to the 90 MME/day elevated-risk threshold.
+ * Exceeding that cap by even 20% (1.2× → 108 MME) crosses into the zone
+ * where respiratory-depression and overdose risk climbs steeply, so we
+ * escalate to critical aggressively.
+ *
+ * Non-opioid NSAID / analgesic over-limits cause cumulative rather than
+ * acute harm (hepatic, renal, GI), so 1–2× is warning, ≥2× is critical.
+ */
+function severityForDailyOver(
+  ratio: number,
+  isOpioid: boolean,
+): FlagSeverity {
+  if (isOpioid) return ratio >= 1.2 ? "critical" : "warning";
+  return ratio >= 2.0 ? "critical" : "warning";
+}
+
+export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
+  const flags: RuleFlag[] = [];
+
+  const triggerType = context.trigger_event?.type;
+  if (
+    triggerType !== "medication.created" &&
+    triggerType !== "medication.updated"
+  ) {
+    return flags;
+  }
+
+  const details = context.active_medications_detail;
+  if (!details || details.length === 0) return flags;
+
+  // Find the triggering medication by resourceId. Falls back to name+status
+  // if no resourceId (older event payloads). Unknown → bail.
+  const triggerResourceId = context.trigger_event?.data?.resourceId as
+    | string
+    | undefined;
+  const triggerName = context.trigger_event?.data?.name as string | undefined;
+
+  let med: PatientMedication | undefined;
+  if (triggerResourceId) {
+    med = details.find((m) => m.id === triggerResourceId);
+  }
+  if (!med && triggerName) {
+    const triggerLower = triggerName.toLowerCase();
+    med = details.find((m) => m.name.toLowerCase() === triggerLower);
+  }
+  if (!med) return flags;
+
+  if (med.dose_amount == null) return flags;
+  // Per-drug ceilings are expressed in mg. Skip non-mg prescriptions
+  // (mcg patches, mL infusions) — a future issue will add unit conversion.
+  const unit = (med.dose_unit ?? "").toLowerCase();
+  if (unit !== "mg") return flags;
+
+  const limit = getMedicationDoseLimit(med.name);
+  if (!limit) return flags;
+
+  const freq = parseFrequencyText(med.frequency);
+  const daily = estimateDailyDose(
+    med.dose_amount,
+    freq,
+    med.max_doses_per_day ?? null,
+  );
+
+  const isOpioid = limit.mme_factor !== undefined;
+  const slug = slugForRuleId(limit.display_name);
+
+  // ── Per-dose over-max check ───────────────────────────────────
+  // validateMedicationDose covers this when the writer supplies drugName;
+  // mirror the check here so the AI layer catches the case even when the
+  // writer didn't thread drugName through (most callers today).
+  if (
+    limit.max_single_dose_mg !== undefined &&
+    med.dose_amount > limit.max_single_dose_mg
+  ) {
+    flags.push({
+      severity: "critical",
+      category: "medication-safety" as FlagCategory,
+      summary:
+        `"${med.name}" ${med.dose_amount} ${med.dose_unit ?? ""} single dose ` +
+        `exceeds the ${limit.max_single_dose_mg} mg maximum for ${limit.display_name}`,
+      rationale:
+        `Per ${limit.source}, the maximum single oral dose of ${limit.display_name} ` +
+        `is ${limit.max_single_dose_mg} mg. The prescribed single dose of ` +
+        `${med.dose_amount} ${med.dose_unit ?? ""} exceeds this ceiling` +
+        (isOpioid
+          ? ". For opioids this raises the risk of respiratory depression."
+          : "."),
+      suggested_action:
+        `Verify the prescribed dose. If the order is intentional (e.g. titrated ` +
+        `for opioid-tolerant patient), document the justification. Otherwise ` +
+        `reduce to ${limit.max_single_dose_mg} mg or below.`,
+      notify_specialties: ["pharmacy"],
+      rule_id: `MED-SINGLE-OVER-${slug.toUpperCase()}`,
+    });
+  }
+
+  // ── Daily-cumulative over-max check ───────────────────────────
+  if (
+    daily !== null &&
+    limit.max_daily_dose_mg !== undefined &&
+    daily > limit.max_daily_dose_mg
+  ) {
+    const ratio = daily / limit.max_daily_dose_mg;
+    const severity = severityForDailyOver(ratio, isOpioid);
+    const mmeNote = isOpioid
+      ? ` (implied ${Math.round(daily * (limit.mme_factor ?? 1))} MME/day; CDC elevated-risk threshold is 90 MME/day)`
+      : "";
+    flags.push({
+      severity,
+      category: "medication-safety" as FlagCategory,
+      summary:
+        `"${med.name}" at ${med.dose_amount} ${med.dose_unit ?? ""} ${med.frequency ?? ""} ` +
+        `implies ~${Math.round(daily)} mg/day — exceeds ${limit.display_name} max ` +
+        `(${limit.max_daily_dose_mg} mg/day)${mmeNote}`,
+      rationale:
+        `${limit.display_name} daily cap is ${limit.max_daily_dose_mg} mg ` +
+        `(${limit.source}). The prescribed ${med.dose_amount} ${med.dose_unit ?? ""} ` +
+        `${med.frequency ?? ""} translates to approximately ${Math.round(daily)} mg/day, ` +
+        `which is ${ratio.toFixed(1)}× the ceiling. ` +
+        (isOpioid
+          ? `Over-prescription beyond the CDC 90 MME/day elevated-risk ` +
+            `threshold is a leading driver of respiratory depression and overdose.`
+          : `Chronic dosing above this threshold carries hepatic, renal, and ` +
+            `GI risks depending on the agent.`),
+      suggested_action:
+        `Review frequency and dose. Typical options: reduce per-dose amount, ` +
+        `widen dosing interval (e.g. q6h → q8h), or impose a PRN cap ` +
+        `(max_doses_per_day) that bounds the daily total below ` +
+        `${limit.max_daily_dose_mg} mg.`,
+      notify_specialties: isOpioid ? ["pharmacy", "pain"] : ["pharmacy"],
+      rule_id: `MED-DAILY-OVER-${slug.toUpperCase()}`,
+    });
+  }
+
+  return flags;
+}

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -52,6 +52,7 @@ import { checkDrugInteractions } from "../rules/drug-interactions.js";
 import { screenPatientMessage } from "../rules/message-screening.js";
 import { screenPatientObservation } from "../rules/observation-screening.js";
 import { checkAllergyMedication } from "../rules/allergy-medication.js";
+import { checkMedicationDailyDose } from "../rules/medication-daily-dose.js";
 import {
   isoBefore,
   isoLTE,
@@ -238,6 +239,18 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
     if (allergyFlags.length > 0) {
       rulesFired.push("allergy-medication");
       allRuleFlags.push(...allergyFlags);
+    }
+
+    // 2d-bis. Medication daily-cumulative dose (issue #235). Parses the
+    // newly-prescribed medication's frequency string into a doses-per-24h
+    // count, multiplies by dose_amount, and compares to the per-drug cap
+    // from MEDICATION_MAX_DAILY_DOSES (#238). Catches Q2H PRN opioid
+    // over-prescription that per-dose validation would miss.
+    rulesEvaluated.push("medication-daily-dose");
+    const dailyDoseFlags = checkMedicationDailyDose(patientContext);
+    if (dailyDoseFlags.length > 0) {
+      rulesFired.push("medication-daily-dose");
+      allRuleFlags.push(...dailyDoseFlags);
     }
 
     // 2e. Patient message screening (only for message.received events)
@@ -867,6 +880,19 @@ export async function buildPatientContextForRules(
     })),
     active_medications: activeMedsList.map((m) => m.name),
     active_medication_rxnorm_codes: activeMedsList.map((m) => m.rxnorm_code),
+    // Structured shape for dose/frequency-aware rules (#235). Keep the
+    // flat name array above unchanged so existing rules that only match
+    // on name don't need to migrate.
+    active_medications_detail: activeMedsList.map((m) => ({
+      id: m.id,
+      name: m.name,
+      dose_amount: m.dose_amount ?? null,
+      dose_unit: m.dose_unit ?? null,
+      route: m.route ?? null,
+      frequency: m.frequency ?? null,
+      max_doses_per_day: null,
+      rxnorm_code: m.rxnorm_code ?? null,
+    })),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future
     allergies: patientAllergies.map((a) => ({


### PR DESCRIPTION
## Summary

- **New parser** `packages/medical-logic/src/medication-frequency.ts`: `parseFrequencyText()` converts clinical shorthand (q2h, bid, tid, qid, qd, daily, weekly, monthly, prn, stat and longhand equivalents) into a `MedFrequency` enum; `estimateDailyDose()` multiplies by dose_amount with `max_doses_per_day` as an explicit tighter cap
- **New rule** `services/ai-oversight/src/rules/medication-daily-dose.ts` (wired after allergy-medication in `review-service.ts:237`):
  - Looks up the newly-prescribed drug in `MEDICATION_MAX_DAILY_DOSES` (from #238)
  - Emits `MED-SINGLE-OVER-<drug>` when `dose_amount > max_single_dose_mg`
  - Emits `MED-DAILY-OVER-<drug>` when `estimated daily > max_daily_dose_mg`
  - Opioids escalate to critical at ratio ≥1.2× (108 MME); non-opioids at ≥2× (cumulative rather than acute harm)
  - Fail-open on unparseable frequency, unknown drug, non-mg unit, missing dose_amount
- **PatientContext extension**: `active_medications_detail: PatientMedication[]` populated by `buildPatientContextForRules` so rules can get dose/frequency/route without a DB round-trip. Existing `active_medications: string[]` unchanged

## Why

Issue #235: \"Morphine 10 mg Q2H PRN\" → implied 120 mg/day (respiratory depression territory) was impossible to flag because `frequency` is free-text. Combined with per-dose-only validation, the worst overdose scenarios slipped through the pipeline entirely.

This PR is the consumer side of the reference data added in #918 (#238). They stack — #235 branches off #238.

## Scope note

No DB migration. The rule parses the free-text `frequency` column at evaluation time, which covers the risk surface without a writer-side change. Persisting a structured enum belongs in a follow-up when UI/FHIR-import grow frequency-picker controls.

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 291/291 (54 new frequency tests)
- [x] `pnpm --filter @carebridge/ai-oversight test` — 817/817 (18 new daily-dose tests covering Morphine/Acetaminophen/Percocet-alias/fail-open cases and rule_id conventions)
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — 22/22, no new warnings
- [x] Clinical anchor: 10 mg morphine Q2H flags critical with 120 mg/day, 10 mg Q4H PRN max 4/day correctly silent at 40 mg/day

Closes #235

**Depends on #918** (adds `MEDICATION_MAX_DAILY_DOSES` reference data — merge in that order).