### PR TITLE
feat: split iodine from iodinated contrast (#934)

### DIFF
--- a/packages/medical-logic/src/allergen-synonyms.ts
+++ b/packages/medical-logic/src/allergen-synonyms.ts
@@ -235,12 +235,28 @@ export const ALLERGEN_SYNONYMS: Record<string, string[]> = {
     "iodinated contrast",
     "iv contrast",
     "contrast dye",
-    "iodine",
     "iohexol",
     "omnipaque",
     "iopamidol",
     "iodixanol",
     "visipaque",
+    "ioversol",
+    "optiray",
+  ],
+  // Elemental / topical iodine is a distinct canonical. Chart entries of
+  // "iodine allergy" are usually Betadine (povidone-iodine) skin-prep
+  // irritation or the "shellfish iodine" folk belief — NOT an IV contrast
+  // reaction. Cross-reactivity to iodinated contrast is linked at the
+  // rule layer (allergy-medication.ts) with a downgraded warning severity
+  // rather than conflated at the synonym layer, so a patient charted
+  // "allergic to iodine" doesn't get a critical contrast-CT flag.
+  iodine: [
+    "iodine",
+    "elemental iodine",
+    "betadine",
+    "povidone iodine",
+    "povidone-iodine",
+    "povidone",
   ],
   latex: ["latex", "natural rubber latex"],
 };

--- a/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
@@ -34,6 +34,11 @@ const CANONICAL_NAME: Record<string, string> = {
   benzodiazepine: "benzodiazepine",
   "iodinated contrast": "iodinated-contrast",
   latex: "latex",
+  // Iodine-to-contrast advisory (warning-severity cross-reactivity for
+  // charted bare "iodine" / Betadine) — same canonical class as true
+  // iodinated contrast, just a separate rule entry with a severity
+  // override. See #934 for the split rationale.
+  "iodine-contrast-advisory": "iodinated-contrast",
   // Shared (both maps use these directly)
   "ace-inhibitor": "ace-inhibitor",
   "iodinated-contrast": "iodinated-contrast",

--- a/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
@@ -38,7 +38,7 @@ const CANONICAL_NAME: Record<string, string> = {
   // charted bare "iodine" / Betadine) — same canonical class as true
   // iodinated contrast, just a separate rule entry with a severity
   // override. See #934 for the split rationale.
-  "iodine-contrast-advisory": "iodinated-contrast",
+  "iodine contrast advisory": "iodinated-contrast",
   // Shared (both maps use these directly)
   "ace-inhibitor": "ace-inhibitor",
   "iodinated-contrast": "iodinated-contrast",

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -113,7 +113,12 @@ export const CROSS_REACTIVITY_MAP: Array<{
     // hard critical flag on routine imaging orders.
     allergenPattern: /\b(iodine|betadine|povidone[-\s]?iodine)\b/i,
     medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
-    class: "iodine-contrast-advisory",
+    // Human-readable class label — appears verbatim in the flag's
+    // summary/rationale/suggested_action text shown to clinicians. Keep
+    // free of internal slugs. The canonical-name mapping in the
+    // cross-reactivity-sync test collapses this back to "iodinated-contrast"
+    // for LLM⇔rule symmetry.
+    class: "iodine contrast advisory",
     severityOverride: "warning",
   },
   {

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -26,6 +26,14 @@ export const CROSS_REACTIVITY_MAP: Array<{
   allergenPattern: RegExp;
   medicationPattern: RegExp;
   class: string;
+  /**
+   * Optional severity override. When present, the cross-reactivity flag is
+   * emitted at this severity regardless of the charted allergy severity.
+   * Used for ambiguous cross-reactivities (e.g. charted "iodine" → IV
+   * contrast) where a hard critical flag would over-escalate the common
+   * case (topical Betadine irritation).
+   */
+  severityOverride?: FlagSeverity;
 }> = [
   {
     allergenPattern: /penicillin|amoxicillin|ampicillin/i,
@@ -89,9 +97,24 @@ export const CROSS_REACTIVITY_MAP: Array<{
     class: "benzodiazepine",
   },
   {
-    allergenPattern: /contrast|iodine|iodinated/i,
-    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol/i,
+    // True iodinated-contrast allergy (IV radiocontrast) — keeps the
+    // default severity path (critical for severe/moderate charted
+    // allergies). Bare "iodine" is handled by the next entry at warning
+    // severity to avoid over-escalating topical-Betadine charts.
+    allergenPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
+    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
     class: "iodinated contrast",
+  },
+  {
+    // Charted "iodine" / Betadine / povidone-iodine — usually a topical
+    // skin-prep reaction or the shellfish-iodine folk belief, not a true
+    // IV contrast allergy. Still surface the combination but at warning
+    // severity so the clinician confirms intent rather than getting a
+    // hard critical flag on routine imaging orders.
+    allergenPattern: /\b(iodine|betadine|povidone[-\s]?iodine)\b/i,
+    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
+    class: "iodine-contrast-advisory",
+    severityOverride: "warning",
   },
   {
     allergenPattern: /latex/i,
@@ -261,7 +284,9 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
             break; // Already cleared — no flag for this cross-reactivity pair.
           }
           flags.push({
-            severity: mapAllergyToFlagSeverity(allergy.severity),
+            severity:
+              mapping.severityOverride ??
+              mapAllergyToFlagSeverity(allergy.severity),
             category: "medication-safety" as FlagCategory,
             summary: `Medication "${med}" may cross-react with allergy to "${allergy.allergen}" (${mapping.class} class)`,
             rationale:

--- a/services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts
+++ b/services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Iodine vs iodinated-contrast disambiguation (issue #934).
+ *
+ * Charted "iodine allergy" is usually topical Betadine irritation or the
+ * shellfish-iodine folk belief, not an IV radiocontrast reaction. The
+ * cross-reactivity table splits the two so:
+ *  - "iodinated contrast" allergen → contrast med → critical (default)
+ *  - "iodine" / "Betadine" allergen → contrast med → warning (advisory)
+ */
+import { describe, it, expect } from "vitest";
+import { checkAllergyMedication } from "./allergy-medication.js";
+import type { PatientContext } from "./cross-specialty.js";
+
+function ctxWithAllergyAndMed(
+  allergen: string,
+  med: string,
+  severity: "severe" | "moderate" | "mild" = "severe",
+): PatientContext {
+  return {
+    active_diagnoses: [],
+    active_diagnosis_codes: [],
+    active_medications: [med],
+    new_symptoms: [],
+    care_team_specialties: [],
+    allergies: [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        allergen,
+        severity,
+        reaction: "rash",
+      },
+    ],
+  };
+}
+
+describe("iodine vs iodinated-contrast disambiguation (#934)", () => {
+  it("iodinated contrast allergy + iohexol prescription → critical", () => {
+    const ctx = ctxWithAllergyAndMed(
+      "Iodinated contrast",
+      "Iohexol 350 mg/mL IV",
+      "severe",
+    );
+    const flags = checkAllergyMedication(ctx);
+    // Direct alias match (iohexol is in the "iodinated contrast" alias list)
+    // yields an ALLERGY-MED-DIRECT rule_id at critical severity for a
+    // severe charted allergy.
+    expect(flags.length).toBeGreaterThan(0);
+    expect(flags[0]!.severity).toBe("critical");
+  });
+
+  it("bare 'iodine' allergy + iohexol prescription → warning (not critical)", () => {
+    const ctx = ctxWithAllergyAndMed("Iodine", "Iohexol 350 mg/mL IV", "severe");
+    const flags = checkAllergyMedication(ctx);
+    const advisoryFlag = flags.find((f) =>
+      f.rule_id.includes("iodine-contrast-advisory"),
+    );
+    expect(advisoryFlag).toBeDefined();
+    expect(advisoryFlag!.severity).toBe("warning");
+  });
+
+  it("'Betadine' allergy + iohexol → warning advisory (topical ≠ IV)", () => {
+    const ctx = ctxWithAllergyAndMed("Betadine", "Iohexol 350 mg/mL IV", "severe");
+    const flags = checkAllergyMedication(ctx);
+    const advisoryFlag = flags.find((f) =>
+      f.rule_id.includes("iodine-contrast-advisory"),
+    );
+    expect(advisoryFlag).toBeDefined();
+    expect(advisoryFlag!.severity).toBe("warning");
+  });
+
+  it("'Povidone-iodine' allergy + iopamidol → warning advisory", () => {
+    const ctx = ctxWithAllergyAndMed(
+      "Povidone-iodine",
+      "Iopamidol 300 IV",
+      "moderate",
+    );
+    const flags = checkAllergyMedication(ctx);
+    const advisoryFlag = flags.find((f) =>
+      f.rule_id.includes("iodine-contrast-advisory"),
+    );
+    expect(advisoryFlag).toBeDefined();
+    expect(advisoryFlag!.severity).toBe("warning");
+  });
+
+  it("iodine allergy + oral (non-contrast) medication → no contrast flag", () => {
+    const ctx = ctxWithAllergyAndMed("Iodine", "Amoxicillin 500 mg PO", "severe");
+    const flags = checkAllergyMedication(ctx);
+    const contrastFlag = flags.find(
+      (f) =>
+        f.rule_id.includes("iodinated-contrast") ||
+        f.rule_id.includes("iodine-contrast-advisory"),
+    );
+    expect(contrastFlag).toBeUndefined();
+  });
+});

--- a/services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts
+++ b/services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts
@@ -52,7 +52,7 @@ describe("iodine vs iodinated-contrast disambiguation (#934)", () => {
     const ctx = ctxWithAllergyAndMed("Iodine", "Iohexol 350 mg/mL IV", "severe");
     const flags = checkAllergyMedication(ctx);
     const advisoryFlag = flags.find((f) =>
-      f.rule_id.includes("iodine-contrast-advisory"),
+      f.rule_id.includes("iodine contrast advisory"),
     );
     expect(advisoryFlag).toBeDefined();
     expect(advisoryFlag!.severity).toBe("warning");
@@ -62,7 +62,7 @@ describe("iodine vs iodinated-contrast disambiguation (#934)", () => {
     const ctx = ctxWithAllergyAndMed("Betadine", "Iohexol 350 mg/mL IV", "severe");
     const flags = checkAllergyMedication(ctx);
     const advisoryFlag = flags.find((f) =>
-      f.rule_id.includes("iodine-contrast-advisory"),
+      f.rule_id.includes("iodine contrast advisory"),
     );
     expect(advisoryFlag).toBeDefined();
     expect(advisoryFlag!.severity).toBe("warning");
@@ -76,7 +76,7 @@ describe("iodine vs iodinated-contrast disambiguation (#934)", () => {
     );
     const flags = checkAllergyMedication(ctx);
     const advisoryFlag = flags.find((f) =>
-      f.rule_id.includes("iodine-contrast-advisory"),
+      f.rule_id.includes("iodine contrast advisory"),
     );
     expect(advisoryFlag).toBeDefined();
     expect(advisoryFlag!.severity).toBe("warning");
@@ -87,8 +87,8 @@ describe("iodine vs iodinated-contrast disambiguation (#934)", () => {
     const flags = checkAllergyMedication(ctx);
     const contrastFlag = flags.find(
       (f) =>
-        f.rule_id.includes("iodinated-contrast") ||
-        f.rule_id.includes("iodine-contrast-advisory"),
+        f.rule_id.includes("iodinated contrast") ||
+        f.rule_id.includes("iodine contrast advisory"),
     );
     expect(contrastFlag).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

\`ALLERGEN_SYNONYMS\` conflated elemental/topical \"iodine\" and Betadine with IV radiocontrast media, producing a \`critical\` flag on routine contrast CT orders whenever a chart read \"allergic to iodine\" — which in practice usually meant Betadine skin irritation or the shellfish-iodine folk belief.

### Changes

- Split the allergen synonym map:
  - \`iodinated contrast\` keeps the IV-radiocontrast brand/generic aliases (iohexol, Omnipaque, Visipaque, iopamidol, iodixanol, ioversol, Optiray).
  - \`iodine\` is a new canonical covering bare iodine, Betadine, povidone-iodine.
- Add optional \`severityOverride\` to \`CROSS_REACTIVITY_MAP\`.
- Two rule entries for the contrast class:
  - True iodinated-contrast allergens → default severity (\`critical\` when the charted allergy is severe/moderate).
  - Bare iodine / Betadine allergens → \`severityOverride: \"warning\"\` so the advisory still surfaces but doesn't hard-flag as critical.

### Why warning, not suppressed

Elemental-iodine reactions are almost never true radiocontrast anaphylaxis, but the pairing still warrants clinician confirmation — a warning surfaces it without over-escalating the routine case.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 848 tests pass (was 843, +5 new cases covering iodine vs contrast)
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 332 tests pass
- [x] \`pnpm typecheck\` clean
- [x] Cross-reactivity-sync test passes (advisory class canonicalises to \`iodinated-contrast\`)

Closes #934