### PR TITLE
test(portal): freeze clock in appointments-reschedule-flow test

### DIFF
--- a/apps/patient-portal/src/__tests__/appointments-reschedule-flow.test.tsx
+++ b/apps/patient-portal/src/__tests__/appointments-reschedule-flow.test.tsx
@@ -56,9 +56,13 @@ describe("AppointmentsPageInner", () => {
   // silently rots once real wall-clock passes the fixture date — the row
   // moves to the "past" tab where action buttons are intentionally hidden,
   // and `getByRole("button", { name: /reschedule/i })` cannot find them.
+  // Derived from upcomingAppt.start_time so updating the fixture date
+  // can never drift from the frozen clock.
   beforeAll(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.setSystemTime(new Date("2026-04-20T00:00:00.000Z"));
+    const fixtureStart = new Date(upcomingAppt.start_time).getTime();
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    vi.setSystemTime(new Date(fixtureStart - oneDayMs));
   });
   afterAll(() => {
     vi.useRealTimers();

--- a/apps/patient-portal/src/__tests__/appointments-reschedule-flow.test.tsx
+++ b/apps/patient-portal/src/__tests__/appointments-reschedule-flow.test.tsx
@@ -7,7 +7,7 @@
  * atomic reschedule — called out as a follow-up in the PR body.
  */
 import React from "react";
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import {
@@ -51,6 +51,18 @@ async function walkBookWizard() {
 }
 
 describe("AppointmentsPageInner", () => {
+  // Freeze the test clock to a moment BEFORE the fixture appointment so
+  // isUpcoming(row.end_time >= Date.now()) holds. Without this the suite
+  // silently rots once real wall-clock passes the fixture date — the row
+  // moves to the "past" tab where action buttons are intentionally hidden,
+  // and `getByRole("button", { name: /reschedule/i })` cannot find them.
+  beforeAll(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-04-20T00:00:00.000Z"));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
   afterEach(() => cleanup());
 
   it("cancel flow: invokes onCancel with appointmentId and reason", async () => {


### PR DESCRIPTION
## Summary
- `apps/patient-portal/src/__tests__/appointments-reschedule-flow.test.tsx` uses hardcoded fixture `end_time = "2026-04-25T15:30:00.000Z"`. `AppointmentList` hides action buttons for rows where `end_time < Date.now()` (the "past" tab). Once real wall-clock passed the fixture date the suite started failing in CI with `Unable to find an accessible element with the role "button" and name /reschedule/i`
- Froze the test clock at 2026-04-20 (a few days before the fixture appointment) in `beforeAll`, restored real timers in `afterAll`. `shouldAdvanceTime: true` keeps async microtask ordering working under fake timers so React's act() flushes don't deadlock
- Confirmed reproducible on raw `main` (c84e95f) — this is rot, not introduced by any in-flight PR

## Why this matters today
Six in-flight PRs (#987–#992 from the 2026-05-22 marathon) all fail the required `Test` check on main due to this single test rot. Landing this fix unblocks all of them.

## Test plan
- [x] `pnpm --filter @carebridge/patient-portal test appointments-reschedule-flow` — 5/5 green (was 4 failed)
- [x] `pnpm --filter @carebridge/patient-portal test` — 70/70, 17 files green
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean