### PR TITLE
fix(scheduling): start reminder-worker process via src/server.ts (#984)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3

--- a/services/scheduling/package.json
+++ b/services/scheduling/package.json
@@ -7,6 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
   "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -27,6 +29,7 @@
     "@carebridge/test-utils": "workspace:*",
     "typescript": "^5.7.0",
     "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
     "vitest": "^3.0.0"
   }
 }

--- a/services/scheduling/src/__tests__/reminder-worker-server.test.ts
+++ b/services/scheduling/src/__tests__/reminder-worker-server.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Structural test for the reminder-worker entrypoint (#984).
+ *
+ * The worker factory `startReminderWorker` was exported but never invoked
+ * because the scheduling service had no server.ts. Jobs enqueued by
+ * `scheduleReminders` accumulated in Redis with no drainer. This test
+ * fails if either the entrypoint file or the `dev` script disappears so
+ * the regression can't recur silently.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const PACKAGE_ROOT = join(__dirname, "..", "..");
+const SERVER_PATH = join(PACKAGE_ROOT, "src", "server.ts");
+const PACKAGE_JSON_PATH = join(PACKAGE_ROOT, "package.json");
+
+describe("scheduling service worker entrypoint (#984)", () => {
+  it("has src/server.ts that imports and invokes startReminderWorker", () => {
+    expect(existsSync(SERVER_PATH)).toBe(true);
+    const source = readFileSync(SERVER_PATH, "utf8");
+    expect(source).toMatch(/from\s+["']\.\/workers\/reminder-worker\.js["']/);
+    expect(source).toMatch(/startReminderWorker\s*\(/);
+  });
+
+  it("registers a SIGTERM handler so the BullMQ worker shuts down cleanly", () => {
+    const source = readFileSync(SERVER_PATH, "utf8");
+    expect(source).toMatch(/process\.on\(\s*["']SIGTERM["']/);
+  });
+
+  it("package.json has a dev script that runs the entrypoint", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const devScript = pkg.scripts?.dev;
+    expect(devScript).toBeDefined();
+    expect(devScript).toMatch(/src\/server\.ts/);
+  });
+
+  it("package.json has a start script that runs the built entrypoint", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    expect(pkg.scripts?.start).toBeDefined();
+    expect(pkg.scripts?.start).toMatch(/dist\/server\.js/);
+  });
+});

--- a/services/scheduling/src/server.ts
+++ b/services/scheduling/src/server.ts
@@ -19,17 +19,25 @@ const worker = startReminderWorker();
 const REDIS_PING_TIMEOUT_MS = 2_000;
 
 async function checkRedis(): Promise<"connected" | "disconnected"> {
+  let timer: NodeJS.Timeout | undefined;
   try {
     const client = await worker.client;
     const result = await Promise.race([
       client.ping(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("timeout")), REDIS_PING_TIMEOUT_MS),
-      ),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("timeout")),
+          REDIS_PING_TIMEOUT_MS,
+        );
+      }),
     ]);
     return result === "PONG" ? "connected" : "disconnected";
   } catch {
     return "disconnected";
+  } finally {
+    // Cancel the timeout when ping resolves first so we don't leak a
+    // 2-second pending timer (and an unhandled-rejection) per /health hit.
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/services/scheduling/src/server.ts
+++ b/services/scheduling/src/server.ts
@@ -1,0 +1,72 @@
+/**
+ * Scheduling worker entrypoint (#984).
+ *
+ * Starts the BullMQ reminder worker so jobs enqueued by `scheduleReminders`
+ * are actually drained. Exposes a minimal `/health` endpoint for orchestrators
+ * to verify liveness alongside Redis reachability.
+ */
+
+import { createServer } from "node:http";
+import { createLogger } from "@carebridge/logger";
+import { startReminderWorker } from "./workers/reminder-worker.js";
+
+const log = createLogger("scheduling");
+
+const HEALTH_PORT = Number(process.env.SCHEDULING_HEALTH_PORT ?? 4003);
+
+const worker = startReminderWorker();
+
+const REDIS_PING_TIMEOUT_MS = 2_000;
+
+async function checkRedis(): Promise<"connected" | "disconnected"> {
+  try {
+    const client = await worker.client;
+    const result = await Promise.race([
+      client.ping(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("timeout")), REDIS_PING_TIMEOUT_MS),
+      ),
+    ]);
+    return result === "PONG" ? "connected" : "disconnected";
+  } catch {
+    return "disconnected";
+  }
+}
+
+const healthServer = createServer(async (req, res) => {
+  if (req.url === "/health" && req.method === "GET") {
+    const redis = await checkRedis();
+    const workerOk = worker.isRunning() && !worker.isPaused();
+    const isHealthy = workerOk && redis === "connected";
+    res.writeHead(isHealthy ? 200 : 503, {
+      "Content-Type": "application/json",
+    });
+    res.end(
+      JSON.stringify({
+        status: isHealthy ? "healthy" : "unhealthy",
+        service: "scheduling-worker",
+        worker: { running: worker.isRunning(), paused: worker.isPaused() },
+        redis,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+healthServer.listen(HEALTH_PORT, () => {
+  log.info(`Health check listening on port ${HEALTH_PORT}`);
+});
+
+async function shutdown(signal: string) {
+  log.info(`Received ${signal}, shutting down…`);
+  healthServer.close();
+  await worker.close();
+  log.info("Shutdown complete");
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## Summary
- `startReminderWorker` was exported from `workers/reminder-worker.ts` but never invoked — the scheduling service had no entrypoint, no `dev` script, and no `start` script. Every call to `scheduleReminders` enqueued a delayed BullMQ job that no worker drained, so no reminder ever fired
- Added `services/scheduling/src/server.ts` modeled on `services/notifications/src/server.ts` — starts the worker, exposes `/health` on `SCHEDULING_HEALTH_PORT` (default 4003), registers SIGTERM/SIGINT shutdown handlers
- Added `dev` (`tsx watch src/server.ts`) and `start` (`node dist/server.js`) scripts, plus `tsx` devDependency
- Added structural test (`reminder-worker-server.test.ts`) guarding the entrypoint shape so a future refactor cannot silently delete the drainer again

## Why no turbo.json change
`turbo.json` already declares a generic `dev` task — it picks up any service that declares a `dev` script in its own package.json. Confirmed by `pnpm dev` listing the new task without a turbo.json edit.

## Test plan
- [x] `pnpm --filter @carebridge/scheduling test` — 46/46 green (4 new entrypoint assertions, 17 existing reminder-worker tests, 25 other)
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean
- [ ] Reviewer: confirm `pnpm dev` starts the scheduling worker alongside the other services; verify `/health` returns 200 once Redis is reachable

## Follow-up (out of scope here)
- Issue suggestion 3 (docker-compose / deployment manifest) is deployment-config territory — splitting that into its own change keeps this PR small enough to land quickly while reminders are silently broken in production
- Issue suggestion 4 (decide jointly with #C-15 whether scheduling owns reminders or gateway calls directly) is an architectural question that should not block restoring reminder delivery

Closes #984