### PR TITLE
refactor(medical-logic): split MedicationDoseLimit source into terse + rich citation

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -442,16 +442,31 @@ describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {
     }
   });
 
-  it("naproxen source string flags the unenforced chronic ceiling (#1028)", () => {
+  it("naproxen citation flags the unenforced chronic ceiling (#1028)", () => {
     // Encoded ceiling is the acute 1500 mg/day. The chronic 1000 mg/day
     // ceiling on the same FDA label is intentionally NOT enforced until
-    // use-context-aware lookup (#927) lands. The source string must
-    // advertise that gap so a reviewer reading the entry can't be misled
-    // into treating 1500 mg/day as the chronic ceiling.
+    // use-context-aware lookup (#927) lands. After #1026 split source
+    // into a terse label + rich citation, the chronic-use warning lives
+    // in citation (the source is now "FDA Rx label (Naprosyn)" alone).
     const naproxen = MEDICATION_MAX_DAILY_DOSES.naproxen!;
     expect(naproxen.maxDailyDoseMg).toBe(1500);
-    expect(naproxen.source).toMatch(/chronic[- ]use 1000 mg\/day ceiling NOT enforced/i);
-    expect(naproxen.source).toMatch(/#927/);
+    expect(naproxen.citation).toMatch(/chronic[- ]use 1000 mg\/day ceiling NOT enforced/i);
+    expect(naproxen.citation).toMatch(/#927/);
+  });
+
+  it("source field is a terse inline label, citation carries the rich text (#1026)", () => {
+    // Inline single-dose error strings interpolate `source` directly into
+    // a clinician-facing warning where space is tight. Cap `source` at
+    // 40 chars so a future verbose addition can't accidentally bloat the
+    // inline warning — it should land in `citation` instead.
+    for (const [drug, limit] of Object.entries(MEDICATION_MAX_DAILY_DOSES)) {
+      expect(limit.source.length, `drug=${drug} source too long for inline use`).toBeLessThanOrEqual(40);
+      if (limit.citation) {
+        expect(limit.citation.length, `drug=${drug} citation should be richer than source`).toBeGreaterThanOrEqual(
+          limit.source.length,
+        );
+      }
+    }
   });
 
   it("every limit's maxSingleDoseMg <= maxDailyDoseMg (internal consistency)", () => {

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -42,8 +42,20 @@ export interface MedicationDoseLimit {
    * non-opioids.
    */
   mmeFactor?: number;
-  /** Authoritative source the limit is drawn from. */
+  /**
+   * Short authority label safe for inline warnings (≤ ~40 chars).
+   * Examples: "FDA Rx label (Naprosyn)", "CDC 2022 opioid guideline".
+   * Consumed by single-dose error messages in validateMedicationDose
+   * where space is tight. (#1026)
+   */
   source: string;
+  /**
+   * Full citation: authority + route + population + caveats / arithmetic.
+   * Consumed by rationale fields in flag emission (AI-oversight rule
+   * rationale, audit trail) where more room is available. Falls back to
+   * `source` when omitted. (#1026)
+   */
+  citation?: string;
 }
 
 /**
@@ -64,7 +76,8 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxSingleDoseMg: 1000,
     warnSingleDoseMg: 650,
     maxDailyDoseMg: 4000,
-    source: "FDA prescription label (adult acetaminophen, 4000 mg/day)",
+    source: "FDA Rx label (acetaminophen)",
+    citation: "FDA prescription label (adult acetaminophen, 4000 mg/day)",
   },
   // Ibuprofen Rx ceiling is 800 mg single / 3200 mg/day. OTC monograph
   // separately caps at 400 mg single / 1200 mg/day for self-medication —
@@ -74,7 +87,9 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxSingleDoseMg: 800,
     warnSingleDoseMg: 400,
     maxDailyDoseMg: 3200,
-    source: "FDA prescription label (adult PO ibuprofen, Rx 800 mg single / 3200 mg/day)",
+    source: "FDA Rx label (ibuprofen)",
+    citation:
+      "FDA prescription label (adult PO ibuprofen, Rx 800 mg single / 3200 mg/day)",
   },
   // Naproxen Rx (Naprosyn) caps at 1000 mg single / 1500 mg/day for acute use,
   // 1000 mg/day chronic. OTC Aleve (naproxen sodium 220 mg) is a separate
@@ -93,7 +108,8 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxSingleDoseMg: 1000,
     warnSingleDoseMg: 500,
     maxDailyDoseMg: 1500,
-    source:
+    source: "FDA Rx label (Naprosyn)",
+    citation:
       "FDA prescription label (Naprosyn; adult PO naproxen, Rx 1500 mg/day acute — chronic-use 1000 mg/day ceiling NOT enforced here, pending use-context lookup #927)",
   },
   // Aspirin analgesic dosing — 4 g/day is the OTC monograph adult ceiling.
@@ -105,14 +121,18 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxSingleDoseMg: 1000,
     warnSingleDoseMg: 650,
     maxDailyDoseMg: 4000,
-    source: "FDA OTC monograph (adult analgesic aspirin, 4000 mg/day; antiplatelet Rx 81–325 mg is out of scope)",
+    source: "FDA OTC monograph (aspirin)",
+    citation:
+      "FDA OTC monograph (adult analgesic aspirin, 4000 mg/day; antiplatelet Rx 81–325 mg is out of scope)",
   },
   // Diclofenac IR (Voltaren) — 50 mg single / 150 mg/day.
   diclofenac: {
     displayName: "Diclofenac",
     maxSingleDoseMg: 50,
     maxDailyDoseMg: 150,
-    source: "FDA prescription label (Voltaren IR; adult PO diclofenac IR, Rx 150 mg/day)",
+    source: "FDA Rx label (Voltaren IR)",
+    citation:
+      "FDA prescription label (Voltaren IR; adult PO diclofenac IR, Rx 150 mg/day)",
   },
   // Diclofenac ER (Voltaren XR) — FDA-labelled adult ceiling is 100 mg
   // once-daily. Because the Rx is a once-daily regimen, the single-dose
@@ -123,13 +143,17 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     displayName: "Diclofenac ER",
     maxSingleDoseMg: 100,
     maxDailyDoseMg: 100,
-    source: "FDA prescription label (Voltaren XR; adult PO diclofenac ER, 100 mg once-daily — single = daily ceiling)",
+    source: "FDA Rx label (Voltaren XR)",
+    citation:
+      "FDA prescription label (Voltaren XR; adult PO diclofenac ER, 100 mg once-daily — single = daily ceiling)",
   },
   meloxicam: {
     displayName: "Meloxicam",
     maxSingleDoseMg: 15,
     maxDailyDoseMg: 15,
-    source: "FDA prescription label (Mobic; adult PO meloxicam, Rx 15 mg/day single dose)",
+    source: "FDA Rx label (Mobic)",
+    citation:
+      "FDA prescription label (Mobic; adult PO meloxicam, Rx 15 mg/day single dose)",
   },
   // Celecoxib — 400 mg/day for adult RA dosing. Acute pain dosing has a
   // loading-dose pattern (400 mg day 1, then 200 mg) not modeled here.
@@ -137,7 +161,9 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     displayName: "Celecoxib",
     maxSingleDoseMg: 200,
     maxDailyDoseMg: 400,
-    source: "FDA prescription label (Celebrex; adult PO celecoxib, Rx 200 mg single / 400 mg/day RA dosing)",
+    source: "FDA Rx label (Celebrex)",
+    citation:
+      "FDA prescription label (Celebrex; adult PO celecoxib, Rx 200 mg single / 400 mg/day RA dosing)",
   },
 
   // ── Oral opioids (PO). Daily caps are calibrated to CDC 2022 90 MME/day
@@ -152,38 +178,48 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     maxSingleDoseMg: 30,
     maxDailyDoseMg: 90,
     mmeFactor: 1.0,
-    source: "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO)",
+    source: "CDC 2022 opioid guideline",
+    citation:
+      "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO)",
   },
   oxycodone: {
     displayName: "Oxycodone (PO)",
     maxSingleDoseMg: 20,
     maxDailyDoseMg: 60,
     mmeFactor: 1.5,
-    source: "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 60 mg × 1.5 MME = 90 MME)",
+    source: "CDC 2022 opioid guideline",
+    citation:
+      "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 60 mg × 1.5 MME = 90 MME)",
   },
   hydrocodone: {
     displayName: "Hydrocodone (PO)",
     maxSingleDoseMg: 10,
     maxDailyDoseMg: 90,
     mmeFactor: 1.0,
-    source: "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO)",
+    source: "CDC 2022 opioid guideline",
+    citation:
+      "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO)",
   },
   codeine: {
     displayName: "Codeine (PO)",
     maxSingleDoseMg: 60,
     maxDailyDoseMg: 360,
     mmeFactor: 0.15,
-    source: "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 360 mg × 0.15 MME = 54 MME)",
+    source: "CDC 2022 opioid guideline",
+    citation:
+      "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 360 mg × 0.15 MME = 54 MME)",
   },
   // Tramadol — FDA Ultram label hard-caps at 400 mg/day; the lower CDC MME
   // threshold of 90 MME would be ~450 mg, so the FDA label is the binding
-  // constraint here. Source string credits both.
+  // constraint here. Citation credits both.
   tramadol: {
     displayName: "Tramadol (PO)",
     maxSingleDoseMg: 100,
     maxDailyDoseMg: 400,
     mmeFactor: 0.2,
-    source: "FDA prescription label (Ultram; adult PO tramadol, Rx 400 mg/day) + CDC 2022 MME context",
+    source: "FDA Rx label (Ultram)",
+    citation:
+      "FDA prescription label (Ultram; adult PO tramadol, Rx 400 mg/day) + CDC 2022 MME context",
   },
 };
 

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -259,7 +259,7 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
         `"${med.name}" ${med.dose_amount} ${med.dose_unit ?? ""} single dose ` +
         `exceeds the ${limit.maxSingleDoseMg} mg maximum for ${limit.displayName}`,
       rationale:
-        `Per ${limit.source}, the maximum single oral dose of ${limit.displayName} ` +
+        `Per ${limit.citation ?? limit.source}, the maximum single oral dose of ${limit.displayName} ` +
         `is ${limit.maxSingleDoseMg} mg. The prescribed single dose of ` +
         `${med.dose_amount} ${med.dose_unit ?? ""} exceeds this ceiling` +
         (isOpioid
@@ -313,7 +313,7 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
         `(${limit.maxDailyDoseMg} mg/day)${mmeNote}`,
       rationale:
         `${limit.displayName} daily cap is ${limit.maxDailyDoseMg} mg ` +
-        `(${limit.source}). The prescribed ${med.dose_amount} ${med.dose_unit ?? ""} ` +
+        `(${limit.citation ?? limit.source}). The prescribed ${med.dose_amount} ${med.dose_unit ?? ""} ` +
         `${med.frequency ?? ""} translates to approximately ${Math.round(daily)} mg/day, ` +
         `which is ${ratio.toFixed(1)}× the ceiling. ` +
         (isOpioid


### PR DESCRIPTION
## Summary

After PR #1013 the \`source\` strings ballooned to 60-100 chars encoding authority + route + population + parenthetical MME arithmetic. \`limit.source\` is interpolated directly into clinician-facing inline warnings where parenthesis-dense text is awkward.

Split the field:

- **\`source\`** — terse authority label (≤ 40 chars). Consumed inline by \`validateMedicationDose\` single-dose error strings where space is tight. Now reads \"FDA Rx label (Naprosyn)\" or \"CDC 2022 opioid guideline\".
- **\`citation\`** — full citation with route + population + caveats / arithmetic. Consumed by rationale fields (AI-oversight flag rationale, audit trail) where more room is available. Falls back to \`source\` when omitted.

### Updated call sites

- \`packages/medical-logic/src/medical-validation.ts:317\` — keeps using \`source\` (inline error).
- \`services/ai-oversight/src/rules/medication-daily-dose.ts:262,316\` — switches to \`limit.citation ?? limit.source\` (rationale fields with room to render the rich text).

All 13 current entries get a \`citation\` matching their pre-split source string; sources are shortened to the terse form. Added a data-sanity test pinning \`source\` ≤ 40 chars and \`citation\` ≥ source length, so a future verbose addition can't accidentally bloat the inline warning.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` → 432/432 pass (+1 new)
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean
- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 900/900 pass
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean

## Conflict note

Touches the naproxen entry, which also moves in #1058. Either order can land; reviewer can resolve naproxen-entry merge by keeping the new \`source: \"FDA Rx label (Naprosyn)\"\` + moving the unenforced-chronic-ceiling warning text into \`citation\`.

Closes #1026