### PR TITLE
fix(clinical-data): single canonical CROSS_REACTIVITY_MAP in medical-logic (#986)

### DIFF
--- a/packages/medical-logic/src/cross-reactivity-map.ts
+++ b/packages/medical-logic/src/cross-reactivity-map.ts
@@ -1,0 +1,126 @@
+/**
+ * Canonical allergen-medication cross-reactivity table.
+ *
+ * Issue #986: prior to this module the table was duplicated between the
+ * order-time allergy check (services/clinical-data) and the post-write
+ * AI oversight rule (services/ai-oversight). The two copies drifted —
+ * the writer was silently missing entries (iodine/contrast, latex) that
+ * the AI rule had, so contrast/latex orders cleared the writer's check
+ * and only got flagged AFTER the row was written. Sentinel-event class
+ * misses (intra-procedural anaphylaxis).
+ *
+ * Both writer and rule now import this single source of truth.
+ *
+ * Naming
+ * ------
+ * The `class` field is the canonical drug-class slug used by the
+ * cross-reactivity-sync test (services/ai-oversight/src/__tests__/
+ * cross-reactivity-sync.test.ts) to verify symmetry with the LLM prompt
+ * anchors in @carebridge/ai-prompts. Adding a new entry here requires a
+ * matching anchor on the LLM side (or a CANONICAL_NAME mapping in the
+ * sync test) — see feedback_cross_reactivity_sync_canonical.md.
+ */
+
+import type { FlagSeverity } from "@carebridge/shared-types";
+
+export interface CrossReactivityEntry {
+  allergenPattern: RegExp;
+  medicationPattern: RegExp;
+  /** Canonical class slug; matched against LLM anchors by the sync test. */
+  class: string;
+  /**
+   * Optional severity override. When present, AI rule consumers emit the
+   * cross-reactivity flag at this severity regardless of the charted
+   * allergy severity. Writer consumers ignore this field (they raise a
+   * hard block on any conflict).
+   */
+  severityOverride?: FlagSeverity;
+}
+
+export const CROSS_REACTIVITY_MAP: readonly CrossReactivityEntry[] = [
+  {
+    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
+    medicationPattern: /penicillin|amoxicillin|ampicillin|augmentin|amoxil|piperacillin|nafcillin|oxacillin|dicloxacillin/i,
+    class: "penicillin",
+  },
+  {
+    allergenPattern: /cephalosporin|cefazolin|ceftriaxone|cephalexin/i,
+    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime|ceftazidime|cefdinir|cefpodoxime|cefotaxime/i,
+    class: "cephalosporin",
+  },
+  {
+    // Penicillin↔cephalosporin cross-reactivity (~2% risk).
+    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
+    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime/i,
+    class: "penicillin-cephalosporin-cross",
+  },
+  {
+    allergenPattern: /sulfa|sulfamethoxazole|bactrim|septra|trimethoprim/i,
+    medicationPattern: /sulfamethoxazole|bactrim|septra|sulfasalazine|sulfadiazine|dapsone/i,
+    class: "sulfonamide",
+  },
+  {
+    allergenPattern: /nsaid|ibuprofen|naproxen|aspirin/i,
+    medicationPattern: /ibuprofen|naproxen|diclofenac|celecoxib|indomethacin|ketorolac|meloxicam|piroxicam|aspirin/i,
+    class: "NSAID",
+  },
+  {
+    allergenPattern: /codeine|morphine|opioid/i,
+    medicationPattern: /codeine|morphine|hydrocodone|oxycodone|fentanyl|tramadol|hydromorphone|meperidine/i,
+    class: "opioid",
+  },
+  {
+    allergenPattern: /fluoroquinolone|ciprofloxacin|levofloxacin/i,
+    medicationPattern: /ciprofloxacin|levofloxacin|moxifloxacin|norfloxacin|ofloxacin/i,
+    class: "fluoroquinolone",
+  },
+  {
+    allergenPattern: /ace inhibitor|lisinopril|enalapril/i,
+    medicationPattern: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
+    class: "ACE inhibitor",
+  },
+  {
+    allergenPattern: /statin|atorvastatin|simvastatin/i,
+    medicationPattern: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
+    class: "statin",
+  },
+  {
+    allergenPattern: /macrolide|azithromycin|erythromycin|clarithromycin/i,
+    medicationPattern: /azithromycin|erythromycin|clarithromycin|fidaxomicin/i,
+    class: "macrolide",
+  },
+  {
+    allergenPattern: /tetracycline|doxycycline|minocycline/i,
+    medicationPattern: /tetracycline|doxycycline|minocycline|tigecycline/i,
+    class: "tetracycline",
+  },
+  {
+    allergenPattern: /benzodiazepine|diazepam|lorazepam|alprazolam/i,
+    medicationPattern: /diazepam|lorazepam|alprazolam|clonazepam|midazolam|temazepam|triazolam/i,
+    class: "benzodiazepine",
+  },
+  {
+    // True iodinated-contrast allergy (IV radiocontrast). Default severity
+    // path (critical for severe/moderate charted allergies). Bare "iodine"
+    // gets the next entry at warning severity.
+    allergenPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
+    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
+    class: "iodinated contrast",
+  },
+  {
+    // Charted "iodine" / Betadine / povidone-iodine — usually a topical
+    // skin-prep reaction, not a true IV contrast allergy. Still surface
+    // the combination but at warning severity (rule consumers honour
+    // severityOverride; writer ignores it and raises a hard block, which
+    // is the safer order-time default).
+    allergenPattern: /\b(iodine|betadine|povidone[-\s]?iodine)\b/i,
+    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
+    class: "iodine contrast advisory",
+    severityOverride: "warning",
+  },
+  {
+    allergenPattern: /latex/i,
+    medicationPattern: /latex/i,
+    class: "latex",
+  },
+];

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -5,4 +5,5 @@ export * from "./vital-staleness-thresholds.js";
 export * from "./medication-max-doses.js";
 export * from "./medication-frequency.js";
 export * from "./allergen-synonyms.js";
+export * from "./cross-reactivity-map.js";
 export * from "./patient-education.js";

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -10,123 +10,20 @@
  */
 
 import type { FlagSeverity, FlagCategory, RuleFlag } from "@carebridge/shared-types";
-import { expandAllergenAliases } from "@carebridge/medical-logic";
+import {
+  expandAllergenAliases,
+  CROSS_REACTIVITY_MAP,
+} from "@carebridge/medical-logic";
 import type {
   PatientContext,
   PatientAllergy,
   ResolvedAllergyOverride,
 } from "./cross-specialty.js";
 
-/**
- * Known drug class → ingredient mappings for cross-reactivity detection.
- * Maps an allergen class to medication name patterns that share the same
- * active ingredient or belong to the same drug family.
- */
-export const CROSS_REACTIVITY_MAP: Array<{
-  allergenPattern: RegExp;
-  medicationPattern: RegExp;
-  class: string;
-  /**
-   * Optional severity override. When present, the cross-reactivity flag is
-   * emitted at this severity regardless of the charted allergy severity.
-   * Used for ambiguous cross-reactivities (e.g. charted "iodine" → IV
-   * contrast) where a hard critical flag would over-escalate the common
-   * case (topical Betadine irritation).
-   */
-  severityOverride?: FlagSeverity;
-}> = [
-  {
-    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
-    medicationPattern: /penicillin|amoxicillin|ampicillin|augmentin|amoxil|piperacillin|nafcillin|oxacillin|dicloxacillin/i,
-    class: "penicillin",
-  },
-  {
-    allergenPattern: /cephalosporin|cefazolin|ceftriaxone|cephalexin/i,
-    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime|ceftazidime|cefdinir|cefpodoxime|cefotaxime/i,
-    class: "cephalosporin",
-  },
-  {
-    // Cross-reactivity between penicillins and cephalosporins (~2% risk)
-    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
-    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime/i,
-    class: "penicillin-cephalosporin-cross",
-  },
-  {
-    allergenPattern: /sulfa|sulfamethoxazole|bactrim|septra|trimethoprim/i,
-    medicationPattern: /sulfamethoxazole|bactrim|septra|sulfasalazine|sulfadiazine|dapsone/i,
-    class: "sulfonamide",
-  },
-  {
-    allergenPattern: /nsaid|ibuprofen|naproxen|aspirin/i,
-    medicationPattern: /ibuprofen|naproxen|diclofenac|celecoxib|indomethacin|ketorolac|meloxicam|piroxicam|aspirin/i,
-    class: "NSAID",
-  },
-  {
-    allergenPattern: /codeine|morphine|opioid/i,
-    medicationPattern: /codeine|morphine|hydrocodone|oxycodone|fentanyl|tramadol|hydromorphone|meperidine/i,
-    class: "opioid",
-  },
-  {
-    allergenPattern: /fluoroquinolone|ciprofloxacin|levofloxacin/i,
-    medicationPattern: /ciprofloxacin|levofloxacin|moxifloxacin|norfloxacin|ofloxacin/i,
-    class: "fluoroquinolone",
-  },
-  {
-    allergenPattern: /ace inhibitor|lisinopril|enalapril/i,
-    medicationPattern: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
-    class: "ACE inhibitor",
-  },
-  {
-    allergenPattern: /statin|atorvastatin|simvastatin/i,
-    medicationPattern: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
-    class: "statin",
-  },
-  {
-    allergenPattern: /macrolide|azithromycin|erythromycin|clarithromycin/i,
-    medicationPattern: /azithromycin|erythromycin|clarithromycin|fidaxomicin/i,
-    class: "macrolide",
-  },
-  {
-    allergenPattern: /tetracycline|doxycycline|minocycline/i,
-    medicationPattern: /tetracycline|doxycycline|minocycline|tigecycline/i,
-    class: "tetracycline",
-  },
-  {
-    allergenPattern: /benzodiazepine|diazepam|lorazepam|alprazolam/i,
-    medicationPattern: /diazepam|lorazepam|alprazolam|clonazepam|midazolam|temazepam|triazolam/i,
-    class: "benzodiazepine",
-  },
-  {
-    // True iodinated-contrast allergy (IV radiocontrast) — keeps the
-    // default severity path (critical for severe/moderate charted
-    // allergies). Bare "iodine" is handled by the next entry at warning
-    // severity to avoid over-escalating topical-Betadine charts.
-    allergenPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
-    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
-    class: "iodinated contrast",
-  },
-  {
-    // Charted "iodine" / Betadine / povidone-iodine — usually a topical
-    // skin-prep reaction or the shellfish-iodine folk belief, not a true
-    // IV contrast allergy. Still surface the combination but at warning
-    // severity so the clinician confirms intent rather than getting a
-    // hard critical flag on routine imaging orders.
-    allergenPattern: /\b(iodine|betadine|povidone[-\s]?iodine)\b/i,
-    medicationPattern: /contrast|iodinated|iohexol|iopamidol|iodixanol|ioversol|optiray|omnipaque|visipaque/i,
-    // Human-readable class label — appears verbatim in the flag's
-    // summary/rationale/suggested_action text shown to clinicians. Keep
-    // free of internal slugs. The canonical-name mapping in the
-    // cross-reactivity-sync test collapses this back to "iodinated-contrast"
-    // for LLM⇔rule symmetry.
-    class: "iodine contrast advisory",
-    severityOverride: "warning",
-  },
-  {
-    allergenPattern: /latex/i,
-    medicationPattern: /latex/i,
-    class: "latex",
-  },
-];
+// Re-export the canonical map so existing consumers (cross-reactivity-sync
+// test) continue to resolve `../rules/allergy-medication.js` for it.
+// New code should import directly from @carebridge/medical-logic.
+export { CROSS_REACTIVITY_MAP };
 
 /**
  * Map allergy severity to flag severity.

--- a/services/clinical-data/src/__tests__/medication-repo.test.ts
+++ b/services/clinical-data/src/__tests__/medication-repo.test.ts
@@ -330,7 +330,12 @@ describe("allergy safety check", () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it("blocks medication that cross-reacts with a patient allergy (penicillin → amoxicillin)", async () => {
+  it("blocks penicillin-class prescription against a penicillin allergy (via allergen alias expansion)", async () => {
+    // Amoxicillin is a penicillin (synonym table maps the penicillin
+    // canonical class to amoxicillin/ampicillin/augmentin/…). After #986
+    // the writer expands aliases and treats this as a direct match — the
+    // older "cross-reactivity via penicillin class" framing was less
+    // accurate because amoxicillin IS a penicillin, not just cross-reactive.
     db.willSelect([
       {
         id: "allergy-2",
@@ -346,7 +351,97 @@ describe("allergy safety check", () => {
 
     await expect(
       createMedication({ ...sampleMedInput, name: "Amoxicillin 500mg" }),
-    ).rejects.toThrow(/ALLERGY_CONFLICT.*Amoxicillin.*Penicillin.*penicillin/);
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Amoxicillin.*Penicillin/);
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("blocks iodinated contrast prescription against a contrast allergy (#986)", async () => {
+    db.willSelect([
+      {
+        id: "allergy-contrast",
+        patient_id: PATIENT_ID,
+        allergen: "Iodinated Contrast",
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Iohexol 350 mg/mL IV contrast" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Iohexol/);
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("blocks contrast prescription against a bare iodine allergy via the warning-severity advisory entry (#986)", async () => {
+    db.willSelect([
+      {
+        id: "allergy-iodine",
+        patient_id: PATIENT_ID,
+        allergen: "Iodine",
+        rxnorm_code: null,
+        severity: "moderate",
+        reaction: "rash",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Iopamidol 370" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Iopamidol/);
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("blocks latex device prescription against a latex allergy (#986)", async () => {
+    db.willSelect([
+      {
+        id: "allergy-latex",
+        patient_id: PATIENT_ID,
+        allergen: "Latex",
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Latex urinary catheter" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Latex/);
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("blocks vancomycin prescription against a Red Man Syndrome allergy via synonym expansion (#986)", async () => {
+    // Red Man Syndrome is the vancomycin infusion reaction. Pre-#986 the
+    // writer matched on raw allergen string only, so "Red Man" never
+    // textually overlapped with "vancomycin" and the prescription cleared
+    // the order-time check. With expandAllergenAliases the canonical
+    // "vancomycin" class expands to include "red man" / "red man syndrome"
+    // — the alias-aware direct-match now catches it.
+    db.willSelect([
+      {
+        id: "allergy-vanco",
+        patient_id: PATIENT_ID,
+        allergen: "Red Man Syndrome",
+        rxnorm_code: null,
+        severity: "moderate",
+        reaction: "histamine release",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      createMedication({ ...sampleMedInput, name: "Vancomycin 1g IV" }),
+    ).rejects.toThrow(/ALLERGY_CONFLICT.*Vancomycin/);
 
     expect(db.insert).not.toHaveBeenCalled();
   });

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -2,78 +2,11 @@ import { eq, and, desc } from "drizzle-orm";
 import { getDb, medications, medLogs, allergies } from "@carebridge/db-schema";
 import type { CreateMedicationInput, UpdateMedicationInput } from "@carebridge/validators";
 import type { Medication, MedLog, MedStatus } from "@carebridge/shared-types";
+import {
+  CROSS_REACTIVITY_MAP,
+  expandAllergenAliases,
+} from "@carebridge/medical-logic";
 import { emitClinicalEvent } from "../events.js";
-
-// ─── Allergy cross-reactivity map ─────────────────────────────────
-// Maps allergen name patterns to medication name patterns that belong to
-// the same drug class or share cross-reactive ingredients.
-
-const CROSS_REACTIVITY_MAP: Array<{
-  allergenPattern: RegExp;
-  medicationPattern: RegExp;
-  class: string;
-}> = [
-  {
-    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
-    medicationPattern: /penicillin|amoxicillin|ampicillin|augmentin|amoxil|piperacillin|nafcillin|oxacillin|dicloxacillin/i,
-    class: "penicillin",
-  },
-  {
-    allergenPattern: /cephalosporin|cefazolin|ceftriaxone|cephalexin/i,
-    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime|ceftazidime|cefdinir|cefpodoxime|cefotaxime/i,
-    class: "cephalosporin",
-  },
-  {
-    allergenPattern: /penicillin|amoxicillin|ampicillin/i,
-    medicationPattern: /cefazolin|ceftriaxone|cephalexin|cefepime|cefuroxime/i,
-    class: "penicillin-cephalosporin-cross",
-  },
-  {
-    allergenPattern: /sulfa|sulfamethoxazole|bactrim|septra|trimethoprim/i,
-    medicationPattern: /sulfamethoxazole|bactrim|septra|sulfasalazine|sulfadiazine|dapsone/i,
-    class: "sulfonamide",
-  },
-  {
-    allergenPattern: /nsaid|ibuprofen|naproxen|aspirin/i,
-    medicationPattern: /ibuprofen|naproxen|diclofenac|celecoxib|indomethacin|ketorolac|meloxicam|piroxicam|aspirin/i,
-    class: "NSAID",
-  },
-  {
-    allergenPattern: /codeine|morphine|opioid/i,
-    medicationPattern: /codeine|morphine|hydrocodone|oxycodone|fentanyl|tramadol|hydromorphone|meperidine/i,
-    class: "opioid",
-  },
-  {
-    allergenPattern: /fluoroquinolone|ciprofloxacin|levofloxacin/i,
-    medicationPattern: /ciprofloxacin|levofloxacin|moxifloxacin|norfloxacin|ofloxacin/i,
-    class: "fluoroquinolone",
-  },
-  {
-    allergenPattern: /ace inhibitor|lisinopril|enalapril/i,
-    medicationPattern: /lisinopril|enalapril|ramipril|captopril|benazepril|fosinopril|quinapril|perindopril/i,
-    class: "ACE inhibitor",
-  },
-  {
-    allergenPattern: /statin|atorvastatin|simvastatin/i,
-    medicationPattern: /atorvastatin|simvastatin|rosuvastatin|pravastatin|lovastatin|fluvastatin|pitavastatin/i,
-    class: "statin",
-  },
-  {
-    allergenPattern: /macrolide|azithromycin|erythromycin|clarithromycin/i,
-    medicationPattern: /azithromycin|erythromycin|clarithromycin|fidaxomicin/i,
-    class: "macrolide",
-  },
-  {
-    allergenPattern: /tetracycline|doxycycline|minocycline/i,
-    medicationPattern: /tetracycline|doxycycline|minocycline|tigecycline/i,
-    class: "tetracycline",
-  },
-  {
-    allergenPattern: /benzodiazepine|diazepam|lorazepam|alprazolam/i,
-    medicationPattern: /diazepam|lorazepam|alprazolam|clonazepam|midazolam|temazepam|triazolam/i,
-    class: "benzodiazepine",
-  },
-];
 
 export interface AllergyConflict {
   allergen: string;
@@ -101,15 +34,37 @@ export async function checkAllergyConflicts(
 
   const conflicts: AllergyConflict[] = [];
   const medLower = medicationName.toLowerCase();
+  const firstMedToken = medLower.split(" ")[0] ?? "";
 
   for (const allergy of patientAllergies) {
-    const allergenLower = allergy.allergen.toLowerCase();
+    // Expand shorthand / brand-name allergens to their canonical generic /
+    // class via the shared synonym table (#232). Without this the writer
+    // missed cases the post-write AI rule caught — e.g. allergy "Red Man
+    // Syndrome" + medication "vancomycin 1g IV" matched no entry on the
+    // direct path because the strings don't overlap textually, even
+    // though Red Man IS the vancomycin infusion reaction.
+    const allergenAliases = expandAllergenAliases(allergy.allergen);
+    const allergenBlob = allergenAliases.join(" ");
 
-    // Strategy 1: Direct name match
-    if (
-      medLower.includes(allergenLower) ||
-      allergenLower.includes(medLower.split(" ")[0])
-    ) {
+    // Strategy 1: Direct name match against any alias of the allergen.
+    const directMatch = allergenAliases.some((alias) => {
+      const aliasLower = alias.toLowerCase();
+      if (aliasLower.length < 4) {
+        // Short aliases (PCN, ASA) need a word boundary so "pcn" doesn't
+        // accidentally hit "pentoxifylline".
+        const boundary = new RegExp(
+          `\\b${aliasLower.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+          "i",
+        );
+        return boundary.test(medLower);
+      }
+      if (medLower.includes(aliasLower)) return true;
+      // Catch the case where the medication's first token is a stem of
+      // the alias (e.g. med "amoxicillin" first token "amoxicillin" sits
+      // inside alias-blob "penicillin amoxicillin ampicillin").
+      return firstMedToken.length > 3 && aliasLower.includes(firstMedToken);
+    });
+    if (directMatch) {
       conflicts.push({
         allergen: allergy.allergen,
         severity: allergy.severity,
@@ -119,10 +74,12 @@ export async function checkAllergyConflicts(
       continue; // Don't double-match via cross-reactivity
     }
 
-    // Strategy 2: Cross-reactivity class matching
+    // Strategy 2: Cross-reactivity class matching. Run the allergen
+    // pattern against the alias blob so e.g. an allergy charted as "PCN"
+    // still reaches the penicillin cross-reactivity rule.
     for (const mapping of CROSS_REACTIVITY_MAP) {
       if (
-        mapping.allergenPattern.test(allergy.allergen) &&
+        mapping.allergenPattern.test(allergenBlob) &&
         mapping.medicationPattern.test(medicationName)
       ) {
         conflicts.push({


### PR DESCRIPTION
## Summary
- Two copies of `CROSS_REACTIVITY_MAP` had drifted — writer (12 entries) was silently missing iodine/contrast and latex that the AI rule (15 entries) had. Contrast and latex orders cleared the order-time block and only got flagged after the row was written
- Extracted the canonical 15-entry map to `@carebridge/medical-logic/cross-reactivity-map.ts`. Both writer and AI rule now import the single source of truth
- AI rule re-exports `CROSS_REACTIVITY_MAP` so the existing `cross-reactivity-sync.test.ts` resolves its prior import path without a churn change
- Writer's direct-match path now uses `expandAllergenAliases` (matching the AI rule's behaviour from #232) so a "Red Man Syndrome" allergy + vancomycin prescription blocks at order time

## Vancomycin nuance
The issue called out vancomycin as missing from the writer. The actual gap was the writer not using the synonym table — `allergen-synonyms.ts` already maps the "vancomycin" canonical class to `red man` / `glycopeptide` / `teicoplanin` (#932). Switching the writer's direct-match to operate against alias expansion closes the gap end-to-end without adding a new map entry (which would have required updating the LLM symmetry side too).

## Behaviour change captured in tests
One existing test was updated: amoxicillin against a penicillin allergy is now reported as "direct" (amoxicillin IS a penicillin) rather than "cross-reactivity via penicillin class". Same rejection, more accurate framing.

## Test plan
- [x] `pnpm --filter @carebridge/clinical-data test medication-repo` — 16/16 (4 new assertions on iodine/contrast, iodine→contrast advisory, latex, Red Man → vancomycin)
- [x] `pnpm --filter @carebridge/ai-oversight test cross-reactivity-sync` — 4/4 (LLM symmetry preserved via re-export)
- [x] `pnpm --filter @carebridge/ai-oversight test allergy-medication` — 13/13 (rule behaviour unchanged)
- [x] `pnpm --filter @carebridge/ai-oversight test` — 857/857
- [x] `pnpm --filter @carebridge/clinical-data test` — 45/45
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean

Closes #986