### PR TITLE
feat(ai): upper-bound sanity check on critical-escalation ratio overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ covers every value below tagged "secret".
 | `OPIOID_CRITICAL_RATIO` | Excess-over-cap ratio at which opioid daily-dose flags escalate warning → critical. Tune for deployment context: hospice/palliative may raise to 2.0+; outpatient CDC-calibrated stays at default. | `1.2` |
 | `NON_OPIOID_CRITICAL_RATIO` | Same gradient for NSAID / analgesic daily-dose flags. Hepatic-clinic deployments may want 1.5. | `2.0` |
 
-Invalid overrides (non-numeric, ≤1.0, or >10) fall back to default and log a structured `invalid_ratio_override` warning so the misconfiguration surfaces in CI / startup logs. The upper bound catches decimal-point typos like `OPIOID_CRITICAL_RATIO=120` (intended `1.20`) that would otherwise silently disable critical escalation. Flag rationale surfaces the active value when an override is in effect.
+Invalid overrides fall back to default and log a structured `invalid_ratio_override` warning so the misconfiguration surfaces in CI / startup logs. Rejected forms: non-decimal-literal strings (including partial-numerics like `"2.0x"`, locale-typos like `"2,0"`, scientific notation `"1e3"`, sign-prefix `"+1.5"`), values ≤ 1.0 (collapsed warning band), and values > 10 (catches decimal-point typos like `OPIOID_CRITICAL_RATIO=120` intended as `1.20`, which would otherwise silently disable critical escalation). Flag rationale surfaces the active value when an override is in effect.
 
 #### Dev-mode flags
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ covers every value below tagged "secret".
 | `OPIOID_CRITICAL_RATIO` | Excess-over-cap ratio at which opioid daily-dose flags escalate warning → critical. Tune for deployment context: hospice/palliative may raise to 2.0+; outpatient CDC-calibrated stays at default. | `1.2` |
 | `NON_OPIOID_CRITICAL_RATIO` | Same gradient for NSAID / analgesic daily-dose flags. Hepatic-clinic deployments may want 1.5. | `2.0` |
 
-Invalid overrides (non-numeric or ≤1.0) fall back to default and log a structured `invalid_ratio_override` warning so the misconfiguration surfaces in CI / startup logs. Flag rationale surfaces the active value when an override is in effect.
+Invalid overrides (non-numeric, ≤1.0, or >10) fall back to default and log a structured `invalid_ratio_override` warning so the misconfiguration surfaces in CI / startup logs. The upper bound catches decimal-point typos like `OPIOID_CRITICAL_RATIO=120` (intended `1.20`) that would otherwise silently disable critical escalation. Flag rationale surfaces the active value when an override is in effect.
 
 #### Dev-mode flags
 

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -341,6 +341,28 @@ describe("checkMedicationDailyDose (#235)", () => {
       process.env[envKey] = "  1.5  ";
       expect(resolveRatio(envKey, 1.2)).toBe(1.5);
     });
+
+    it("falls back on > MAX_RATIO_OVERRIDE (likely decimal-point typo) (#1033)", () => {
+      // 120 is intended as 1.20 — silently accepting would effectively
+      // disable critical escalation. Upper bound is 10.
+      process.env[envKey] = "120";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("falls back on 100 (above the 10 upper bound) (#1033)", () => {
+      process.env[envKey] = "100";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
+
+    it("accepts boundary value of exactly 10 (#1033)", () => {
+      process.env[envKey] = "10";
+      expect(resolveRatio(envKey, 1.2)).toBe(10);
+    });
+
+    it("falls back on 10.5 (just above bound) (#1033)", () => {
+      process.env[envKey] = "10.5";
+      expect(resolveRatio(envKey, 1.2)).toBe(1.2);
+    });
   });
 
   describe("override rationale surfacing (#968)", () => {

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -70,6 +70,15 @@ export const NON_OPIOID_CRITICAL_RATIO_DEFAULT = 2.0;
 const STRICT_NUMERIC = /^\d+(?:\.\d+)?$/;
 
 /**
+ * Upper bound on critical-escalation ratio overrides (#1033). 10× is well
+ * above any clinically defensible setting — even hospice / palliative
+ * tuning (typically 2.0–3.0×) is comfortably below. The bound catches
+ * decimal-point typos like `OPIOID_CRITICAL_RATIO=120` (intended 1.20)
+ * that would silently disable critical escalation entirely.
+ */
+const MAX_RATIO_OVERRIDE = 10;
+
+/**
  * Resolve a per-deployment ratio override from an env var. Returns the
  * default when the env var is unset, empty, fails strict numeric parsing,
  * or is ≤ 1.0 (a ratio of 1.0 or below would fire critical on any
@@ -105,6 +114,17 @@ export function resolveRatio(envKey: string, defaultValue: number): number {
       envKey,
       raw,
       reason: "non-finite or ≤ 1.0",
+      fallback: defaultValue,
+    });
+    return defaultValue;
+  }
+  if (parsed > MAX_RATIO_OVERRIDE) {
+    // Likely decimal-point typo (e.g. 120 for 1.20). Silently accepting
+    // would effectively disable critical escalation.
+    log.warn("invalid_ratio_override", {
+      envKey,
+      raw,
+      reason: `> ${MAX_RATIO_OVERRIDE} (likely decimal-point typo)`,
       fallback: defaultValue,
     });
     return defaultValue;

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -80,20 +80,20 @@ const MAX_RATIO_OVERRIDE = 10;
 
 /**
  * Resolve a per-deployment ratio override from an env var. Returns the
- * default when the env var is unset, empty, fails strict numeric parsing,
- * or is ≤ 1.0 (a ratio of 1.0 or below would fire critical on any
- * over-cap dose at all, collapsing the warning band and almost certainly
- * a misconfiguration).
+ * default when any of the following fails:
+ *  - env var unset or empty
+ *  - fails strict-decimal parsing (rejects "2.0x", "2,0", "1e3", "+1.5",
+ *    leading-dot ".5", etc. — anything Number.parseFloat would partial-
+ *    accept) (#1043)
+ *  - parsed value is non-finite or ≤ 1.0 (collapsed warning band)
+ *  - parsed value is > {@link MAX_RATIO_OVERRIDE} (likely decimal-point
+ *    typo — `OPIOID_CRITICAL_RATIO=120` for intended 1.20 would silently
+ *    disable critical escalation) (#1033)
  *
- * Strict numeric parsing rejects partial matches that Number.parseFloat
- * would accept silently: "2.0x" (typo), "2,0" (locale typo), "1e3"
- * (scientific notation — unusual for a human-set ratio), "+1.5" (sign
- * prefix). Any of these surface as `invalid_ratio_override` rather than
- * a silently de-tuned safety guard (#1043).
- *
- * Invalid values fall back to the default with a structured warning so
- * the operator can see the misconfiguration in CI / startup logs without
- * the safety guard silently de-tuning to nothing.
+ * Invalid values fall back to the default with a structured
+ * `invalid_ratio_override` warning so the operator can see the
+ * misconfiguration in CI / startup logs without the safety guard
+ * silently de-tuning to nothing.
  */
 export function resolveRatio(envKey: string, defaultValue: number): number {
   const raw = process.env[envKey];


### PR DESCRIPTION
## Summary
The lower bound (≤ 1.0) added in #1019 protects against under-tuning. There was no upper bound — a decimal-point typo like \`OPIOID_CRITICAL_RATIO=120\` (intended 1.20) would silently disable critical escalation, the exact failure mode the lower bound was added to prevent.

New \`MAX_RATIO_OVERRIDE = 10\` rejects values above 10 with the same fallback + \`invalid_ratio_override\` log warning. 10× is well above any clinically defensible setting (hospice / palliative ≤ 3×).

The log warning's \`reason\` field distinguishes upper-bound from lower-bound failures so ops can diagnose the typo class.

## Depends on
- #1048 (\`STRICT_NUMERIC\` parsing) — branched off that PR's branch. If #1048 lands first the rebase to main is clean.

## Closes
- #1033

## Test plan
- [x] 4 new tests: \`"120"\`, \`"100"\`, \`"10"\` (boundary), \`"10.5"\`
- [x] README env-var table updated to mention the upper bound
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 899/899 (was 895)