### PR TITLE
refactor(fhir): use canonical URL system for Practitioner identifier (#942)

### DIFF
--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -42,7 +42,9 @@ describe("toFhirPractitioner (#388)", () => {
     const p = toFhirPractitioner(makeUser({ id: "prov-123" }));
     expect(p.resourceType).toBe("Practitioner");
     expect(p.id).toBe("prov-123");
-    expect(p.identifier?.[0]?.system).toBe("urn:carebridge:users");
+    expect(p.identifier?.[0]?.system).toBe(
+      "https://carebridge.dev/fhir/sid/user-id",
+    );
     expect(p.identifier?.[0]?.value).toBe("prov-123");
   });
 

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -49,13 +49,25 @@ function parseName(fullName: string): HumanName {
   return { text: fullName, family, given };
 }
 
+/**
+ * Canonical URL namespace for CareBridge-minted FHIR identifiers. Using
+ * a URL-form `system` rather than an ad-hoc `urn:` scheme is the shape
+ * Epic, Cerner, and other major EHRs are trained to recognise.
+ *
+ * Convention: append a domain-specific path segment (`/user-id`,
+ * `/patient-id`, `/encounter-id`, …) under this base so new resource
+ * generators reuse the same namespace root.
+ */
+export const CAREBRIDGE_IDENTIFIER_BASE =
+  "https://carebridge.dev/fhir/sid";
+
 export function toFhirPractitioner(user: UserRow): FhirPractitioner {
   const resource: FhirPractitioner = {
     resourceType: "Practitioner",
     id: user.id,
     identifier: [
       {
-        system: "urn:carebridge:users",
+        system: `${CAREBRIDGE_IDENTIFIER_BASE}/user-id`,
         value: user.id,
       },
     ],


### PR DESCRIPTION
## Summary

- Replace the ad-hoc \`urn:carebridge:users\` identifier system with a URL-form system: \`https://carebridge.dev/fhir/sid/user-id\`.
- Export \`CAREBRIDGE_IDENTIFIER_BASE\` constant so future resource generators (Patient, Organization, Location) reuse the same namespace root.

## Why

FHIR R4 permits URN systems, but URL-form systems are the shape external EHRs (Epic, Cerner) are trained to recognise. This is a free interop improvement with no behaviour change for internal consumers.

## Test plan

- [x] \`pnpm --filter @carebridge/fhir-gateway test\` — 163 tests pass (updated practitioner.test.ts assertion)
- [x] \`pnpm typecheck\` clean

Closes #942