### PR TITLE
fix(ai): GI bleed pattern false-positive on 'lower gi series' (#943)

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -215,6 +215,42 @@ describe("CROSS-ANTICOAG-NSAID-GIBLEED-001 — triple bleed risk (#263)", () => 
       ),
     ).toBeDefined();
   });
+
+  it("does NOT fire on 'Lower GI series' imaging history (#943 false positive)", () => {
+    const ctx = emptyCtx({
+      active_diagnoses: ["Lower GI series 2023, normal"],
+      active_medications: ["Warfarin 5mg daily", "Ibuprofen 400mg PRN"],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does NOT fire on 'Upper GI endoscopy normal' (#943 false positive)", () => {
+    const ctx = emptyCtx({
+      active_diagnoses: ["Upper GI endoscopy, normal"],
+      active_medications: ["Apixaban 5mg BID", "Naproxen 500mg BID"],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("still fires on 'Lower GI hemorrhage' (actual bleed phrasing)", () => {
+    const ctx = emptyCtx({
+      active_diagnoses: ["Lower GI hemorrhage, 2021"],
+      active_medications: ["Warfarin 5mg daily", "Aspirin 81mg daily"],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+      ),
+    ).toBeDefined();
+  });
 });
 
 describe("CROSS-IMMUNOSUPPRESSED-FEVER-001 — non-chemo immunosuppression + fever (#263)", () => {

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -1178,8 +1178,14 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     id: "CROSS-ANTICOAG-NSAID-GIBLEED-001",
     name: "Anticoagulant + NSAID with prior GI bleed history",
     check: (ctx: PatientContext) => {
+      // Require bleed/hemorrhage/hematochezia context for "upper gi" / "lower
+      // gi" mentions so imaging studies ("Lower GI series, normal 2023") and
+      // generic symptom blurbs ("upper GI symptoms") don't trigger a
+      // critical flag. Specific entities (peptic ulcer, variceal,
+      // angiodysplasia) stay bare because the diagnosis itself implies
+      // bleed risk in this clinical context.
       const GI_BLEED_HISTORY_PATTERN =
-        /gi bleed|gastrointestinal bleed|peptic ulcer|hematemesis|melena|upper gi|lower gi|diverticular bleed|angiodysplasia|variceal/i;
+        /gi bleed|gastrointestinal bleed|peptic ulcer|hematemesis|melena|hematochezia|(?:upper|lower)\s+gi\s+(?:bleed|hemorrhage|haemorrhage|hematemesis|melena|hematochezia)|diverticular bleed|angiodysplasia|variceal/i;
       // Deliberately include aspirin here (not part of NSAID_PATTERN because
       // other NSAID rules care about prostaglandin / renal-profile risks
       // where aspirin kinetics differ). For GI-bleed risk in


### PR DESCRIPTION
## Summary

- Tighten \`GI_BLEED_HISTORY_PATTERN\` in \`CROSS-ANTICOAG-NSAID-GIBLEED-001\` so bare \`upper gi\` / \`lower gi\` qualifiers only match when adjacent to a bleed keyword (\`bleed\`, \`hemorrhage\`, \`hematemesis\`, \`melena\`, \`hematochezia\`).
- Add \`hematochezia\` to the bare alternates (was missing).
- Add three tests covering the false-positive cases (\`Lower GI series 2023, normal\`, \`Upper GI endoscopy, normal\`) and a true-positive regression guard (\`Lower GI hemorrhage\`).

## Why

The prior pattern matched imaging-study history and reassuring endoscopy notes, escalating otherwise-acceptable anticoag + NSAID co-prescription to \`critical\`. For a rule surfacing in oncology and cardiology anticoag workflows, the FP rate at critical severity was too high.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 846 tests pass (was 843, +3 new cases)
- [x] \`pnpm typecheck\` clean

Closes #943