### PR TITLE
fix(outbox): pass event.id as BullMQ jobId for idempotent primary emit (#1003)

### DIFF
--- a/packages/outbox/src/__tests__/emit.test.ts
+++ b/packages/outbox/src/__tests__/emit.test.ts
@@ -46,8 +46,26 @@ describe("emitClinicalEvent", () => {
   it("adds event to BullMQ queue on success", async () => {
     await emitClinicalEvent(sampleEvent);
 
-    expect(addMock).toHaveBeenCalledWith(sampleEvent.type, sampleEvent);
+    expect(addMock).toHaveBeenCalledWith(
+      sampleEvent.type,
+      sampleEvent,
+      expect.objectContaining({ jobId: sampleEvent.id }),
+    );
     expect(writeOutboxEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("passes event.id as the BullMQ jobId for idempotent enqueue (#1003)", async () => {
+    // BullMQ dedupes jobs by jobId. The reconciler path already passes
+    // { jobId: outbox_row.id } at outbox-reconciler.ts:93; the primary
+    // path must symmetrically pass { jobId: event.id } so a retried emit
+    // from the same writer (network glitch, partial-success replay)
+    // becomes a no-op at the queue layer instead of producing a duplicate
+    // BullMQ job → duplicate review_jobs row.
+    await emitClinicalEvent(sampleEvent);
+
+    const opts = addMock.mock.calls[0]?.[2];
+    expect(opts).toBeDefined();
+    expect(opts.jobId).toBe(sampleEvent.id);
   });
 
   it("falls back to outbox when queue fails", async () => {

--- a/packages/outbox/src/emit.ts
+++ b/packages/outbox/src/emit.ts
@@ -31,7 +31,14 @@ const clinicalEventsQueue = new Queue("clinical-events", {
 
 export async function emitClinicalEvent(event: ClinicalEvent): Promise<void> {
   try {
-    await clinicalEventsQueue.add(event.type, event);
+    // jobId: event.id — BullMQ dedupes jobs by jobId. A retried emit from
+    // the same writer (network glitch / partial-success replay) becomes a
+    // no-op at the queue layer instead of producing a duplicate BullMQ
+    // job and a downstream duplicate review_jobs row. The reconciler path
+    // (outbox-reconciler.ts:93) uses { jobId: row.id } for the same
+    // reason, scoped to outbox-row identity rather than event identity.
+    // See #1003.
+    await clinicalEventsQueue.add(event.type, event, { jobId: event.id });
   } catch (queueError) {
     // Redis/BullMQ unavailable — persist to DB outbox for later retry
     try {


### PR DESCRIPTION
## Summary
- The reconciler path (`services/ai-oversight/src/workers/outbox-reconciler.ts:93`) already passes `{ jobId: row.id }` to dedupe retries of the same outbox row. The primary emit path in `packages/outbox/src/emit.ts:34` had no jobId, so a retried emit from the same writer (network glitch, partial-success replay) created a second BullMQ job → second `review_jobs` row in `processing` status
- The pipeline's idempotency probe (`review-service.ts:138-157`, ASCII-quote-fixed in #981) caught the duplicate at the DB layer so no duplicate flags fired in production — but queue-level dedup is cheaper, prevents the lingering extra row, and is the natural symmetric counterpart to the reconciler's pattern
- Used `event.id` (writer-assigned canonical UUID) as the jobId. The reconciler keeps `row.id` because its dedup scope is "this outbox-row retry attempt", a distinct semantic

## Test plan
- [x] `pnpm --filter @carebridge/outbox test` — 21/21 (1 updated assertion on existing test, 1 new dedicated `#1003` test pinning `jobId === event.id`)
- [x] `pnpm typecheck` — 40/40
- [x] `pnpm lint` — clean

Closes #1003