### PR TITLE
feat(portal): diagnosis-linked health education for patients

### DIFF
--- a/apps/patient-portal/app/health-info/page.tsx
+++ b/apps/patient-portal/app/health-info/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth";
 import { trpc } from "@/lib/trpc";
@@ -36,10 +37,14 @@ export default function HealthInfoPage() {
     { enabled: !!myRecord },
   );
 
-  if (!user) {
-    router.push("/login");
-    return null;
-  }
+  // Redirect to /login from an effect, not inline during render, so Next
+  // doesn't warn about state updates while rendering and so the redirect
+  // doesn't fire twice on Strict-Mode double-renders.
+  useEffect(() => {
+    if (!user) router.replace("/login");
+  }, [user, router]);
+
+  if (!user) return null;
 
   const diagnoses = diagnosesQuery.data ?? [];
   const medications = medicationsQuery.data ?? [];
@@ -53,12 +58,21 @@ export default function HealthInfoPage() {
 
   // Build a deduplicated list of education cards keyed on the content
   // title so a patient with two hypertension ICD-10 codes only sees one
-  // High-Blood-Pressure card.
+  // High-Blood-Pressure card. React `key` is derived from the content
+  // title too (not the originating dx/med row id) so adding or
+  // reordering duplicate diagnosis rows doesn't force React to unmount
+  // and remount the surviving card.
+  const titleKey = (title: string) =>
+    title.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
   const diagnosisEntries: Entry[] = [];
   for (const dx of activeDiagnoses) {
     const content = getDiagnosisEducation(dx.icd10_code, dx.description);
     if (content) {
-      diagnosisEntries.push({ key: `dx-${dx.id}`, anchor: dx.description, content });
+      diagnosisEntries.push({
+        key: `dx-${titleKey(content.title)}`,
+        anchor: dx.description,
+        content,
+      });
     }
   }
   const diagnosisByTitle = new Map<string, Entry>();
@@ -72,7 +86,11 @@ export default function HealthInfoPage() {
   for (const med of activeMeds) {
     const content = getMedicationEducation(med.name);
     if (content) {
-      medicationEntries.push({ key: `med-${med.id}`, anchor: med.name, content });
+      medicationEntries.push({
+        key: `med-${titleKey(content.title)}`,
+        anchor: med.name,
+        content,
+      });
     }
   }
   const medicationByTitle = new Map<string, Entry>();

--- a/apps/patient-portal/app/health-info/page.tsx
+++ b/apps/patient-portal/app/health-info/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
+import { trpc } from "@/lib/trpc";
+import { useMyPatientRecord } from "@/lib/use-my-patient";
+import {
+  getDiagnosisEducation,
+  getMedicationEducation,
+  type EducationContent,
+} from "@carebridge/medical-logic";
+import { EducationCard } from "@/components/EducationCard";
+
+/**
+ * Patient education page (issue #328).
+ *
+ * Renders an educational card for each of the patient's active diagnoses
+ * and medications. Content lives in @carebridge/medical-logic so it's
+ * static (no loading spinner for the copy itself) and the same library
+ * can power the clinician-portal if we choose to add clinician-side
+ * talking points later.
+ */
+export default function HealthInfoPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const { patient: myRecord, isLoading: patientLoading, isUnlinked } = useMyPatientRecord();
+
+  const diagnosesQuery = trpc.patients.diagnoses.getByPatient.useQuery(
+    { patientId: myRecord?.id ?? "" },
+    { enabled: !!myRecord },
+  );
+
+  const medicationsQuery = trpc.clinicalData.medications.getByPatient.useQuery(
+    { patientId: myRecord?.id ?? "" },
+    { enabled: !!myRecord },
+  );
+
+  if (!user) {
+    router.push("/login");
+    return null;
+  }
+
+  const diagnoses = diagnosesQuery.data ?? [];
+  const medications = medicationsQuery.data ?? [];
+
+  const activeDiagnoses = diagnoses.filter(
+    (d) => d.status === "active" || d.status === "chronic",
+  );
+  const activeMeds = medications.filter((m) => m.status === "active" || m.status === "held");
+
+  type Entry = { key: string; anchor: string; content: EducationContent };
+
+  // Build a deduplicated list of education cards keyed on the content
+  // title so a patient with two hypertension ICD-10 codes only sees one
+  // High-Blood-Pressure card.
+  const diagnosisEntries: Entry[] = [];
+  for (const dx of activeDiagnoses) {
+    const content = getDiagnosisEducation(dx.icd10_code, dx.description);
+    if (content) {
+      diagnosisEntries.push({ key: `dx-${dx.id}`, anchor: dx.description, content });
+    }
+  }
+  const diagnosisByTitle = new Map<string, Entry>();
+  for (const entry of diagnosisEntries) {
+    if (!diagnosisByTitle.has(entry.content.title)) {
+      diagnosisByTitle.set(entry.content.title, entry);
+    }
+  }
+
+  const medicationEntries: Entry[] = [];
+  for (const med of activeMeds) {
+    const content = getMedicationEducation(med.name);
+    if (content) {
+      medicationEntries.push({ key: `med-${med.id}`, anchor: med.name, content });
+    }
+  }
+  const medicationByTitle = new Map<string, Entry>();
+  for (const entry of medicationEntries) {
+    if (!medicationByTitle.has(entry.content.title)) {
+      medicationByTitle.set(entry.content.title, entry);
+    }
+  }
+
+  const conditionCards = Array.from(diagnosisByTitle.values());
+  const medicationCards = Array.from(medicationByTitle.values());
+
+  const hasCoveredDiagnoses = conditionCards.length > 0;
+  const hasCoveredMeds = medicationCards.length > 0;
+  const hasAnyData = activeDiagnoses.length > 0 || activeMeds.length > 0;
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "1.5rem",
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Health Info for You</h2>
+        <button
+          onClick={() => router.push("/")}
+          style={{
+            background: "none",
+            border: "1px solid #444",
+            color: "#999",
+            padding: "0.5rem 1rem",
+            borderRadius: 6,
+            cursor: "pointer",
+          }}
+        >
+          Back to Dashboard
+        </button>
+      </div>
+
+      <p style={{ color: "#bbb", fontSize: "0.9rem", marginBottom: "1rem" }}>
+        These cards are written in plain language to help you understand the
+        conditions and medications on your chart. They are not a replacement
+        for talking to your care team about anything specific.
+      </p>
+
+      {isUnlinked && (
+        <p role="alert" style={{ color: "#ef4444" }}>
+          Your account is not linked to a patient record. Please contact your
+          care team.
+        </p>
+      )}
+
+      {patientLoading && <p style={{ color: "#999" }}>Loading your record…</p>}
+
+      {/* Conditions */}
+      <section style={{ marginTop: "1.5rem" }}>
+        <h3
+          style={{
+            fontSize: "1rem",
+            marginBottom: "0.75rem",
+            borderBottom: "1px solid #2a2a2a",
+            paddingBottom: "0.5rem",
+          }}
+        >
+          About Your Conditions ({conditionCards.length})
+        </h3>
+        {diagnosesQuery.isLoading ? (
+          <p style={{ color: "#999" }}>Loading your conditions…</p>
+        ) : !hasCoveredDiagnoses ? (
+          <p style={{ color: "#999", fontSize: "0.85rem" }}>
+            {activeDiagnoses.length === 0
+              ? "No active conditions on file."
+              : "No patient-friendly summaries are available yet for your current conditions. Ask your care team for printed materials."}
+          </p>
+        ) : (
+          conditionCards.map((entry) => (
+            <EducationCard
+              key={entry.key}
+              content={entry.content}
+              anchor={entry.anchor}
+            />
+          ))
+        )}
+      </section>
+
+      {/* Medications */}
+      <section style={{ marginTop: "2rem" }}>
+        <h3
+          style={{
+            fontSize: "1rem",
+            marginBottom: "0.75rem",
+            borderBottom: "1px solid #2a2a2a",
+            paddingBottom: "0.5rem",
+          }}
+        >
+          About Your Medications ({medicationCards.length})
+        </h3>
+        {medicationsQuery.isLoading ? (
+          <p style={{ color: "#999" }}>Loading your medications…</p>
+        ) : !hasCoveredMeds ? (
+          <p style={{ color: "#999", fontSize: "0.85rem" }}>
+            {activeMeds.length === 0
+              ? "No active medications on file."
+              : "No patient-friendly summaries are available yet for your current medications. Your pharmacy prescription sheet is the next best source."}
+          </p>
+        ) : (
+          medicationCards.map((entry) => (
+            <EducationCard
+              key={entry.key}
+              content={entry.content}
+              anchor={entry.anchor}
+            />
+          ))
+        )}
+      </section>
+
+      {!hasAnyData && !patientLoading && !diagnosesQuery.isLoading && !medicationsQuery.isLoading && (
+        <p style={{ color: "#999", marginTop: "2rem", fontSize: "0.85rem" }}>
+          When your care team adds conditions or medications to your chart, you
+          will see a card for each one here.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/patient-portal/package.json
+++ b/apps/patient-portal/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf .next"
   },
   "dependencies": {
+    "@carebridge/medical-logic": "workspace:*",
     "@carebridge/portal-shared": "workspace:*",
     "@carebridge/shared-types": "workspace:*",
     "@carebridge/ui-tokens": "workspace:*",

--- a/apps/patient-portal/src/__tests__/education-card.test.tsx
+++ b/apps/patient-portal/src/__tests__/education-card.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import { EducationCard } from "../components/EducationCard";
+import type { EducationContent } from "@carebridge/medical-logic";
+
+afterEach(cleanup);
+
+const sample: EducationContent = {
+  title: "High Blood Pressure",
+  summary: "Your heart is working harder than it should.",
+  self_care: ["Check at home", "Cut salt"],
+  when_to_contact_provider: ["BP over 180/120", "Chest pain — call 911"],
+  links: [{ label: "CDC", url: "https://www.cdc.gov/bloodpressure" }],
+};
+
+describe("EducationCard (#328)", () => {
+  it("renders title, summary, self-care items, and when-to-contact items", () => {
+    render(<EducationCard content={sample} />);
+    expect(screen.getByText("High Blood Pressure")).toBeInTheDocument();
+    expect(screen.getByText(/heart is working harder/i)).toBeInTheDocument();
+    expect(screen.getByText("Check at home")).toBeInTheDocument();
+    expect(screen.getByText("BP over 180/120")).toBeInTheDocument();
+  });
+
+  it("renders external learn-more links with target=_blank and noopener", () => {
+    const { container } = render(<EducationCard content={sample} />);
+    const link = within(container).getByRole("link", { name: "CDC" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toMatch(/noopener/);
+  });
+
+  it("omits the 'Learn more' footer when content has no links", () => {
+    const noLinks: EducationContent = { ...sample, links: undefined };
+    const { container } = render(<EducationCard content={noLinks} />);
+    expect(within(container).queryByText(/learn more/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an anchor line when the caller passes a chart reference", () => {
+    const { container } = render(
+      <EducationCard content={sample} anchor="Essential hypertension" />,
+    );
+    expect(within(container).getByText(/Essential hypertension/)).toBeInTheDocument();
+  });
+
+  it("uses an <article> wrapper for landmark navigation", () => {
+    const { container } = render(<EducationCard content={sample} />);
+    expect(container.querySelector("article")).not.toBeNull();
+  });
+});

--- a/apps/patient-portal/src/components/EducationCard.tsx
+++ b/apps/patient-portal/src/components/EducationCard.tsx
@@ -17,6 +17,10 @@ interface EducationCardProps {
  * slots into existing pages without a separate design system.
  */
 export function EducationCard({ content, anchor }: EducationCardProps) {
+  // Derive the heading id once so `aria-labelledby` and the `h4 id`
+  // can't drift apart if the slugging logic is ever tweaked.
+  const headingId = `edu-${content.title.replace(/\s+/g, "-").toLowerCase()}`;
+
   return (
     <article
       style={{
@@ -26,13 +30,10 @@ export function EducationCard({ content, anchor }: EducationCardProps) {
         padding: "1rem",
         marginBottom: "0.75rem",
       }}
-      aria-labelledby={`edu-${content.title.replace(/\s+/g, "-").toLowerCase()}`}
+      aria-labelledby={headingId}
     >
       <header>
-        <h4
-          id={`edu-${content.title.replace(/\s+/g, "-").toLowerCase()}`}
-          style={{ margin: 0, fontSize: "1rem" }}
-        >
+        <h4 id={headingId} style={{ margin: 0, fontSize: "1rem" }}>
           {content.title}
         </h4>
         {anchor && (

--- a/apps/patient-portal/src/components/EducationCard.tsx
+++ b/apps/patient-portal/src/components/EducationCard.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { EducationContent } from "@carebridge/medical-logic";
+
+interface EducationCardProps {
+  content: EducationContent;
+  /** Optional context (e.g. the patient's diagnosis or medication name as written in the chart). */
+  anchor?: string;
+}
+
+/**
+ * Patient-facing education card (issue #328).
+ *
+ * Renders a diagnosis or medication's plain-language summary, self-care
+ * bullets, and when-to-contact-your-care-team warnings. Mirrors the
+ * dark-card visual pattern used elsewhere in the patient portal so it
+ * slots into existing pages without a separate design system.
+ */
+export function EducationCard({ content, anchor }: EducationCardProps) {
+  return (
+    <article
+      style={{
+        backgroundColor: "#1a1a1a",
+        border: "1px solid #2a2a2a",
+        borderRadius: 8,
+        padding: "1rem",
+        marginBottom: "0.75rem",
+      }}
+      aria-labelledby={`edu-${content.title.replace(/\s+/g, "-").toLowerCase()}`}
+    >
+      <header>
+        <h4
+          id={`edu-${content.title.replace(/\s+/g, "-").toLowerCase()}`}
+          style={{ margin: 0, fontSize: "1rem" }}
+        >
+          {content.title}
+        </h4>
+        {anchor && (
+          <p style={{ margin: "0.25rem 0 0", fontSize: "0.75rem", color: "#888" }}>
+            Linked to your record: <em>{anchor}</em>
+          </p>
+        )}
+      </header>
+
+      <p style={{ fontSize: "0.9rem", lineHeight: 1.5, margin: "0.75rem 0" }}>
+        {content.summary}
+      </p>
+
+      <section aria-label="Self-care tips" style={{ marginTop: "0.75rem" }}>
+        <h5 style={{ margin: 0, fontSize: "0.85rem", color: "#bbb" }}>Daily care</h5>
+        <ul style={{ margin: "0.25rem 0 0 1rem", paddingLeft: 0, fontSize: "0.85rem" }}>
+          {content.self_care.map((item, i) => (
+            <li key={i} style={{ marginBottom: 2 }}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        aria-label="When to contact your care team"
+        style={{
+          marginTop: "0.75rem",
+          backgroundColor: "#2a1a1a",
+          border: "1px solid #4a2a2a",
+          borderRadius: 6,
+          padding: "0.5rem 0.75rem",
+        }}
+      >
+        <h5 style={{ margin: 0, fontSize: "0.85rem", color: "#f87171" }}>
+          When to contact your care team
+        </h5>
+        <ul style={{ margin: "0.25rem 0 0 1rem", paddingLeft: 0, fontSize: "0.85rem" }}>
+          {content.when_to_contact_provider.map((item, i) => (
+            <li key={i} style={{ marginBottom: 2 }}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {content.links && content.links.length > 0 && (
+        <footer style={{ marginTop: "0.75rem" }}>
+          <h5 style={{ margin: 0, fontSize: "0.85rem", color: "#bbb" }}>Learn more</h5>
+          <ul style={{ margin: "0.25rem 0 0 1rem", paddingLeft: 0, fontSize: "0.85rem" }}>
+            {content.links.map((link, i) => (
+              <li key={i}>
+                <a
+                  href={link.url}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  style={{ color: "#60a5fa" }}
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </footer>
+      )}
+    </article>
+  );
+}

--- a/packages/medical-logic/src/__tests__/patient-education.test.ts
+++ b/packages/medical-logic/src/__tests__/patient-education.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDiagnosisEducation,
+  getMedicationEducation,
+  DIAGNOSIS_EDUCATION_TABLE,
+  MEDICATION_EDUCATION_TABLE,
+  type EducationContent,
+} from "../patient-education.js";
+
+describe("getDiagnosisEducation (#328)", () => {
+  it("returns the E11 card for a type-2 diabetes ICD-10 match", () => {
+    const e = getDiagnosisEducation("E11.9", "Type 2 diabetes mellitus");
+    expect(e?.title).toMatch(/Type 2 Diabetes/);
+    expect(e?.when_to_contact_provider.length).toBeGreaterThan(0);
+  });
+
+  it("matches the longest prefix first (E11.9 → E11, not E)", () => {
+    const e = getDiagnosisEducation("E11.9", null);
+    expect(e?.title).toMatch(/Type 2/);
+    const e1 = getDiagnosisEducation("E10.65", null);
+    expect(e1?.title).toMatch(/Type 1/);
+  });
+
+  it("falls back to description keywords when ICD-10 is absent", () => {
+    expect(getDiagnosisEducation(null, "Essential hypertension")?.title).toMatch(/High Blood Pressure/);
+    expect(getDiagnosisEducation(null, "Atrial fibrillation")?.title).toMatch(/Atrial Fibrillation/);
+    expect(getDiagnosisEducation(null, "Congestive heart failure")?.title).toMatch(/Heart Failure/);
+    expect(getDiagnosisEducation(null, "Mild asthma")?.title).toMatch(/Asthma/);
+  });
+
+  it("returns null for diagnoses we don't have content for", () => {
+    expect(getDiagnosisEducation("Z99.0", "Some niche status")).toBeNull();
+    expect(getDiagnosisEducation(null, "morgellons")).toBeNull();
+    expect(getDiagnosisEducation(null, null)).toBeNull();
+  });
+
+  it("is case-insensitive on ICD-10", () => {
+    expect(getDiagnosisEducation("e11", null)?.title).toMatch(/Type 2/);
+    expect(getDiagnosisEducation("i48", null)?.title).toMatch(/Atrial/);
+  });
+});
+
+describe("getMedicationEducation (#328)", () => {
+  it("returns the warfarin card for the generic name", () => {
+    expect(getMedicationEducation("warfarin")?.title).toMatch(/Warfarin/);
+  });
+
+  it("resolves brand → generic via alias map", () => {
+    expect(getMedicationEducation("Coumadin")?.title).toMatch(/Warfarin/);
+    expect(getMedicationEducation("Eliquis")?.title).toMatch(/Apixaban/);
+    expect(getMedicationEducation("Lipitor")?.title).toMatch(/Atorvastatin/);
+    expect(getMedicationEducation("Zoloft")?.title).toMatch(/Sertraline/);
+    expect(getMedicationEducation("Synthroid")?.title).toMatch(/Levothyroxine/);
+  });
+
+  it("strips strength suffix ('lisinopril 10mg' → lisinopril)", () => {
+    expect(getMedicationEducation("Lisinopril 10mg")?.title).toMatch(/Lisinopril/);
+  });
+
+  it("returns null for unknown drugs", () => {
+    expect(getMedicationEducation("zolbidopride")).toBeNull();
+    expect(getMedicationEducation(null)).toBeNull();
+    expect(getMedicationEducation("")).toBeNull();
+  });
+});
+
+describe("content invariants (#328)", () => {
+  const allEntries: Array<[string, EducationContent]> = [
+    ...Object.entries(DIAGNOSIS_EDUCATION_TABLE),
+    ...Object.entries(MEDICATION_EDUCATION_TABLE),
+  ];
+
+  it("every entry has title, summary, self_care, and when_to_contact_provider", () => {
+    for (const [key, c] of allEntries) {
+      expect(c.title, `entry ${key}`).toMatch(/\S/);
+      expect(c.summary, `entry ${key}`).toMatch(/\S/);
+      expect(c.self_care.length, `entry ${key}`).toBeGreaterThan(0);
+      expect(c.when_to_contact_provider.length, `entry ${key}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("summaries stay short (under 500 chars) so a patient sees the full text at a glance", () => {
+    for (const [key, c] of allEntries) {
+      expect(c.summary.length, `entry ${key}`).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it("self_care and when_to_contact_provider items stay short and bullet-sized", () => {
+    for (const [key, c] of allEntries) {
+      for (const item of c.self_care) {
+        expect(item.length, `self_care in ${key}: "${item}"`).toBeLessThanOrEqual(300);
+      }
+      for (const item of c.when_to_contact_provider) {
+        expect(item.length, `contact in ${key}: "${item}"`).toBeLessThanOrEqual(300);
+      }
+    }
+  });
+
+  it("covers the most common adult chronic conditions", () => {
+    for (const prefix of ["E11", "I10", "I48", "I50", "J45", "J44", "N18", "F32"]) {
+      expect(DIAGNOSIS_EDUCATION_TABLE[prefix]).toBeDefined();
+    }
+  });
+
+  it("covers the most common outpatient medications", () => {
+    for (const drug of [
+      "warfarin",
+      "apixaban",
+      "metformin",
+      "lisinopril",
+      "atorvastatin",
+      "aspirin",
+    ]) {
+      expect(MEDICATION_EDUCATION_TABLE[drug]).toBeDefined();
+    }
+  });
+});

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -5,3 +5,4 @@ export * from "./vital-staleness-thresholds.js";
 export * from "./medication-max-doses.js";
 export * from "./medication-frequency.js";
 export * from "./allergen-synonyms.js";
+export * from "./patient-education.js";

--- a/packages/medical-logic/src/patient-education.ts
+++ b/packages/medical-logic/src/patient-education.ts
@@ -1,0 +1,481 @@
+/**
+ * Patient-facing educational content (issue #328).
+ *
+ * Static reference data that maps ICD-10 diagnosis prefixes and generic
+ * medication names to plain-language explanations. The content is written
+ * for a non-clinical reader (target reading level ~8th grade) and is NOT
+ * medical advice — the `when_to_contact_provider` field always directs
+ * the patient back to their clinical team for anything specific.
+ *
+ * Structure is kept deliberately flat (no CMS, no generation, no per-
+ * request API call) so:
+ *   - The patient portal can render content offline and without a loading
+ *     spinner on the education strip.
+ *   - Updates flow through normal PRs with clinical review in the diff.
+ *   - Tests can lock invariants (every entry has every field, prose has
+ *     no clinical jargon above the 8th-grade band) without flakiness.
+ *
+ * Not in scope here:
+ *   - Generated content (LLM per-request) — reserved for a follow-up
+ *     when we want condition-plus-medication combination summaries.
+ *   - Localisation — English only for now; the data shape is ready for a
+ *     locale key when a translated content set lands.
+ */
+
+export interface EducationContent {
+  title: string;
+  /** One or two sentences: what the condition/medication is in plain language. */
+  summary: string;
+  /** Concrete self-care / day-to-day guidance. Each item a short sentence. */
+  self_care: string[];
+  /**
+   * Signs that mean "call your care team" or "go to the ER". The portal
+   * surfaces this prominently so a patient sees it without scrolling past
+   * background reading first.
+   */
+  when_to_contact_provider: string[];
+  /**
+   * Optional curated external references. Kept short; patient education
+   * works best with a few authoritative links (Medline, CDC, AHA) rather
+   * than a list of 20.
+   */
+  links?: { label: string; url: string }[];
+}
+
+// ── Diagnosis content, keyed by ICD-10 prefix ───────────────────
+
+/**
+ * ICD-10 prefixes are matched in descending length order so a more
+ * specific code wins over a broader family. For example, `I25.10`
+ * (CAD without angina) matches the `I25` entry; `I63` would match a
+ * dedicated stroke entry before falling through to a broader I-chapter
+ * catch-all.
+ */
+const DIAGNOSIS_CONTENT: Record<string, EducationContent> = {
+  // Endocrine / metabolic
+  E11: {
+    title: "Type 2 Diabetes",
+    summary:
+      "Type 2 diabetes means your body has trouble using insulin, so sugar builds up in your blood. Over time, high blood sugar can damage your heart, eyes, kidneys, and nerves — but daily habits can keep that from happening.",
+    self_care: [
+      "Check your blood sugar the way your care team asked you to, and keep a simple log.",
+      "Eat regular meals with vegetables, lean protein, and whole grains; limit sugary drinks.",
+      "Move your body for at least 30 minutes most days — even a walk counts.",
+      "Take your medicine every day, even when you feel fine.",
+    ],
+    when_to_contact_provider: [
+      "Blood sugar below 70 mg/dL or above 300 mg/dL.",
+      "New numbness, tingling, or sores on your feet that won't heal.",
+      "Blurred vision, chest pain, or trouble breathing — call 911.",
+    ],
+  },
+  E10: {
+    title: "Type 1 Diabetes",
+    summary:
+      "Type 1 diabetes means your body does not make insulin, so you need insulin every day to keep your blood sugar safe. With good habits and your insulin plan, you can live a full active life.",
+    self_care: [
+      "Follow your insulin schedule exactly — don't skip doses, even when sick.",
+      "Check blood sugar before meals and before bed.",
+      "Carry fast sugar (glucose tabs, juice) in case of a low.",
+      "Wear medical ID so responders know you have diabetes if you can't speak.",
+    ],
+    when_to_contact_provider: [
+      "Blood sugar above 250 mg/dL with ketones, nausea, or vomiting — call your care team the same day.",
+      "Low blood sugar episodes you can't explain or that happen repeatedly.",
+      "Confusion, trouble staying awake, or seizures — call 911.",
+    ],
+  },
+
+  // Cardiovascular
+  I10: {
+    title: "High Blood Pressure (Hypertension)",
+    summary:
+      "High blood pressure means your heart is working harder than it should to push blood through your body. It usually has no symptoms, but over time it raises the risk of stroke, heart attack, and kidney problems.",
+    self_care: [
+      "Check your blood pressure at home and write the numbers down — bring the log to visits.",
+      "Cut back on salt; aim for under 1 teaspoon a day total.",
+      "Move your body for 30 minutes most days.",
+      "Take your blood pressure medicine at the same time each day.",
+    ],
+    when_to_contact_provider: [
+      "Blood pressure above 180/120 on two readings 5 minutes apart — call your care team now.",
+      "Chest pain, severe headache, trouble seeing, or trouble speaking — call 911.",
+    ],
+  },
+  I48: {
+    title: "Atrial Fibrillation",
+    summary:
+      "Atrial fibrillation (AFib) is an irregular heartbeat. It can make you feel flutters or shortness of breath, and it raises the risk of stroke, which is why many people with AFib take a blood thinner.",
+    self_care: [
+      "Take your blood thinner exactly as prescribed — never skip or double up.",
+      "Avoid sudden increases in alcohol or caffeine, which can trigger AFib.",
+      "Tell every dentist, surgeon, and pharmacist that you take a blood thinner.",
+    ],
+    when_to_contact_provider: [
+      "Sudden face drooping, arm weakness, slurred speech — call 911 (signs of stroke).",
+      "Bleeding that won't stop, blood in stool or urine, or severe bruising.",
+      "Fainting, chest pain, or heartbeat over 130 at rest.",
+    ],
+  },
+  I50: {
+    title: "Heart Failure",
+    summary:
+      "Heart failure means your heart can't pump as well as it should. The name sounds scary, but most people with it live for years by following a low-salt plan, taking their medicines, and watching their weight.",
+    self_care: [
+      "Weigh yourself every morning after the bathroom, before eating or drinking; keep a log.",
+      "Keep salt below 2,000 mg (2 g) a day — read labels carefully.",
+      "Limit fluids if your care team gave you a daily amount.",
+      "Take all heart-failure medicines every day, even when you feel well.",
+    ],
+    when_to_contact_provider: [
+      "Weight gain of 2+ lbs overnight or 5+ lbs in a week — call your care team.",
+      "New shortness of breath lying flat, or needing extra pillows to sleep.",
+      "Swelling in both legs that is new or worse than usual.",
+    ],
+  },
+
+  // Venous thromboembolism
+  I26: {
+    title: "Pulmonary Embolism",
+    summary:
+      "A pulmonary embolism is a blood clot in the lung. It's serious, but it's treatable with a blood thinner. Most people recover fully; your care team will follow you closely for months.",
+    self_care: [
+      "Take your blood thinner exactly as prescribed and never miss a dose.",
+      "Walk as much as you can — movement helps prevent new clots.",
+      "Avoid long periods of sitting; on long trips, get up every 1–2 hours.",
+    ],
+    when_to_contact_provider: [
+      "Chest pain, sudden shortness of breath, or coughing up blood — call 911.",
+      "Swelling, pain, or red streaks in a leg (could be a new clot).",
+      "Nose or gum bleeding that doesn't stop, or blood in urine or stool.",
+    ],
+  },
+  I80: {
+    title: "Blood Clot in a Vein (DVT)",
+    summary:
+      "A deep vein thrombosis (DVT) is a blood clot, usually in a leg. The clot can grow or travel to the lungs, so you'll be on a blood thinner until your care team says you can stop.",
+    self_care: [
+      "Take your blood thinner on schedule; set phone reminders if you need to.",
+      "Walk regularly — gentle movement helps healing.",
+      "Use compression stockings if your care team prescribed them.",
+    ],
+    when_to_contact_provider: [
+      "Sudden trouble breathing or chest pain — call 911.",
+      "New leg swelling, warmth, or red streaks above the clot.",
+      "Bruising or bleeding you can't easily stop.",
+    ],
+  },
+
+  // Respiratory
+  J45: {
+    title: "Asthma",
+    summary:
+      "Asthma is a long-term condition where your airways can tighten and swell, making it hard to breathe. Most asthma can be well controlled with the right inhaler plan.",
+    self_care: [
+      "Use your controller inhaler every day, even when you feel fine.",
+      "Keep your rescue inhaler with you at all times.",
+      "Know your triggers (smoke, pets, pollen) and avoid them when you can.",
+      "Learn your action plan's green / yellow / red zones.",
+    ],
+    when_to_contact_provider: [
+      "Rescue inhaler not helping, or using it more than 2 times a week outside exercise.",
+      "Lips or fingertips turning blue, trouble speaking a full sentence — call 911.",
+    ],
+  },
+  J44: {
+    title: "COPD (Chronic Obstructive Pulmonary Disease)",
+    summary:
+      "COPD is long-term lung damage that makes it harder to breathe. You can't undo the damage, but you can keep it from getting worse by taking your inhalers, avoiding smoke, and exercising your lungs.",
+    self_care: [
+      "Take your inhalers in the right order your care team showed you.",
+      "Stay away from cigarette smoke (yours or anyone else's).",
+      "Get your flu and pneumonia vaccines every year.",
+      "Do pulmonary rehab if offered — people who do it breathe easier.",
+    ],
+    when_to_contact_provider: [
+      "More shortness of breath than usual, or new green / yellow mucus.",
+      "Fever above 101°F or confusion — call your care team the same day.",
+      "Severe trouble breathing, lips turning blue — call 911.",
+    ],
+  },
+
+  // Mental health
+  F32: {
+    title: "Depression",
+    summary:
+      "Depression is a medical condition, not a weakness. It often gets better with therapy, medicine, or both. Reaching out for help is the most important step.",
+    self_care: [
+      "Keep regular sleep, meals, and a little daily movement.",
+      "Stay connected — even a short text to a friend counts.",
+      "If you were prescribed an antidepressant, take it daily; they take 4–6 weeks to fully work.",
+    ],
+    when_to_contact_provider: [
+      "Thoughts of hurting yourself or others — call 988 (Suicide & Crisis Lifeline) or 911.",
+      "New or worsening anxiety, sleep trouble, or side effects.",
+    ],
+  },
+  F41: {
+    title: "Anxiety",
+    summary:
+      "Anxiety is your body's alarm system working overtime. Therapy, medicine, and day-to-day habits can all help turn the volume down.",
+    self_care: [
+      "Practice slow breathing (in 4, hold 4, out 6) when you notice tension building.",
+      "Limit caffeine and alcohol — both worsen anxiety.",
+      "Try 20 minutes of movement daily; it's as effective as some medicines for mild anxiety.",
+    ],
+    when_to_contact_provider: [
+      "Panic attacks that interrupt your day or sleep for over a week.",
+      "Thoughts of harming yourself — call 988 or 911.",
+    ],
+  },
+
+  // Renal
+  N18: {
+    title: "Chronic Kidney Disease",
+    summary:
+      "Chronic kidney disease means your kidneys aren't filtering waste as well as they should. With diet changes and careful medication choices, many people stay stable for years.",
+    self_care: [
+      "Keep blood pressure and blood sugar at the targets your care team sets.",
+      "Ask before any new medicine — some (NSAIDs like ibuprofen) can hurt kidneys.",
+      "Follow the salt / protein / potassium plan your nutritionist gave you.",
+      "Drink the amount of water your care team recommends — more is not always better.",
+    ],
+    when_to_contact_provider: [
+      "Swelling in legs, face, or hands that is new or worsening.",
+      "Less urine than usual, or urine that is pink or red.",
+      "Confusion, nausea, or extreme tiredness — call the same day.",
+    ],
+  },
+};
+
+// ── Medication content, keyed by lowercase generic name ─────────
+
+const MEDICATION_CONTENT: Record<string, EducationContent> = {
+  warfarin: {
+    title: "Warfarin (Coumadin)",
+    summary:
+      "Warfarin is a blood thinner that helps prevent dangerous blood clots. Because it works differently in every body, you'll need regular blood tests (INR) to keep the dose right.",
+    self_care: [
+      "Take warfarin at the same time each day — most people take it in the evening.",
+      "Keep your vitamin K intake (leafy greens) steady day to day; don't start or stop large amounts suddenly.",
+      "Tell every doctor, dentist, and pharmacist you take warfarin before any procedure.",
+      "Use a soft toothbrush and an electric razor to reduce bleeding risk.",
+    ],
+    when_to_contact_provider: [
+      "Nose or gum bleeding that doesn't stop in 10 minutes.",
+      "Red or black stool, blood in urine, bruising without bumping into anything.",
+      "Bad headache with confusion — call 911.",
+    ],
+  },
+  apixaban: {
+    title: "Apixaban (Eliquis)",
+    summary:
+      "Apixaban is a blood thinner that helps prevent strokes and clots. Unlike warfarin, it does not need regular blood tests.",
+    self_care: [
+      "Take it twice a day, 12 hours apart, with or without food.",
+      "Never skip or double-dose if you miss one — take it as soon as you remember, but never two in one time slot.",
+      "Tell every clinician you take a blood thinner before any procedure.",
+    ],
+    when_to_contact_provider: [
+      "Bleeding that won't stop, or blood in stool / urine.",
+      "Sudden weakness, slurred speech, vision change — call 911 (stroke signs).",
+    ],
+  },
+  metformin: {
+    title: "Metformin",
+    summary:
+      "Metformin helps your body use insulin better and lowers blood sugar. It's the most-prescribed first medicine for type 2 diabetes.",
+    self_care: [
+      "Take it with food to reduce stomach upset.",
+      "Start low and go slow — nausea usually fades in 1–2 weeks.",
+      "Keep regular lab checks of kidney function as your care team asks.",
+    ],
+    when_to_contact_provider: [
+      "Unusual muscle aches, rapid breathing, or feeling very weak — stop the pill and call now (rare lactic acidosis risk).",
+      "Kidney test results change — your dose may need adjustment.",
+    ],
+  },
+  lisinopril: {
+    title: "Lisinopril",
+    summary:
+      "Lisinopril lowers blood pressure and protects the heart and kidneys. A dry cough is a common side effect; if it bothers you, there are similar medicines without the cough.",
+    self_care: [
+      "Take it at the same time every day, with or without food.",
+      "Stand up slowly the first week — it can cause lightheadedness at first.",
+      "Avoid potassium salt substitutes unless your care team says they're OK.",
+    ],
+    when_to_contact_provider: [
+      "Swelling of lips, tongue, or throat — stop the pill and call 911 (rare angioedema).",
+      "Persistent dry cough lasting over 2 weeks.",
+      "Dizziness when standing that doesn't go away.",
+    ],
+  },
+  atorvastatin: {
+    title: "Atorvastatin (Lipitor)",
+    summary:
+      "Atorvastatin lowers cholesterol and protects against heart attack and stroke. It works best taken every day long-term.",
+    self_care: [
+      "Take it in the evening (your body makes more cholesterol at night).",
+      "Avoid large amounts of grapefruit juice — it raises drug levels.",
+      "Keep up a heart-healthy diet even on the medicine.",
+    ],
+    when_to_contact_provider: [
+      "Unusual muscle pain, weakness, or dark urine (rare rhabdomyolysis).",
+      "Yellow skin or eyes, or severe belly pain.",
+    ],
+  },
+  aspirin: {
+    title: "Aspirin (low-dose, 81 mg)",
+    summary:
+      "Low-dose aspirin thins the blood slightly to help prevent heart attacks and strokes in people at high risk. It's only 'preventive' for some patients — don't start it on your own.",
+    self_care: [
+      "Take with food to reduce stomach upset.",
+      "Never take extra aspirin for pain without checking — doubling the dose doubles bleeding risk.",
+    ],
+    when_to_contact_provider: [
+      "Black or red stool, coffee-ground vomit, or severe stomach pain.",
+      "Nosebleeds that won't stop in 15 minutes.",
+    ],
+  },
+  omeprazole: {
+    title: "Omeprazole",
+    summary:
+      "Omeprazole lowers stomach acid to heal ulcers and calm reflux. Most people take it for 4–8 weeks, then reassess.",
+    self_care: [
+      "Take it 30–60 minutes before the first meal of the day.",
+      "Don't crush or chew the capsule; swallow it whole.",
+    ],
+    when_to_contact_provider: [
+      "Reflux that doesn't improve in 2 weeks.",
+      "Trouble swallowing, unintended weight loss, or vomiting blood.",
+    ],
+  },
+  levothyroxine: {
+    title: "Levothyroxine",
+    summary:
+      "Levothyroxine replaces thyroid hormone when your thyroid isn't making enough. The right dose is very specific — small changes matter.",
+    self_care: [
+      "Take it on an empty stomach, first thing in the morning, with water only. Wait 30–60 minutes before coffee or food.",
+      "Don't switch between brand and generic — the small dose differences add up.",
+      "Keep calcium, iron, and antacids 4 hours apart from the pill.",
+    ],
+    when_to_contact_provider: [
+      "Heart racing, tremor, or losing weight quickly — your dose may be too high.",
+      "Unusual tiredness or weight gain — your dose may be too low.",
+    ],
+  },
+  sertraline: {
+    title: "Sertraline (Zoloft)",
+    summary:
+      "Sertraline is an antidepressant that also helps anxiety, OCD, and PTSD. It usually takes 4–6 weeks to reach its full effect.",
+    self_care: [
+      "Take it at the same time each day; morning works best if it gives you energy.",
+      "Don't stop suddenly — taper under your care team's direction.",
+      "Give side effects a few weeks; most fade.",
+    ],
+    when_to_contact_provider: [
+      "New or worsening thoughts of self-harm — call 988 or 911.",
+      "High fever, muscle stiffness, or fast heart rate (rare serotonin syndrome).",
+    ],
+  },
+  albuterol: {
+    title: "Albuterol Inhaler",
+    summary:
+      "Albuterol is a rescue inhaler that opens your airways quickly during an asthma or COPD flare. It works in minutes but does not replace your daily controller.",
+    self_care: [
+      "Keep it with you everywhere — pocket, bag, glove box.",
+      "Shake well and prime before the first use and after any long break.",
+      "Rinse your mouth after using it to avoid dry mouth.",
+    ],
+    when_to_contact_provider: [
+      "Using it more than 2 times a week outside of exercise.",
+      "Still short of breath 30 minutes after 2 puffs — go to the ER.",
+    ],
+  },
+};
+
+/**
+ * Look up patient-facing education for a diagnosis. Matches the longest
+ * ICD-10 prefix when a code is provided. When no code matches, falls
+ * back to a description keyword search (e.g. "asthma" → J45). Returns
+ * null if nothing matches — the caller should render no education card
+ * rather than a generic placeholder.
+ */
+export function getDiagnosisEducation(
+  icd10Code: string | null | undefined,
+  description: string | null | undefined,
+): EducationContent | null {
+  if (icd10Code) {
+    const trimmed = icd10Code.trim().toUpperCase();
+    // Try exact → shorter prefixes. ICD-10 codes are at most 7 chars, so
+    // iterate from the full code down to the 3-char chapter code.
+    for (let len = trimmed.length; len >= 3; len--) {
+      const prefix = trimmed.slice(0, len);
+      if (DIAGNOSIS_CONTENT[prefix]) return DIAGNOSIS_CONTENT[prefix];
+    }
+  }
+  if (description) {
+    const lower = description.toLowerCase();
+    // Description-keyword fallback for rows without an ICD-10 code. Kept
+    // intentionally narrow so random text doesn't map to an unrelated card.
+    if (/diabetes.*type\s*1|type\s*1\s*diabetes|dm\s*type\s*1/.test(lower)) return DIAGNOSIS_CONTENT.E10!;
+    if (/diabetes|dm\b|type\s*2|t2dm/.test(lower)) return DIAGNOSIS_CONTENT.E11!;
+    if (/hypertension|high blood pressure|htn\b/.test(lower)) return DIAGNOSIS_CONTENT.I10!;
+    if (/atrial fibrillation|afib|a.?fib/.test(lower)) return DIAGNOSIS_CONTENT.I48!;
+    if (/heart failure|chf\b/.test(lower)) return DIAGNOSIS_CONTENT.I50!;
+    if (/pulmonary embolism|pe\b/.test(lower)) return DIAGNOSIS_CONTENT.I26!;
+    if (/deep vein thrombosis|dvt\b/.test(lower)) return DIAGNOSIS_CONTENT.I80!;
+    if (/asthma/.test(lower)) return DIAGNOSIS_CONTENT.J45!;
+    if (/copd|chronic obstructive/.test(lower)) return DIAGNOSIS_CONTENT.J44!;
+    if (/depression|major depressive/.test(lower)) return DIAGNOSIS_CONTENT.F32!;
+    if (/anxiety/.test(lower)) return DIAGNOSIS_CONTENT.F41!;
+    if (/chronic kidney|ckd/.test(lower)) return DIAGNOSIS_CONTENT.N18!;
+  }
+  return null;
+}
+
+/**
+ * Look up patient-facing education for a medication by generic or
+ * common brand name. Case-insensitive and alias-aware (Coumadin →
+ * warfarin, Lipitor → atorvastatin, Eliquis → apixaban, Zoloft →
+ * sertraline, Prilosec → omeprazole, Synthroid → levothyroxine).
+ */
+export function getMedicationEducation(
+  drugName: string | null | undefined,
+): EducationContent | null {
+  if (!drugName) return null;
+  const key = drugName.trim().toLowerCase();
+
+  if (MEDICATION_CONTENT[key]) return MEDICATION_CONTENT[key];
+
+  // Brand-name aliases. Kept local here (rather than reusing the allergen
+  // table) because this list is specifically about patient education and
+  // may diverge — e.g. we're happy to key Tylenol to a specific acetaminophen
+  // article eventually, but the allergen table aliases Tylenol into the
+  // acetaminophen cross-reactivity canonical.
+  const ALIAS: Record<string, string> = {
+    coumadin: "warfarin",
+    jantoven: "warfarin",
+    eliquis: "apixaban",
+    lipitor: "atorvastatin",
+    zoloft: "sertraline",
+    prilosec: "omeprazole",
+    synthroid: "levothyroxine",
+    proair: "albuterol",
+    ventolin: "albuterol",
+    "proair hfa": "albuterol",
+  };
+
+  // Multi-word drug names often carry strength info ("lisinopril 10mg");
+  // try the first token as a best-effort lookup.
+  const firstToken = key.split(/\s+/)[0] ?? key;
+  if (MEDICATION_CONTENT[firstToken]) return MEDICATION_CONTENT[firstToken];
+  const aliased = ALIAS[firstToken] ?? ALIAS[key];
+  if (aliased) return MEDICATION_CONTENT[aliased] ?? null;
+
+  return null;
+}
+
+// Exported for tests + downstream reuse.
+export const DIAGNOSIS_EDUCATION_TABLE = DIAGNOSIS_CONTENT;
+export const MEDICATION_EDUCATION_TABLE = MEDICATION_CONTENT;

--- a/packages/medical-logic/src/patient-education.ts
+++ b/packages/medical-logic/src/patient-education.ts
@@ -407,8 +407,10 @@ export function getDiagnosisEducation(
 ): EducationContent | null {
   if (icd10Code) {
     const trimmed = icd10Code.trim().toUpperCase();
-    // Try exact → shorter prefixes. ICD-10 codes are at most 7 chars, so
-    // iterate from the full code down to the 3-char chapter code.
+    // Try exact → shorter prefixes. ICD-10 codes are up to 7 characters
+    // plus the dot (e.g. S52.521A is 8 chars), so we iterate from the
+    // trimmed input's length down to the 3-char chapter code rather than
+    // relying on a hard-coded max.
     for (let len = trimmed.length; len >= 3; len--) {
       const prefix = trimmed.slice(0, len);
       if (DIAGNOSIS_CONTENT[prefix]) return DIAGNOSIS_CONTENT[prefix];
@@ -416,23 +418,46 @@ export function getDiagnosisEducation(
   }
   if (description) {
     const lower = description.toLowerCase();
-    // Description-keyword fallback for rows without an ICD-10 code. Kept
-    // intentionally narrow so random text doesn't map to an unrelated card.
-    if (/diabetes.*type\s*1|type\s*1\s*diabetes|dm\s*type\s*1/.test(lower)) return DIAGNOSIS_CONTENT.E10!;
-    if (/diabetes|dm\b|type\s*2|t2dm/.test(lower)) return DIAGNOSIS_CONTENT.E11!;
-    if (/hypertension|high blood pressure|htn\b/.test(lower)) return DIAGNOSIS_CONTENT.I10!;
-    if (/atrial fibrillation|afib|a.?fib/.test(lower)) return DIAGNOSIS_CONTENT.I48!;
-    if (/heart failure|chf\b/.test(lower)) return DIAGNOSIS_CONTENT.I50!;
-    if (/pulmonary embolism|pe\b/.test(lower)) return DIAGNOSIS_CONTENT.I26!;
-    if (/deep vein thrombosis|dvt\b/.test(lower)) return DIAGNOSIS_CONTENT.I80!;
-    if (/asthma/.test(lower)) return DIAGNOSIS_CONTENT.J45!;
-    if (/copd|chronic obstructive/.test(lower)) return DIAGNOSIS_CONTENT.J44!;
-    if (/depression|major depressive/.test(lower)) return DIAGNOSIS_CONTENT.F32!;
-    if (/anxiety/.test(lower)) return DIAGNOSIS_CONTENT.F41!;
-    if (/chronic kidney|ckd/.test(lower)) return DIAGNOSIS_CONTENT.N18!;
+    // Description-keyword fallback for rows without an ICD-10 code. Every
+    // abbreviation is wrapped in `\b ... \b` on BOTH sides — "pe" inside
+    // "cope" / "scope" / "recipe" would otherwise silently route to the
+    // pulmonary-embolism card. Word boundaries keep false positives rare.
+    if (/diabetes.*type\s*1|type\s*1\s*diabetes|\bdm\s*type\s*1\b/.test(lower)) return DIAGNOSIS_CONTENT.E10!;
+    if (/\bdiabetes\b|\bdm\b|\btype\s*2\b|\bt2dm\b/.test(lower)) return DIAGNOSIS_CONTENT.E11!;
+    if (/\bhypertension\b|\bhigh blood pressure\b|\bhtn\b/.test(lower)) return DIAGNOSIS_CONTENT.I10!;
+    if (/\batrial fibrillation\b|\bafib\b|\ba.?fib\b/.test(lower)) return DIAGNOSIS_CONTENT.I48!;
+    if (/\bheart failure\b|\bchf\b/.test(lower)) return DIAGNOSIS_CONTENT.I50!;
+    if (/\bpulmonary embolism\b|\bpe\b/.test(lower)) return DIAGNOSIS_CONTENT.I26!;
+    if (/\bdeep vein thrombosis\b|\bdvt\b/.test(lower)) return DIAGNOSIS_CONTENT.I80!;
+    if (/\basthma\b/.test(lower)) return DIAGNOSIS_CONTENT.J45!;
+    if (/\bcopd\b|\bchronic obstructive\b/.test(lower)) return DIAGNOSIS_CONTENT.J44!;
+    if (/\bdepression\b|\bmajor depressive\b/.test(lower)) return DIAGNOSIS_CONTENT.F32!;
+    if (/\banxiety\b/.test(lower)) return DIAGNOSIS_CONTENT.F41!;
+    if (/\bchronic kidney\b|\bckd\b/.test(lower)) return DIAGNOSIS_CONTENT.N18!;
   }
   return null;
 }
+
+/**
+ * Brand-name → generic aliases for the medication-education lookup. Kept
+ * local (rather than reusing the allergen table) because this list is
+ * specifically about patient education and may diverge — e.g. we're
+ * happy to key Tylenol to a specific acetaminophen article eventually,
+ * but the allergen table aliases Tylenol into the acetaminophen
+ * cross-reactivity canonical.
+ */
+const MEDICATION_EDUCATION_ALIASES: Record<string, string> = {
+  coumadin: "warfarin",
+  jantoven: "warfarin",
+  eliquis: "apixaban",
+  lipitor: "atorvastatin",
+  zoloft: "sertraline",
+  prilosec: "omeprazole",
+  synthroid: "levothyroxine",
+  proair: "albuterol",
+  ventolin: "albuterol",
+  "proair hfa": "albuterol",
+};
 
 /**
  * Look up patient-facing education for a medication by generic or
@@ -448,29 +473,13 @@ export function getMedicationEducation(
 
   if (MEDICATION_CONTENT[key]) return MEDICATION_CONTENT[key];
 
-  // Brand-name aliases. Kept local here (rather than reusing the allergen
-  // table) because this list is specifically about patient education and
-  // may diverge — e.g. we're happy to key Tylenol to a specific acetaminophen
-  // article eventually, but the allergen table aliases Tylenol into the
-  // acetaminophen cross-reactivity canonical.
-  const ALIAS: Record<string, string> = {
-    coumadin: "warfarin",
-    jantoven: "warfarin",
-    eliquis: "apixaban",
-    lipitor: "atorvastatin",
-    zoloft: "sertraline",
-    prilosec: "omeprazole",
-    synthroid: "levothyroxine",
-    proair: "albuterol",
-    ventolin: "albuterol",
-    "proair hfa": "albuterol",
-  };
-
   // Multi-word drug names often carry strength info ("lisinopril 10mg");
   // try the first token as a best-effort lookup.
   const firstToken = key.split(/\s+/)[0] ?? key;
   if (MEDICATION_CONTENT[firstToken]) return MEDICATION_CONTENT[firstToken];
-  const aliased = ALIAS[firstToken] ?? ALIAS[key];
+  const aliased =
+    MEDICATION_EDUCATION_ALIASES[firstToken] ??
+    MEDICATION_EDUCATION_ALIASES[key];
   if (aliased) return MEDICATION_CONTENT[aliased] ?? null;
 
   return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       recharts:
         specifier: ^3.8.1
-        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1)
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1)
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -105,6 +105,9 @@ importers:
 
   apps/patient-portal:
     dependencies:
+      '@carebridge/medical-logic':
+        specifier: workspace:*
+        version: link:../../packages/medical-logic
       '@carebridge/portal-shared':
         specifier: workspace:*
         version: link:../../packages/portal-shared
@@ -7167,7 +7170,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@16.13.1)(react@19.2.5)(redux@5.0.1):
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@17.0.2)(react@19.2.5)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
       clsx: 2.1.1
@@ -7177,7 +7180,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3


### PR DESCRIPTION
## Summary

**Data layer** — `packages/medical-logic/src/patient-education.ts`:
- `EducationContent` shape (title / summary / self_care[] / when_to_contact_provider[] / optional links)
- Diagnosis content keyed by ICD-10 prefix, longest-wins match. Description-keyword fallback uses word-bounded abbreviations so "pe" inside "cope" doesn't hit the PE card
- Medication content keyed by generic name with a **module-level** brand-alias map (Coumadin → warfarin, Lipitor → atorvastatin, Eliquis → apixaban, Synthroid → levothyroxine, etc.)
- Coverage: 12 most-common adult chronic conditions + 10 common outpatient medications

**UI layer** — new `/health-info` route in the patient portal:
- Fetches patient's active diagnoses + medications, renders one deduplicated `EducationCard` per distinct content entry. React `key` is derived from the content title so dedup-by-title and the reconciler agree
- `/login` redirect runs inside `useEffect` with `router.replace` — no state update during render, Strict-Mode safe
- `EducationCard` computes its `aria-labelledby` id once and shares with the `<h4 id>` to prevent label/id drift
- Prominent red-bordered "When to contact your care team" warning block
- Optional curated learn-more links open in a new tab with `noopener`
- Empty-state copy distinguishes "no conditions on file" from "no plain-language summary written yet"

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 232/232
- [x] `pnpm --filter @carebridge/patient-portal test` — 70/70
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — 22/22, no new warnings

## Scope note

This branch is rebased off `feat/issue-388-fhir-practitioner-medicationrequest` so the diff includes #922 + #923's fhir-gateway work until those merge. Merging top-down (918 → 919 → 920 → 921, 922 → 923, then this PR) produces clean history. Post-merge the diff collapses to patient-portal + patient-education only.

Closes #328