### PR TITLE
feat(medical-logic): extend glycopeptide allergen synonyms to lipoglycopeptides

### DIFF
--- a/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
+++ b/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
@@ -55,6 +55,16 @@ describe("normalizeAllergen (#232)", () => {
     expect(normalizeAllergen("teicoplanin")).toBe("vancomycin");
   });
 
+  it("resolves lipoglycopeptide class members to vancomycin (#973)", () => {
+    expect(normalizeAllergen("dalbavancin")).toBe("vancomycin");
+    expect(normalizeAllergen("Dalvance")).toBe("vancomycin");
+    expect(normalizeAllergen("oritavancin")).toBe("vancomycin");
+    expect(normalizeAllergen("Orbactiv")).toBe("vancomycin");
+    expect(normalizeAllergen("telavancin")).toBe("vancomycin");
+    expect(normalizeAllergen("Vibativ")).toBe("vancomycin");
+    expect(normalizeAllergen("lipoglycopeptide")).toBe("vancomycin");
+  });
+
   it("returns the trimmed/lowercased input for unknown allergens", () => {
     expect(normalizeAllergen("  Salmon  ")).toBe("salmon");
     expect(normalizeAllergen("zolbidopride")).toBe("zolbidopride");
@@ -97,6 +107,21 @@ describe("expandAllergenAliases (#232)", () => {
     const redManAliases = expandAllergenAliases("Red Man Syndrome");
     expect(redManAliases).toContain("vancomycin");
     expect(redManAliases).toContain("vancocin");
+  });
+
+  it("'glycopeptide' chart entry expands to the full lipoglycopeptide class (#973)", () => {
+    // Strategy 1 in services/ai-oversight/src/rules/allergy-medication.ts
+    // iterates the expanded alias list and substring-tests against each
+    // active medication. A charted "glycopeptide" allergy must therefore
+    // expand to dalbavancin / oritavancin / telavancin so an Rx for any
+    // of those triggers a direct-match flag without depending on the
+    // (separately gated) class-level cross-reactivity map.
+    const aliases = expandAllergenAliases("glycopeptide");
+    expect(aliases).toContain("vancomycin");
+    expect(aliases).toContain("teicoplanin");
+    expect(aliases).toContain("dalbavancin");
+    expect(aliases).toContain("oritavancin");
+    expect(aliases).toContain("telavancin");
   });
 
   it("unknown allergen returns single-element list", () => {

--- a/packages/medical-logic/src/allergen-synonyms.ts
+++ b/packages/medical-logic/src/allergen-synonyms.ts
@@ -106,18 +106,34 @@ export const ALLERGEN_SYNONYMS: Record<string, string[]> = {
     "minocycline",
     "minocin",
   ],
-  // Glycopeptides. Vancomycin is the common chart entry; "Red Man" (a
-  // pseudoallergic histamine-release reaction, not IgE) is frequently
+  // Glycopeptides (vancomycin, teicoplanin) and lipoglycopeptides
+  // (dalbavancin, oritavancin, telavancin) — same mechanistic class for
+  // allergy purposes. Vancomycin is the common chart entry; "Red Man"
+  // (a pseudoallergic histamine-release reaction, not IgE) is frequently
   // charted in the allergy field regardless of mechanism — the synonym
   // layer captures the class match and leaves the true-allergy vs
   // infusion-reaction judgement to the flag consumer.
+  //
+  // #973 extends class coverage to the lipoglycopeptides; a charted
+  // "glycopeptide" allergy now expands to the full class so a
+  // dalbavancin or telavancin prescription hits the Strategy-1
+  // direct-match path in allergy-medication.ts.
   vancomycin: [
     "vancomycin",
     "vanco",
     "vancocin",
     "glycopeptide",
     "glycopeptides",
+    "lipoglycopeptide",
+    "lipoglycopeptides",
     "teicoplanin",
+    "dalbavancin",
+    "dalvance",
+    "oritavancin",
+    "orbactiv",
+    "kimyrsa",
+    "telavancin",
+    "vibativ",
     "red man",
     "red man syndrome",
   ],


### PR DESCRIPTION
## Summary
Closes Gap 1 of #973. Adds dalbavancin / oritavancin / telavancin (plus brand names) and the umbrella \`lipoglycopeptide\` aliases to the vancomycin canonical. A charted "glycopeptide" allergy now expands to the full class so Strategy 1 (direct-match) in \`allergy-medication.ts\` catches an Rx for any lipoglycopeptide.

### Why split from Gap 2
Gap 2 ("Add a \`CROSS_REACTIVITY_MAP\` entry for glycopeptides") triggers the \`cross-reactivity-sync.test.ts\` symmetry check, which requires a matching LLM-side anchor in \`packages/ai-prompts/src/drug-class-anchors.ts\`. That falls under the clinical sign-off process documented in \`docs/ai-prompt-editing.md\` (clinical-reviewer approval, references, \`PROMPT_VERSION\` bump). Filing as a separate follow-up so the synonym-layer fix can ship now without the heavier sign-off.

## Closes
- #973 (Gap 1 — synonym extension)

## Follow-up
- Gap 2 (CROSS_REACTIVITY_MAP + LLM anchor) — separate issue to follow.

## Test plan
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 424/424 (was 422)
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 862/862 (no regressions)