### PR TITLE
docs(fhir): pin parseName 'First Middle Last' Anglo tradeoff and add regression test

### DIFF
--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -122,4 +122,16 @@ describe("toFhirPractitioner (#388)", () => {
     expect(p.name?.[0]?.family).toBe("Jones");
     expect(p.name?.[0]?.given).toEqual(["Sarah", "M."]);
   });
+
+  it("spelled-out Anglo middle name: 'Sarah Marie Jones' → family='Marie Jones' (#974 known tradeoff)", () => {
+    // Pinning test for the documented tradeoff: with no bare-initial
+    // signal, the penultimate token is treated as the first half of a
+    // two-part family. See parseName docstring. Long-term fix is the
+    // structured name_family / name_given[] columns tracked in #972 —
+    // until then, this test prevents silent behaviour flips on either
+    // side of the Anglo/Hispanic split.
+    const p = toFhirPractitioner(makeUser({ name: "Sarah Marie Jones" }));
+    expect(p.name?.[0]?.family).toBe("Marie Jones");
+    expect(p.name?.[0]?.given).toEqual(["Sarah"]);
+  });
 });

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -61,19 +61,34 @@ const FAMILY_PARTICLES = new Set([
  * "Sarah M. Jones, MD"). FHIR consumers expect a structured split so they
  * can render `{given[0]} {family}` or `{family}, {given[0]}` to taste.
  *
- * Heuristic:
- *  1. Strip trailing credentials after a comma ("Jones, MD").
- *  2. Walk tokens from the right, accreting into `family` while tokens are
- *     either FAMILY_PARTICLES (de, del, van, von, bin, ibn, …) OR the last
- *     two non-particle tokens when there are ≥3 tokens total. This keeps
- *     Hispanic two-part surnames ("María García López" → family "García
- *     López") and particle-prefixed family names ("Sarah de Klerk" →
- *     family "de Klerk") intact.
- *  3. Hyphenated surnames ("Smith-Jones") stay as one token and need no
- *     special handling.
+ * Heuristic for ≥3-token names
+ * ----------------------------
+ * 1. If the penultimate token is a bare initial ("M" or "M."), treat the
+ *    name as Anglo `First Middle Last` — family is the last token, given
+ *    captures everything else.
+ * 2. Otherwise the penultimate is assumed to be the first half of a
+ *    two-part family (Hispanic / Portuguese pattern). This means
+ *    `María García López` → family=`García López`, given=`[María]`.
+ * 3. Particles (de, del, van, von, der, bin, ibn, …) immediately before
+ *    the family group are absorbed into family so `Sarah de Klerk` →
+ *    family=`de Klerk` and `Jan van der Berg` → family=`van der Berg`.
+ *
+ * Known tradeoff (#974)
+ * ---------------------
+ * Anglo full-middle-name inputs like `Sarah Marie Jones` parse as
+ * family=`Marie Jones`, given=`[Sarah]` — because we have no signal at
+ * this layer to tell a middle-name from a Hispanic first-half-of-family.
+ * The bare-initial guard above keeps `Sarah M. Jones` working, but
+ * spelled-out middle names regress. Long-term fix is the structured
+ * `name_family` / `name_given[]` columns on the users table tracked in
+ * #972; until then, the test suite pins both shapes so a future edit
+ * cannot silently flip the behaviour the other way.
+ *
+ * Hyphenated surnames (`Smith-Jones`) stay as one token and need no
+ * special handling.
  *
  * This is a heuristic; structured name fields on the users table are the
- * long-term fix (see issue #944 for the migration plan).
+ * long-term fix (see #972 for the migration plan).
  */
 function parseName(fullName: string): HumanName {
   // Strip any trailing ", MD" / ", RN" / ", PhD" credentials.


### PR DESCRIPTION
## Summary
Per the issue scope (docstring + pinning test only):

- Rewrites the \`parseName\` docstring to describe the 3+-token heuristic and explicitly call out the Anglo middle-name tradeoff with the #972 follow-up.
- Adds a pinning test \`'Sarah Marie Jones' → family='Marie Jones'\` so a future edit can't silently flip behaviour either way.

The real fix is structured \`name_family\` / \`name_given[]\` columns on the users table (#972). This PR is the interim correctness contract on the current heuristic.

## Closes
- #974

## Test plan
- [x] \`pnpm --filter @carebridge/fhir-gateway test\` — 196/196 (was 195)