### PR TITLE
fix(ai): strict numeric parsing in resolveRatio rejects partial / locale typos

### DIFF
--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -309,6 +309,38 @@ describe("checkMedicationDailyDose (#235)", () => {
       process.env[envKey] = "Infinity";
       expect(resolveRatio(envKey, 1.2)).toBe(1.2);
     });
+
+    it("falls back on partial-numeric '2.0x' (#1043)", () => {
+      process.env[envKey] = "2.0x";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on locale-typo '2,0' (#1043)", () => {
+      process.env[envKey] = "2,0";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on scientific notation '1e2' (#1043)", () => {
+      // Scientific notation is unusual for a human-set ratio and is a
+      // common copy-paste artifact from spreadsheets. Reject it.
+      process.env[envKey] = "1e2";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on explicit-positive prefix '+1.5' (#1043)", () => {
+      process.env[envKey] = "+1.5";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on leading-dot '.5' (#1043)", () => {
+      process.env[envKey] = ".5";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("accepts whitespace-padded valid values (trimmed)", () => {
+      process.env[envKey] = "  1.5  ";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.5);
+    });
   });
 
   describe("override rationale surfacing (#968)", () => {

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -63,10 +63,24 @@ export const OPIOID_CRITICAL_RATIO_DEFAULT = 1.2;
 export const NON_OPIOID_CRITICAL_RATIO_DEFAULT = 2.0;
 
 /**
+ * Strict numeric pattern: positive decimal, no sign, no trailing junk,
+ * no commas. Rejects partials that Number.parseFloat would silently
+ * accept like "2.0x" → 2.0 or "2,0" → 2 (#1043).
+ */
+const STRICT_NUMERIC = /^\d+(?:\.\d+)?$/;
+
+/**
  * Resolve a per-deployment ratio override from an env var. Returns the
- * default when the env var is unset, empty, non-numeric, or ≤ 1.0 (a
- * ratio of 1.0 or below would fire critical on any over-cap dose at all,
- * collapsing the warning band and almost certainly a misconfiguration).
+ * default when the env var is unset, empty, fails strict numeric parsing,
+ * or is ≤ 1.0 (a ratio of 1.0 or below would fire critical on any
+ * over-cap dose at all, collapsing the warning band and almost certainly
+ * a misconfiguration).
+ *
+ * Strict numeric parsing rejects partial matches that Number.parseFloat
+ * would accept silently: "2.0x" (typo), "2,0" (locale typo), "1e3"
+ * (scientific notation — unusual for a human-set ratio), "+1.5" (sign
+ * prefix). Any of these surface as `invalid_ratio_override` rather than
+ * a silently de-tuned safety guard (#1043).
  *
  * Invalid values fall back to the default with a structured warning so
  * the operator can see the misconfiguration in CI / startup logs without
@@ -75,7 +89,17 @@ export const NON_OPIOID_CRITICAL_RATIO_DEFAULT = 2.0;
 export function resolveRatio(envKey: string, defaultValue: number): number {
   const raw = process.env[envKey];
   if (raw === undefined || raw === "") return defaultValue;
-  const parsed = Number.parseFloat(raw);
+  const trimmed = raw.trim();
+  if (!STRICT_NUMERIC.test(trimmed)) {
+    log.warn("invalid_ratio_override", {
+      envKey,
+      raw,
+      reason: "not a strict decimal literal",
+      fallback: defaultValue,
+    });
+    return defaultValue;
+  }
+  const parsed = Number.parseFloat(trimmed);
   if (!Number.isFinite(parsed) || parsed <= 1.0) {
     log.warn("invalid_ratio_override", {
       envKey,


### PR DESCRIPTION
## Summary
\`Number.parseFloat\` silently accepts partials. For a deployment-set safety ratio that's a footgun:
- \`"2.0x"\` → 2.0 (trailing-garbage typo)
- \`"2,0"\` → 2 (European decimal locale typo)
- \`"1e3"\` → 1000 (scientific notation, unusual for a human-set ratio)
- \`"+1.5"\` → 1.5 (sign-prefix oddity)

New \`STRICT_NUMERIC\` regex (\`^\\d+(?:\\.\\d+)?$\`) rejects all four before \`parseFloat\` runs, falling back to the default with the same \`invalid_ratio_override\` log warning as the existing guards. \`raw.trim()\` first so whitespace-padded valid values still work.

## Closes
- #1043

## Test plan
- [x] 6 new tests: \`"2.0x"\`, \`"2,0"\`, \`"1e2"\`, \`"+1.5"\`, \`".5"\`, and trimmed positive case
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 895/895 (was 889)