### PR TITLE
feat(medical-logic): add diclofenac ER (Voltaren XR) entry with stricter 100 mg/day ceiling

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -492,6 +492,27 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
   it("getMedicationDoseLimit returns undefined for unknown drugs", () => {
     expect(getMedicationDoseLimit("unobtanium")).toBeUndefined();
   });
+
+  it("getMedicationDoseLimit distinguishes diclofenac IR (Voltaren) vs ER (Voltaren XR) (#1041)", () => {
+    // IR resolves to the 150 mg/day ceiling.
+    const ir = getMedicationDoseLimit("Voltaren");
+    expect(ir?.displayName).toBe("Diclofenac");
+    expect(ir?.maxDailyDoseMg).toBe(150);
+
+    // ER (Voltaren XR) resolves to the stricter 100 mg/day ceiling.
+    const er = getMedicationDoseLimit("Voltaren XR");
+    expect(er?.displayName).toBe("Diclofenac ER");
+    expect(er?.maxDailyDoseMg).toBe(100);
+
+    // Brand variants and generic-er forms all hit the ER entry.
+    expect(getMedicationDoseLimit("Voltaren-XR")?.displayName).toBe("Diclofenac ER");
+    expect(getMedicationDoseLimit("diclofenac er")?.displayName).toBe("Diclofenac ER");
+    expect(getMedicationDoseLimit("Diclofenac XR")?.displayName).toBe("Diclofenac ER");
+    expect(getMedicationDoseLimit("diclofenac extended-release")?.displayName).toBe("Diclofenac ER");
+
+    // Strength-token strip still works for ER.
+    expect(getMedicationDoseLimit("Voltaren XR 100mg daily")?.displayName).toBe("Diclofenac ER");
+  });
 });
 
 // ─── validateLabResult ──────────────────────────────────────────

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -104,15 +104,16 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxDailyDoseMg: 150,
     source: "FDA prescription label (Voltaren IR; adult PO diclofenac IR, Rx 150 mg/day)",
   },
-  // Diclofenac ER (Voltaren XR) — 100 mg once-daily, hard ceiling. The
-  // extended-release formulation is intentionally a stricter daily cap
-  // than IR because the slower release maintains supratherapeutic plasma
-  // levels longer (#1041). Aliased via voltaren xr / diclofenac xr below.
+  // Diclofenac ER (Voltaren XR) — FDA-labelled adult ceiling is 100 mg
+  // once-daily. Because the Rx is a once-daily regimen, the single-dose
+  // and daily ceilings coincide (both 100 mg). The 100 mg/day cap is
+  // stricter than the 150 mg/day IR cap, which is the formulation-aware
+  // distinction this entry exists for (#1041).
   "diclofenac er": {
     displayName: "Diclofenac ER",
     maxSingleDoseMg: 100,
     maxDailyDoseMg: 100,
-    source: "FDA prescription label (Voltaren XR; adult PO diclofenac ER, Rx 100 mg/day single-dose ceiling)",
+    source: "FDA prescription label (Voltaren XR; adult PO diclofenac ER, 100 mg once-daily — single = daily ceiling)",
   },
   meloxicam: {
     displayName: "Meloxicam",

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -97,15 +97,22 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxDailyDoseMg: 4000,
     source: "FDA OTC monograph (adult analgesic aspirin, 4000 mg/day; antiplatelet Rx 81–325 mg is out of scope)",
   },
-  // Diclofenac IR (Voltaren) — 50 mg single / 150 mg/day. ER formulation
-  // (Voltaren XR) is a single 100 mg/day cap and is NOT encoded here; an
-  // ER prescription should resolve to a separate `diclofenac er` entry
-  // when formulation-aware lookup lands (issue #927).
+  // Diclofenac IR (Voltaren) — 50 mg single / 150 mg/day.
   diclofenac: {
     displayName: "Diclofenac",
     maxSingleDoseMg: 50,
     maxDailyDoseMg: 150,
     source: "FDA prescription label (Voltaren IR; adult PO diclofenac IR, Rx 150 mg/day)",
+  },
+  // Diclofenac ER (Voltaren XR) — 100 mg once-daily, hard ceiling. The
+  // extended-release formulation is intentionally a stricter daily cap
+  // than IR because the slower release maintains supratherapeutic plasma
+  // levels longer (#1041). Aliased via voltaren xr / diclofenac xr below.
+  "diclofenac er": {
+    displayName: "Diclofenac ER",
+    maxSingleDoseMg: 100,
+    maxDailyDoseMg: 100,
+    source: "FDA prescription label (Voltaren XR; adult PO diclofenac ER, Rx 100 mg/day single-dose ceiling)",
   },
   meloxicam: {
     displayName: "Meloxicam",
@@ -193,9 +200,15 @@ const DRUG_NAME_ALIASES: Record<string, string> = {
   asa: "aspirin",
   bufferin: "aspirin",
   ecotrin: "aspirin",
-  // Diclofenac
+  // Diclofenac. IR vs ER resolves to separate entries because the ER
+  // ceiling (100 mg/day) is stricter than IR (150 mg/day) — #1041.
   voltaren: "diclofenac",
   cataflam: "diclofenac",
+  "voltaren xr": "diclofenac er",
+  "voltaren-xr": "diclofenac er",
+  "diclofenac xr": "diclofenac er",
+  "diclofenac extended-release": "diclofenac er",
+  "diclofenac extended release": "diclofenac er",
   // Meloxicam
   mobic: "meloxicam",
   // Celecoxib


### PR DESCRIPTION
## Summary
Diclofenac IR (Voltaren) caps at 150 mg/day; the extended-release form (Voltaren XR) is a stricter 100 mg/day hard ceiling. Previously a Voltaren XR prescription resolved to the IR entry and under-flagged against the wrong ceiling.

Adds a new \`diclofenac er\` entry (max 100 mg single / 100 mg/day) plus aliases for the common brand and generic XR spellings. Strength-token strip continues to work — \`Voltaren XR 100mg daily\` resolves to \`Diclofenac ER\`.

The pre-#1041 inline comment on the IR entry referenced #927 (route-aware opioids) — wrong issue. This PR closes that misattribution.

## Closes
- #1041

## Test plan
- [x] 1 new test covering IR vs ER, brand aliases, generic-er variants, strength-token strip
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 429/429