### PR TITLE
feat(medical-logic): restore single-word iodinated/contrast cross-reactivity coverage

### DIFF
--- a/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
+++ b/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
@@ -203,6 +203,22 @@ describe("ALLERGEN_SYNONYMS data sanity", () => {
       expect(aliases).not.toContain("iohexol");
       expect(aliases).not.toContain("omnipaque");
     });
+
+    it("bare 'iodinated' / 'contrast' / 'radiocontrast' tokens resolve to iodinated contrast (#1030)", () => {
+      // After PR #1012 narrowed the iodinated-contrast allergenPattern,
+      // single-word chart entries lost their fallback. These aliases
+      // restore Strategy-2 coverage: a charted "iodinated" expands into
+      // the full canonical group via allergenBlob.
+      expect(normalizeAllergen("iodinated")).toBe("iodinated contrast");
+      expect(normalizeAllergen("Contrast")).toBe("iodinated contrast");
+      expect(normalizeAllergen("radiocontrast")).toBe("iodinated contrast");
+      const aliases = expandAllergenAliases("iodinated");
+      expect(aliases).toContain("iodinated contrast");
+      expect(aliases).toContain("iohexol");
+      // Reciprocally: must NOT cross into the iodine (Betadine) canonical.
+      expect(aliases).not.toContain("betadine");
+      expect(aliases).not.toContain("povidone-iodine");
+    });
   });
 
   it("aspirin/ASA folds into nsaid so cross-reactivity with ibuprofen still fires", () => {

--- a/packages/medical-logic/src/allergen-synonyms.ts
+++ b/packages/medical-logic/src/allergen-synonyms.ts
@@ -293,6 +293,15 @@ export const ALLERGEN_SYNONYMS: Record<string, string[]> = {
     "iodinated contrast",
     "iv contrast",
     "contrast dye",
+    // #1030 — Single-word chart entries. After PR #1012 simplified the
+    // iodinated-contrast cross-reactivity allergenPattern to canonical
+    // multi-word forms, these bare tokens lost their pre-#1012 fallback
+    // path. Adding them as aliases means a charted "iodinated" or
+    // "contrast" expands into the full canonical group and hits the
+    // simplified regex via allergenBlob.
+    "iodinated",
+    "contrast",
+    "radiocontrast",
     "iohexol",
     "omnipaque",
     "iopamidol",


### PR DESCRIPTION
## Summary
PR #1012 narrowed the iodinated-contrast \`allergenPattern\` to canonical multi-word forms, relying on \`expandAllergenAliases\` to feed \`allergenBlob\`. Single-word chart entries (\`iodinated\`, \`contrast\`, \`radiocontrast\`) had no alias path and lost their pre-#1012 fallback.

Per the issue's preferred Option 1, restore coverage at the synonym layer rather than re-widening the regex:
- Adds \`iodinated\`, \`contrast\`, \`radiocontrast\` as aliases under \`iodinated contrast\` canonical
- Simplified cross-reactivity regex stays intact
- Synonyms file remains single source of truth

## Closes
- #1030

## Test plan
- [x] 1 new test covering normalization + expansion + reciprocal non-leak into iodine canonical
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 429/429
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 889/889 (no regression)