### PR TITLE
test(ai): preserve/restore pre-existing env vars in resolveRatio tests

### DIFF
--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -262,8 +262,17 @@ describe("checkMedicationDailyDose (#235)", () => {
 
   describe("resolveRatio — deployment override (#968)", () => {
     const envKey = "TEST_RATIO_OVERRIDE_968";
+    // Even though TEST_RATIO_OVERRIDE_968 is fixture-only and unlikely to
+    // be set in a developer shell, preserve and restore symmetrically with
+    // the override-rationale block below — keeps the pattern uniform so
+    // a future env-key rename doesn't quietly start clobbering dev state.
+    let prev: string | undefined;
+    beforeEach(() => {
+      prev = process.env[envKey];
+    });
     afterEach(() => {
-      delete process.env[envKey];
+      if (prev === undefined) delete process.env[envKey];
+      else process.env[envKey] = prev;
     });
 
     it("returns default when env var is unset", () => {
@@ -370,13 +379,21 @@ describe("checkMedicationDailyDose (#235)", () => {
     // override-note rendering we have to reload the module with the env
     // var pre-set. vi.resetModules + dynamic import keeps the override
     // contained to this test.
-    let prev: string | undefined;
+    //
+    // Preserve and restore BOTH opioid and non-opioid env vars (#1052) —
+    // earlier revisions only saved OPIOID and blasted whatever the
+    // developer had set in NON_OPIOID_CRITICAL_RATIO.
+    let prevOpioid: string | undefined;
+    let prevNonOpioid: string | undefined;
     beforeEach(() => {
-      prev = process.env.OPIOID_CRITICAL_RATIO;
+      prevOpioid = process.env.OPIOID_CRITICAL_RATIO;
+      prevNonOpioid = process.env.NON_OPIOID_CRITICAL_RATIO;
     });
     afterEach(() => {
-      if (prev === undefined) delete process.env.OPIOID_CRITICAL_RATIO;
-      else process.env.OPIOID_CRITICAL_RATIO = prev;
+      if (prevOpioid === undefined) delete process.env.OPIOID_CRITICAL_RATIO;
+      else process.env.OPIOID_CRITICAL_RATIO = prevOpioid;
+      if (prevNonOpioid === undefined) delete process.env.NON_OPIOID_CRITICAL_RATIO;
+      else process.env.NON_OPIOID_CRITICAL_RATIO = prevNonOpioid;
       vi.resetModules();
     });
 
@@ -418,8 +435,7 @@ describe("checkMedicationDailyDose (#235)", () => {
       expect(daily!.rationale).toMatch(/cumulative-harm default/);
       // The 'CDC default' string must NOT appear in non-opioid rationale.
       expect(daily!.rationale).not.toMatch(/CDC default/);
-      // Reset for subsequent tests in this describe block.
-      delete process.env.NON_OPIOID_CRITICAL_RATIO;
+      // afterEach handles env restoration for NON_OPIOID_CRITICAL_RATIO (#1052).
     });
 
     it("omits the override note when running at the default ratio", () => {


### PR DESCRIPTION
## Summary

Mirror the beforeEach/afterEach env-restore pattern across both resolveRatio test blocks in \`services/ai-oversight/src/rules/medication-daily-dose.test.ts\`:

1. **\`resolveRatio — deployment override\`** now snapshots and restores \`TEST_RATIO_OVERRIDE_968\`. Even though it's a fixture-only key, keeps the pattern uniform so a future env-key rename can't quietly start clobbering dev state.

2. **\`override rationale surfacing\`** now tracks BOTH \`OPIOID_CRITICAL_RATIO\` and \`NON_OPIOID_CRITICAL_RATIO\`. Earlier revisions only saved opioid, so a developer with \`NON_OPIOID_CRITICAL_RATIO\` set in their shell would lose it on test cleanup.

The inline \`delete process.env.NON_OPIOID_CRITICAL_RATIO\` in the non-opioid test is removed — afterEach handles restoration symmetrically.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 40/40 pass
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean

Closes #1052