### PR TITLE
docs(medical-logic): document AERD aspirin-NSAID fold tradeoff (#936)

### DIFF
--- a/packages/medical-logic/src/allergen-synonyms.ts
+++ b/packages/medical-logic/src/allergen-synonyms.ts
@@ -113,9 +113,13 @@ export const ALLERGEN_SYNONYMS: Record<string, string[]> = {
   //
   // Why: aspirin-exacerbated respiratory disease (AERD, Samter's triad)
   // means a documented aspirin allergy usually implies cross-reactivity
-  // to all non-selective NSAIDs. The safest default for a clinical-safety
-  // layer is to treat "allergic to aspirin" as "allergic to the NSAID
-  // class" rather than silently allow ibuprofen/naproxen/etc.
+  // to the NSAID class (classically non-selective NSAIDs; COX-2 agents
+  // like celecoxib are often tolerated in AERD but not reliably so).
+  // The safest default for a clinical-safety layer is to treat
+  // "allergic to aspirin" as "allergic to the NSAID class" — including
+  // celecoxib — rather than silently allow ibuprofen/naproxen/celecoxib/
+  // etc. Narrower COX-2 tolerance is a clinician-reviewed decision, not
+  // a synonym-layer default.
   //
   // Tradeoff: patients with true isolated aspirin hypersensitivity (not
   // AERD, not NSAID-class cross-reactive) will be over-flagged on other

--- a/packages/medical-logic/src/allergen-synonyms.ts
+++ b/packages/medical-logic/src/allergen-synonyms.ts
@@ -108,6 +108,29 @@ export const ALLERGEN_SYNONYMS: Record<string, string[]> = {
   ],
 
   // ── Analgesics ──────────────────────────────────────────────────
+  // AERD tradeoff: aspirin / ASA / acetylsalicylic acid are intentionally
+  // folded into the `nsaid` canonical rather than given a standalone class.
+  //
+  // Why: aspirin-exacerbated respiratory disease (AERD, Samter's triad)
+  // means a documented aspirin allergy usually implies cross-reactivity
+  // to all non-selective NSAIDs. The safest default for a clinical-safety
+  // layer is to treat "allergic to aspirin" as "allergic to the NSAID
+  // class" rather than silently allow ibuprofen/naproxen/etc.
+  //
+  // Tradeoff: patients with true isolated aspirin hypersensitivity (not
+  // AERD, not NSAID-class cross-reactive) will be over-flagged on other
+  // NSAIDs. The override-suppression mechanism in
+  // services/ai-oversight/src/rules/allergy-medication.ts handles the
+  // "clinician reviewed, approved, proceed" workflow for those patients.
+  //
+  // If a future policy splits aspirin into its own canonical, the
+  // migration path is: (1) add `aspirin: ["aspirin","asa",...]` here,
+  // (2) remove aspirin aliases from the `nsaid` entry, (3) move AERD
+  // cross-reactivity coverage to a rule-layer cross-reactivity map so
+  // it's not silently baked into synonym normalization.
+  //
+  // Ref: Szczeklik & Stevenson, "Aspirin-induced asthma: advances in
+  // pathogenesis, diagnosis, and management" (J Allergy Clin Immunol).
   nsaid: [
     "nsaid",
     "nsaids",


### PR DESCRIPTION
## Summary

- Add a block comment above the \`nsaid\` entry in \`ALLERGEN_SYNONYMS\` explaining the AERD clinical rationale for folding aspirin / ASA / acetylsalicylic acid into the NSAID canonical.
- Document the over-flag tradeoff for patients with true isolated aspirin hypersensitivity and how override-suppression in \`allergy-medication.ts\` covers that workflow.
- Include a concrete migration path if a future policy decision splits aspirin back out (standalone canonical + rule-layer cross-reactivity map).

## Why

PR #920 made a deliberate clinical-safety call (aspirin allergy → NSAID class flag) with the reasoning in the PR body and a test comment. A reviewer re-opening this question will look at \`allergen-synonyms.ts\` first, so that is where the rationale needs to live.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` — 332 tests pass (comment-only change)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean

Closes #936