### PR TITLE
feat(fhir): add Practitioner and MedicationRequest R4 generators (#388)

### DIFF
--- a/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-bundle-audit.test.ts
@@ -27,6 +27,7 @@ const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
 const encountersTable = { __name: "encounters" };
 const proceduresTable = { __name: "procedures" };
+const usersTable = { __name: "users" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -73,14 +74,16 @@ vi.mock("@carebridge/db-schema", () => ({
   allergies: allergiesTable,
   encounters: encountersTable,
   procedures: proceduresTable,
+  users: usersTable,
 }));
 
-// drizzle-orm's `eq` is only used to build where-clauses; our select mock
-// ignores the predicate and returns rows based solely on the table, so
-// stub `eq` to a no-op sentinel.
+// drizzle-orm's `eq` / `inArray` are only used to build where-clauses; our
+// select mock ignores the predicate and returns rows based solely on the
+// table, so stub them to no-op sentinels.
 vi.mock("drizzle-orm", () => ({
   eq: (_col: unknown, _val: unknown) => ({ __eq: true }),
   and: (..._args: unknown[]) => ({ __and: true }),
+  inArray: (_col: unknown, _values: unknown[]) => ({ __inArray: true }),
   sql: Object.assign(
     (_strings: TemplateStringsArray, ..._values: unknown[]) => ({ __sql: true }),
     { raw: (s: string) => ({ __raw: s }) },
@@ -107,6 +110,10 @@ vi.mock("../generators/index.js", () => ({
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
   toFhirEncounter: () => ({ resourceType: "Encounter" }),
   toFhirProcedure: () => ({ resourceType: "Procedure" }),
+  toFhirPractitioner: () => ({ resourceType: "Practitioner" }),
+  toFhirMedicationRequest: () => ({ resourceType: "MedicationRequest" }),
+  isClinicalRole: (role: string) =>
+    ["physician", "specialist", "nurse"].includes(role),
 }));
 
 // PHI sanitizer pass-through.

--- a/services/fhir-gateway/src/__tests__/export-headers.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-headers.test.ts
@@ -19,6 +19,7 @@ const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
 const encountersTable = { __name: "encounters" };
 const proceduresTable = { __name: "procedures" };
+const usersTable = { __name: "users" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -58,11 +59,13 @@ vi.mock("@carebridge/db-schema", () => ({
   allergies: allergiesTable,
   encounters: encountersTable,
   procedures: proceduresTable,
+  users: usersTable,
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: (_col: unknown, _val: unknown) => ({ __eq: true }),
   and: (..._args: unknown[]) => ({ __and: true }),
+  inArray: (_col: unknown, _values: unknown[]) => ({ __inArray: true }),
   sql: Object.assign(
     (_strings: TemplateStringsArray, ..._values: unknown[]) => ({ __sql: true }),
     { raw: (s: string) => ({ __raw: s }) },
@@ -87,6 +90,10 @@ vi.mock("../generators/index.js", () => ({
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
   toFhirEncounter: () => ({ resourceType: "Encounter" }),
   toFhirProcedure: () => ({ resourceType: "Procedure" }),
+  toFhirPractitioner: () => ({ resourceType: "Practitioner" }),
+  toFhirMedicationRequest: () => ({ resourceType: "MedicationRequest" }),
+  isClinicalRole: (role: string) =>
+    ["physician", "specialist", "nurse"].includes(role),
 }));
 
 vi.mock("@carebridge/phi-sanitizer", () => ({

--- a/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
+++ b/services/fhir-gateway/src/__tests__/export-purge-warning.test.ts
@@ -19,6 +19,7 @@ const diagnosesTable = { __name: "diagnoses" };
 const allergiesTable = { __name: "allergies" };
 const encountersTable = { __name: "encounters" };
 const proceduresTable = { __name: "procedures" };
+const usersTable = { __name: "users" };
 const fhirResourcesTable = { __name: "fhir_resources" };
 const auditLogTable = { __name: "audit_log" };
 
@@ -61,11 +62,13 @@ vi.mock("@carebridge/db-schema", () => ({
   allergies: allergiesTable,
   encounters: encountersTable,
   procedures: proceduresTable,
+  users: usersTable,
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: (_col: unknown, _val: unknown) => ({ __eq: true }),
   and: (..._args: unknown[]) => ({ __and: true }),
+  inArray: (_col: unknown, _values: unknown[]) => ({ __inArray: true }),
   sql: Object.assign(
     (_strings: TemplateStringsArray, ..._values: unknown[]) => ({
       __sql: true,
@@ -83,6 +86,10 @@ vi.mock("../generators/index.js", () => ({
   toFhirAllergyIntolerance: () => ({ resourceType: "AllergyIntolerance" }),
   toFhirEncounter: () => ({ resourceType: "Encounter" }),
   toFhirProcedure: () => ({ resourceType: "Procedure" }),
+  toFhirPractitioner: () => ({ resourceType: "Practitioner" }),
+  toFhirMedicationRequest: () => ({ resourceType: "MedicationRequest" }),
+  isClinicalRole: (role: string) =>
+    ["physician", "specialist", "nurse"].includes(role),
 }));
 
 vi.mock("@carebridge/phi-sanitizer", () => ({

--- a/services/fhir-gateway/src/__tests__/medication-request.test.ts
+++ b/services/fhir-gateway/src/__tests__/medication-request.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { toFhirMedicationRequest } from "../generators/medication-request.js";
+
+type Medication = Parameters<typeof toFhirMedicationRequest>[0];
+
+function makeMed(overrides: Partial<Medication> = {}): Medication {
+  return {
+    id: "m1",
+    patient_id: "p1",
+    name: "Amoxicillin",
+    brand_name: null,
+    dose_amount: 500,
+    dose_unit: "mg",
+    route: "oral",
+    frequency: "TID x 10 days",
+    status: "active",
+    started_at: "2026-04-10T00:00:00.000Z",
+    ended_at: null,
+    prescribed_by: null,
+    notes: null,
+    rxnorm_code: "723",
+    ordering_provider_id: "prov1",
+    encounter_id: null,
+    source_system: "internal",
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    ...overrides,
+  } as Medication;
+}
+
+describe("toFhirMedicationRequest (#388)", () => {
+  it("always emits intent='order' for CareBridge prescriptions", () => {
+    const r = toFhirMedicationRequest(makeMed(), "p1");
+    expect(r.resourceType).toBe("MedicationRequest");
+    expect(r.intent).toBe("order");
+  });
+
+  describe("status mapping (MedicationRequest value set)", () => {
+    const cases: Array<[string, string]> = [
+      ["active", "active"],
+      ["held", "on-hold"],
+      ["on-hold", "on-hold"],
+      ["cancelled", "cancelled"],
+      ["canceled", "cancelled"],
+      ["completed", "completed"],
+      ["discontinued", "stopped"],
+      ["stopped", "stopped"],
+      ["draft", "draft"],
+      ["entered-in-error", "entered-in-error"],
+      ["xyz", "unknown"],
+    ];
+    for (const [input, expected] of cases) {
+      it(`maps status '${input}' → '${expected}'`, () => {
+        expect(toFhirMedicationRequest(makeMed({ status: input }), "p1").status).toBe(
+          expected,
+        );
+      });
+    }
+  });
+
+  it("emits RxNorm coding when rxnorm_code is present", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ rxnorm_code: "723", name: "Amoxicillin" }),
+      "p1",
+    );
+    const coding = r.medicationCodeableConcept?.coding?.[0];
+    expect(coding?.system).toBe("http://www.nlm.nih.gov/research/umls/rxnorm");
+    expect(coding?.code).toBe("723");
+    expect(coding?.display).toBe("Amoxicillin");
+  });
+
+  it("falls back to 'unknown' code when rxnorm_code absent", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ rxnorm_code: null }),
+      "p1",
+    );
+    expect(r.medicationCodeableConcept?.coding?.[0]?.code).toBe("unknown");
+  });
+
+  it("includes brand_name parenthetically in medicationCodeableConcept.text", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ name: "Atorvastatin", brand_name: "Lipitor" }),
+      "p1",
+    );
+    expect(r.medicationCodeableConcept?.text).toBe("Atorvastatin (Lipitor)");
+  });
+
+  it("sets authoredOn to started_at", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ started_at: "2026-04-10T00:00:00.000Z" }),
+      "p1",
+    );
+    expect(r.authoredOn).toBe("2026-04-10T00:00:00.000Z");
+  });
+
+  it("requester prefers ordering_provider_id over prescribed_by", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ ordering_provider_id: "op1", prescribed_by: "pb1" }),
+      "p1",
+    );
+    expect(r.requester?.reference).toBe("Practitioner/op1");
+  });
+
+  it("requester falls back to prescribed_by when ordering_provider_id is null", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({ ordering_provider_id: null, prescribed_by: "pb1" }),
+      "p1",
+    );
+    expect(r.requester?.reference).toBe("Practitioner/pb1");
+  });
+
+  it("emits dosageInstruction with route SNOMED + dose + frequency", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({
+        dose_amount: 500,
+        dose_unit: "mg",
+        route: "oral",
+        frequency: "TID x 10 days",
+      }),
+      "p1",
+    );
+    const d = r.dosageInstruction?.[0];
+    expect(d?.doseAndRate?.[0]?.doseQuantity?.value).toBe(500);
+    expect(d?.doseAndRate?.[0]?.doseQuantity?.unit).toBe("mg");
+    expect(d?.route?.coding?.[0]?.system).toBe("http://snomed.info/sct");
+    expect(d?.route?.coding?.[0]?.code).toBe("26643006"); // Oral route
+    expect(d?.timing?.code?.text).toBe("TID x 10 days");
+    expect(d?.text).toBe("500 mg oral TID x 10 days");
+  });
+
+  it("omits dosageInstruction entirely when no dosage fields are set", () => {
+    const r = toFhirMedicationRequest(
+      makeMed({
+        dose_amount: null,
+        dose_unit: null,
+        route: null,
+        frequency: null,
+      }),
+      "p1",
+    );
+    expect(r.dosageInstruction).toBeUndefined();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/medication-request.test.ts
+++ b/services/fhir-gateway/src/__tests__/medication-request.test.ts
@@ -48,6 +48,12 @@ describe("toFhirMedicationRequest (#388)", () => {
       ["draft", "draft"],
       ["entered-in-error", "entered-in-error"],
       ["xyz", "unknown"],
+      // Case-insensitive — prior version mapped any non-lowercase value
+      // to "unknown", hiding legitimate active prescriptions in the FHIR
+      // export when the DB carried a mixed-case status.
+      ["ACTIVE", "active"],
+      ["On-Hold", "on-hold"],
+      ["COMPLETED", "completed"],
     ];
     for (const [input, expected] of cases) {
       it(`maps status '${input}' → '${expected}'`, () => {

--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { toFhirPractitioner, isClinicalRole } from "../generators/practitioner.js";
+
+type User = Parameters<typeof toFhirPractitioner>[0];
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "u1",
+    email: "dr.jones@carebridge.dev",
+    password_hash: "hash",
+    name: "Sarah Jones",
+    role: "physician",
+    patient_id: null,
+    specialty: "Oncology",
+    department: "Hem-Onc",
+    is_active: true,
+    mfa_secret: null,
+    mfa_enabled: false,
+    recovery_codes: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as User;
+}
+
+describe("isClinicalRole", () => {
+  it("accepts physician, specialist, nurse", () => {
+    expect(isClinicalRole("physician")).toBe(true);
+    expect(isClinicalRole("specialist")).toBe(true);
+    expect(isClinicalRole("nurse")).toBe(true);
+  });
+
+  it("rejects non-clinical roles", () => {
+    expect(isClinicalRole("patient")).toBe(false);
+    expect(isClinicalRole("admin")).toBe(false);
+    expect(isClinicalRole("family_caregiver")).toBe(false);
+  });
+});
+
+describe("toFhirPractitioner (#388)", () => {
+  it("uses user.id as resource id and internal identifier", () => {
+    const p = toFhirPractitioner(makeUser({ id: "prov-123" }));
+    expect(p.resourceType).toBe("Practitioner");
+    expect(p.id).toBe("prov-123");
+    expect(p.identifier?.[0]?.system).toBe("urn:carebridge:users");
+    expect(p.identifier?.[0]?.value).toBe("prov-123");
+  });
+
+  it("parses 'First Last' into family + given", () => {
+    const p = toFhirPractitioner(makeUser({ name: "Sarah Jones" }));
+    const n = p.name?.[0];
+    expect(n?.family).toBe("Jones");
+    expect(n?.given).toEqual(["Sarah"]);
+    expect(n?.text).toBe("Sarah Jones");
+  });
+
+  it("parses 'First Middle Last' into given[First, Middle] + family=Last", () => {
+    const p = toFhirPractitioner(makeUser({ name: "Sarah M. Jones" }));
+    expect(p.name?.[0]?.given).toEqual(["Sarah", "M."]);
+    expect(p.name?.[0]?.family).toBe("Jones");
+  });
+
+  it("strips trailing credentials after the first comma", () => {
+    const p = toFhirPractitioner(makeUser({ name: "Sarah Jones, MD" }));
+    expect(p.name?.[0]?.family).toBe("Jones");
+    expect(p.name?.[0]?.given).toEqual(["Sarah"]);
+    expect(p.name?.[0]?.text).toBe("Sarah Jones, MD"); // full original preserved
+  });
+
+  it("handles single-token names (family only, no given)", () => {
+    const p = toFhirPractitioner(makeUser({ name: "Plato" }));
+    expect(p.name?.[0]?.family).toBe("Plato");
+    expect(p.name?.[0]?.given).toBeUndefined();
+  });
+
+  it("emits specialty as a text-only qualification coding when present", () => {
+    const p = toFhirPractitioner(makeUser({ specialty: "Oncology" }));
+    expect(p.qualification?.[0]?.code?.text).toBe("Oncology");
+    // We intentionally avoid a NUCC coded value without structured input.
+    expect(p.qualification?.[0]?.code?.coding).toBeUndefined();
+  });
+
+  it("omits qualification entirely when specialty is null", () => {
+    const p = toFhirPractitioner(makeUser({ specialty: null }));
+    expect(p.qualification).toBeUndefined();
+  });
+});

--- a/services/fhir-gateway/src/generators/index.ts
+++ b/services/fhir-gateway/src/generators/index.ts
@@ -9,3 +9,5 @@ export { toFhirMedicationStatement } from "./medication-statement.js";
 export { toFhirAllergyIntolerance } from "./allergy-intolerance.js";
 export { toFhirEncounter } from "./encounter.js";
 export { toFhirProcedure } from "./procedure.js";
+export { toFhirPractitioner, isClinicalRole } from "./practitioner.js";
+export { toFhirMedicationRequest } from "./medication-request.js";

--- a/services/fhir-gateway/src/generators/medication-request.ts
+++ b/services/fhir-gateway/src/generators/medication-request.ts
@@ -46,7 +46,7 @@ const ROUTE_SNOMED: Record<string, { code: string; display: string }> = {
  *   stopped | draft | unknown
  */
 function mapRequestStatus(status: string): FhirMedicationRequest["status"] {
-  switch (status) {
+  switch (status.toLowerCase()) {
     case "active":
       return "active";
     case "held":

--- a/services/fhir-gateway/src/generators/medication-request.ts
+++ b/services/fhir-gateway/src/generators/medication-request.ts
@@ -1,0 +1,183 @@
+/**
+ * FHIR R4 MedicationRequest resource generator (issue #388).
+ *
+ * Epic (and most EHRs that consume FHIR R4) expect active prescriptions
+ * as MedicationRequest resources — MedicationStatement is for recorded
+ * current / historical meds the patient reports taking, not for orders.
+ * Both formats remain so the exported bundle round-trips cleanly in
+ * either direction.
+ *
+ * Mapping conventions mirror medication-statement.ts where the underlying
+ * fields overlap (RxNorm coding, route SNOMED, dose in UCUM-like unit)
+ * so downstream consumers see consistent data shapes.
+ */
+
+import type { medications } from "@carebridge/db-schema";
+import type {
+  FhirMedicationRequest,
+  Coding,
+  DosageInstruction,
+} from "../types/fhir-r4.js";
+
+type Medication = typeof medications.$inferSelect;
+
+type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
+
+/**
+ * SNOMED route codings, shared shape with medication-statement.ts. Kept
+ * local here to avoid reaching across generator boundaries for a private
+ * table.
+ */
+const ROUTE_SNOMED: Record<string, { code: string; display: string }> = {
+  oral: { code: "26643006", display: "Oral route" },
+  IV: { code: "47625008", display: "Intravenous route" },
+  IM: { code: "78421000", display: "Intramuscular route" },
+  subcutaneous: { code: "34206005", display: "Subcutaneous route" },
+  topical: { code: "6064005", display: "Topical route" },
+  inhaled: { code: "418730005", display: "Inhalation route" },
+  rectal: { code: "37161004", display: "Rectal route" },
+  other: { code: "284009009", display: "Route of administration" },
+};
+
+/**
+ * FHIR R4 MedicationRequest status value set (narrower than
+ * MedicationStatement):
+ *   active | on-hold | cancelled | completed | entered-in-error |
+ *   stopped | draft | unknown
+ */
+function mapRequestStatus(status: string): FhirMedicationRequest["status"] {
+  switch (status) {
+    case "active":
+      return "active";
+    case "held":
+    case "on-hold":
+      return "on-hold";
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
+    case "completed":
+      return "completed";
+    case "discontinued":
+    case "stopped":
+      return "stopped";
+    case "draft":
+    case "proposed":
+      return "draft";
+    case "entered-in-error":
+      return "entered-in-error";
+    default:
+      return "unknown";
+  }
+}
+
+export function toFhirMedicationRequest(
+  medication: Medication,
+  patientId: string,
+): FhirMedicationRequest {
+  const codings: FhirCoding[] = [];
+
+  if (medication.rxnorm_code) {
+    codings.push({
+      system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+      code: medication.rxnorm_code,
+      display: medication.name,
+    });
+  }
+
+  if (codings.length === 0) {
+    codings.push({
+      system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+      code: "unknown",
+      display: medication.name,
+    });
+  }
+
+  const resource: FhirMedicationRequest = {
+    resourceType: "MedicationRequest",
+    id: medication.id,
+    status: mapRequestStatus(medication.status),
+    // CareBridge-internal medications are prescription orders; there's no
+    // plan-vs-order distinction in the current data model, so we emit
+    // "order" (a concrete, actionable request) per the FHIR value set.
+    intent: "order",
+    medicationCodeableConcept: {
+      coding: codings,
+      text: medication.brand_name
+        ? `${medication.name} (${medication.brand_name})`
+        : medication.name,
+    },
+    subject: {
+      reference: `Patient/${patientId}`,
+    },
+  };
+
+  if (medication.started_at) {
+    resource.authoredOn = medication.started_at;
+  }
+
+  // Requester: ordering_provider_id is the canonical prescriber; fall
+  // back to the older prescribed_by column for rows written before the
+  // field split.
+  const prescriberId = medication.ordering_provider_id ?? medication.prescribed_by;
+  if (prescriberId) {
+    resource.requester = {
+      reference: `Practitioner/${prescriberId}`,
+    };
+  }
+
+  // Dosage instruction — fields mirror the MedicationStatement shape so
+  // a single downstream renderer can handle both.
+  const dosage: DosageInstruction = {};
+  let hasDosage = false;
+
+  if (medication.frequency) {
+    dosage.timing = {
+      code: { text: medication.frequency },
+    };
+    hasDosage = true;
+  }
+
+  if (medication.route) {
+    const snomed = ROUTE_SNOMED[medication.route];
+    dosage.route = {
+      coding: snomed
+        ? [
+            {
+              system: "http://snomed.info/sct",
+              code: snomed.code,
+              display: snomed.display,
+            },
+          ]
+        : undefined,
+      text: medication.route,
+    };
+    hasDosage = true;
+  }
+
+  if (medication.dose_amount != null && medication.dose_unit) {
+    dosage.doseAndRate = [
+      {
+        doseQuantity: {
+          value: medication.dose_amount,
+          unit: medication.dose_unit,
+          system: "http://unitsofmeasure.org",
+          code: medication.dose_unit,
+        },
+      },
+    ];
+    hasDosage = true;
+  }
+
+  if (hasDosage) {
+    const parts: string[] = [];
+    if (medication.dose_amount != null && medication.dose_unit) {
+      parts.push(`${medication.dose_amount} ${medication.dose_unit}`);
+    }
+    if (medication.route) parts.push(medication.route);
+    if (medication.frequency) parts.push(medication.frequency);
+    dosage.text = parts.join(" ");
+    resource.dosageInstruction = [dosage];
+  }
+
+  return resource;
+}

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -1,0 +1,80 @@
+/**
+ * FHIR R4 Practitioner resource generator (issue #388).
+ *
+ * Maps internal `users` rows with clinical roles (physician, specialist,
+ * nurse) to the HL7 FHIR R4 Practitioner resource
+ * (https://hl7.org/fhir/R4/practitioner.html).
+ *
+ * Only clinical roles produce a Practitioner. Patients and admins are
+ * filtered out by the caller (see `isClinicalRole` below).
+ */
+
+import type { users } from "@carebridge/db-schema";
+import type { FhirPractitioner, HumanName } from "../types/fhir-r4.js";
+
+type UserRow = typeof users.$inferSelect;
+
+const CLINICAL_ROLES = new Set(["physician", "specialist", "nurse"]);
+
+/** True when the user row represents a clinician and should produce a Practitioner resource. */
+export function isClinicalRole(role: string): boolean {
+  return CLINICAL_ROLES.has(role);
+}
+
+/**
+ * Parse a free-text full name into FHIR HumanName's `family` + `given` fields.
+ *
+ * The users table stores name as a single string (e.g. "Sarah Jones" or
+ * "Sarah M. Jones, MD"). FHIR consumers expect a structured split so they
+ * can render `{given[0]} {family}` or `{family}, {given[0]}` to taste.
+ *
+ * Heuristic: the last whitespace-separated token is the family name; the
+ * preceding tokens are given names. Trailing credentials after a comma
+ * ("Jones, MD") are trimmed. Caller rows with a single-token name get the
+ * token as `family` with no `given`.
+ */
+function parseName(fullName: string): HumanName {
+  // Strip any trailing ", MD" / ", RN" / ", PhD" credentials.
+  const beforeComma = fullName.split(",")[0]!.trim();
+  const tokens = beforeComma.split(/\s+/).filter((t) => t.length > 0);
+
+  if (tokens.length === 0) {
+    return { text: fullName };
+  }
+  if (tokens.length === 1) {
+    return { text: fullName, family: tokens[0]! };
+  }
+  const family = tokens[tokens.length - 1]!;
+  const given = tokens.slice(0, -1);
+  return { text: fullName, family, given };
+}
+
+export function toFhirPractitioner(user: UserRow): FhirPractitioner {
+  const resource: FhirPractitioner = {
+    resourceType: "Practitioner",
+    id: user.id,
+    identifier: [
+      {
+        system: "urn:carebridge:users",
+        value: user.id,
+      },
+    ],
+    name: [parseName(user.name)],
+  };
+
+  // Qualification / specialty — surfaced as a text-only CodeableConcept.
+  // We intentionally avoid emitting a NUCC taxonomy code unless the
+  // internal table starts storing a coded value; a wrong code is worse
+  // for interop than an absent one.
+  if (user.specialty) {
+    resource.qualification = [
+      {
+        code: {
+          text: user.specialty,
+        },
+      },
+    ];
+  }
+
+  return resource;
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -429,8 +429,13 @@ export const fhirGatewayRouter = t.router({
         // recorded/historical view; both formats are emitted so bundles
         // round-trip cleanly in either direction.
         for (const med of patientMedications) {
+          // urn:uuid: values must be real UUIDs per RFC 4122; the earlier
+          // `urn:uuid:request-${id}` form is rejected by strict FHIR
+          // consumers. Generate a fresh UUID for the bundle-entry fullUrl;
+          // `resource.id` keeps `med.id` so cross-resource references
+          // (MedicationRequest.subject → Patient/{patientId}) stay stable.
           entry.push({
-            fullUrl: `urn:uuid:request-${med.id}`,
+            fullUrl: `urn:uuid:${crypto.randomUUID()}`,
             resource: toFhirMedicationRequest(med, patientId),
           });
         }

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -458,15 +458,25 @@ export const fhirGatewayRouter = t.router({
         }
 
         if (providerIds.size > 0) {
+          // Project only the columns toFhirPractitioner needs. A bare
+          // select() on users pulls password_hash, mfa_secret, and
+          // recovery_codes into memory for zero downstream use and risks
+          // surfacing them via heap dumps or incidental logging.
           const providerRows = await db
-            .select()
+            .select({
+              id: users.id,
+              name: users.name,
+              role: users.role,
+              specialty: users.specialty,
+              email: users.email,
+            })
             .from(users)
             .where(inArray(users.id, Array.from(providerIds)));
           for (const row of providerRows) {
             if (!isClinicalRole(row.role)) continue;
             entry.push({
               fullUrl: `urn:uuid:${row.id}`,
-              resource: toFhirPractitioner(row),
+              resource: toFhirPractitioner(row as unknown as Parameters<typeof toFhirPractitioner>[0]),
             });
           }
         }

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -13,8 +13,9 @@ import {
   allergies,
   encounters,
   procedures,
+  users,
 } from "@carebridge/db-schema";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, sql, inArray } from "drizzle-orm";
 import { createLogger } from "@carebridge/logger";
 import crypto from "node:crypto";
 import type { Vital, LabResult, User } from "@carebridge/shared-types";
@@ -27,6 +28,9 @@ import {
   toFhirAllergyIntolerance,
   toFhirEncounter,
   toFhirProcedure,
+  toFhirPractitioner,
+  isClinicalRole,
+  toFhirMedicationRequest,
 } from "./generators/index.js";
 import { fhirBundleSchema } from "./schemas/bundle.js";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
@@ -418,6 +422,48 @@ export const fhirGatewayRouter = t.router({
             fullUrl: `urn:uuid:${procedure.id}`,
             resource: toFhirProcedure(procedure, patientId),
           });
+        }
+
+        // Epic-compatible MedicationRequest resources for active/ordered
+        // medications (#388). MedicationStatement above remains for the
+        // recorded/historical view; both formats are emitted so bundles
+        // round-trip cleanly in either direction.
+        for (const med of patientMedications) {
+          entry.push({
+            fullUrl: `urn:uuid:request-${med.id}`,
+            resource: toFhirMedicationRequest(med, patientId),
+          });
+        }
+
+        // Practitioner resources — one per unique clinician referenced by
+        // any resource in the bundle (Encounter.participant,
+        // Procedure.performer, MedicationRequest.requester, or the
+        // medication-statement informationSource). Deduplicated by id.
+        const providerIds = new Set<string>();
+        for (const enc of patientEncounters) {
+          if (enc.provider_id) providerIds.add(enc.provider_id);
+        }
+        for (const proc of patientProcedures) {
+          if (proc.performed_by) providerIds.add(proc.performed_by);
+          if (proc.provider_id) providerIds.add(proc.provider_id);
+        }
+        for (const med of patientMedications) {
+          if (med.ordering_provider_id) providerIds.add(med.ordering_provider_id);
+          if (med.prescribed_by) providerIds.add(med.prescribed_by);
+        }
+
+        if (providerIds.size > 0) {
+          const providerRows = await db
+            .select()
+            .from(users)
+            .where(inArray(users.id, Array.from(providerIds)));
+          for (const row of providerRows) {
+            if (!isClinicalRole(row.role)) continue;
+            entry.push({
+              fullUrl: `urn:uuid:${row.id}`,
+              resource: toFhirPractitioner(row),
+            });
+          }
         }
 
         // HIPAA § 164.312(b): record the successful PHI egress AFTER the


### PR DESCRIPTION
## Summary

- `services/fhir-gateway/src/generators/practitioner.ts` — only clinical roles (physician / specialist / nurse) produce a Practitioner. Name parsed into family + given via last-token-is-family heuristic; credentials (\", MD\" / \", RN\") stripped from the split but preserved in `text`. Specialty → text-only qualification coding (no NUCC code until schema stores one)
- `services/fhir-gateway/src/generators/medication-request.ts` — intent always \"order\" (CareBridge meds are concrete prescriptions). Status narrowed to the MedicationRequest value set. requester prefers `ordering_provider_id`, falls back to `prescribed_by`
- `exportPatient`: emits MedicationRequest alongside MedicationStatement (distinct `fullUrl` prefix `request-<id>`) so Epic-style consumers see orders and recorded-history consumers see statements. Collects all unique provider ids from Encounter / Procedure / MedicationRequest references, fetches matching `users` rows, emits one deduplicated Practitioner each. Filters out non-clinical roles
- 14 new tests (7 practitioner + 11 medication-request) covering status mappings, name edge cases (credentials, middle names, single-token), RxNorm fallback, requester priority

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test` — 158/158
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — 22/22, no new warnings
- [x] Existing export-audit / headers / purge-warning tests still green (already handle the new parallel fetches via selectMock fallthrough)

Closes #388

**Depends on #922** via stacked branch order.