### PR TITLE
fix(ai): ASCII quotes in idempotency SQL + byte-exact test guard (#981, #982)

### DIFF
--- a/services/ai-oversight/src/__tests__/review-service-db-clock-idempotency.test.ts
+++ b/services/ai-oversight/src/__tests__/review-service-db-clock-idempotency.test.ts
@@ -186,7 +186,7 @@ describe("DB-clock interval derivation in idempotency probe", () => {
     expect(intervalCall).toBeDefined();
   });
 
-  it("embeds the interval in a NOW() - N * interval '1 second' template", async () => {
+  it("embeds the interval in a NOW() - N * interval '1 second' template with ASCII quotes only", async () => {
     try {
       await processReviewJob(makeEvent());
     } catch {
@@ -202,9 +202,40 @@ describe("DB-clock interval derivation in idempotency probe", () => {
     );
 
     expect(intervalCall).toBeDefined();
-    expect(intervalCall!.strings.join("")).toContain("NOW()");
-    expect(intervalCall!.strings.join("")).toContain("interval");
-    expect(intervalCall!.strings.join("")).toContain("1 second");
+
+    // Exact byte assertion on each template segment. The sql tag splits at
+    // each interpolation, so the cutoff `NOW() - ${windowSec} * interval '1 second'`
+    // produces strings = ["NOW() - ", " * interval '1 second'"]. Substring
+    // matching ("1 second", "interval") passes whether the quotes are ASCII
+    // (U+0027) or curly (U+2018/U+2019), and the latter makes Postgres reject
+    // the literal — see #981 / #982.
+    expect(intervalCall!.strings[0]).toBe("NOW() - ");
+    expect(intervalCall!.strings[1]).toBe(" * interval '1 second'");
+  });
+
+  it("rendered SQL contains no non-ASCII characters (guard against smart-quote substitution)", async () => {
+    try {
+      await processReviewJob(makeEvent());
+    } catch {
+      // Downstream mocks may throw
+    }
+
+    const intervalCall = sqlTemplateCalls.find(
+      (call) =>
+        call.strings.some((s) => s.includes("NOW()")) &&
+        call.strings.some((s) => s.includes("interval")),
+    );
+    expect(intervalCall).toBeDefined();
+
+    const rendered = intervalCall!.strings.join("");
+    // Code point check — anything outside printable ASCII (0x20-0x7E) plus
+    // standard whitespace (\t \n \r) fails. Curly quotes U+2018/U+2019 land
+    // in the > 0x7E band and trip this guard.
+    const nonAscii = [...rendered].filter((ch) => {
+      const cp = ch.codePointAt(0)!;
+      return !(cp === 9 || cp === 10 || cp === 13 || (cp >= 32 && cp <= 126));
+    });
+    expect(nonAscii).toEqual([]);
   });
 
   it("interval seconds match IN_FLIGHT_WINDOW_MS / 1000 (no hardcoded drift)", () => {

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -129,11 +129,11 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
   //   2) In-flight run: prior row in `processing` that is fresh
   //      (< IN_FLIGHT_WINDOW_MS old). Another worker is mid-pipeline for
   //      this event — running concurrently risks duplicate flags for any
-  //      rule whose open-flag dedup can’t span the race window. Stale
+  //      rule whose open-flag dedup can't span the race window. Stale
   //      `processing` rows (orphans from crashed workers) fall outside
   //      the window and do NOT short-circuit — matching the prior
   //      behavior for crash recovery. See #522.
-  const inFlightCutoff = sql`NOW() - ${IN_FLIGHT_WINDOW_SEC} * interval ‘1 second’`;
+  const inFlightCutoff = sql`NOW() - ${IN_FLIGHT_WINDOW_SEC} * interval '1 second'`;
 
   const existingJob = await db
     .select({


### PR DESCRIPTION
## Summary
- `review-service.ts:136` embedded U+2018/U+2019 curly quotes around `'1 second'` in the in-flight cutoff `sql\`...\`` — Postgres rejected the literal, the idempotency probe threw before writing the review_jobs row, BullMQ retried to exhaustion, every clinical event DLQ'd (including the DVT scenario)
- Replaced with ASCII U+0027 quotes; hexdump confirms `27 ... 27`
- Tightened the idempotency test from substring matching on English words ("interval", "1 second") to byte-exact equality on each tagged-template segment, plus a non-ASCII guard on the rendered SQL — smart-quote substitution from a paste cannot regress silently
- Normalized one curly apostrophe in an adjacent comment (benign, flagged by repo-wide grep)

## Why two issues in one PR
- The fix and the regression test are explicitly companions per the issue bodies — the test must FAIL before the fix and PASS after, so they ship together
- Confirmed locally: red on the strengthened test against the curly source, green after the ASCII fix

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test review-service-db-clock-idempotency` — 7/7 green
- [x] Hexdump of line 136: `... interval ' 1   s e c o n d ' ...` (0x27 ASCII)
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean (pre-existing portal warnings unchanged)
- [x] Repo-wide grep for `[‘’]` confirms no other occurrences left in `services/` or `packages/`

Closes #981
Closes #982