### PR TITLE
feat(db): persist medication max_doses_per_day + propagate to rules (#935)

### DIFF
--- a/packages/db-schema/drizzle/0041_medications_max_doses_per_day.sql
+++ b/packages/db-schema/drizzle/0041_medications_max_doses_per_day.sql
@@ -1,0 +1,8 @@
+-- #935: optional PRN / hard-cap dose count per 24 h on the medications table.
+--
+-- Populated when a prescription carries an explicit cap (e.g. "morphine 10 mg
+-- q4h PRN, max 4 doses/day"). Consumed by the ai-oversight worker via
+-- buildPatientContextForRules so PatientMedication.max_doses_per_day flows
+-- into estimateDailyDose and the PRN bound actually applies end-to-end.
+
+ALTER TABLE medications ADD COLUMN IF NOT EXISTS max_doses_per_day integer;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1747152000000,
       "tag": "0040_allergy_overrides_hardening",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1747238400000,
+      "tag": "0041_medications_max_doses_per_day",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, real, index, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, real, integer, index, jsonb } from "drizzle-orm/pg-core";
 import { encryptedText, encryptedNumeric } from "../encryption.js";
 import { patients } from "./patients.js";
 
@@ -11,6 +11,14 @@ export const medications = pgTable("medications", {
   dose_unit: text("dose_unit"),
   route: text("route"),
   frequency: text("frequency"),
+  /**
+   * Optional PRN / hard-cap dose count per 24 h. Populated when a
+   * prescription carries an explicit cap (e.g. "morphine 10 mg q4h PRN,
+   * max 4 doses/day"). Consumed by ai-oversight to bound PRN daily
+   * totals via estimateDailyDose; absent means PRN is unboundable and
+   * the rule fails open. See issue #935.
+   */
+  max_doses_per_day: integer("max_doses_per_day"),
   status: text("status").notNull().default("active"),
   started_at: text("started_at"),
   ended_at: text("ended_at"),

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -890,7 +890,10 @@ export async function buildPatientContextForRules(
       dose_unit: m.dose_unit ?? null,
       route: m.route ?? null,
       frequency: m.frequency ?? null,
-      max_doses_per_day: null,
+      // Populate from the persisted column (#935). Null when the writer
+      // didn't record a cap — PRN prescriptions stay unboundable and the
+      // rule fails open by design.
+      max_doses_per_day: m.max_doses_per_day ?? null,
       rxnorm_code: m.rxnorm_code ?? null,
     })),
     new_symptoms: newSymptoms,


### PR DESCRIPTION
## Summary

- Add \`medications.max_doses_per_day: integer | null\` via Drizzle migration 0041, with \`IF NOT EXISTS\` for safety against databases that pre-populated the column via \`drizzle-kit push\`.
- Journal entry for 0041.
- Propagate the persisted value through \`buildPatientContextForRules\` into \`PatientMedication.max_doses_per_day\`. Pre-fix this was hard-coded \`null\`, so \`estimateDailyDose\`'s PRN-cap branch (already unit-tested) had no production path — any real prescription for e.g. \"morphine 10 mg q4h PRN, max 4 doses/day\" collapsed to the unbounded branch.

## Out of scope (this PR)

This PR lands the DB column + rule plumbing. Two pieces remain and stay open under #935:

1. **Writer** — \`clinical-data\` service tRPC mutation schema needs to accept and persist the new field.
2. **FHIR ingest** — \`fhir-gateway\` import path should extract \`Dosage.maxDosePerPeriod\` from MedicationRequest/Statement bundles and map to the column.

Both are cleanly separable from the DB+rule work and reviewing them as distinct PRs is easier.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 843 tests pass (no regression)
- [x] \`pnpm --filter @carebridge/db-schema test\` — passes
- [x] \`pnpm typecheck\` clean across workspace

Refs #935