### PR TITLE
feat(ai): anchor CROSS-ANTICOAG-NSAID-GIBLEED-001 on ICD-10 codes

### DIFF
--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -402,6 +402,95 @@ describe("CROSS-ANTICOAG-NSAID-GIBLEED-001 — triple bleed risk (#263)", () => 
       ),
     ).toBeDefined();
   });
+
+  describe("ICD-10 structured-code branch (#971)", () => {
+    it("fires on K92.2 (GI hemorrhage unspecified) even with non-bleed free text", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K92.2"],
+        active_diagnoses: ["Chronic anemia"],
+        active_medications: ["Warfarin 5mg daily", "Ibuprofen 400mg PRN"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on K92.0 (hematemesis) by code", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K92.0"],
+        active_medications: ["Apixaban 5mg BID", "Naproxen 500mg BID"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on K25.4 (gastric ulcer with chronic hemorrhage) by code", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K25.4"],
+        active_medications: ["Warfarin 5mg daily", "Aspirin 81mg daily"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on I85.01 (esophageal varices with bleeding) by code", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["I85.01"],
+        active_medications: ["Apixaban 5mg BID", "Ketorolac 30mg IV"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("does NOT fire on K25.9 (gastric ulcer, unspecified — no hemorrhage) with 'no bleed' text", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K25.9"],
+        active_diagnoses: ["Peptic ulcer disease, treated, no bleed"],
+        active_medications: ["Apixaban 5mg BID", "Ibuprofen 400mg PRN"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does NOT fire on unrelated K-block codes (K21.9 GERD)", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K21.9"],
+        active_diagnoses: ["GERD"],
+        active_medications: ["Apixaban 5mg BID", "Ibuprofen 400mg PRN"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("fires on UGIB / LGIB shorthand in free text (#971 previously-FN)", () => {
+      const ctx = emptyCtx({
+        active_diagnoses: ["History of UGIB 2022"],
+        active_medications: ["Warfarin 5mg daily", "Aspirin 81mg daily"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+  });
 });
 
 describe("CROSS-IMMUNOSUPPRESSED-FEVER-001 — non-chemo immunosuppression + fever (#263)", () => {

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -490,6 +490,78 @@ describe("CROSS-ANTICOAG-NSAID-GIBLEED-001 — triple bleed risk (#263)", () => 
         ),
       ).toBeDefined();
     });
+
+    it("fires on K25.0 (acute gastric ulcer with hemorrhage) — #1029 acute-vs-chronic fix", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K25.0"],
+        active_medications: ["Warfarin 5mg daily", "Ibuprofen 400mg PRN"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on K26.2 (acute duodenal ulcer with hemorrhage) — #1029", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K26.2"],
+        active_medications: ["Apixaban 5mg BID", "Naproxen 500mg BID"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on K57.01 (diverticulosis of small intestine with bleeding) — #1034", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K57.01"],
+        active_medications: ["Warfarin 5mg daily", "Aspirin 81mg daily"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("does NOT false-match on truncated K57.1 (incomplete code) — #1034", () => {
+      const ctx = emptyCtx({
+        active_diagnosis_codes: ["K57.1"],
+        active_medications: ["Apixaban 5mg BID", "Naproxen 500mg BID"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("fires on 'peptic ulcer with bleeding' (gerund form) — #1031", () => {
+      const ctx = emptyCtx({
+        active_diagnoses: ["History of peptic ulcer with bleeding, treated 2022"],
+        active_medications: ["Warfarin 5mg daily", "Ibuprofen 400mg PRN"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
+
+    it("fires on 'peptic ulcer hemorrhaging' (-ing form on hemorrhage) — #1031", () => {
+      const ctx = emptyCtx({
+        active_diagnoses: ["Peptic ulcer hemorrhaging on admission"],
+        active_medications: ["Apixaban 5mg BID", "Naproxen 500mg BID"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CROSS-ANTICOAG-NSAID-GIBLEED-001",
+        ),
+      ).toBeDefined();
+    });
   });
 });
 

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -1218,12 +1218,16 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       //
       // Codes that imply an active or prior hemorrhagic GI event:
       //  - K92.0/1/2  Hematemesis / Melena / GI hemorrhage unspecified
-      //  - K25-K28 .4 / .6  Gastric/duodenal/peptic/gastrojejunal ulcer
-      //    with hemorrhage (chronic / acute)
+      //  - K25-K28 .0/.2/.4/.6  Gastric/duodenal/peptic/gastrojejunal
+      //    ulcer with hemorrhage — acute (.0, .2) and chronic (.4, .6).
+      //    Acute bleeds are the more clinically urgent case (#1029).
       //  - I85.01 / I85.11  Esophageal varices with bleeding
-      //  - K57.x1 / K57.x3  Diverticular disease with bleeding
+      //  - K57.x1 / K57.x3  Diverticular disease with bleeding. The `x`
+      //    is the per-site sub-category digit (K57.01, K57.11, K57.41, …);
+      //    `[0-9]+[13]` requires at least one digit so the truncated
+      //    K57.1 / K57.3 don't false-match (#1034).
       const GI_BLEED_ICD10_PATTERN =
-        /^(K92\.[012]|K2[5-8]\.[46]|I85\.[01]1|K57\.[0-9]*[13])\b/;
+        /^(K92\.[012]|K2[5-8]\.[0246]|I85\.[01]1|K57\.[0-9]+[13])\b/;
       // Require bleed/hemorrhage/hematochezia context for "upper gi" / "lower
       // gi" mentions so imaging studies ("Lower GI series, normal 2023") and
       // generic symptom blurbs ("upper GI symptoms") don't trigger a
@@ -1231,12 +1235,27 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       //
       // `peptic ulcer` was previously a bare match — tightened in #971 to
       // require an adjacent bleed term so "Peptic ulcer disease, no bleed"
-      // no longer fires on the text path. Coded peptic-ulcer bleeds are
-      // still caught by the K25-K28 .4/.6 ICD-10 branch above. Variceal
-      // and angiodysplasia stay bare because the diagnosis text itself
-      // implies bleed risk in this clinical context.
-      const GI_BLEED_HISTORY_PATTERN =
-        /gi bleed|gastrointestinal bleed|\b[ul]gib\b|peptic ulcer[^,]*\b(?:bleed|hemorrhage|haemorrhage)\b|\b(?:bleed|hemorrhage|haemorrhage)\b[^,]*peptic ulcer|hematemesis|melena|hematochezia|(?:upper|lower)\s+gi\s+(?:bleed|hemorrhage|haemorrhage|hematemesis|melena|hematochezia)|diverticular bleed|angiodysplasia|variceal/i;
+      // no longer fires on the text path. The bleed token captures noun and
+      // gerund forms (`bleed`, `bleeds`, `bleeding`, `hemorrhage`,
+      // `hemorrhagic`, `hemorrhaging`) so "peptic ulcer with bleeding"
+      // matches (#1031). The `[^,]*` (no commas allowed) keeps the
+      // clause-local semantics that reject "Peptic ulcer disease, treated,
+      // no bleed". Comma-separated true-bleed cases ("Peptic ulcer,
+      // hemorrhage 2022") are caught by the K25-K28 .0/.2/.4/.6 ICD-10
+      // branch when coded. Variceal and angiodysplasia stay bare because
+      // the diagnosis text itself implies bleed risk in this clinical
+      // context.
+      const BLEED_TERM =
+        "(?:bleed(?:ing|s)?|hemorrhag(?:e|ic|ing)|haemorrhag(?:e|ic|ing))";
+      const GI_BLEED_HISTORY_PATTERN = new RegExp(
+        `gi bleed|gastrointestinal bleed|\\b[ul]gib\\b|` +
+        `peptic ulcer[^,]*\\b${BLEED_TERM}\\b|` +
+        `\\b${BLEED_TERM}\\b[^,]*peptic ulcer|` +
+        `hematemesis|melena|hematochezia|` +
+        `(?:upper|lower)\\s+gi\\s+(?:${BLEED_TERM}|hematemesis|melena|hematochezia)|` +
+        `diverticular bleed|angiodysplasia|variceal`,
+        "i",
+      );
       // Deliberately include aspirin here (not part of NSAID_PATTERN because
       // other NSAID rules care about prostaglandin / renal-profile risks
       // where aspirin kinetics differ). For GI-bleed risk in

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -1211,14 +1211,32 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     id: "CROSS-ANTICOAG-NSAID-GIBLEED-001",
     name: "Anticoagulant + NSAID with prior GI bleed history",
     check: (ctx: PatientContext) => {
+      // #971 — Free-text matching is fundamentally fragile for a
+      // critical-severity rule. Anchor on ICD-10 codes first (the
+      // structured signal already populated by review-service.ts) and
+      // fall back to the text pattern for un-coded notes.
+      //
+      // Codes that imply an active or prior hemorrhagic GI event:
+      //  - K92.0/1/2  Hematemesis / Melena / GI hemorrhage unspecified
+      //  - K25-K28 .4 / .6  Gastric/duodenal/peptic/gastrojejunal ulcer
+      //    with hemorrhage (chronic / acute)
+      //  - I85.01 / I85.11  Esophageal varices with bleeding
+      //  - K57.x1 / K57.x3  Diverticular disease with bleeding
+      const GI_BLEED_ICD10_PATTERN =
+        /^(K92\.[012]|K2[5-8]\.[46]|I85\.[01]1|K57\.[0-9]*[13])\b/;
       // Require bleed/hemorrhage/hematochezia context for "upper gi" / "lower
       // gi" mentions so imaging studies ("Lower GI series, normal 2023") and
       // generic symptom blurbs ("upper GI symptoms") don't trigger a
-      // critical flag. Specific entities (peptic ulcer, variceal,
-      // angiodysplasia) stay bare because the diagnosis itself implies
-      // bleed risk in this clinical context.
+      // critical flag.
+      //
+      // `peptic ulcer` was previously a bare match — tightened in #971 to
+      // require an adjacent bleed term so "Peptic ulcer disease, no bleed"
+      // no longer fires on the text path. Coded peptic-ulcer bleeds are
+      // still caught by the K25-K28 .4/.6 ICD-10 branch above. Variceal
+      // and angiodysplasia stay bare because the diagnosis text itself
+      // implies bleed risk in this clinical context.
       const GI_BLEED_HISTORY_PATTERN =
-        /gi bleed|gastrointestinal bleed|peptic ulcer|hematemesis|melena|hematochezia|(?:upper|lower)\s+gi\s+(?:bleed|hemorrhage|haemorrhage|hematemesis|melena|hematochezia)|diverticular bleed|angiodysplasia|variceal/i;
+        /gi bleed|gastrointestinal bleed|\b[ul]gib\b|peptic ulcer[^,]*\b(?:bleed|hemorrhage|haemorrhage)\b|\b(?:bleed|hemorrhage|haemorrhage)\b[^,]*peptic ulcer|hematemesis|melena|hematochezia|(?:upper|lower)\s+gi\s+(?:bleed|hemorrhage|haemorrhage|hematemesis|melena|hematochezia)|diverticular bleed|angiodysplasia|variceal/i;
       // Deliberately include aspirin here (not part of NSAID_PATTERN because
       // other NSAID rules care about prostaglandin / renal-profile risks
       // where aspirin kinetics differ). For GI-bleed risk in
@@ -1234,10 +1252,13 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
         NSAID_OR_ASPIRIN.test(m),
       );
       if (!onNSAID) return false;
-      const hasGIBleedHistory = ctx.active_diagnoses.some((d) =>
+      const hasGIBleedByCode = ctx.active_diagnosis_codes.some((code) =>
+        GI_BLEED_ICD10_PATTERN.test(code),
+      );
+      if (hasGIBleedByCode) return true;
+      return ctx.active_diagnoses.some((d) =>
         GI_BLEED_HISTORY_PATTERN.test(d),
       );
-      return hasGIBleedHistory;
     },
     severity: "critical" as const,
     category: "cross-specialty" as const,


### PR DESCRIPTION
## Summary
Follow-up from PR #960 review. The other cross-specialty rules (VTE, CHF, hepatic, renal, pregnancy) already consult \`ctx.active_diagnosis_codes\` alongside description regex. \`CROSS-ANTICOAG-NSAID-GIBLEED-001\` was the outlier — free-text only on a critical-severity rule.

### Changes
- New \`GI_BLEED_ICD10_PATTERN\` covering K92.0/1/2 (hematemesis/melena/GI hemorrhage), K25-K28 .4/.6 (peptic ulcer with hemorrhage), I85.01/I85.11 (esophageal varices with bleeding), and K57.x1/K57.x3 (diverticular with bleeding).
- Tightened the \`peptic ulcer\` text branch to require an adjacent \`bleed\`/\`hemorrhage\` term, so "Peptic ulcer disease, no bleed" no longer fires on the text path. Coded peptic-ulcer bleeds are still caught by the ICD-10 K25-K28 .4/.6 branch.
- Added \`UGIB\` / \`LGIB\` shorthand to the text pattern (was a known FN per #971).

### New tests
- K92.2 + non-bleed free text fires (new code path)
- K92.0 / K25.4 / I85.01 each fire by code alone
- K25.9 (no hemorrhage) + "no bleed" text does NOT fire (tightening)
- K21.9 (GERD, unrelated code) does NOT fire (negative)
- UGIB shorthand fires (previously FN)

## Closes
- #971

## Test plan
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 869/869 (was 862)