### PR TITLE
fix(medical-logic): tighten allergen alias boundary cutoff to <=4 chars (#994)

### DIFF
--- a/services/ai-oversight/src/rules/allergy-medication.test.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.test.ts
@@ -168,4 +168,60 @@ describe("allergy-medication allergen normalization (#232)", () => {
     const flags = checkAllergyMedication(ctx);
     expect(flags).toHaveLength(0);
   });
+
+  // ── Issue #994: 4-letter abbreviation substring false-positives ────────
+  //
+  // ALLERGEN_SYNONYMS includes 4-letter abbreviations (amox, ampi, apap,
+  // lmwh, acei). The original direct-match path applied word-boundary
+  // checks only for aliases with length < 4, so the 4-char abbreviations
+  // hit via substring match anywhere in the medication name. This caused
+  // unrelated drugs whose names happened to contain those 4 chars to
+  // produce a false-positive allergy flag at order time.
+  //
+  // The fix tightens the boundary check to length <= 4 so every known
+  // 4-letter abbreviation uses word-boundary matching, while genuine
+  // class-level matches still work via the longer canonical alias
+  // (e.g. PCN → penicillin → "amoxicillin" full string).
+
+  it("PCN allergy does NOT false-positive on amoxapine via the 'amox' alias (#994)", () => {
+    // Amoxapine is a tetracyclic antidepressant. Pre-#994 the 4-letter
+    // alias "amox" hit it via substring match against the PCN canonical
+    // class. Now the word-boundary check rejects the match — "amox" is
+    // not a separate token inside "amoxapine".
+    const ctx = makeContext(
+      [{ allergen: "PCN", severity: "severe", reaction: "anaphylaxis" }],
+      ["Amoxapine 50mg PO BID"],
+    );
+    const flags = checkAllergyMedication(ctx);
+    expect(flags).toHaveLength(0);
+  });
+
+  it("PCN allergy DOES still flag amoxicillin (regression guard for #994 fix)", () => {
+    // The fix must not break the legitimate match. Amoxicillin is in the
+    // alias set as a full canonical name (length 11), so the substring
+    // path still catches it regardless of the boundary tightening.
+    const ctx = makeContext(
+      [{ allergen: "PCN", severity: "severe", reaction: "anaphylaxis" }],
+      ["Amoxicillin 500mg PO q8h"],
+    );
+    const flags = checkAllergyMedication(ctx);
+    expect(flags.length).toBeGreaterThan(0);
+  });
+
+  it("Penicillin allergy does NOT false-positive on ampyra via the 'ampi' alias (#994)", () => {
+    // Ampyra (dalfampridine) is an MS treatment. The 4-letter alias
+    // "ampi" under penicillin would have matched substring-wise.
+    const ctx = makeContext(
+      [
+        {
+          allergen: "Penicillin",
+          severity: "moderate",
+          reaction: "rash",
+        },
+      ],
+      ["Ampyra 10mg PO BID"],
+    );
+    const flags = checkAllergyMedication(ctx);
+    expect(flags).toHaveLength(0);
+  });
 });

--- a/services/ai-oversight/src/rules/allergy-medication.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.ts
@@ -139,11 +139,13 @@ export function checkAllergyMedication(context: PatientContext): RuleFlag[] {
       // Strategy 1: Direct name match across ANY alias of the allergen.
       // A prescription for "penicillin VK" and an allergy recorded as
       // "PCN" must match — which they do once we expand PCN to
-      // [penicillin, pcn, amoxicillin, …]. Aliases shorter than 4 chars
-      // are matched with a word-boundary guard so "pcn" doesn't hit
-      // "pentoxifylline" / "norpace" (#920 review).
+      // [penicillin, pcn, amoxicillin, …]. Aliases up to 4 chars long
+      // are matched with a word-boundary guard so abbreviations like
+      // "pcn", "asa", "amox", "ampi", "apap" don't substring-hit
+      // unrelated drugs ("pentoxifylline", "amoxapine", "ampyra" —
+      // #920 review + #994).
       const directMatch = allergenAliases.some((alias) => {
-        if (alias.length < 4) {
+        if (alias.length <= 4) {
           const boundary = new RegExp(`\\b${alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
           if (boundary.test(medLower)) return true;
         } else if (medLower.includes(alias)) {

--- a/services/clinical-data/src/__tests__/medication-repo.test.ts
+++ b/services/clinical-data/src/__tests__/medication-repo.test.ts
@@ -446,6 +446,34 @@ describe("allergy safety check", () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
+  it("does NOT false-positive on amoxapine against a penicillin allergy via 'amox' alias (#994)", async () => {
+    // Amoxapine is a tetracyclic antidepressant. Pre-#994 the 4-letter
+    // alias "amox" (under penicillin canonical class) hit it via
+    // substring match. With the boundary tightening to length <= 4 the
+    // alias must occur as a separate token in the medication name,
+    // which it does not in "amoxapine".
+    db.willSelect([
+      {
+        id: "allergy-pcn",
+        patient_id: PATIENT_ID,
+        allergen: "Penicillin",
+        rxnorm_code: null,
+        severity: "severe",
+        reaction: "anaphylaxis",
+        snomed_code: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await createMedication({
+      ...sampleMedInput,
+      name: "Amoxapine 50mg PO BID",
+    });
+
+    expect(result.name).toBe("Amoxapine 50mg PO BID");
+    expect(db.insert).toHaveBeenCalledOnce();
+  });
+
   it("allows medication when no allergy conflicts exist", async () => {
     db.willSelect([
       {

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -49,9 +49,12 @@ export async function checkAllergyConflicts(
     // Strategy 1: Direct name match against any alias of the allergen.
     const directMatch = allergenAliases.some((alias) => {
       const aliasLower = alias.toLowerCase();
-      if (aliasLower.length < 4) {
-        // Short aliases (PCN, ASA) need a word boundary so "pcn" doesn't
-        // accidentally hit "pentoxifylline".
+      if (aliasLower.length <= 4) {
+        // Short aliases (PCN, ASA, amox, ampi, apap, lmwh, acei) need
+        // a word boundary so they don't substring-hit unrelated drugs
+        // ("pcn" → "pentoxifylline", "amox" → "amoxapine",
+        // "ampi" → "ampyra"). The boundary cutoff matches the AI rule
+        // (#994) so writer and rule agree on false-positive avoidance.
         const boundary = new RegExp(
           `\\b${aliasLower.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
           "i",


### PR DESCRIPTION
## Summary
- ALLERGEN_SYNONYMS includes 4-letter abbreviations (`amox`, `ampi`, `apap`, `lmwh`, `acei`). The direct-match path applied word-boundary checks only for aliases with length **< 4**, so the 4-char abbreviations matched via plain substring against the medication name. Unrelated drugs whose names contained those 4 chars produced a false-positive allergy block at order time
- Concrete examples: `amox` → `amoxapine` (tetracyclic antidepressant), `ampi` → `ampyra` (dalfampridine, MS treatment)
- Tightened the boundary cutoff to `<= 4` in both consumers of `expandAllergenAliases` so all known abbreviations use word-boundary matching
- Class-level matches still work because the alias set includes the full canonical name (e.g. `amoxicillin` length 11) which matches via the substring path regardless of the boundary tightening

## Why two sites
The AI rule (#232) and the writer (#986) share the alias-expansion algorithm. The bug was pre-existing in the AI rule from #232; #986 inherited it when the writer adopted the same pattern. Both fixed in parallel so they don't drift again.

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test allergy-medication` — 16/16 (2 new false-positive guards on amoxapine + ampyra, 1 regression guard on amoxicillin)
- [x] `pnpm --filter @carebridge/ai-oversight test` — 862/862
- [x] `pnpm --filter @carebridge/clinical-data test medication-repo` — 17/17 (1 new writer-side amoxapine guard)
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean

Closes #994