### PR TITLE
refactor(ai): extract opioid critical-ratio as named constants (#930)

### DIFF
--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -61,7 +61,7 @@ function slugForRuleId(name: string): string {
  * tolerant of over-threshold prescribing.
  *
  * If clinical teams want deployment-specific tuning (e.g. hospice vs
- * outpatient), follow-up #930 tracks exposing this as config. Until then
+ * outpatient), follow-up #968 tracks exposing this as config. Until then
  * any calibration change requires a deliberate code edit + review.
  */
 export const OPIOID_CRITICAL_RATIO = 1.2;

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -51,23 +51,37 @@ function slugForRuleId(name: string): string {
 }
 
 /**
- * Map the excess-ratio of estimated-over-max into a flag severity.
+ * Opioid daily-dose excess-ratio at which we escalate warning → critical.
  *
- * Opioids: the CDC 2022 guidance calibrates the per-drug daily caps in
- * MEDICATION_MAX_DAILY_DOSES to the 90 MME/day elevated-risk threshold.
- * Exceeding that cap by even 20% (1.2× → 108 MME) crosses into the zone
- * where respiratory-depression and overdose risk climbs steeply, so we
- * escalate to critical aggressively.
+ * CDC 2022 calibrates the per-drug daily caps in MEDICATION_MAX_DAILY_DOSES
+ * to the 90 MME/day elevated-risk threshold. Exceeding that cap by even 20%
+ * (1.2× → 108 MME) crosses into the zone where respiratory-depression and
+ * overdose risk climb steeply, so we escalate aggressively. Lowering this
+ * number makes the rule more sensitive; raising it makes the rule more
+ * tolerant of over-threshold prescribing.
  *
- * Non-opioid NSAID / analgesic over-limits cause cumulative rather than
- * acute harm (hepatic, renal, GI), so 1–2× is warning, ≥2× is critical.
+ * If clinical teams want deployment-specific tuning (e.g. hospice vs
+ * outpatient), follow-up #930 tracks exposing this as config. Until then
+ * any calibration change requires a deliberate code edit + review.
  */
+export const OPIOID_CRITICAL_RATIO = 1.2;
+
+/**
+ * Non-opioid NSAID / analgesic over-limits cause cumulative rather than
+ * acute harm (hepatic, renal, GI over weeks of over-dosing), so we use a
+ * gentler gradient: 1–2× is warning, ≥2× is critical.
+ */
+export const NON_OPIOID_CRITICAL_RATIO = 2.0;
+
+/** Map the excess-ratio of estimated-over-max into a flag severity. */
 function severityForDailyOver(
   ratio: number,
   isOpioid: boolean,
 ): FlagSeverity {
-  if (isOpioid) return ratio >= 1.2 ? "critical" : "warning";
-  return ratio >= 2.0 ? "critical" : "warning";
+  const critThreshold = isOpioid
+    ? OPIOID_CRITICAL_RATIO
+    : NON_OPIOID_CRITICAL_RATIO;
+  return ratio >= critThreshold ? "critical" : "warning";
 }
 
 export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {


### PR DESCRIPTION
## Summary

- Replace the inline 1.2 / 2.0 critical-severity thresholds in \`severityForDailyOver\` with module-level exports \`OPIOID_CRITICAL_RATIO\` and \`NON_OPIOID_CRITICAL_RATIO\`.
- Move the CDC 2022 rationale into docstrings on the constants themselves so it is visible at the call site of any future tuning change.
- Note on the opioid constant that deployment-configurable tuning is tracked in this issue's follow-up.

## Why

\"1.2\" was a load-bearing magic number with clinical reasoning — the CDC 90 MME/day elevated-risk threshold, plus a 20% margin before escalating to critical — buried in a function-level comment. Lifting it to a named constant makes the knob visible, review-able, and searchable.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 843 tests pass (no behaviour change)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean

Closes #930