### PR TITLE
docs(fhir): clarify parseName Anglo-middle-name tradeoff covers 3+ tokens

### DIFF
--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -135,4 +135,14 @@ describe("toFhirPractitioner (#388)", () => {
     expect(p.name?.[0]?.family).toBe("Marie Jones");
     expect(p.name?.[0]?.given).toEqual(["Sarah"]);
   });
+
+  it("4-token Anglo full middle name: 'John Robert Quincy Adams' → family='Quincy Adams' (#1027)", () => {
+    // The Anglo-middle-name tradeoff isn't bounded to 3 tokens. With any
+    // 3+-token name and a non-initial penultimate, family absorbs the
+    // penultimate. Pinning a 4-token case so a future edit doesn't
+    // silently change behaviour for longer chains.
+    const p = toFhirPractitioner(makeUser({ name: "John Robert Quincy Adams" }));
+    expect(p.name?.[0]?.family).toBe("Quincy Adams");
+    expect(p.name?.[0]?.given).toEqual(["John", "Robert"]);
+  });
 });

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -81,10 +81,10 @@ const FAMILY_PARTICLES = new Set([
  * The bare-initial guard above keeps `Sarah M. Jones` working, but
  * spelled-out middle names regress.
  *
- * The same applies to longer Anglo chains — any non-initial penultimate
- * is absorbed into family regardless of token count, so
- * `John Robert Quincy Adams` parses as family=`Quincy Adams`,
- * given=`[John, Robert]`. This is not a 3-token-only quirk.
+ * The same applies to longer Anglo chains — whenever the penultimate
+ * token is not a bare initial, it is absorbed into family regardless of
+ * token count. So `John Robert Quincy Adams` parses as family=`Quincy
+ * Adams`, given=`[John, Robert]`. This is not a 3-token-only quirk.
  *
  * Long-term fix is the structured `name_family` / `name_given[]` columns
  * on the users table tracked in #972; until then, the test suite pins

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -73,16 +73,22 @@ const FAMILY_PARTICLES = new Set([
  *    the family group are absorbed into family so `Sarah de Klerk` →
  *    family=`de Klerk` and `Jan van der Berg` → family=`van der Berg`.
  *
- * Known tradeoff (#974)
- * ---------------------
+ * Known tradeoff (#974, #1027)
+ * ----------------------------
  * Anglo full-middle-name inputs like `Sarah Marie Jones` parse as
  * family=`Marie Jones`, given=`[Sarah]` — because we have no signal at
  * this layer to tell a middle-name from a Hispanic first-half-of-family.
  * The bare-initial guard above keeps `Sarah M. Jones` working, but
- * spelled-out middle names regress. Long-term fix is the structured
- * `name_family` / `name_given[]` columns on the users table tracked in
- * #972; until then, the test suite pins both shapes so a future edit
- * cannot silently flip the behaviour the other way.
+ * spelled-out middle names regress.
+ *
+ * The same applies to longer Anglo chains — any non-initial penultimate
+ * is absorbed into family regardless of token count, so
+ * `John Robert Quincy Adams` parses as family=`Quincy Adams`,
+ * given=`[John, Robert]`. This is not a 3-token-only quirk.
+ *
+ * Long-term fix is the structured `name_family` / `name_given[]` columns
+ * on the users table tracked in #972; until then, the test suite pins
+ * representative cases so a future edit cannot silently flip behaviour.
  *
  * Hyphenated surnames (`Smith-Jones`) stay as one token and need no
  * special handling.


### PR DESCRIPTION
## Summary
PR #1015 framed the parseName Anglo-middle-name tradeoff as a 3-token case. The heuristic actually applies to all 3+-token Anglo names — \`John Robert Quincy Adams\` parses as family=\`Quincy Adams\`, given=\`[John, Robert]\`.

- Docstring sentence added covering longer chains
- New pinning test for the 4-token case

## Closes
- #1027

## Test plan
- [x] \`pnpm --filter @carebridge/fhir-gateway test\` — 201/201 (was 200)