### PR TITLE
fix(audit): surface swallowed audit-write failures via shared helper (#996)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       '@carebridge/fhir-gateway':
         specifier: workspace:*
         version: link:../fhir-gateway
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
       '@carebridge/messaging':
         specifier: workspace:*
         version: link:../messaging

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -21,6 +21,7 @@
     "@carebridge/clinical-notes": "workspace:*",
     "@carebridge/ai-oversight": "workspace:*",
     "@carebridge/notifications": "workspace:*",
+    "@carebridge/logger": "workspace:*",
     "@carebridge/messaging": "workspace:*",
     "@carebridge/scheduling": "workspace:*",
     "@carebridge/redis-config": "workspace:*",

--- a/services/api-gateway/src/__tests__/audit-write-failure-visibility.test.ts
+++ b/services/api-gateway/src/__tests__/audit-write-failure-visibility.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for audit-write failure visibility (#996).
+ *
+ * Three call sites swallowed audit-insert failures with .catch(() => {})
+ * or empty catch blocks, allowing PHI mutations to succeed without an
+ * audit row — a HIPAA §164.312(b) integrity gap. This suite pins the
+ * contract that each site now invokes a shared logger so the failure
+ * lands in structured logs / alerts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { errorLog, mockLogger } = vi.hoisted(() => {
+  const errorLog = vi.fn();
+  return {
+    errorLog,
+    mockLogger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: errorLog,
+    },
+  };
+});
+
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => mockLogger,
+}));
+
+import { recordAuditWriteFailure } from "../middleware/audit-failure.js";
+
+describe("recordAuditWriteFailure (#996)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs at error level with stable msg 'audit_write_failed'", () => {
+    recordAuditWriteFailure(new Error("connection refused"), {
+      site: "rbac.emergency_access_used",
+      userId: "user-1",
+    });
+
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const [msg, meta] = errorLog.mock.calls[0];
+    // Stable log msg so a log aggregator can alert on this exact string
+    // without depending on the wording of any one call site.
+    expect(msg).toBe("audit_write_failed");
+    expect(meta).toEqual(
+      expect.objectContaining({
+        site: "rbac.emergency_access_used",
+        userId: "user-1",
+        error: expect.objectContaining({ message: "connection refused" }),
+      }),
+    );
+  });
+
+  it("handles non-Error throwables (caller passed a string, object, etc.)", () => {
+    recordAuditWriteFailure("string thrown", { site: "test" });
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const [msg, meta] = errorLog.mock.calls[0];
+    expect(msg).toBe("audit_write_failed");
+    // Non-Error values still produce a structured error field with the
+    // stringified value so log search doesn't lose the signal.
+    expect(meta.error).toBeDefined();
+  });
+
+  it("never throws (audit failures must not crash the surrounding request path)", () => {
+    expect(() =>
+      recordAuditWriteFailure(new Error("x"), { site: "test" }),
+    ).not.toThrow();
+    expect(() =>
+      recordAuditWriteFailure(null as unknown as Error, { site: "test" }),
+    ).not.toThrow();
+    expect(() =>
+      recordAuditWriteFailure(undefined as unknown as Error, { site: "test" }),
+    ).not.toThrow();
+  });
+});

--- a/services/api-gateway/src/middleware/audit-failure.ts
+++ b/services/api-gateway/src/middleware/audit-failure.ts
@@ -1,0 +1,69 @@
+/**
+ * Audit-write failure visibility (#996).
+ *
+ * The audit-after-PHI-mutation pattern wraps the audit insert in a try/catch
+ * or `.catch(() => {})` so an audit failure does not crash the request
+ * cycle. That intent is correct — what was missing was visibility into
+ * the failures. With this helper, an audit insert that fails still does
+ * not crash the request, but it DOES land in the structured-log stream
+ * with a stable `msg` so log aggregators / alerting can detect ongoing
+ * audit-write degradation.
+ *
+ * HIPAA §164.312(b) requires audit trail integrity. Silent failures
+ * undermine that requirement; visible failures preserve the
+ * "never block the request path" property while making the gap
+ * observable for the on-call.
+ */
+
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("audit");
+
+/**
+ * Stable log msg searched on by alerts and dashboards. Do not change
+ * without coordinating with whatever consumes the structured log stream.
+ */
+export const AUDIT_WRITE_FAILED_MSG = "audit_write_failed";
+
+export interface AuditWriteFailureContext {
+  /**
+   * Short identifier for the call site (e.g. "rbac.emergency_access_used"
+   * or "auth.session_rejected_inactive"). Lets a single alert split by
+   * source so partial outages are diagnosable.
+   */
+  site: string;
+  userId?: string | null;
+  patientId?: string | null;
+  action?: string | null;
+  /** Free-form additional context the caller wants in the log line. */
+  [key: string]: unknown;
+}
+
+/**
+ * Record an audit-write failure to the structured log stream.
+ *
+ * Never throws — even when the input is `null`/`undefined`/non-Error —
+ * so it is safe to use inside Promise rejection handlers and catch
+ * blocks whose contract is "never crash the caller".
+ */
+export function recordAuditWriteFailure(
+  err: unknown,
+  context: AuditWriteFailureContext,
+): void {
+  try {
+    const errorPayload =
+      err instanceof Error
+        ? { message: err.message, name: err.name, stack: err.stack }
+        : { message: String(err), name: "NonErrorThrown" };
+
+    log.error(AUDIT_WRITE_FAILED_MSG, {
+      ...context,
+      error: errorPayload,
+    });
+  } catch {
+    // Defense-in-depth: if the logger itself fails (rare — would mean the
+    // log transport is dead), still don't crash the request cycle. There
+    // is nothing more we can do here without escalating the failure mode
+    // beyond the original audit-write problem.
+  }
+}

--- a/services/api-gateway/src/middleware/audit.ts
+++ b/services/api-gateway/src/middleware/audit.ts
@@ -8,6 +8,7 @@ import {
 } from "@carebridge/db-schema";
 import { and, eq } from "drizzle-orm";
 import crypto from "node:crypto";
+import { recordAuditWriteFailure } from "./audit-failure.js";
 
 /** Map HTTP methods to human-readable actions. */
 function methodToAction(method: string): string {
@@ -322,7 +323,15 @@ export async function auditMiddleware(
       timestamp: new Date().toISOString(),
     });
   } catch (err) {
-    // Audit logging should never crash the request cycle.
-    request.log.error({ err }, "Failed to write audit log entry");
+    // Audit logging should never crash the request cycle. Surface the
+    // failure via the shared structured-log helper so an outage / DB
+    // disconnect produces a stable `audit_write_failed` signal in the
+    // log stream (HIPAA §164.312(b) visibility, #996).
+    recordAuditWriteFailure(err, {
+      site: "audit.middleware",
+      userId,
+      patientId,
+      action,
+    });
   }
 }

--- a/services/api-gateway/src/middleware/auth.ts
+++ b/services/api-gateway/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import { users, sessions, auditLog } from "@carebridge/db-schema";
 import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
 import { verifyJWT, JWTError } from "@carebridge/auth";
+import { recordAuditWriteFailure } from "./audit-failure.js";
 
 /** Hardcoded dev users for local development without a seeded database. */
 const DEV_USERS: Record<string, User> = {
@@ -177,8 +178,16 @@ export async function authMiddleware(
         ip_address: request.ip,
         timestamp: new Date().toISOString(),
       })
-      .catch(() => {
-        // Audit logging must never block or crash the rejection flow.
+      .catch((err) => {
+        // Audit logging must never block or crash the rejection flow,
+        // but the failure must be observable — surfaces in the log
+        // stream as the stable `audit_write_failed` signal so an outage
+        // produces a real alert rather than silent loss (#996).
+        recordAuditWriteFailure(err, {
+          site: "auth.session_rejected_inactive",
+          userId: row.id,
+          action: "session_rejected_inactive",
+        });
       });
 
     _reply.code(401).send({ error: "Session expired" });

--- a/services/api-gateway/src/middleware/rbac.ts
+++ b/services/api-gateway/src/middleware/rbac.ts
@@ -5,6 +5,7 @@ import { hasPermission } from "@carebridge/shared-types";
 import { getDb, careTeamAssignments, auditLog, emergencyAccess } from "@carebridge/db-schema";
 import { eq, and, isNull, gt } from "drizzle-orm";
 import crypto from "node:crypto";
+import { recordAuditWriteFailure } from "./audit-failure.js";
 
 /**
  * tRPC-side RBAC enforcement: throws `FORBIDDEN` when the user's role
@@ -271,8 +272,17 @@ export async function assertCareTeamAccess(
         ip_address: clientIp ?? "",
         timestamp: now,
       })
-      .catch(() => {
-        // Swallow — audit logging must never block access decisions.
+      .catch((err) => {
+        // Audit logging must never block access decisions, but the
+        // failure must be observable — log via the shared helper so
+        // an audit-write outage produces a `audit_write_failed`
+        // structured-log signal (HIPAA §164.312(b) visibility, #996).
+        recordAuditWriteFailure(err, {
+          site: "rbac.emergency_access_used",
+          userId,
+          patientId,
+          action: "emergency_access_used",
+        });
       });
 
     setCache(key, true);


### PR DESCRIPTION
## Summary
- Three call sites in `services/api-gateway/src/middleware/` swallowed audit-insert failures with `.catch(() => {})` or prose-only log lines, so a PHI mutation could succeed without an audit row — a HIPAA §164.312(b) visibility gap
- Added `middleware/audit-failure.ts` with a shared `recordAuditWriteFailure(err, context)` helper that emits a stable `audit_write_failed` structured-log line. Log aggregators / alerts can key on that exact string regardless of which call site failed
- Wired the helper into all three sites: `middleware/audit.ts:325` (top-level audit middleware), `middleware/auth.ts:180` (session_rejected_inactive), `middleware/rbac.ts:274` (emergency_access_used)
- Added `@carebridge/logger` as a workspace dep of api-gateway (not previously consumed)

## Contract preserved
The "audit logging must never block the request" property is preserved — `.catch` and `try/catch` are still in place, so a database disconnect still doesn't crash the request. What's new is that the failure produces a structured-log signal instead of silence.

## Out of scope
The audit-after-PHI-write paths in routers (`patient-records.ts`, `clinical-notes.ts`, etc.) use transaction-scoped audit inserts that already fail-closed (audit failure → PHI rollback). The remaining gap there is that the rollback masks the audit-side fault from the on-call view; tracking as follow-up.

## Test plan
- [x] `pnpm --filter @carebridge/api-gateway test audit-write-failure-visibility` — 3/3 (stable msg, non-Error throwables, never-throws)
- [x] `pnpm --filter @carebridge/api-gateway test` — 512/512
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean

Closes #996