### PR TITLE
feat(ai): make opioid daily-dose critical ratios deployment-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,15 @@ covers every value below tagged "secret".
 | `SCHEDULING_HEALTH_PORT` | scheduling reminder worker health check port | `4003` |
 | `CORS_ORIGIN` | Allowed origin for the gateway CORS plugin | none (locked down) |
 
+#### Clinical-rule tuning
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPIOID_CRITICAL_RATIO` | Excess-over-cap ratio at which opioid daily-dose flags escalate warning → critical. Tune for deployment context: hospice/palliative may raise to 2.0+; outpatient CDC-calibrated stays at default. | `1.2` |
+| `NON_OPIOID_CRITICAL_RATIO` | Same gradient for NSAID / analgesic daily-dose flags. Hepatic-clinic deployments may want 1.5. | `2.0` |
+
+Invalid overrides (non-numeric or ≤1.0) fall back to default and log a structured `invalid_ratio_override` warning so the misconfiguration surfaces in CI / startup logs. Flag rationale surfaces the active value when an override is in effect.
+
 #### Dev-mode flags
 
 | Variable | Description | Example |

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { ClinicalEvent } from "@carebridge/shared-types";
-import { checkMedicationDailyDose } from "./medication-daily-dose.js";
+import {
+  checkMedicationDailyDose,
+  resolveRatio,
+  OPIOID_CRITICAL_RATIO_DEFAULT,
+} from "./medication-daily-dose.js";
 import type { PatientContext, PatientMedication } from "./cross-specialty.js";
 
 function makeMed(
@@ -253,6 +257,102 @@ describe("checkMedicationDailyDose (#235)", () => {
       ctx.active_medications_detail = [];
       const flags = checkMedicationDailyDose(ctx);
       expect(flags).toHaveLength(0);
+    });
+  });
+
+  describe("resolveRatio — deployment override (#968)", () => {
+    const envKey = "TEST_RATIO_OVERRIDE_968";
+    afterEach(() => {
+      delete process.env[envKey];
+    });
+
+    it("returns default when env var is unset", () => {
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("returns default when env var is empty string", () => {
+      process.env[envKey] = "";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("parses a valid numeric override", () => {
+      process.env[envKey] = "1.5";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.5);
+    });
+
+    it("parses an integer override", () => {
+      process.env[envKey] = "2";
+      expect(resolveRatio(envKey, 1.2)).toBe(2);
+    });
+
+    it("falls back when env value is non-numeric", () => {
+      process.env[envKey] = "tomato";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back when env value is exactly 1.0 (collapsed warning band)", () => {
+      process.env[envKey] = "1.0";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back when env value is ≤ 1.0", () => {
+      process.env[envKey] = "0.8";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back when env value is negative", () => {
+      process.env[envKey] = "-1.5";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on Infinity", () => {
+      process.env[envKey] = "Infinity";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+  });
+
+  describe("override rationale surfacing (#968)", () => {
+    // The constants are resolved at module-load time, so to test the
+    // override-note rendering we have to reload the module with the env
+    // var pre-set. vi.resetModules + dynamic import keeps the override
+    // contained to this test.
+    let prev: string | undefined;
+    beforeEach(() => {
+      prev = process.env.OPIOID_CRITICAL_RATIO;
+    });
+    afterEach(() => {
+      if (prev === undefined) delete process.env.OPIOID_CRITICAL_RATIO;
+      else process.env.OPIOID_CRITICAL_RATIO = prev;
+      vi.resetModules();
+    });
+
+    it("includes 'deployment override' note in flag rationale when overridden", async () => {
+      process.env.OPIOID_CRITICAL_RATIO = "2.0";
+      vi.resetModules();
+      const fresh = await import("./medication-daily-dose.js");
+      // 10 mg morphine q2h = 120 mg/day, 1.33× the 90 mg cap. Under default
+      // 1.2× this would be critical; under override 2.0× it stays warning.
+      // The rationale should mention the active override either way.
+      const flags = fresh.checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q2h" })),
+      );
+      const daily = flags.find((f) => f.rule_id?.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.rationale).toMatch(/deployment override/);
+      expect(daily!.rationale).toMatch(/2(\.0)?×/);
+      expect(daily!.rationale).toMatch(
+        new RegExp(`${OPIOID_CRITICAL_RATIO_DEFAULT}×`),
+      );
+    });
+
+    it("omits the override note when running at the default ratio", () => {
+      // Module-load default path — no env override.
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Morphine", dose_amount: 10, frequency: "q2h" })),
+      );
+      const daily = flags.find((f) => f.rule_id?.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.rationale).not.toMatch(/deployment override/);
     });
   });
 

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -34,6 +34,9 @@ import {
   getMedicationDoseLimit,
 } from "@carebridge/medical-logic";
 import type { PatientContext, PatientMedication } from "./cross-specialty.js";
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("medication-daily-dose");
 
 /**
  * Canonicalise a drug name into a rule_id slug: lowercase, replace
@@ -51,27 +54,87 @@ function slugForRuleId(name: string): string {
 }
 
 /**
+ * CDC-calibrated defaults for the opioid / non-opioid critical-escalation
+ * ratios. The active values are exported as
+ * {@link OPIOID_CRITICAL_RATIO} / {@link NON_OPIOID_CRITICAL_RATIO} below
+ * and may be tuned per-deployment via env vars (see {@link resolveRatio}).
+ */
+export const OPIOID_CRITICAL_RATIO_DEFAULT = 1.2;
+export const NON_OPIOID_CRITICAL_RATIO_DEFAULT = 2.0;
+
+/**
+ * Resolve a per-deployment ratio override from an env var. Returns the
+ * default when the env var is unset, empty, non-numeric, or ≤ 1.0 (a
+ * ratio of 1.0 or below would fire critical on any over-cap dose at all,
+ * collapsing the warning band and almost certainly a misconfiguration).
+ *
+ * Invalid values fall back to the default with a structured warning so
+ * the operator can see the misconfiguration in CI / startup logs without
+ * the safety guard silently de-tuning to nothing.
+ */
+export function resolveRatio(envKey: string, defaultValue: number): number {
+  const raw = process.env[envKey];
+  if (raw === undefined || raw === "") return defaultValue;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed <= 1.0) {
+    log.warn("invalid_ratio_override", {
+      envKey,
+      raw,
+      reason: "non-finite or ≤ 1.0",
+      fallback: defaultValue,
+    });
+    return defaultValue;
+  }
+  return parsed;
+}
+
+/**
  * Opioid daily-dose excess-ratio at which we escalate warning → critical.
  *
- * CDC 2022 calibrates the per-drug daily caps in MEDICATION_MAX_DAILY_DOSES
- * to the 90 MME/day elevated-risk threshold. Exceeding that cap by even 20%
- * (1.2× → 108 MME) crosses into the zone where respiratory-depression and
- * overdose risk climb steeply, so we escalate aggressively. Lowering this
- * number makes the rule more sensitive; raising it makes the rule more
- * tolerant of over-threshold prescribing.
+ * Default (1.2×) is calibrated against the CDC 2022 90 MME/day elevated-
+ * risk threshold — per-drug daily caps in MEDICATION_MAX_DAILY_DOSES are
+ * pegged to 90 MME, so 1.2× → 108 MME, the zone where respiratory-
+ * depression and overdose risk climb steeply.
  *
- * If clinical teams want deployment-specific tuning (e.g. hospice vs
- * outpatient), follow-up #968 tracks exposing this as config. Until then
- * any calibration change requires a deliberate code edit + review.
+ * Override via `OPIOID_CRITICAL_RATIO` env var. Different care settings
+ * have legitimate calibration needs:
+ *  - Hospice / palliative: CDC exempts active cancer / sickle-cell /
+ *    end-of-life from the 90 MME threshold. Raise to 2.0+ to avoid
+ *    flooding the flag queue with expected-and-appropriate prescriptions.
+ *  - Outpatient / primary care: 1.2× is CDC's target — keep default.
+ *  - Inpatient acute / post-op: short-horizon higher doses are routine;
+ *    consider 1.5–1.8×.
+ *
+ * When the override differs from the default, the active value is
+ * surfaced in the flag rationale so reviewers see which threshold fired.
  */
-export const OPIOID_CRITICAL_RATIO = 1.2;
+export const OPIOID_CRITICAL_RATIO = resolveRatio(
+  "OPIOID_CRITICAL_RATIO",
+  OPIOID_CRITICAL_RATIO_DEFAULT,
+);
 
 /**
  * Non-opioid NSAID / analgesic over-limits cause cumulative rather than
- * acute harm (hepatic, renal, GI over weeks of over-dosing), so we use a
- * gentler gradient: 1–2× is warning, ≥2× is critical.
+ * acute harm (hepatic, renal, GI over weeks of over-dosing), so the
+ * default is a gentler 2.0× gradient: 1–2× is warning, ≥2× is critical.
+ *
+ * Override via `NON_OPIOID_CRITICAL_RATIO` env var (e.g. hepatic-clinic
+ * deployments may want 1.5× given Child-Pugh-B patients' diminished
+ * tolerance). Same fallback / audit-rationale visibility as the opioid
+ * ratio above.
  */
-export const NON_OPIOID_CRITICAL_RATIO = 2.0;
+export const NON_OPIOID_CRITICAL_RATIO = resolveRatio(
+  "NON_OPIOID_CRITICAL_RATIO",
+  NON_OPIOID_CRITICAL_RATIO_DEFAULT,
+);
+
+/** Per-deployment override active? */
+function isOpioidRatioOverridden(): boolean {
+  return OPIOID_CRITICAL_RATIO !== OPIOID_CRITICAL_RATIO_DEFAULT;
+}
+function isNonOpioidRatioOverridden(): boolean {
+  return NON_OPIOID_CRITICAL_RATIO !== NON_OPIOID_CRITICAL_RATIO_DEFAULT;
+}
 
 /** Map the excess-ratio of estimated-over-max into a flag severity. */
 function severityForDailyOver(
@@ -175,6 +238,18 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
     const mmeNote = isOpioid
       ? ` (implied ${Math.round(daily * (limit.mmeFactor ?? 1))} MME/day; CDC elevated-risk threshold is 90 MME/day)`
       : "";
+    // Surface the active critical-escalation ratio in the audit trail
+    // when it has been overridden via env config so reviewers can see
+    // which threshold fired (#968).
+    const activeRatio = isOpioid ? OPIOID_CRITICAL_RATIO : NON_OPIOID_CRITICAL_RATIO;
+    const isOverridden = isOpioid
+      ? isOpioidRatioOverridden()
+      : isNonOpioidRatioOverridden();
+    const overrideNote = isOverridden
+      ? ` Active critical-escalation ratio: ${activeRatio}× (deployment override; CDC default ${
+          isOpioid ? OPIOID_CRITICAL_RATIO_DEFAULT : NON_OPIOID_CRITICAL_RATIO_DEFAULT
+        }×).`
+      : "";
     flags.push({
       severity,
       category: "medication-safety" as FlagCategory,
@@ -191,7 +266,8 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
           ? `Over-prescription beyond the CDC 90 MME/day elevated-risk ` +
             `threshold is a leading driver of respiratory depression and overdose.`
           : `Chronic dosing above this threshold carries hepatic, renal, and ` +
-            `GI risks depending on the agent.`),
+            `GI risks depending on the agent.`) +
+        overrideNote,
       suggested_action:
         `Review frequency and dose. Typical options: reduce per-dose amount, ` +
         `widen dosing interval (e.g. q6h → q8h), or impose a PRN cap ` +


### PR DESCRIPTION
## Summary
Closes #968. Follow-up to #955 (which extracted the inline ratios into constants but deferred the deployment-config half of #930).

\`OPIOID_CRITICAL_RATIO\` and \`NON_OPIOID_CRITICAL_RATIO\` now read optional env-var overrides. Defaults stay at the CDC-calibrated 1.2× and 2.0×.

### Why
- **Hospice / palliative**: active cancer / sickle-cell / end-of-life are CDC-exempt from the 90 MME threshold. 1.2× floods the flag queue with appropriate prescriptions. Raise to 2.0+.
- **Outpatient**: 1.2× is CDC's target — keep default.
- **Inpatient acute / post-op**: short-horizon higher doses are routine; consider 1.5–1.8×.

### Safety properties
- Invalid overrides (non-numeric, ≤1.0, Infinity, negative) fall back to the default and emit a structured \`invalid_ratio_override\` log warning. A typo can't silently de-tune the rule.
- When the override is active, the flag rationale surfaces \`Active critical-escalation ratio: X× (deployment override; CDC default Y×).\` so reviewers see which threshold fired.
- README updated with a new "Clinical-rule tuning" env-var section.

### Test coverage
- 9 unit tests on \`resolveRatio\` covering: unset, empty, valid, integer, non-numeric, exactly 1.0, ≤1.0, negative, Infinity.
- 2 integration tests via \`vi.resetModules\` + dynamic import verifying the rationale text includes the override note when set, omits it when default.

## Closes
- #968

## Test plan
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 873/873 (was 862)
- [x] \`pnpm typecheck\` — 36/36

## Refs
- CDC 2022 opioid prescribing guideline §4 (exemptions)
- #930 (parent), #955 (refactor that landed first)