### PR TITLE
feat(fhir): add Encounter and Procedure R4 resource generators (#387)

### DIFF
--- a/services/fhir-gateway/src/__tests__/encounter.test.ts
+++ b/services/fhir-gateway/src/__tests__/encounter.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { toFhirEncounter } from "../generators/encounter.js";
+
+type Encounter = Parameters<typeof toFhirEncounter>[0];
+
+function makeEncounter(overrides: Partial<Encounter> = {}): Encounter {
+  return {
+    id: "e1",
+    patient_id: "p1",
+    encounter_type: "outpatient",
+    status: "finished",
+    start_time: "2026-04-10T10:00:00.000Z",
+    end_time: "2026-04-10T10:45:00.000Z",
+    provider_id: "prov1",
+    location: null,
+    reason: null,
+    notes: null,
+    created_at: "2026-04-10T10:00:00.000Z",
+    ...overrides,
+  } as Encounter;
+}
+
+describe("toFhirEncounter (#387)", () => {
+  describe("class mapping (HL7 v3 ActCode)", () => {
+    const cases: Array<[string, string]> = [
+      ["inpatient", "IMP"],
+      ["outpatient", "AMB"],
+      ["ambulatory", "AMB"],
+      ["emergency", "EMER"],
+      ["ED", "EMER"],
+      ["telehealth", "VR"],
+      ["virtual", "VR"],
+      ["home", "HH"],
+      ["observation", "OBSENC"],
+    ];
+    for (const [input, code] of cases) {
+      it(`maps encounter_type '${input}' → class.code '${code}'`, () => {
+        const enc = toFhirEncounter(makeEncounter({ encounter_type: input }), "p1");
+        expect(enc.class.code).toBe(code);
+        expect(enc.class.system).toBe(
+          "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        );
+      });
+    }
+
+    it("falls back to AMB for unknown encounter_type", () => {
+      const enc = toFhirEncounter(makeEncounter({ encounter_type: "xyz" }), "p1");
+      expect(enc.class.code).toBe("AMB");
+    });
+  });
+
+  describe("status mapping", () => {
+    const canonical = [
+      "planned",
+      "arrived",
+      "triaged",
+      "in-progress",
+      "onleave",
+      "finished",
+      "cancelled",
+      "entered-in-error",
+      "unknown",
+    ];
+    for (const s of canonical) {
+      it(`passes through canonical status '${s}'`, () => {
+        const enc = toFhirEncounter(makeEncounter({ status: s }), "p1");
+        expect(enc.status).toBe(s);
+      });
+    }
+
+    it("maps unrecognised status to 'unknown'", () => {
+      const enc = toFhirEncounter(makeEncounter({ status: "scheduled" }), "p1");
+      expect(enc.status).toBe("unknown");
+    });
+  });
+
+  describe("subject / period / participant / reason", () => {
+    it("attaches a Patient reference", () => {
+      const enc = toFhirEncounter(makeEncounter(), "p1");
+      expect(enc.subject?.reference).toBe("Patient/p1");
+    });
+
+    it("emits period.start and period.end when both present", () => {
+      const enc = toFhirEncounter(
+        makeEncounter({
+          start_time: "2026-04-10T10:00:00.000Z",
+          end_time: "2026-04-10T10:45:00.000Z",
+        }),
+        "p1",
+      );
+      expect(enc.period?.start).toBe("2026-04-10T10:00:00.000Z");
+      expect(enc.period?.end).toBe("2026-04-10T10:45:00.000Z");
+    });
+
+    it("omits period.end for open-ended in-progress encounters", () => {
+      const enc = toFhirEncounter(
+        makeEncounter({ end_time: null, status: "in-progress" }),
+        "p1",
+      );
+      expect(enc.period?.start).toBe("2026-04-10T10:00:00.000Z");
+      expect(enc.period?.end).toBeUndefined();
+    });
+
+    it("includes a Practitioner participant when provider_id set", () => {
+      const enc = toFhirEncounter(makeEncounter({ provider_id: "prov99" }), "p1");
+      expect(enc.participant?.[0]?.individual?.reference).toBe("Practitioner/prov99");
+    });
+
+    it("omits participant when provider_id is null", () => {
+      const enc = toFhirEncounter(makeEncounter({ provider_id: null }), "p1");
+      expect(enc.participant).toBeUndefined();
+    });
+
+    it("includes reasonCode when reason set", () => {
+      const enc = toFhirEncounter(
+        makeEncounter({ reason: "Chest pain workup" }),
+        "p1",
+      );
+      expect(enc.reasonCode?.[0]?.text).toBe("Chest pain workup");
+    });
+  });
+});

--- a/services/fhir-gateway/src/__tests__/encounter.test.ts
+++ b/services/fhir-gateway/src/__tests__/encounter.test.ts
@@ -111,6 +111,19 @@ describe("toFhirEncounter (#387)", () => {
       expect(enc.participant).toBeUndefined();
     });
 
+    it("maps encounter.location to a FHIR Encounter.location reference with display text", () => {
+      const enc = toFhirEncounter(
+        makeEncounter({ location: "Main Hospital, Room 302B" }),
+        "p1",
+      );
+      expect(enc.location?.[0]?.location?.display).toBe("Main Hospital, Room 302B");
+    });
+
+    it("omits Encounter.location when the column is null", () => {
+      const enc = toFhirEncounter(makeEncounter({ location: null }), "p1");
+      expect(enc.location).toBeUndefined();
+    });
+
     it("includes reasonCode when reason set", () => {
       const enc = toFhirEncounter(
         makeEncounter({ reason: "Chest pain workup" }),

--- a/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
@@ -105,6 +105,8 @@ vi.mock("../generators/index.js", () => ({
   toFhirCondition: () => ({ resourceType: "Condition" }),
   toFhirMedicationStatement: () => ({ resourceType: "MedicationStatement" }),
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
+  toFhirEncounter: () => ({ resourceType: "Encounter" }),
+  toFhirProcedure: () => ({ resourceType: "Procedure" }),
 }));
 
 // PHI sanitizer pass-through.

--- a/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
@@ -25,6 +25,8 @@ const labResultsTable = { __name: "lab_results" };
 const medicationsTable = { __name: "medications" };
 const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
+const encountersTable = { __name: "encounters" };
+const proceduresTable = { __name: "procedures" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -69,6 +71,8 @@ vi.mock("@carebridge/db-schema", () => ({
   medications: medicationsTable,
   diagnoses: diagnosesTable,
   allergies: allergiesTable,
+  encounters: encountersTable,
+  procedures: proceduresTable,
 }));
 
 // drizzle-orm's `eq` is only used to build where-clauses; our select mock

--- a/services/fhir-gateway/src/__tests__/export-headers.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-headers.test.ts
@@ -85,6 +85,8 @@ vi.mock("../generators/index.js", () => ({
   toFhirCondition: () => ({ resourceType: "Condition" }),
   toFhirMedicationStatement: () => ({ resourceType: "MedicationStatement" }),
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
+  toFhirEncounter: () => ({ resourceType: "Encounter" }),
+  toFhirProcedure: () => ({ resourceType: "Procedure" }),
 }));
 
 vi.mock("@carebridge/phi-sanitizer", () => ({

--- a/services/fhir-gateway/src/__tests__/export-headers.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-headers.test.ts
@@ -17,6 +17,8 @@ const labResultsTable = { __name: "lab_results" };
 const medicationsTable = { __name: "medications" };
 const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
+const encountersTable = { __name: "encounters" };
+const proceduresTable = { __name: "procedures" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -54,6 +56,8 @@ vi.mock("@carebridge/db-schema", () => ({
   medications: medicationsTable,
   diagnoses: diagnosesTable,
   allergies: allergiesTable,
+  encounters: encountersTable,
+  procedures: proceduresTable,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
@@ -17,6 +17,8 @@ const labResultsTable = { __name: "lab_results" };
 const medicationsTable = { __name: "medications" };
 const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
+const encountersTable = { __name: "encounters" };
+const proceduresTable = { __name: "procedures" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -57,6 +59,8 @@ vi.mock("@carebridge/db-schema", () => ({
   medications: medicationsTable,
   diagnoses: diagnosesTable,
   allergies: allergiesTable,
+  encounters: encountersTable,
+  procedures: proceduresTable,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
@@ -81,6 +81,8 @@ vi.mock("../generators/index.js", () => ({
   toFhirCondition: () => ({ resourceType: "Condition" }),
   toFhirMedicationStatement: () => ({ resourceType: "MedicationStatement" }),
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
+  toFhirEncounter: () => ({ resourceType: "Encounter" }),
+  toFhirProcedure: () => ({ resourceType: "Procedure" }),
 }));
 
 vi.mock("@carebridge/phi-sanitizer", () => ({

--- a/services/fhir-gateway/src/__tests__/procedure.test.ts
+++ b/services/fhir-gateway/src/__tests__/procedure.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { toFhirProcedure } from "../generators/procedure.js";
+
+type Procedure = Parameters<typeof toFhirProcedure>[0];
+
+function makeProcedure(overrides: Partial<Procedure> = {}): Procedure {
+  return {
+    id: "p1",
+    patient_id: "pat1",
+    name: "Appendectomy",
+    cpt_code: "44970",
+    icd10_codes: ["K35.80"],
+    status: "completed",
+    performed_at: "2026-04-10T14:00:00.000Z",
+    performed_by: "surg1",
+    provider_id: null,
+    encounter_id: null,
+    notes: null,
+    source_system: "internal",
+    created_at: "2026-04-10T14:00:00.000Z",
+    ...overrides,
+  } as Procedure;
+}
+
+describe("toFhirProcedure (#387)", () => {
+  describe("status mapping", () => {
+    const cases: Array<[string, string]> = [
+      ["scheduled", "preparation"],
+      ["preparation", "preparation"],
+      ["in-progress", "in-progress"],
+      ["in_progress", "in-progress"],
+      ["completed", "completed"],
+      ["done", "completed"],
+      ["cancelled", "stopped"],
+      ["canceled", "stopped"],
+      ["stopped", "stopped"],
+      ["on-hold", "on-hold"],
+      ["not-done", "not-done"],
+      ["entered-in-error", "entered-in-error"],
+      ["xyz", "unknown"],
+    ];
+    for (const [input, expected] of cases) {
+      it(`maps status '${input}' → '${expected}'`, () => {
+        const proc = toFhirProcedure(makeProcedure({ status: input }), "pat1");
+        expect(proc.status).toBe(expected);
+      });
+    }
+  });
+
+  describe("code / CPT coding", () => {
+    it("emits CPT coding when cpt_code is present", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+        "pat1",
+      );
+      const coding = proc.code?.coding?.[0];
+      expect(coding?.system).toBe("http://www.ama-assn.org/go/cpt");
+      expect(coding?.code).toBe("44970");
+      expect(coding?.display).toBe("Laparoscopic appendectomy");
+      expect(proc.code?.text).toBe("Laparoscopic appendectomy");
+    });
+
+    it("falls back to text-only code when cpt_code is null but name is set", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: null, name: "Wound dressing change" }),
+        "pat1",
+      );
+      expect(proc.code?.coding).toBeUndefined();
+      expect(proc.code?.text).toBe("Wound dressing change");
+    });
+  });
+
+  describe("reasonCode (ICD-10)", () => {
+    it("maps icd10_codes[] to reasonCode array", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ icd10_codes: ["K35.80", "R10.9"] }),
+        "pat1",
+      );
+      expect(proc.reasonCode).toHaveLength(2);
+      expect(proc.reasonCode![0]?.coding?.[0]?.system).toBe(
+        "http://hl7.org/fhir/sid/icd-10-cm",
+      );
+      expect(proc.reasonCode![0]?.coding?.[0]?.code).toBe("K35.80");
+      expect(proc.reasonCode![1]?.coding?.[0]?.code).toBe("R10.9");
+    });
+
+    it("omits reasonCode when icd10_codes is empty", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ icd10_codes: [] }),
+        "pat1",
+      );
+      expect(proc.reasonCode).toBeUndefined();
+    });
+
+    it("omits reasonCode when icd10_codes is null", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ icd10_codes: null }),
+        "pat1",
+      );
+      expect(proc.reasonCode).toBeUndefined();
+    });
+  });
+
+  describe("subject / performer / performedDateTime", () => {
+    it("attaches a Patient reference", () => {
+      const proc = toFhirProcedure(makeProcedure(), "pat1");
+      expect(proc.subject.reference).toBe("Patient/pat1");
+    });
+
+    it("emits performer as Practitioner when performed_by set", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ performed_by: "surg99" }),
+        "pat1",
+      );
+      expect(proc.performer?.[0]?.actor?.reference).toBe("Practitioner/surg99");
+    });
+
+    it("omits performer when performed_by is null", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ performed_by: null }),
+        "pat1",
+      );
+      expect(proc.performer).toBeUndefined();
+    });
+
+    it("emits performedDateTime when performed_at set", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ performed_at: "2026-04-10T14:00:00.000Z" }),
+        "pat1",
+      );
+      expect(proc.performedDateTime).toBe("2026-04-10T14:00:00.000Z");
+    });
+
+    it("omits performedDateTime when performed_at is null (scheduled procedure)", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({
+          performed_at: null,
+          status: "scheduled",
+        }),
+        "pat1",
+      );
+      expect(proc.performedDateTime).toBeUndefined();
+      expect(proc.status).toBe("preparation");
+    });
+  });
+});

--- a/services/fhir-gateway/src/generators/encounter.ts
+++ b/services/fhir-gateway/src/generators/encounter.ts
@@ -109,5 +109,20 @@ export function toFhirEncounter(
     resource.reasonCode = [{ text: encounter.reason }];
   }
 
+  // Encounter.location — the internal `location` column is a free-text
+  // identifier (bed, unit, clinic room). FHIR R4 wants a Location
+  // Reference, so we emit a reference whose `display` carries the
+  // internal string. When a proper Location resource set exists the
+  // reference string can be upgraded to `Location/<id>`.
+  if (encounter.location) {
+    resource.location = [
+      {
+        location: {
+          display: encounter.location,
+        },
+      },
+    ];
+  }
+
   return resource;
 }

--- a/services/fhir-gateway/src/generators/encounter.ts
+++ b/services/fhir-gateway/src/generators/encounter.ts
@@ -1,0 +1,113 @@
+/**
+ * FHIR R4 Encounter resource generator (issue #387).
+ *
+ * Maps internal encounter rows to the HL7 FHIR R4 Encounter resource
+ * (https://hl7.org/fhir/R4/encounter.html). The internal `encounter_type`
+ * maps to Encounter.class using the HL7 v3 ActCode system; the internal
+ * `status` aligns to the FHIR EncounterStatus value set (mostly identical
+ * strings, with a fallback to "unknown" for unrecognised values).
+ */
+
+import type { encounters } from "@carebridge/db-schema";
+import type { FhirEncounter } from "../types/fhir-r4.js";
+
+type EncounterRow = typeof encounters.$inferSelect;
+
+/**
+ * HL7 v3 ActCode system used for Encounter.class. FHIR R4 requires
+ * exactly this URL.
+ */
+const ACT_CODE_SYSTEM = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+/**
+ * Map internal encounter_type → HL7 v3 ActCode coding for FHIR
+ * Encounter.class.
+ *
+ * Telehealth is coded as VR (virtual) in FHIR R4; some integrations also
+ * use HH (home). VR is more explicit about the remote modality.
+ */
+function mapEncounterClass(encounterType: string): { code: string; display: string } {
+  switch (encounterType.toLowerCase()) {
+    case "inpatient":
+      return { code: "IMP", display: "inpatient encounter" };
+    case "outpatient":
+    case "ambulatory":
+      return { code: "AMB", display: "ambulatory" };
+    case "emergency":
+    case "ed":
+      return { code: "EMER", display: "emergency" };
+    case "telehealth":
+    case "virtual":
+      return { code: "VR", display: "virtual" };
+    case "home":
+      return { code: "HH", display: "home health" };
+    case "observation":
+      return { code: "OBSENC", display: "observation encounter" };
+    default:
+      return { code: "AMB", display: "ambulatory" };
+  }
+}
+
+/**
+ * FHIR R4 EncounterStatus value set. Narrower than the internal enum, so
+ * unknown/custom statuses fall through to "unknown".
+ */
+const FHIR_ENCOUNTER_STATUSES = new Set<FhirEncounter["status"]>([
+  "planned",
+  "arrived",
+  "triaged",
+  "in-progress",
+  "onleave",
+  "finished",
+  "cancelled",
+  "entered-in-error",
+  "unknown",
+]);
+
+function mapEncounterStatus(status: string): FhirEncounter["status"] {
+  const normalized = status.toLowerCase() as FhirEncounter["status"];
+  return FHIR_ENCOUNTER_STATUSES.has(normalized) ? normalized : "unknown";
+}
+
+export function toFhirEncounter(
+  encounter: EncounterRow,
+  patientId: string,
+): FhirEncounter {
+  const klass = mapEncounterClass(encounter.encounter_type);
+
+  const resource: FhirEncounter = {
+    resourceType: "Encounter",
+    id: encounter.id,
+    status: mapEncounterStatus(encounter.status),
+    class: {
+      system: ACT_CODE_SYSTEM,
+      code: klass.code,
+      display: klass.display,
+    },
+    subject: {
+      reference: `Patient/${patientId}`,
+    },
+  };
+
+  // Period: start_time is required on the internal row; end_time is
+  // optional (open-ended for in-progress encounters).
+  const period: { start: string; end?: string } = { start: encounter.start_time };
+  if (encounter.end_time) period.end = encounter.end_time;
+  resource.period = period;
+
+  if (encounter.provider_id) {
+    resource.participant = [
+      {
+        individual: {
+          reference: `Practitioner/${encounter.provider_id}`,
+        },
+      },
+    ];
+  }
+
+  if (encounter.reason) {
+    resource.reasonCode = [{ text: encounter.reason }];
+  }
+
+  return resource;
+}

--- a/services/fhir-gateway/src/generators/index.ts
+++ b/services/fhir-gateway/src/generators/index.ts
@@ -7,3 +7,5 @@ export { toFhirPatient } from "./patient.js";
 export { toFhirCondition } from "./condition.js";
 export { toFhirMedicationStatement } from "./medication-statement.js";
 export { toFhirAllergyIntolerance } from "./allergy-intolerance.js";
+export { toFhirEncounter } from "./encounter.js";
+export { toFhirProcedure } from "./procedure.js";

--- a/services/fhir-gateway/src/generators/procedure.ts
+++ b/services/fhir-gateway/src/generators/procedure.ts
@@ -1,0 +1,115 @@
+/**
+ * FHIR R4 Procedure resource generator (issue #387).
+ *
+ * Maps internal procedure rows to the HL7 FHIR R4 Procedure resource
+ * (https://hl7.org/fhir/R4/procedure.html). CPT codes attach to
+ * Procedure.code via the AMA CPT system; ICD-10 reason codes attach to
+ * Procedure.reasonCode via the CM value set.
+ */
+
+import type { procedures } from "@carebridge/db-schema";
+import type { FhirProcedure } from "../types/fhir-r4.js";
+
+type ProcedureRow = typeof procedures.$inferSelect;
+
+const CPT_SYSTEM = "http://www.ama-assn.org/go/cpt";
+const ICD10_CM_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm";
+
+/**
+ * FHIR R4 ProcedureStatus value set. Internal statuses "scheduled" and
+ * "cancelled" don't exactly match — we remap them ("scheduled" → preparation,
+ * "cancelled" → stopped) so downstream FHIR consumers see only spec-valid
+ * values.
+ */
+function mapProcedureStatus(status: string): FhirProcedure["status"] {
+  switch (status.toLowerCase()) {
+    case "scheduled":
+    case "preparation":
+      return "preparation";
+    case "in-progress":
+    case "in_progress":
+      return "in-progress";
+    case "completed":
+    case "done":
+    case "finished":
+      return "completed";
+    case "cancelled":
+    case "canceled":
+    case "stopped":
+      return "stopped";
+    case "on-hold":
+    case "hold":
+      return "on-hold";
+    case "not-done":
+    case "abandoned":
+      return "not-done";
+    case "entered-in-error":
+      return "entered-in-error";
+    default:
+      return "unknown";
+  }
+}
+
+export function toFhirProcedure(
+  procedure: ProcedureRow,
+  patientId: string,
+): FhirProcedure {
+  const resource: FhirProcedure = {
+    resourceType: "Procedure",
+    id: procedure.id,
+    status: mapProcedureStatus(procedure.status),
+    subject: {
+      reference: `Patient/${patientId}`,
+    },
+  };
+
+  // Procedure.code: prefer CPT coding when available, otherwise surface
+  // the free-text procedure name so the resource is still useful to
+  // downstream consumers.
+  if (procedure.cpt_code) {
+    resource.code = {
+      coding: [
+        {
+          system: CPT_SYSTEM,
+          code: procedure.cpt_code,
+          display: procedure.name,
+        },
+      ],
+      text: procedure.name,
+    };
+  } else if (procedure.name) {
+    resource.code = {
+      text: procedure.name,
+    };
+  }
+
+  // ICD-10 reason codes — empty array is treated as "no reason provided"
+  // and the field is omitted rather than emitted as an empty list.
+  const icd10 = procedure.icd10_codes ?? [];
+  if (icd10.length > 0) {
+    resource.reasonCode = icd10.map((code) => ({
+      coding: [
+        {
+          system: ICD10_CM_SYSTEM,
+          code,
+        },
+      ],
+    }));
+  }
+
+  if (procedure.performed_at) {
+    resource.performedDateTime = procedure.performed_at;
+  }
+
+  if (procedure.performed_by) {
+    resource.performer = [
+      {
+        actor: {
+          reference: `Practitioner/${procedure.performed_by}`,
+        },
+      },
+    ];
+  }
+
+  return resource;
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -11,6 +11,8 @@ import {
   medications,
   diagnoses,
   allergies,
+  encounters,
+  procedures,
 } from "@carebridge/db-schema";
 import { eq, and, sql } from "drizzle-orm";
 import { createLogger } from "@carebridge/logger";
@@ -23,6 +25,8 @@ import {
   toFhirCondition,
   toFhirMedicationStatement,
   toFhirAllergyIntolerance,
+  toFhirEncounter,
+  toFhirProcedure,
 } from "./generators/index.js";
 import { fhirBundleSchema } from "./schemas/bundle.js";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
@@ -334,12 +338,16 @@ export const fhirGatewayRouter = t.router({
           patientMedications,
           patientDiagnoses,
           patientAllergies,
+          patientEncounters,
+          patientProcedures,
         ] = await Promise.all([
           db.select().from(vitals).where(eq(vitals.patient_id, patientId)),
           db.select().from(labPanels).where(eq(labPanels.patient_id, patientId)),
           db.select().from(medications).where(eq(medications.patient_id, patientId)),
           db.select().from(diagnoses).where(eq(diagnoses.patient_id, patientId)),
           db.select().from(allergies).where(eq(allergies.patient_id, patientId)),
+          db.select().from(encounters).where(eq(encounters.patient_id, patientId)),
+          db.select().from(procedures).where(eq(procedures.patient_id, patientId)),
         ]);
 
         // Fetch lab results for all panels
@@ -395,6 +403,20 @@ export const fhirGatewayRouter = t.router({
           entry.push({
             fullUrl: `urn:uuid:${allergy.id}`,
             resource: toFhirAllergyIntolerance(allergy, patientId),
+          });
+        }
+
+        for (const encounter of patientEncounters) {
+          entry.push({
+            fullUrl: `urn:uuid:${encounter.id}`,
+            resource: toFhirEncounter(encounter, patientId),
+          });
+        }
+
+        for (const procedure of patientProcedures) {
+          entry.push({
+            fullUrl: `urn:uuid:${procedure.id}`,
+            resource: toFhirProcedure(procedure, patientId),
           });
         }
 

--- a/services/fhir-gateway/src/types/fhir-r4.ts
+++ b/services/fhir-gateway/src/types/fhir-r4.ts
@@ -24,6 +24,8 @@ export interface Quantity {
 
 export interface Reference {
   reference?: string;
+  /** Human-readable label for the referenced resource. */
+  display?: string;
 }
 
 export interface Period {
@@ -129,6 +131,12 @@ export interface EncounterParticipant {
   individual?: Reference;
 }
 
+export interface EncounterLocation {
+  location: Reference;
+  status?: "planned" | "active" | "reserved" | "completed";
+  period?: Period;
+}
+
 export interface FhirEncounter {
   resourceType: "Encounter";
   id: string;
@@ -139,6 +147,7 @@ export interface FhirEncounter {
   subject?: Reference;
   period?: Period;
   participant?: EncounterParticipant[];
+  location?: EncounterLocation[];
   serviceProvider?: Reference;
   reasonCode?: CodeableConcept[];
 }


### PR DESCRIPTION
## Summary

- `services/fhir-gateway/src/generators/encounter.ts` — maps `encounter_type` to HL7 v3 ActCode (inpatient → IMP, outpatient → AMB, emergency → EMER, telehealth → VR, home → HH, observation → OBSENC). Status passes through when it matches the FHIR EncounterStatus set, otherwise \"unknown\". Emits period, participant (Practitioner via `provider_id`), reasonCode (text from `reason`)
- `services/fhir-gateway/src/generators/procedure.ts` — CPT codes attach to `Procedure.code` via `http://www.ama-assn.org/go/cpt`; ICD-10 codes become `reasonCode` entries. Status remaps internal variants (\"scheduled\" → preparation, \"cancelled\" → stopped) so downstream FHIR consumers only see spec-valid values
- `exportPatient` in `router.ts`: added encounters + procedures to the parallel fetch and bundle assembly
- Updated existing export-audit / headers / purge-warning test mocks with the two new table handles
- 49 new generator tests (26 encounter + 23 procedure) covering status boundaries, class-code mapping, optional-field omissions, and ICD-10 `reasonCode` edge cases

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test` — 129/129
- [x] `pnpm typecheck` — 40/40
- [x] All existing export tests still pass after the parallel-fetch addition

Closes #387