### PR TITLE
fhir: migrate Patient MRN to CAREBRIDGE_IDENTIFIER_BASE namespace

### DIFF
--- a/services/fhir-gateway/src/__tests__/patient.test.ts
+++ b/services/fhir-gateway/src/__tests__/patient.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { toFhirPatient } from "../generators/patient.js";
+import { CAREBRIDGE_IDENTIFIER_BASE } from "../generators/identifiers.js";
+
+type Patient = Parameters<typeof toFhirPatient>[0];
+
+function makePatient(overrides: Partial<Patient> = {}): Patient {
+  return {
+    id: "pat-1",
+    name: "Jane Doe",
+    date_of_birth: "1980-05-12",
+    biological_sex: "female",
+    mrn: "MRN-12345",
+    ...overrides,
+  };
+}
+
+describe("toFhirPatient MRN identifier (#969)", () => {
+  it("emits MRN under CAREBRIDGE_IDENTIFIER_BASE/mrn", () => {
+    const p = toFhirPatient(makePatient());
+    const ident = p.identifier?.[0];
+    expect(ident).toBeDefined();
+    expect(ident?.system).toBe(`${CAREBRIDGE_IDENTIFIER_BASE}/mrn`);
+    expect(ident?.value).toBe("MRN-12345");
+  });
+
+  it("uses the shared canonical https carebridge.dev namespace", () => {
+    const p = toFhirPatient(makePatient());
+    expect(p.identifier?.[0]?.system).toMatch(
+      /^https:\/\/carebridge\.dev\/fhir\/sid\/mrn$/,
+    );
+    expect(p.identifier?.[0]?.system).not.toMatch(/carebridge\.health/);
+    expect(p.identifier?.[0]?.system).not.toMatch(/^http:/);
+  });
+
+  it("preserves the HL7 v2-0203 'MR' type coding alongside the system change", () => {
+    const p = toFhirPatient(makePatient());
+    const coding = p.identifier?.[0]?.type?.coding?.[0];
+    expect(coding?.system).toBe(
+      "http://terminology.hl7.org/CodeSystem/v2-0203",
+    );
+    expect(coding?.code).toBe("MR");
+  });
+
+  it("omits identifier entirely when MRN is null", () => {
+    const p = toFhirPatient(makePatient({ mrn: null }));
+    expect(p.identifier).toBeUndefined();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toFhirPractitioner, isClinicalRole } from "../generators/practitioner.js";
+import { CAREBRIDGE_IDENTIFIER_BASE } from "../generators/identifiers.js";
 
 type User = Parameters<typeof toFhirPractitioner>[0];
 
@@ -43,7 +44,7 @@ describe("toFhirPractitioner (#388)", () => {
     expect(p.resourceType).toBe("Practitioner");
     expect(p.id).toBe("prov-123");
     expect(p.identifier?.[0]?.system).toBe(
-      "https://carebridge.dev/fhir/sid/user-id",
+      `${CAREBRIDGE_IDENTIFIER_BASE}/user-id`,
     );
     expect(p.identifier?.[0]?.value).toBe("prov-123");
   });

--- a/services/fhir-gateway/src/generators/identifiers.ts
+++ b/services/fhir-gateway/src/generators/identifiers.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical URL namespace for CareBridge-minted FHIR identifiers.
+ *
+ * Using a URL-form `system` rather than an ad-hoc `urn:` scheme is the
+ * shape Epic, Cerner, and other major EHRs are trained to recognise.
+ *
+ * Convention: append a domain-specific path segment (`/user-id`,
+ * `/mrn`, `/encounter-id`, …) under this base so every resource
+ * generator reuses the same namespace root.
+ *
+ * Hoisted out of practitioner.ts in #969 — patient.ts previously used an
+ * unrelated `http://carebridge.health/mrn` namespace (different domain,
+ * different scheme, different path shape). Sharing this constant keeps
+ * any new CareBridge identifier consistent.
+ */
+export const CAREBRIDGE_IDENTIFIER_BASE =
+  "https://carebridge.dev/fhir/sid";

--- a/services/fhir-gateway/src/generators/index.ts
+++ b/services/fhir-gateway/src/generators/index.ts
@@ -10,4 +10,5 @@ export { toFhirAllergyIntolerance } from "./allergy-intolerance.js";
 export { toFhirEncounter } from "./encounter.js";
 export { toFhirProcedure } from "./procedure.js";
 export { toFhirPractitioner, isClinicalRole } from "./practitioner.js";
+export { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
 export { toFhirMedicationRequest } from "./medication-request.js";

--- a/services/fhir-gateway/src/generators/patient.ts
+++ b/services/fhir-gateway/src/generators/patient.ts
@@ -1,4 +1,5 @@
 import type { FhirPatient } from "../types/index.js";
+import { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
 
 /** Shape of a row from the `patients` table after decryption. */
 interface PatientRow {
@@ -65,7 +66,7 @@ export function toFhirPatient(patient: PatientRow): FhirPatient {
                 },
               ],
             },
-            system: "http://carebridge.health/mrn",
+            system: `${CAREBRIDGE_IDENTIFIER_BASE}/mrn`,
             value: patient.mrn,
           },
         ]

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -131,17 +131,8 @@ function parseName(fullName: string): HumanName {
   };
 }
 
-/**
- * Canonical URL namespace for CareBridge-minted FHIR identifiers. Using
- * a URL-form `system` rather than an ad-hoc `urn:` scheme is the shape
- * Epic, Cerner, and other major EHRs are trained to recognise.
- *
- * Convention: append a domain-specific path segment (`/user-id`,
- * `/patient-id`, `/encounter-id`, …) under this base so new resource
- * generators reuse the same namespace root.
- */
-export const CAREBRIDGE_IDENTIFIER_BASE =
-  "https://carebridge.dev/fhir/sid";
+export { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
+import { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
 
 export function toFhirPractitioner(user: UserRow): FhirPractitioner {
   const resource: FhirPractitioner = {


### PR DESCRIPTION
## Summary
Follow-up from PR #958 review.

Patient \`identifier[].system\` was emitted under \`http://carebridge.health/mrn\` — a different domain, scheme, and path shape than the canonical namespace introduced by #958 for the Practitioner identifier (\`https://carebridge.dev/fhir/sid/user-id\`).

This PR:
- Hoists \`CAREBRIDGE_IDENTIFIER_BASE\` into a shared \`generators/identifiers.ts\` so every resource generator imports the same constant.
- Updates Patient to use \`\${CAREBRIDGE_IDENTIFIER_BASE}/mrn\`.
- Re-exports the constant from \`generators/index.ts\` (and keeps the existing re-export from \`practitioner.js\` for backward compatibility).
- Updates the practitioner test to import the constant instead of hard-coding.
- Adds \`patient.test.ts\` that asserts the new MRN namespace, preserves the HL7 v2-0203 'MR' type coding, and omits identifier when MRN is null.

## Closes
- #969

## Breaking-change note
The \`identifier[].system\` URL on exported Patient FHIR bundles changes. No external EHR consumers exist today, so no migration shim is included. If we wire up an Epic / Cerner integration later, that consumer would need to key on the new namespace.

## Test plan
- [x] \`pnpm --filter @carebridge/fhir-gateway test\` — 199/199 (was 195)