### PR TITLE
docs(medical-logic): clarify acetaminophen 4000 mg/day rationale (#928)

### DIFF
--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -52,12 +52,19 @@ export interface MedicationDoseLimit {
  */
 export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
   // ── NSAIDs / analgesics ─────────────────────────────────────────
+  // Acetaminophen daily ceiling is 4000 mg/day, matching the FDA prescription
+  // label for adults. Note McNeil voluntarily reduced the OTC Tylenol Extra
+  // Strength label to 3000 mg/day in 2011 as a safety margin for consumers
+  // self-medicating. CareBridge is a prescribing-safety tool — the clinician
+  // ceiling is 4000; the 3000 mg/day OTC figure is not applied here. If a
+  // future policy decision prefers the conservative OTC ceiling, drop this
+  // to 3000 and update the source string accordingly.
   acetaminophen: {
     displayName: "Acetaminophen",
     maxSingleDoseMg: 1000,
     warnSingleDoseMg: 650,
     maxDailyDoseMg: 4000,
-    source: "FDA label (McNeil, 2011 max-daily reduction)",
+    source: "FDA prescription label (adult acetaminophen, 4000 mg/day)",
   },
   ibuprofen: {
     displayName: "Ibuprofen",


### PR DESCRIPTION
## Summary

- Replace the ambiguous \`source\` string for acetaminophen (\"FDA label (McNeil, 2011 max-daily reduction)\") with the unambiguous \"FDA prescription label (adult acetaminophen, 4000 mg/day)\".
- Add a code comment explaining the distinction from McNeil's 2011 OTC Tylenol Extra Strength reduction to 3000 mg/day, so a future reviewer does not re-raise this question.

## Rationale

CareBridge is a prescribing-safety tool. The 4000 mg/day FDA prescription label ceiling is the correct bound for clinicians; the 3000 mg/day OTC figure is a consumer self-dosing safety margin and does not apply here. If a future policy decision prefers the more conservative OTC ceiling, the comment flags the call-site to update.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` — 332 tests pass
- [x] \`pnpm typecheck\` clean
- [x] No tests depend on the source string text

Closes #928