### PR TITLE
docs(medical-logic): cross-reference rule-layer iodine test in synonym describe block

### DIFF
--- a/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
+++ b/packages/medical-logic/src/__tests__/allergen-synonyms.test.ts
@@ -156,6 +156,14 @@ describe("ALLERGEN_SYNONYMS data sanity", () => {
     // to iodine" chart note doesn't trigger a critical contrast-CT flag.
     // These assertions guard against accidental re-merging at the synonym
     // layer.
+    //
+    // Synonym-layer disjointness is only half the story — at the rule
+    // layer, iodine and iodinated-contrast remain *cross-reactive* with a
+    // downgraded warning severity (not critical). That separate guarantee
+    // is verified in:
+    //   services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts
+    // Do not interpret the not-equal assertions below as "fully disjoint" —
+    // they only assert canonical-name separation, not clinical relationship.
 
     it("Betadine resolves to iodine, not iodinated contrast", () => {
       expect(normalizeAllergen("Betadine")).toBe("iodine");


### PR DESCRIPTION
## Summary

The \`iodine vs iodinated-contrast canonicals\` describe block in \`packages/medical-logic/src/__tests__/allergen-synonyms.test.ts\` asserts synonym-layer disjointness — that normalizing \"iodine\" doesn't produce \"iodinated contrast\" and vice versa. A contributor reading those assertions in isolation could reasonably (and incorrectly) conclude the two are fully unrelated.

At the rule layer, the two remain *cross-reactive with a downgraded warning severity* (not critical). That guarantee lives in \`services/ai-oversight/src/rules/iodine-cross-reactivity.test.ts\`.

This PR adds a pointer comment in the synonym-layer describe block so future readers know the assertions there only pin canonical-name separation, not clinical relationship.

Comment-only — no test or production code change.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` → 28/28 pass
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean

Closes #1025