### PR TITLE
fix(medical-logic): advertise unenforced chronic naproxen ceiling

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -442,6 +442,18 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
     }
   });
 
+  it("naproxen source string flags the unenforced chronic ceiling (#1028)", () => {
+    // Encoded ceiling is the acute 1500 mg/day. The chronic 1000 mg/day
+    // ceiling on the same FDA label is intentionally NOT enforced until
+    // use-context-aware lookup (#927) lands. The source string must
+    // advertise that gap so a reviewer reading the entry can't be misled
+    // into treating 1500 mg/day as the chronic ceiling.
+    const naproxen = MEDICATION_MAX_DAILY_DOSES.naproxen!;
+    expect(naproxen.maxDailyDoseMg).toBe(1500);
+    expect(naproxen.source).toMatch(/chronic[- ]use 1000 mg\/day ceiling NOT enforced/i);
+    expect(naproxen.source).toMatch(/#927/);
+  });
+
   it("every limit's maxSingleDoseMg <= maxDailyDoseMg (internal consistency)", () => {
     for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
       if (

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -79,12 +79,22 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
   // Naproxen Rx (Naprosyn) caps at 1000 mg single / 1500 mg/day for acute use,
   // 1000 mg/day chronic. OTC Aleve (naproxen sodium 220 mg) is a separate
   // monograph capped at 660 mg/day — not applied here.
+  //
+  // Decision (#1028): the encoded ceiling is the looser ACUTE 1500 mg/day. A
+  // chronic prescription (RA, OA, ankylosing spondylitis) that exceeds the
+  // 1000 mg/day chronic ceiling but stays under 1500 mg/day will NOT flag
+  // here. This is a deliberate trade-off until use-context-aware lookup
+  // lands (see #927 — route/use-aware getMedicationDoseLimit), because
+  // lowering the encoded ceiling to 1000 mg/day would over-flag legitimate
+  // acute prescriptions (gout flare, post-op pain) with no signal to
+  // distinguish them at the rule layer today.
   naproxen: {
     displayName: "Naproxen",
     maxSingleDoseMg: 1000,
     warnSingleDoseMg: 500,
     maxDailyDoseMg: 1500,
-    source: "FDA prescription label (Naprosyn; adult PO naproxen, Rx 1500 mg/day acute)",
+    source:
+      "FDA prescription label (Naprosyn; adult PO naproxen, Rx 1500 mg/day acute — chronic-use 1000 mg/day ceiling NOT enforced here, pending use-context lookup #927)",
   },
   // Aspirin analgesic dosing — 4 g/day is the OTC monograph adult ceiling.
   // Low-dose Rx aspirin (81–325 mg/day) for antiplatelet / cardioprotection


### PR DESCRIPTION
## Summary

The naproxen entry encodes the FDA Naprosyn **acute**-use daily ceiling (1500 mg/day). The same FDA label has a **chronic**-use ceiling of 1000 mg/day. A chronic RA / OA / ankylosing-spondylitis prescription between 1000-1500 mg/day passes silently — even though it exceeds the chronic ceiling on the same label.

Lowering the encoded value to 1000 mg/day would over-flag legitimate acute prescriptions (gout flare, post-op pain, dysmenorrhea bursts) with no signal at the rule layer to distinguish indication. This PR follows the issue's recommended Option 2: keep the looser acute ceiling, but advertise the gap explicitly so a reviewer reading the data can't be misled.

### Changes

- Update naproxen \`source\` to flag "chronic-use 1000 mg/day ceiling NOT enforced here, pending use-context lookup #927"
- Add inline comment with the trade-off rationale and link to #927
- Add data-sanity test pinning the source-string warning so a future refactor that drops it fails CI

### Long-term fix

#927 (route/use-aware \`getMedicationDoseLimit\`) is the proper end-state — both this issue and #927 want context-aware overrides, so they should land together when that lookup signature is designed.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` → 432/432 pass (+1 new)
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean

Closes #1028