### PR TITLE
fix(ai): non-opioid override note credits cumulative-harm default, not CDC

### DIFF
--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -343,6 +343,29 @@ describe("checkMedicationDailyDose (#235)", () => {
       expect(daily!.rationale).toMatch(
         new RegExp(`${OPIOID_CRITICAL_RATIO_DEFAULT}×`),
       );
+      // Opioid path correctly credits CDC as the default-source authority.
+      expect(daily!.rationale).toMatch(/CDC default/);
+    });
+
+    it("non-opioid override note credits cumulative-harm default (NOT CDC) (#1042)", async () => {
+      process.env.NON_OPIOID_CRITICAL_RATIO = "1.5";
+      vi.resetModules();
+      const fresh = await import("./medication-daily-dose.js");
+      // Acetaminophen 1000 mg q4h = 6000 mg/day, 1.5× the 4000 mg cap.
+      // At the override ratio of 1.5 this stays in the critical band; the
+      // rationale must mention the override but must NOT credit CDC for
+      // the non-opioid default (CDC's 90 MME guideline is opioid-only).
+      const flags = fresh.checkMedicationDailyDose(
+        makeCtx(makeMed({ name: "Acetaminophen", dose_amount: 1000, frequency: "q4h" })),
+      );
+      const daily = flags.find((f) => f.rule_id?.startsWith("MED-DAILY-OVER"));
+      expect(daily).toBeDefined();
+      expect(daily!.rationale).toMatch(/deployment override/);
+      expect(daily!.rationale).toMatch(/cumulative-harm default/);
+      // The 'CDC default' string must NOT appear in non-opioid rationale.
+      expect(daily!.rationale).not.toMatch(/CDC default/);
+      // Reset for subsequent tests in this describe block.
+      delete process.env.NON_OPIOID_CRITICAL_RATIO;
     });
 
     it("omits the override note when running at the default ratio", () => {

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -54,10 +54,13 @@ function slugForRuleId(name: string): string {
 }
 
 /**
- * CDC-calibrated defaults for the opioid / non-opioid critical-escalation
- * ratios. The active values are exported as
- * {@link OPIOID_CRITICAL_RATIO} / {@link NON_OPIOID_CRITICAL_RATIO} below
- * and may be tuned per-deployment via env vars (see {@link resolveRatio}).
+ * Default critical-escalation ratios. The opioid default (1.2×) is
+ * CDC-calibrated against the 2022 90 MME/day threshold; the non-opioid
+ * default (2.0×) reflects cumulative hepatic/renal/GI harm — not a CDC
+ * threshold (CDC's 90 MME guideline is opioid-only). Active values are
+ * exported as {@link OPIOID_CRITICAL_RATIO} / {@link NON_OPIOID_CRITICAL_RATIO}
+ * below and may be tuned per-deployment via env vars (see
+ * {@link resolveRatio}).
  */
 export const OPIOID_CRITICAL_RATIO_DEFAULT = 1.2;
 export const NON_OPIOID_CRITICAL_RATIO_DEFAULT = 2.0;

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -245,10 +245,17 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
     const isOverridden = isOpioid
       ? isOpioidRatioOverridden()
       : isNonOpioidRatioOverridden();
+    // The opioid default (1.2×) is CDC-calibrated; the non-opioid default
+    // (2.0×) comes from the cumulative-harm rationale (hepatic / renal /
+    // GI over weeks) — not the CDC 90 MME guideline. Label them correctly
+    // so the audit trail doesn't falsely credit CDC for the non-opioid
+    // threshold (#1042).
+    const defaultRatio = isOpioid
+      ? OPIOID_CRITICAL_RATIO_DEFAULT
+      : NON_OPIOID_CRITICAL_RATIO_DEFAULT;
+    const defaultSource = isOpioid ? "CDC default" : "cumulative-harm default";
     const overrideNote = isOverridden
-      ? ` Active critical-escalation ratio: ${activeRatio}× (deployment override; CDC default ${
-          isOpioid ? OPIOID_CRITICAL_RATIO_DEFAULT : NON_OPIOID_CRITICAL_RATIO_DEFAULT
-        }×).`
+      ? ` Active critical-escalation ratio: ${activeRatio}× (deployment override; ${defaultSource} ${defaultRatio}×).`
       : "";
     flags.push({
       severity,


### PR DESCRIPTION
## Summary
CDC's 90 MME/day guideline is opioid-only. The non-opioid critical ratio (2.0×) is calibrated against cumulative hepatic/renal/GI harm — not CDC. The overrideNote in \`medication-daily-dose.ts\` previously claimed "CDC default 2×" for the non-opioid branch.

Branches now label correctly:
- Opioid: "deployment override; CDC default 1.2×"
- Non-opioid: "deployment override; cumulative-harm default 2×"

## Closes
- #1042

## Test plan
- [x] New test asserts the non-opioid override rationale does NOT contain "CDC default"
- [x] Existing opioid override test now also asserts CDC presence (positive)
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 890/890 (was 888)