### PR TITLE
fix(db): add clinical_flags.rule_id column in migration 0024 (#925)

### DIFF
--- a/packages/db-schema/drizzle/0024_flag_dedup_constraint.sql
+++ b/packages/db-schema/drizzle/0024_flag_dedup_constraint.sql
@@ -2,6 +2,12 @@
 -- Closes the TOCTOU race window in flag-service.ts where concurrent
 -- workers could both SELECT (no dup) then INSERT (two identical flags).
 
+-- Ensure rule_id column exists. It is defined in the Drizzle schema
+-- (packages/db-schema/src/schema/ai-flags.ts) but no prior migration
+-- adds it, so `pnpm db:migrate` against a fresh DB would error on
+-- the partial index below without this ALTER.
+ALTER TABLE clinical_flags ADD COLUMN IF NOT EXISTS rule_id text;
+
 -- Rule-based flags: only one open flag per (patient, rule) at a time.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_flags_open_rule_dedup
   ON clinical_flags (patient_id, rule_id)

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "node --test --import tsx src/__tests__/*.test.ts",
     "generate": "drizzle-kit generate",
     "migrate": "tsx src/migrate.ts",
     "clean": "rm -rf dist"

--- a/packages/db-schema/src/__tests__/migration-0024.test.ts
+++ b/packages/db-schema/src/__tests__/migration-0024.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const MIGRATION_PATH = join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "0024_flag_dedup_constraint.sql",
+);
+
+describe("migration 0024_flag_dedup_constraint", () => {
+  const sql = readFileSync(MIGRATION_PATH, "utf8");
+
+  it("adds clinical_flags.rule_id column before referencing it", () => {
+    const addColIdx = sql.search(
+      /ALTER\s+TABLE\s+clinical_flags\s+ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+rule_id/i,
+    );
+    const refIdx = sql.search(/idx_flags_open_rule_dedup/);
+
+    assert.ok(
+      addColIdx >= 0,
+      "migration must contain ADD COLUMN IF NOT EXISTS rule_id",
+    );
+    assert.ok(refIdx >= 0, "migration must contain partial index using rule_id");
+    assert.ok(
+      addColIdx < refIdx,
+      "ADD COLUMN must come before the partial index that references rule_id",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Prepend \`ALTER TABLE clinical_flags ADD COLUMN IF NOT EXISTS rule_id text;\` to \`0024_flag_dedup_constraint.sql\` so \`pnpm db:migrate\` succeeds against a fresh Postgres (was erroring with \"column rule_id does not exist\" when the partial unique index tried to reference it).
- Add a static-analysis guard test that ensures the ALTER TABLE appears before the partial index that references it.
- Wire the missing \`test\` script in \`packages/db-schema/package.json\` so the new guard (and the pre-existing encryption / hmac / mfa tests) actually run in CI via \`turbo test\`.

## Why this is safe for existing databases

The \`ADD COLUMN IF NOT EXISTS\` is idempotent — existing databases (where \`rule_id\` was added via a prior \`drizzle-kit push\`, schema sync, or manual DDL) are unaffected. Fresh databases now get the column before the partial index references it.

## Test plan

- [x] \`pnpm --filter @carebridge/db-schema test\` — 34 tests pass (9 suites)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [ ] \`pnpm db:migrate\` end-to-end against a fresh Postgres — blocked locally (docker not running); will verify in CI once \`TEST_DATABASE_URL\` is wired in a follow-up PR (tracked in #818 / #917 chain)

Closes #925