### PR TITLE
feat(ai): duration-gate CROSS-STEROID-PCP-001 (#940)

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -239,6 +239,83 @@ describe("CROSS-STEROID-PCP-001 — chronic corticosteroid without PCP prophylax
       ),
     ).toBeDefined();
   });
+
+  it("duration gate anchors to ctx.event_timestamp, not wall-clock (#940)", () => {
+    // Event happened 2026-01-01; steroid started 2025-12-25 (7 days prior
+    // to the event). Even though wall-clock `Date.now()` is well past that,
+    // the rule must evaluate duration against event_timestamp and suppress.
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          started_at: "2025-12-25T00:00:00.000Z",
+        },
+      ],
+      event_timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("event_timestamp anchoring: 35 days elapsed relative to event → fires (#940)", () => {
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          started_at: "2025-11-27T00:00:00.000Z", // 35d before event below
+        },
+      ],
+      event_timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeDefined();
+  });
+
+  it("future-dated started_at (data-entry typo) fails open — fires (#940)", () => {
+    // Start date recorded as after the event. Don't silently suppress on
+    // bad data; treat as unknown duration and fall through to fire.
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          started_at: "2026-06-01T00:00:00.000Z",
+        },
+      ],
+      event_timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeDefined();
+  });
 });
 
 describe("CROSS-ANTICOAG-NSAID-GIBLEED-001 — triple bleed risk (#263)", () => {

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -165,6 +165,80 @@ describe("CROSS-STEROID-PCP-001 — chronic corticosteroid without PCP prophylax
       ),
     ).toBeUndefined();
   });
+
+  // ── #940: duration-awareness gate ──────────────────────────────
+  it("prednisone 40 mg started 3 days ago (short burst) does NOT fire (#940)", () => {
+    const recentStart = new Date(
+      Date.now() - 3 * 86_400_000,
+    ).toISOString();
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          started_at: recentStart,
+        },
+      ],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("prednisone 40 mg started 35 days ago fires (past the 4-week gate) (#940)", () => {
+    const oldStart = new Date(Date.now() - 35 * 86_400_000).toISOString();
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          started_at: oldStart,
+        },
+      ],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeDefined();
+  });
+
+  it("unknown started_at fails open — chronic course without start metadata still fires (#940)", () => {
+    const ctx = emptyCtx({
+      active_medications: ["Prednisone 40mg daily"],
+      active_medications_detail: [
+        {
+          id: "m1",
+          name: "Prednisone",
+          dose_amount: 40,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "daily",
+          rxnorm_code: null,
+          // started_at undefined / not supplied
+        },
+      ],
+    });
+    expect(
+      checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      ),
+    ).toBeDefined();
+  });
 });
 
 describe("CROSS-ANTICOAG-NSAID-GIBLEED-001 — triple bleed risk (#263)", () => {

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -1160,12 +1160,21 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
         // course started < 28 days ago; fail-open (keep firing) when the
         // writer didn't record a start date, so chronic steroid courses
         // without start-date metadata still surface.
+        //
+        // Anchor to `ctx.event_timestamp` (not wall-clock) so replayed /
+        // backfilled / late-processed events evaluate deterministically —
+        // same pattern as the ONCO-VTE recency gate above. A start date in
+        // the future relative to the event (data-entry typo) is treated as
+        // unknown and falls through to fire (fail-open).
         const startedAt = systemicSteroidDetail.started_at;
         if (startedAt) {
           const startedMs = Date.parse(startedAt);
-          if (Number.isFinite(startedMs)) {
-            const daysSinceStart = (Date.now() - startedMs) / 86_400_000;
-            if (daysSinceStart < 28) return false;
+          const refMs = ctx.event_timestamp
+            ? Date.parse(ctx.event_timestamp)
+            : Date.now();
+          if (Number.isFinite(startedMs) && Number.isFinite(refMs)) {
+            const daysSinceStart = (refMs - startedMs) / 86_400_000;
+            if (daysSinceStart >= 0 && daysSinceStart < 28) return false;
           }
         }
       }

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -87,6 +87,12 @@ export interface PatientMedication {
   /** Optional PRN / hard-cap dose count per 24 h (not yet stored in DB). */
   max_doses_per_day?: number | null;
   rxnorm_code: string | null;
+  /**
+   * ISO 8601 prescription start date. Populated from `medications.started_at`
+   * when available. Absent when the writer never recorded a start date —
+   * rules should fail-open (don't rely on duration) in that case.
+   */
+  started_at?: string | null;
 }
 
 export interface PatientContext {
@@ -1143,6 +1149,24 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
             ) ?? perDoseEquiv;
 
           if (dailyEquiv < 20) return false;
+        }
+
+        // Duration gate (#940). IDSA/ATS require prednisone-equivalent
+        // >= 20 mg/day for >= 4 weeks before PCP prophylaxis is indicated.
+        // Short bursts (5–7 day tapers for asthma exacerbation, poison ivy,
+        // acute gout, COPD flare, etc.) routinely use 40–60 mg prednisone
+        // and would otherwise trip this rule with no real prophylaxis
+        // indication. Suppress fire when started_at is known and shows the
+        // course started < 28 days ago; fail-open (keep firing) when the
+        // writer didn't record a start date, so chronic steroid courses
+        // without start-date metadata still surface.
+        const startedAt = systemicSteroidDetail.started_at;
+        if (startedAt) {
+          const startedMs = Date.parse(startedAt);
+          if (Number.isFinite(startedMs)) {
+            const daysSinceStart = (Date.now() - startedMs) / 86_400_000;
+            if (daysSinceStart < 28) return false;
+          }
         }
       }
 

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -892,6 +892,9 @@ export async function buildPatientContextForRules(
       frequency: m.frequency ?? null,
       max_doses_per_day: null,
       rxnorm_code: m.rxnorm_code ?? null,
+      // Expose prescription start date for duration-aware rules (#940).
+      // Null when the writer never recorded a start — rules must fail-open.
+      started_at: m.started_at ?? null,
     })),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future


### PR DESCRIPTION
## Summary

- Extend \`PatientMedication\` with an optional \`started_at\` ISO timestamp.
- Populate it in \`review-service.buildPatientContextForRules\` from \`medications.started_at\` (column already exists in schema).
- In \`CROSS-STEROID-PCP-001\`, suppress the fire when \`started_at\` is known and the course started < 28 days ago. Fail-open (keep firing) when \`started_at\` is absent so chronic courses without start-date metadata still surface.

## Why

IDSA/ATS consensus requires prednisone-equivalent ≥ 20 mg/day **for ≥ 4 weeks** before PCP prophylaxis is indicated. Short bursts (5–7 day tapers for asthma exacerbation, poison ivy, acute gout, COPD flare) routinely use 40–60 mg prednisone; firing the rule on those is alert fatigue without a real prophylaxis indication.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 846 tests pass (+3 duration cases)
- [x] \`pnpm typecheck\` clean across workspace
- [x] Short burst (3 days ago) suppressed; 35-day course fires; missing \`started_at\` still fires (fail-open)

Closes #940