### PR TITLE
feat(medical-logic): compute daily dose for non-canonical qNh intervals (#933)

### DIFF
--- a/packages/medical-logic/src/__tests__/medication-frequency.test.ts
+++ b/packages/medical-logic/src/__tests__/medication-frequency.test.ts
@@ -57,7 +57,8 @@ describe("parseFrequencyText (#235)", () => {
     // uninterpretable
     ["when sleepy", null],
     ["", null],
-    ["every 5 hours", null], // non-canonical interval → fail open
+    // Non-canonical q-N-hour intervals now parse to a QNHoursFrequency;
+    // see the dedicated "non-canonical qNh" describe block below.
     [" ", null],
   ];
 
@@ -70,6 +71,24 @@ describe("parseFrequencyText (#235)", () => {
   it("returns null for null/undefined", () => {
     expect(parseFrequencyText(null)).toBeNull();
     expect(parseFrequencyText(undefined)).toBeNull();
+  });
+});
+
+describe("parseFrequencyText non-canonical qNh intervals (#933)", () => {
+  for (const n of [1, 5, 7, 9, 10, 11, 13, 14, 16, 18, 20, 23]) {
+    it(`q${n}h → structured QNHoursFrequency with n=${n}`, () => {
+      expect(parseFrequencyText(`q${n}h`)).toEqual({ kind: "qNh", n });
+    });
+  }
+
+  it('"every 5 hours" parses to structured qNh', () => {
+    expect(parseFrequencyText("every 5 hours")).toEqual({ kind: "qNh", n: 5 });
+  });
+
+  it("q0h / q25h / q1000h fall outside [1,24] and fail open", () => {
+    expect(parseFrequencyText("q0h")).toBeNull();
+    expect(parseFrequencyText("q25h")).toBeNull();
+    expect(parseFrequencyText("q1000h")).toBeNull();
   });
 });
 
@@ -149,5 +168,33 @@ describe("estimateDailyDose (#235)", () => {
   it("explicit cap looser than scheduled frequency is ignored (frequency wins)", () => {
     // q4h is 6/day; cap of 10 doesn't expand the scheduled dose.
     expect(estimateDailyDose(10, "q4h", 10)).toBe(60);
+  });
+});
+
+describe("estimateDailyDose with non-canonical qNh (#933)", () => {
+  it("10 mg q5h → 48 mg/day (24/5 × 10)", () => {
+    const f = parseFrequencyText("q5h");
+    expect(estimateDailyDose(10, f)).toBe((24 / 5) * 10);
+  });
+
+  it("10 mg q10h → 24 mg/day (24/10 × 10)", () => {
+    const f = parseFrequencyText("q10h");
+    expect(estimateDailyDose(10, f)).toBe((24 / 10) * 10);
+  });
+
+  it("50 mg q16h → 75 mg/day (renal-dosing shape)", () => {
+    const f = parseFrequencyText("q16h");
+    expect(estimateDailyDose(50, f)).toBeCloseTo((24 / 16) * 50);
+  });
+
+  it("25 mg q18h → ~33.33 mg/day", () => {
+    const f = parseFrequencyText("q18h");
+    expect(estimateDailyDose(25, f)).toBeCloseTo((24 / 18) * 25);
+  });
+
+  it("explicit cap still wins for qNh prescriptions", () => {
+    const f = parseFrequencyText("q5h");
+    // q5h ≈ 4.8/day; cap of 3 overrides → 3 × 10.
+    expect(estimateDailyDose(10, f, 3)).toBe(30);
   });
 });

--- a/packages/medical-logic/src/__tests__/medication-frequency.test.ts
+++ b/packages/medical-logic/src/__tests__/medication-frequency.test.ts
@@ -197,4 +197,17 @@ describe("estimateDailyDose with non-canonical qNh (#933)", () => {
     // q5h ≈ 4.8/day; cap of 3 overrides → 3 × 10.
     expect(estimateDailyDose(10, f, 3)).toBe(30);
   });
+
+  it("returns null for hand-constructed QNHoursFrequency with invalid n", () => {
+    // QNHoursFrequency is exported; defend against non-parser callers or
+    // deserialized payloads that bypass parseFrequencyText's range guard.
+    expect(estimateDailyDose(10, { kind: "qNh", n: 0 })).toBeNull();
+    expect(estimateDailyDose(10, { kind: "qNh", n: 25 })).toBeNull();
+    expect(estimateDailyDose(10, { kind: "qNh", n: -3 })).toBeNull();
+    expect(estimateDailyDose(10, { kind: "qNh", n: Number.NaN })).toBeNull();
+    expect(estimateDailyDose(10, { kind: "qNh", n: 4.5 })).toBeNull();
+    expect(
+      estimateDailyDose(10, { kind: "qNh", n: Number.POSITIVE_INFINITY }),
+    ).toBeNull();
+  });
 });

--- a/packages/medical-logic/src/medication-frequency.ts
+++ b/packages/medical-logic/src/medication-frequency.ts
@@ -37,6 +37,28 @@ export type MedFrequency =
   | "prn"; // as-needed — no implicit daily count; caller must supply max_doses_per_day
 
 /**
+ * Non-canonical every-N-hours interval (e.g. q5h, q10h, q16h) for which we
+ * compute the daily multiplier dynamically rather than round to the nearest
+ * canonical slot. Real-world renal-dosing regimens do write these.
+ *
+ * `n` is an integer in [1, 24]. `n === 1` → q1h (24x/day) is allowed but
+ * unusual; `n > 24` is treated as unparseable (cross into q-N-days territory,
+ * handled separately).
+ */
+export interface QNHoursFrequency {
+  kind: "qNh";
+  n: number;
+}
+
+/**
+ * Discriminated union returned by {@link parseFrequencyText}. Callers that
+ * only care about daily-dose math should forward this straight to
+ * {@link estimateDailyDose}; callers that dispatch on frequency shape can
+ * narrow with `typeof f === "string"` vs `f.kind === "qNh"`.
+ */
+export type ParsedFrequency = MedFrequency | QNHoursFrequency;
+
+/**
  * Doses-per-24h multiplier for each structured frequency. `prn` is zero
  * here — PRN prescriptions must carry an explicit `max_doses_per_day`
  * for daily-sum estimation; otherwise the rule cannot bound the dose.
@@ -75,7 +97,7 @@ export const FREQUENCY_DOSES_PER_DAY: Record<MedFrequency, number> = {
  */
 export function parseFrequencyText(
   text: string | null | undefined,
-): MedFrequency | null {
+): ParsedFrequency | null {
   if (!text) return null;
   // Normalise: lowercase, collapse whitespace, drop punctuation that
   // shorthand forms commonly sprinkle in.
@@ -118,9 +140,14 @@ export function parseFrequencyText(
     if (n === 8) return "q8h";
     if (n === 12) return "q12h";
     if (n === 24) return "daily";
-    // Non-canonical intervals (e.g. q5h) — we could compute 24/n but
-    // clinicians rarely write these and being strict avoids false daily
-    // sums for odd values. Return null to fail open.
+    // Non-canonical intervals (q5h, q10h, q16h, q18h). Renal-dosing
+    // regimens do use these. The daily multiplier is well-defined for any
+    // positive integer N in [1, 24] — return a structured QNHoursFrequency
+    // so estimateDailyDose can compute 24/n rather than silently fail-open
+    // and miss overdoses that would have flagged on q8h.
+    if (Number.isInteger(n) && n >= 1 && n <= 24) {
+      return { kind: "qNh", n };
+    }
     return null;
   }
 
@@ -172,13 +199,20 @@ export function parseFrequencyText(
  */
 export function estimateDailyDose(
   doseAmount: number | null | undefined,
-  frequency: MedFrequency | null,
+  frequency: ParsedFrequency | null,
   maxDosesPerDay?: number | null,
 ): number | null {
   if (doseAmount == null || doseAmount <= 0) return null;
   if (frequency === null) return null;
 
-  let dosesPerDay = FREQUENCY_DOSES_PER_DAY[frequency];
+  let dosesPerDay: number;
+  if (typeof frequency === "string") {
+    dosesPerDay = FREQUENCY_DOSES_PER_DAY[frequency];
+  } else {
+    // QNHoursFrequency — compute 24/n dynamically. Parser guarantees
+    // n in [1, 24], so dosesPerDay is in [1, 24].
+    dosesPerDay = 24 / frequency.n;
+  }
 
   // PRN-only prescriptions must have an explicit cap to be boundable.
   if (frequency === "prn") {

--- a/packages/medical-logic/src/medication-frequency.ts
+++ b/packages/medical-logic/src/medication-frequency.ts
@@ -86,11 +86,16 @@ export const FREQUENCY_DOSES_PER_DAY: Record<MedFrequency, number> = {
 };
 
 /**
- * Parse a free-text frequency string into a {@link MedFrequency}.
+ * Parse a free-text frequency string into a {@link ParsedFrequency}.
  *
  * Handles: q2h / q 2 h / q2hr / q2hrs / every 2 hours / every 2h, bid, tid,
  * qid, qd / once daily / daily / once a day, weekly / q7d, monthly, stat /
- * once / one-time, prn / as needed.
+ * once / one-time, prn / as needed. Canonical every-N-hours strings in
+ * {q2,q3,q4,q6,q8,q12} map to a {@link MedFrequency}; q24 collapses to
+ * `daily`; any other integer N in [1,24] returns a structured
+ * {@link QNHoursFrequency} (`{ kind: "qNh", n }`) so `estimateDailyDose`
+ * can compute `24/n` rather than silently fail-open on renal-dosing
+ * intervals like q5h / q10h.
  *
  * Intentionally lenient on whitespace and punctuation. Returns null for
  * strings it cannot classify — callers treat that as "unknown, don't flag".
@@ -209,9 +214,14 @@ export function estimateDailyDose(
   if (typeof frequency === "string") {
     dosesPerDay = FREQUENCY_DOSES_PER_DAY[frequency];
   } else {
-    // QNHoursFrequency — compute 24/n dynamically. Parser guarantees
-    // n in [1, 24], so dosesPerDay is in [1, 24].
-    dosesPerDay = 24 / frequency.n;
+    // QNHoursFrequency — compute 24/n dynamically. The parser guarantees
+    // n in [1, 24], but QNHoursFrequency is exported and could be built
+    // by non-parser callers or deserialized from a queue payload, so
+    // defend against 0 / NaN / non-integer / out-of-range n rather than
+    // returning Infinity or NaN daily doses.
+    const n = frequency.n;
+    if (!Number.isInteger(n) || n < 1 || n > 24) return null;
+    dosesPerDay = 24 / n;
   }
 
   // PRN-only prescriptions must have an explicit cap to be boundable.


### PR DESCRIPTION
## Summary

- Add a structured \`QNHoursFrequency\` value and a widened \`ParsedFrequency\` discriminated union (\`MedFrequency | QNHoursFrequency\`).
- \`parseFrequencyText\` now returns \`{kind: \"qNh\", n}\` for any integer N in \`[1, 24]\` instead of silently returning \`null\` for intervals outside the canonical set (q2h / q3h / q4h / q6h / q8h / q12h / q24h).
- \`estimateDailyDose\` dispatches on the shape and computes \`24/n\` dynamically for \`QNHoursFrequency\`. Canonical \`MedFrequency\` strings still resolve via the fixed \`FREQUENCY_DOSES_PER_DAY\` table — no hot-path regression.

## Why

Renal-dosing regimens legitimately use q5h / q10h / q16h / q18h. Returning \`null\` for those meant the overdose-guard silently shed; a daily total that would have flagged on q8h slipped through on q10h. The daily multiplier is mathematically well-defined for any positive integer N ≤ 24 — refusing to compute it was leaking safety signal.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` — 350 tests pass (was 332; +18 covering qNh + sample renal-dosing shapes)
- [x] \`pnpm typecheck\` clean across the workspace (ai-oversight callers forward the structured value unchanged)
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 843 tests pass

Closes #933