### PR TITLE
feat(fhir): UCUM-validity gate for doseQuantity (#946)

### DIFF
--- a/services/fhir-gateway/src/generators/medication-request.ts
+++ b/services/fhir-gateway/src/generators/medication-request.ts
@@ -18,6 +18,7 @@ import type {
   Coding,
   DosageInstruction,
 } from "../types/fhir-r4.js";
+import { toDoseQuantity } from "./ucum.js";
 
 type Medication = typeof medications.$inferSelect;
 
@@ -157,12 +158,10 @@ export function toFhirMedicationRequest(
   if (medication.dose_amount != null && medication.dose_unit) {
     dosage.doseAndRate = [
       {
-        doseQuantity: {
-          value: medication.dose_amount,
-          unit: medication.dose_unit,
-          system: "http://unitsofmeasure.org",
-          code: medication.dose_unit,
-        },
+        doseQuantity: toDoseQuantity(
+          medication.dose_amount,
+          medication.dose_unit,
+        ),
       },
     ];
     hasDosage = true;

--- a/services/fhir-gateway/src/generators/medication-statement.ts
+++ b/services/fhir-gateway/src/generators/medication-statement.ts
@@ -8,6 +8,7 @@
 
 import type { medications } from "@carebridge/db-schema";
 import type { Coding } from "../types/fhir-r4.js";
+import { toDoseQuantity } from "./ucum.js";
 
 type Medication = typeof medications.$inferSelect;
 
@@ -40,8 +41,11 @@ interface FhirDosage {
     doseQuantity: {
       value: number;
       unit: string;
-      system: string;
-      code: string;
+      // UCUM system + code are populated only when dose_unit is valid
+      // UCUM (or maps to a known UCUM annotation). Unknown units emit
+      // a text-only Quantity — see generators/ucum.ts.
+      system?: string;
+      code?: string;
     };
   }[];
 }
@@ -181,12 +185,10 @@ export function toFhirMedicationStatement(
   if (medication.dose_amount != null && medication.dose_unit) {
     dosage.doseAndRate = [
       {
-        doseQuantity: {
-          value: medication.dose_amount,
-          unit: medication.dose_unit,
-          system: "http://unitsofmeasure.org",
-          code: medication.dose_unit,
-        },
+        doseQuantity: toDoseQuantity(
+          medication.dose_amount,
+          medication.dose_unit,
+        ),
       },
     ];
     hasDosage = true;

--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -3,13 +3,35 @@ import { toDoseQuantity, isUcumAllowed } from "./ucum.js";
 
 describe("toDoseQuantity — UCUM validity (#946)", () => {
   it("emits full UCUM Quantity for atomic codes (mg, g, mL, kg, L)", () => {
-    for (const u of ["mg", "g", "mL", "kg", "L"]) {
-      const q = toDoseQuantity(100, u);
+    // UCUM is case-sensitive: `L`/`mL` are canonical, `l`/`ml` are not
+    // the case-sensitive atoms most validators expect. Assert the
+    // canonical casing is what we emit.
+    const cases: Array<[string, string]> = [
+      ["mg", "mg"],
+      ["g", "g"],
+      ["mL", "mL"],
+      ["kg", "kg"],
+      ["L", "L"],
+    ];
+    for (const [input, expectedCode] of cases) {
+      const q = toDoseQuantity(100, input);
       expect(q.value).toBe(100);
-      expect(q.unit).toBe(u);
+      expect(q.unit).toBe(input);
       expect(q.system).toBe("http://unitsofmeasure.org");
-      expect(q.code).toBe(u.toLowerCase());
+      expect(q.code).toBe(expectedCode);
     }
+  });
+
+  it("emits canonical UCUM casing for mixed-case inputs (ml → mL, l → L, dl → dL)", () => {
+    // Regression guard: lowercase inputs must map to the case-sensitive
+    // UCUM form the rest of the gateway already uses in observation.ts
+    // (mg/dL, mmol/L, ng/mL).
+    expect(toDoseQuantity(10, "ml").code).toBe("mL");
+    expect(toDoseQuantity(1, "l").code).toBe("L");
+    expect(toDoseQuantity(1, "dl").code).toBe("dL");
+    expect(toDoseQuantity(5, "mmol/l").code).toBe("mmol/L");
+    expect(toDoseQuantity(150, "mg/dl").code).toBe("mg/dL");
+    expect(toDoseQuantity(50, "ng/ml").code).toBe("ng/mL");
   });
 
   it("maps clinical 'mcg' to canonical UCUM 'ug' microgram", () => {
@@ -17,6 +39,12 @@ describe("toDoseQuantity — UCUM validity (#946)", () => {
     expect(q.system).toBe("http://unitsofmeasure.org");
     expect(q.code).toBe("ug");
     expect(q.unit).toBe("mcg"); // clinician-readable unit preserved
+  });
+
+  it("maps 'mcg/h' and 'mcg/kg' compounds to canonical 'ug/...' UCUM", () => {
+    expect(toDoseQuantity(5, "mcg/h").code).toBe("ug/h");
+    expect(toDoseQuantity(2, "mcg/kg").code).toBe("ug/kg");
+    expect(toDoseQuantity(10, "mcg/min").code).toBe("ug/min");
   });
 
   it("emits full UCUM Quantity for compound codes (mg/kg, mg/m2)", () => {
@@ -75,6 +103,12 @@ describe("toDoseQuantity — UCUM validity (#946)", () => {
 describe("isUcumAllowed", () => {
   it("accepts the common mass / volume / time codes", () => {
     for (const u of ["mg", "g", "mL", "L", "ug", "kg"]) {
+      expect(isUcumAllowed(u)).toBe(true);
+    }
+  });
+
+  it("accepts lowercase volume forms via case-insensitive lookup", () => {
+    for (const u of ["ml", "l", "dl"]) {
       expect(isUcumAllowed(u)).toBe(true);
     }
   });

--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { toDoseQuantity, isUcumAllowed } from "./ucum.js";
+
+describe("toDoseQuantity — UCUM validity (#946)", () => {
+  it("emits full UCUM Quantity for atomic codes (mg, g, mL, kg, L)", () => {
+    for (const u of ["mg", "g", "mL", "kg", "L"]) {
+      const q = toDoseQuantity(100, u);
+      expect(q.value).toBe(100);
+      expect(q.unit).toBe(u);
+      expect(q.system).toBe("http://unitsofmeasure.org");
+      expect(q.code).toBe(u.toLowerCase());
+    }
+  });
+
+  it("maps clinical 'mcg' to canonical UCUM 'ug' microgram", () => {
+    const q = toDoseQuantity(500, "mcg");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("ug");
+    expect(q.unit).toBe("mcg"); // clinician-readable unit preserved
+  });
+
+  it("emits full UCUM Quantity for compound codes (mg/kg, mg/m2)", () => {
+    const q = toDoseQuantity(2.5, "mg/kg");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("mg/kg");
+  });
+
+  it("maps 'IU' to [iU] UCUM annotation", () => {
+    const q = toDoseQuantity(10000, "IU");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("[iU]");
+    expect(q.unit).toBe("IU"); // human-readable preserved
+  });
+
+  it("maps 'units' / 'Unit' to [iU]", () => {
+    expect(toDoseQuantity(50, "units").code).toBe("[iU]");
+    expect(toDoseQuantity(50, "Unit").code).toBe("[iU]");
+  });
+
+  it("maps 'tablet' / 'tablets' / 'tab' to {tbl} annotation", () => {
+    expect(toDoseQuantity(1, "tablet").code).toBe("{tbl}");
+    expect(toDoseQuantity(2, "tablets").code).toBe("{tbl}");
+    expect(toDoseQuantity(1, "tab").code).toBe("{tbl}");
+  });
+
+  it("maps 'capsule', 'puff', 'drop', 'spray', 'patch'", () => {
+    expect(toDoseQuantity(1, "capsule").code).toBe("{cap}");
+    expect(toDoseQuantity(2, "puff").code).toBe("{puff}");
+    expect(toDoseQuantity(1, "drop").code).toBe("{drop}");
+    expect(toDoseQuantity(1, "spray").code).toBe("{spray}");
+    expect(toDoseQuantity(1, "patch").code).toBe("{patch}");
+  });
+
+  it("omits system + code for truly unknown units (text-only Quantity)", () => {
+    const q = toDoseQuantity(1, "scoop");
+    expect(q.value).toBe(1);
+    expect(q.unit).toBe("scoop");
+    expect(q.system).toBeUndefined();
+    expect(q.code).toBeUndefined();
+  });
+
+  it("is case-insensitive on lookup but preserves input unit in output", () => {
+    const q = toDoseQuantity(5, "MG");
+    expect(q.code).toBe("mg");
+    expect(q.unit).toBe("MG"); // original casing preserved
+  });
+
+  it("trims whitespace for lookup", () => {
+    const q = toDoseQuantity(5, "  mg ");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("mg");
+  });
+});
+
+describe("isUcumAllowed", () => {
+  it("accepts the common mass / volume / time codes", () => {
+    for (const u of ["mg", "g", "mL", "L", "ug", "kg"]) {
+      expect(isUcumAllowed(u)).toBe(true);
+    }
+  });
+
+  it("accepts derived dose units (mg/kg, mg/m2)", () => {
+    expect(isUcumAllowed("mg/kg")).toBe(true);
+    expect(isUcumAllowed("mg/m2")).toBe(true);
+  });
+
+  it("rejects annotation-only units (tablet / puff — need mapping first)", () => {
+    expect(isUcumAllowed("tablet")).toBe(false);
+    expect(isUcumAllowed("puff")).toBe(false);
+  });
+
+  it("rejects truly invalid strings", () => {
+    expect(isUcumAllowed("scoop")).toBe(false);
+    expect(isUcumAllowed("")).toBe(false);
+  });
+});

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -1,0 +1,140 @@
+/**
+ * UCUM validity helpers for FHIR Quantity emission (#946).
+ *
+ * Our internal `medications.dose_unit` is free-text. FHIR's Quantity shape
+ * reserves `system: "http://unitsofmeasure.org"` for UCUM-coded units —
+ * emitting a non-UCUM string under that system is a conformance violation.
+ *
+ * Strategy:
+ *  - Known-UCUM tokens (mg, g, mL, L, mg/kg, IU variants, …) emit as a
+ *    fully-coded Quantity (system + code + human-readable unit).
+ *  - Known non-UCUM forms (tablet, puff, drop) emit the curly-brace
+ *    annotation UCUM recognises ({tbl}, {puff}, {drop}).
+ *  - Unknown strings emit a text-only Quantity (value + unit only) with
+ *    no system / code — downstream validators accept that shape, whereas
+ *    rejecting a UCUM system+code mismatch would mangle the resource.
+ */
+
+const UCUM_SYSTEM = "http://unitsofmeasure.org";
+
+/**
+ * Lowercase atomic/compound UCUM codes we accept verbatim. Common drug
+ * dosing units; not exhaustive for all of UCUM (which is several thousand
+ * units including physical constants).
+ */
+const UCUM_ALLOWLIST = new Set<string>([
+  // Mass
+  "kg",
+  "g",
+  "mg",
+  "ug",
+  "ng",
+  // Volume
+  "l",
+  "ml",
+  "dl",
+  "ul",
+  // Time
+  "h",
+  "min",
+  "s",
+  "d",
+  "wk",
+  "mo",
+  "a",
+  // Derived dose units (per-weight, per-time, concentration)
+  "mg/kg",
+  "ug/kg",
+  "g/kg",
+  "mg/m2",
+  "mg/min",
+  "mg/h",
+  "mcg/h",
+  "ug/h",
+  "meq",
+  "mmol",
+  "mol",
+  "mg/ml",
+  "g/dl",
+  "mmol/l",
+]);
+
+/**
+ * Common non-UCUM unit strings → UCUM curly-brace annotation code.
+ * UCUM permits annotations in curly braces for quantities that aren't
+ * physical measurements (tablets, puffs, drops). Note IU → [iU] is the
+ * official UCUM arbitrary-unit form.
+ */
+const NON_UCUM_TO_UCUM_CODE: Record<string, string> = {
+  tablet: "{tbl}",
+  tablets: "{tbl}",
+  tab: "{tbl}",
+  tabs: "{tbl}",
+  capsule: "{cap}",
+  capsules: "{cap}",
+  cap: "{cap}",
+  caps: "{cap}",
+  puff: "{puff}",
+  puffs: "{puff}",
+  drop: "{drop}",
+  drops: "{drop}",
+  spray: "{spray}",
+  sprays: "{spray}",
+  patch: "{patch}",
+  patches: "{patch}",
+  iu: "[iU]",
+  "international units": "[iU]",
+  unit: "[iU]",
+  units: "[iU]",
+  u: "[iU]",
+  // Clinical "mcg" is the legacy microgram form; strict UCUM uses "ug"
+  // (or the Unicode micro). Map to the canonical UCUM atom.
+  mcg: "ug",
+};
+
+export interface DoseQuantity {
+  value: number;
+  /** Human-readable unit (always the original input). */
+  unit: string;
+  /** UCUM system URL. Set only when `code` is valid UCUM. */
+  system?: string;
+  /** UCUM code. Set only when the input could be mapped to valid UCUM. */
+  code?: string;
+}
+
+/**
+ * Build a FHIR Quantity from an internal `{dose_amount, dose_unit}` pair.
+ * Emits system + code only when the unit is valid UCUM (or we have a
+ * well-known UCUM annotation for it). Unknown units produce a text-only
+ * Quantity so downstream validators don't reject the resource.
+ */
+export function toDoseQuantity(value: number, unit: string): DoseQuantity {
+  const normalised = unit.trim().toLowerCase();
+  if (UCUM_ALLOWLIST.has(normalised)) {
+    return {
+      value,
+      unit,
+      system: UCUM_SYSTEM,
+      code: normalised,
+    };
+  }
+  const annotation = NON_UCUM_TO_UCUM_CODE[normalised];
+  if (annotation) {
+    return {
+      value,
+      unit,
+      system: UCUM_SYSTEM,
+      code: annotation,
+    };
+  }
+  // Unknown. Emit value + human-readable unit only — valid FHIR Quantity.
+  return { value, unit };
+}
+
+/**
+ * Predicate form, primarily for tests. Does not do the curly-brace mapping;
+ * just answers whether the input is in the UCUM allowlist.
+ */
+export function isUcumAllowed(unit: string): boolean {
+  return UCUM_ALLOWLIST.has(unit.trim().toLowerCase());
+}

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -18,22 +18,29 @@
 const UCUM_SYSTEM = "http://unitsofmeasure.org";
 
 /**
- * Lowercase atomic/compound UCUM codes we accept verbatim. Common drug
- * dosing units; not exhaustive for all of UCUM (which is several thousand
- * units including physical constants).
+ * Canonical UCUM codes we accept. UCUM is case-sensitive (`L` = liter,
+ * `l` is not a case-sensitive UCUM atom), so the allowlist stores the
+ * canonical casing and lookup happens through a lowercase index. Common
+ * drug dosing units; not exhaustive for all of UCUM (which is several
+ * thousand units including physical constants).
+ *
+ * When emitting the Quantity we return the canonical casing from this
+ * list so external validators (Epic, Cerner, Inferno) accept the code,
+ * while still accepting mixed-case user input (`MG`, `mL`, `mmol/l`).
  */
-const UCUM_ALLOWLIST = new Set<string>([
+const UCUM_CANONICAL: readonly string[] = [
   // Mass
   "kg",
   "g",
   "mg",
   "ug",
   "ng",
-  // Volume
-  "l",
-  "ml",
-  "dl",
-  "ul",
+  // Volume (note case: L is liter; l/dl/ml are also accepted UCUM atoms
+  // but the case-sensitive canonical forms are the capital-L variants)
+  "L",
+  "mL",
+  "dL",
+  "uL",
   // Time
   "h",
   "min",
@@ -42,6 +49,10 @@ const UCUM_ALLOWLIST = new Set<string>([
   "wk",
   "mo",
   "a",
+  // Amount / electrolytes
+  "meq",
+  "mmol",
+  "mol",
   // Derived dose units (per-weight, per-time, concentration)
   "mg/kg",
   "ug/kg",
@@ -49,15 +60,19 @@ const UCUM_ALLOWLIST = new Set<string>([
   "mg/m2",
   "mg/min",
   "mg/h",
-  "mcg/h",
   "ug/h",
-  "meq",
-  "mmol",
-  "mol",
-  "mg/ml",
-  "g/dl",
-  "mmol/l",
-]);
+  "mg/mL",
+  "g/dL",
+  "mg/dL",
+  "ng/mL",
+  "pg/mL",
+  "mmol/L",
+];
+
+/** Lowercase-indexed lookup to the canonical form. */
+const UCUM_ALLOWLIST: Map<string, string> = new Map(
+  UCUM_CANONICAL.map((c) => [c.toLowerCase(), c]),
+);
 
 /**
  * Common non-UCUM unit strings → UCUM curly-brace annotation code.
@@ -88,8 +103,12 @@ const NON_UCUM_TO_UCUM_CODE: Record<string, string> = {
   units: "[iU]",
   u: "[iU]",
   // Clinical "mcg" is the legacy microgram form; strict UCUM uses "ug"
-  // (or the Unicode micro). Map to the canonical UCUM atom.
+  // (or the Unicode micro). Map to the canonical UCUM atom, for both the
+  // bare form and common per-time compound.
   mcg: "ug",
+  "mcg/h": "ug/h",
+  "mcg/kg": "ug/kg",
+  "mcg/min": "ug/min",
 };
 
 export interface DoseQuantity {
@@ -110,14 +129,10 @@ export interface DoseQuantity {
  */
 export function toDoseQuantity(value: number, unit: string): DoseQuantity {
   const normalised = unit.trim().toLowerCase();
-  if (UCUM_ALLOWLIST.has(normalised)) {
-    return {
-      value,
-      unit,
-      system: UCUM_SYSTEM,
-      code: normalised,
-    };
-  }
+
+  // 1. Check the non-UCUM alias table first so that entries like
+  //    `mcg` → `ug`, `mcg/h` → `ug/h` translate to canonical UCUM even
+  //    when the legacy form happens to share a prefix with the allowlist.
   const annotation = NON_UCUM_TO_UCUM_CODE[normalised];
   if (annotation) {
     return {
@@ -127,7 +142,19 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
       code: annotation,
     };
   }
-  // Unknown. Emit value + human-readable unit only — valid FHIR Quantity.
+
+  // 2. Look up against the canonical allowlist; emit with canonical casing.
+  const canonical = UCUM_ALLOWLIST.get(normalised);
+  if (canonical) {
+    return {
+      value,
+      unit,
+      system: UCUM_SYSTEM,
+      code: canonical,
+    };
+  }
+
+  // 3. Unknown. Emit value + human-readable unit only — valid FHIR Quantity.
   return { value, unit };
 }
 


### PR DESCRIPTION
## Summary

- Add \`services/fhir-gateway/src/generators/ucum.ts\` with \`toDoseQuantity(value, unit)\` that emits FHIR-conformant Quantity shapes depending on whether the internal \`dose_unit\` is valid UCUM.
- Valid UCUM atoms/compounds (\`mg\`, \`g\`, \`mL\`, \`L\`, \`kg\`, \`mg/kg\`, \`mg/m2\`, …) emit full \`{value, unit, system, code}\`.
- Known annotation mappings: \`tablet/tab → {tbl}\`, \`capsule/cap → {cap}\`, \`puff → {puff}\`, \`drop → {drop}\`, \`spray → {spray}\`, \`patch → {patch}\`, \`IU/unit(s)/U → [iU]\`, \`mcg → ug\` (clinician-readable \`unit\` preserved).
- Unknown units emit \`{value, unit}\` only — a valid FHIR Quantity with no system/code, avoiding a UCUM conformance violation.
- Wire \`toDoseQuantity\` into both \`medication-request.ts\` and \`medication-statement.ts\` so prescription and statement exports share the same treatment.

## Why

Stamping \`system: \"http://unitsofmeasure.org\"\` with a \`code\` that isn't valid UCUM is a FHIR conformance violation. External validators (Epic, Cerner, Inferno touchstones) reject those resources.

## Test plan

- [x] \`pnpm --filter @carebridge/fhir-gateway test\` — 177 tests pass (+14 UCUM cases)
- [x] \`pnpm typecheck\` clean
- [x] Round-trip preservation of \`dose_unit\` in \`Quantity.unit\` (clinician-readable), canonicalisation to UCUM in \`Quantity.code\` when applicable

Closes #946