### PR TITLE
feat(ai): prescriber-marked-chronic override for CROSS-STEROID-PCP-001

### DIFF
--- a/packages/db-schema/drizzle/0043_medications_chronic_flag.sql
+++ b/packages/db-schema/drizzle/0043_medications_chronic_flag.sql
@@ -1,0 +1,16 @@
+-- #1023: prescriber-marked-chronic flag for the medications table.
+--
+-- CROSS-STEROID-PCP-001 suppresses for the first 28 days of a steroid
+-- course because most prescriptions are short bursts (asthma flare, gout,
+-- poison ivy, etc.) and tripping prophylaxis warnings for those is
+-- expensive noise. But some patients are on lifelong immunosuppression
+-- from day 1 — solid-organ transplant, autoimmune disease, GVHD — and
+-- the prescriber knows immediately the course is chronic.
+--
+-- When `chronic = true` the duration gate is bypassed and the PCP-
+-- prophylaxis flag fires at prescription time, not four weeks later.
+-- Surfaced in flag metadata as `chronic_marked: true` so downstream
+-- FP-rate analysis can distinguish prescriber-marked firings from
+-- duration-gate firings (extends #976).
+
+ALTER TABLE medications ADD COLUMN IF NOT EXISTS chronic boolean;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1747411200000,
       "tag": "0042_audit_log_truncate_revoke",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1747929600000,
+      "tag": "0043_medications_chronic_flag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, real, integer, index, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, real, integer, boolean, index, jsonb } from "drizzle-orm/pg-core";
 import { encryptedText, encryptedNumeric } from "../encryption.js";
 import { patients } from "./patients.js";
 
@@ -19,6 +19,13 @@ export const medications = pgTable("medications", {
    * the rule fails open. See issue #935.
    */
   max_doses_per_day: integer("max_doses_per_day"),
+  /**
+   * Prescriber-marked-chronic flag (#1023). When true, CROSS-STEROID-PCP-001
+   * fires immediately at prescription time instead of waiting for the
+   * 28-day duration gate. Used for solid-organ transplant, autoimmune,
+   * GVHD, and other day-1-chronic immunosuppression courses.
+   */
+  chronic: boolean("chronic"),
   status: text("status").notNull().default("active"),
   started_at: text("started_at"),
   ended_at: text("ended_at"),

--- a/packages/shared-types/src/clinical-data.schemas.ts
+++ b/packages/shared-types/src/clinical-data.schemas.ts
@@ -55,6 +55,12 @@ export const createMedicationSchema = z.object({
   rxnorm_code: z.string().max(20).optional(),
   ordering_provider_id: z.string().uuid().optional(),
   encounter_id: z.string().uuid().optional(),
+  /**
+   * Prescriber-marked-chronic flag (#1023). Bypass the 28-day duration
+   * gate on CROSS-STEROID-PCP-001 — for day-1-chronic courses
+   * (transplant, autoimmune, GVHD).
+   */
+  chronic: z.boolean().optional(),
 });
 
 export const updateMedicationSchema = createMedicationSchema.partial().omit({ patient_id: true }).extend({

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -43,6 +43,13 @@ export interface Medication extends MutableRecord {
   ordering_provider_id?: string;
   encounter_id?: string;
   source_system?: string;
+  /**
+   * Prescriber-marked-chronic. When true, the CROSS-STEROID-PCP-001
+   * duration gate is bypassed and the flag fires at prescription time
+   * instead of waiting 28 days. For day-1-chronic courses (transplant,
+   * autoimmune, GVHD). See issue #1023.
+   */
+  chronic?: boolean;
 }
 
 export interface MedLog extends BaseRecord {

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -339,7 +339,7 @@ describe("CROSS-STEROID-PCP-001 — chronic corticosteroid without PCP prophylax
         (f) => f.rule_id === "CROSS-STEROID-PCP-001",
       );
       expect(flag).toBeDefined();
-      expect(flag!.metadata).toEqual({ duration_known: true });
+      expect(flag!.metadata).toEqual({ duration_known: true, chronic_marked: false });
     });
 
     it("emits duration_known=false when started_at is unset (fail-open path)", () => {
@@ -361,7 +361,7 @@ describe("CROSS-STEROID-PCP-001 — chronic corticosteroid without PCP prophylax
         (f) => f.rule_id === "CROSS-STEROID-PCP-001",
       );
       expect(flag).toBeDefined();
-      expect(flag!.metadata).toEqual({ duration_known: false });
+      expect(flag!.metadata).toEqual({ duration_known: false, chronic_marked: false });
     });
 
     it("emits duration_known=false when started_at is future-dated (typo)", () => {
@@ -385,7 +385,113 @@ describe("CROSS-STEROID-PCP-001 — chronic corticosteroid without PCP prophylax
         (f) => f.rule_id === "CROSS-STEROID-PCP-001",
       );
       expect(flag).toBeDefined();
-      expect(flag!.metadata).toEqual({ duration_known: false });
+      expect(flag!.metadata).toEqual({ duration_known: false, chronic_marked: false });
+    });
+
+    it("prescriber-marked-chronic fires immediately, bypassing the 28-day duration gate (#1023)", () => {
+      // Patient just started lifelong immunosuppression for renal transplant.
+      // started_at is < 28 days ago, but `chronic: true` short-circuits the
+      // duration gate so the PCP-prophylaxis flag fires at prescription time.
+      const ctx = emptyCtx({
+        active_medications: ["Prednisone 40mg daily"],
+        active_medications_detail: [
+          {
+            id: "m1",
+            name: "Prednisone",
+            dose_amount: 40,
+            dose_unit: "mg",
+            route: "oral",
+            frequency: "daily",
+            rxnorm_code: null,
+            started_at: "2026-04-15T00:00:00.000Z",
+            chronic: true,
+          },
+        ],
+        event_timestamp: "2026-04-18T12:00:00.000Z", // only 3 days in
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.metadata).toMatchObject({ chronic_marked: true });
+    });
+
+    it("chronic=true without started_at still fires and surfaces chronic_marked=true (#1023)", () => {
+      // No started_at at all + chronic: true → flag fires, chronic_marked
+      // tracks the prescriber decision rather than the data path.
+      const ctx = emptyCtx({
+        active_medications: ["Prednisone 40mg daily"],
+        active_medications_detail: [
+          {
+            id: "m1",
+            name: "Prednisone",
+            dose_amount: 40,
+            dose_unit: "mg",
+            route: "oral",
+            frequency: "daily",
+            rxnorm_code: null,
+            chronic: true,
+          },
+        ],
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.metadata).toMatchObject({ chronic_marked: true });
+    });
+
+    it("chronic=false leaves the duration gate in charge (#1023)", () => {
+      // chronic=false is the same as not-set — the duration gate suppresses
+      // the 3-days-in burst, and chronic_marked is false in metadata.
+      const ctx = emptyCtx({
+        active_medications: ["Prednisone 40mg daily"],
+        active_medications_detail: [
+          {
+            id: "m1",
+            name: "Prednisone",
+            dose_amount: 40,
+            dose_unit: "mg",
+            route: "oral",
+            frequency: "daily",
+            rxnorm_code: null,
+            started_at: "2026-04-15T00:00:00.000Z",
+            chronic: false,
+          },
+        ],
+        event_timestamp: "2026-04-18T12:00:00.000Z",
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      );
+      // Duration gate suppresses the flag (started < 28 days ago).
+      expect(flag).toBeUndefined();
+    });
+
+    it("topical/inhaled corticosteroid with chronic=true does NOT trigger chronic_marked (#1023)", () => {
+      // Chronic intranasal triamcinolone (Flonase) for allergic rhinitis is
+      // clinically distinct from systemic immunosuppression — the route
+      // gate must still strip it from the systemic-exposure cohort even
+      // when chronic is marked.
+      const ctx = emptyCtx({
+        active_medications: ["Triamcinolone intranasal"],
+        active_medications_detail: [
+          {
+            id: "m1",
+            name: "Triamcinolone intranasal",
+            dose_amount: 110,
+            dose_unit: "mcg",
+            route: "intranasal",
+            frequency: "daily",
+            rxnorm_code: null,
+            chronic: true,
+          },
+        ],
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CROSS-STEROID-PCP-001",
+      );
+      expect(flag).toBeUndefined();
     });
   });
 });

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -93,6 +93,13 @@ export interface PatientMedication {
    * rules should fail-open (don't rely on duration) in that case.
    */
   started_at?: string | null;
+  /**
+   * Prescriber-marked-chronic (#1023). When true, CROSS-STEROID-PCP-001
+   * fires at prescription time and the 28-day duration gate is bypassed.
+   * For day-1-chronic immunosuppression: transplant, autoimmune, GVHD.
+   * Null / undefined = unknown; rule falls back to duration-gate behaviour.
+   */
+  chronic?: boolean | null;
 }
 
 export interface PatientContext {
@@ -485,6 +492,30 @@ function steroidPcpDurationKnown(ctx: PatientContext): boolean {
   // Future-dated start (typo) is treated as unknown by the gate.
   const daysSinceStart = (refMs - startedMs) / 86_400_000;
   return daysSinceStart >= 0;
+}
+
+/**
+ * Telemetry helper: did the qualifying systemic corticosteroid in the
+ * context carry the prescriber-marked-chronic flag? Surfaced in flag
+ * metadata so downstream FP-rate analysis can separate prescriber-marked
+ * firings (transplant, autoimmune, GVHD) from duration-gate firings.
+ * (#1023)
+ */
+function steroidPcpChronicMarked(ctx: PatientContext): boolean {
+  const details = ctx.active_medications_detail;
+  if (!details) return false;
+  const CORTICOSTEROID_PATTERN =
+    /prednisone|prednisolone|methylprednisolone|medrol|solu-medrol|dexamethasone|decadron|hydrocortisone|solu-cortef|betamethasone|triamcinolone/i;
+  const TOPICAL_ROUTE_PATTERN =
+    /topical|ophthalmic|otic|intranasal|inhaled|inhalation|cream|ointment|gel|drops|spray/i;
+  return details.some((m) => {
+    if (m.chronic !== true) return false;
+    if (!CORTICOSTEROID_PATTERN.test(m.name)) return false;
+    const route = m.route?.toLowerCase() ?? "";
+    if (TOPICAL_ROUTE_PATTERN.test(route)) return false;
+    if (TOPICAL_ROUTE_PATTERN.test(m.name)) return false;
+    return true;
+  });
 }
 
 const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
@@ -1191,40 +1222,52 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
           if (dailyEquiv < 20) return false;
         }
 
-        // Duration gate (#940). IDSA/ATS require prednisone-equivalent
-        // >= 20 mg/day for >= 4 weeks before PCP prophylaxis is indicated.
-        // Short bursts (5–7 day tapers for asthma exacerbation, poison ivy,
-        // acute gout, COPD flare, etc.) routinely use 40–60 mg prednisone
-        // and would otherwise trip this rule with no real prophylaxis
-        // indication. Suppress fire when started_at is known and shows the
-        // course started < 28 days ago; fail-open (keep firing) when the
-        // writer didn't record a start date, so chronic steroid courses
-        // without start-date metadata still surface.
-        //
-        // Anchor to `ctx.event_timestamp` (not wall-clock) so replayed /
-        // backfilled / late-processed events evaluate deterministically —
-        // same pattern as the ONCO-VTE recency gate above. A start date in
-        // the future relative to the event (data-entry typo) is treated as
-        // unknown and falls through to fire (fail-open).
-        //
-        // #976 — also track whether the duration gate had data so the
-        // emitted flag carries `metadata.duration_known`. Downstream
-        // FP-rate analysis uses this to measure how often the rule fires
-        // on the fail-open path (started_at null / unparseable / future-
-        // dated) vs. the data-driven path.
-        const startedAt = systemicSteroidDetail.started_at;
-        if (startedAt) {
-          const startedMs = Date.parse(startedAt);
-          const refMs = ctx.event_timestamp
-            ? Date.parse(ctx.event_timestamp)
-            : Date.now();
-          if (Number.isFinite(startedMs) && Number.isFinite(refMs)) {
-            const daysSinceStart = (refMs - startedMs) / 86_400_000;
-            if (daysSinceStart >= 0 && daysSinceStart < 28) return false;
-            // duration_known is surfaced in flag metadata by
-            // buildSteroidPcpMetadata below; the gate logic above is the
-            // source of truth for whether started_at carried a usable
-            // value at evaluation time.
+        // Prescriber-marked-chronic short-circuit (#1023). Solid-organ
+        // transplant, autoimmune disease, GVHD, etc. are day-1-chronic —
+        // the prescriber knows immediately the course is indefinite.
+        // When `chronic === true`, skip the duration gate entirely so
+        // the PCP-prophylaxis flag fires at prescription time instead
+        // of waiting four weeks. The metadata surfaces this distinction
+        // (`chronic_marked: true`) so FP-rate analysis can separate
+        // prescriber-marked firings from duration-gate firings.
+        if (systemicSteroidDetail.chronic === true) {
+          // Fall through to the PCP-prophylaxis check below.
+        } else {
+          // Duration gate (#940). IDSA/ATS require prednisone-equivalent
+          // >= 20 mg/day for >= 4 weeks before PCP prophylaxis is indicated.
+          // Short bursts (5–7 day tapers for asthma exacerbation, poison ivy,
+          // acute gout, COPD flare, etc.) routinely use 40–60 mg prednisone
+          // and would otherwise trip this rule with no real prophylaxis
+          // indication. Suppress fire when started_at is known and shows the
+          // course started < 28 days ago; fail-open (keep firing) when the
+          // writer didn't record a start date, so chronic steroid courses
+          // without start-date metadata still surface.
+          //
+          // Anchor to `ctx.event_timestamp` (not wall-clock) so replayed /
+          // backfilled / late-processed events evaluate deterministically —
+          // same pattern as the ONCO-VTE recency gate above. A start date in
+          // the future relative to the event (data-entry typo) is treated as
+          // unknown and falls through to fire (fail-open).
+          //
+          // #976 — also track whether the duration gate had data so the
+          // emitted flag carries `metadata.duration_known`. Downstream
+          // FP-rate analysis uses this to measure how often the rule fires
+          // on the fail-open path (started_at null / unparseable / future-
+          // dated) vs. the data-driven path.
+          const startedAt = systemicSteroidDetail.started_at;
+          if (startedAt) {
+            const startedMs = Date.parse(startedAt);
+            const refMs = ctx.event_timestamp
+              ? Date.parse(ctx.event_timestamp)
+              : Date.now();
+            if (Number.isFinite(startedMs) && Number.isFinite(refMs)) {
+              const daysSinceStart = (refMs - startedMs) / 86_400_000;
+              if (daysSinceStart >= 0 && daysSinceStart < 28) return false;
+              // duration_known is surfaced in flag metadata by
+              // buildSteroidPcpMetadata below; the gate logic above is the
+              // source of truth for whether started_at carried a usable
+              // value at evaluation time.
+            }
           }
         }
       }
@@ -1251,6 +1294,11 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
     notify_specialties: ["infectious_disease", "pharmacy"],
     buildMetadata: (ctx: PatientContext) => ({
       duration_known: steroidPcpDurationKnown(ctx),
+      // #1023 — distinguish prescriber-marked-chronic firings from
+      // duration-gate firings. True only when a qualifying systemic
+      // corticosteroid in the context is explicitly marked chronic by
+      // the prescriber, regardless of started_at.
+      chronic_marked: steroidPcpChronicMarked(ctx),
     }),
   },
 

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -912,6 +912,10 @@ export async function buildPatientContextForRules(
       // Expose prescription start date for duration-aware rules (#940).
       // Null when the writer never recorded a start — rules must fail-open.
       started_at: m.started_at ?? null,
+      // Prescriber-marked-chronic flag (#1023). When set, the
+      // CROSS-STEROID-PCP-001 duration gate is bypassed and the flag
+      // fires at prescription time. Null when the writer never recorded.
+      chronic: m.chronic ?? null,
     })),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -149,6 +149,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     rxnorm_code: input.rxnorm_code ?? null,
     ordering_provider_id: input.ordering_provider_id ?? null,
     encounter_id: input.encounter_id ?? null,
+    chronic: input.chronic ?? null,
     created_at: now,
     updated_at: now,
   };
@@ -180,6 +181,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     rxnorm_code: input.rxnorm_code,
     ordering_provider_id: input.ordering_provider_id,
     encounter_id: input.encounter_id,
+    chronic: input.chronic,
     created_at: now,
     updated_at: now,
   };
@@ -222,6 +224,7 @@ export async function updateMedication(
   if (fields.rxnorm_code !== undefined) updates.rxnorm_code = fields.rxnorm_code;
   if (fields.ordering_provider_id !== undefined) updates.ordering_provider_id = fields.ordering_provider_id;
   if (fields.encounter_id !== undefined) updates.encounter_id = fields.encounter_id;
+  if (fields.chronic !== undefined) updates.chronic = fields.chronic;
 
   // Optimistic locking: when expectedUpdatedAt is provided, only update if the
   // row hasn't been modified since the caller last read it.
@@ -273,6 +276,7 @@ export async function updateMedication(
     ordering_provider_id: updated.ordering_provider_id ?? undefined,
     encounter_id: updated.encounter_id ?? undefined,
     source_system: updated.source_system ?? undefined,
+    chronic: updated.chronic ?? undefined,
     created_at: updated.created_at,
     updated_at: updated.updated_at,
   };
@@ -315,6 +319,7 @@ export async function getMedicationsByPatient(
     ordering_provider_id: row.ordering_provider_id ?? undefined,
     encounter_id: row.encounter_id ?? undefined,
     source_system: row.source_system ?? undefined,
+    chronic: row.chronic ?? undefined,
     created_at: row.created_at,
     updated_at: row.updated_at,
   }));


### PR DESCRIPTION
## Summary

CROSS-STEROID-PCP-001 today suppresses for the first 28 days of a steroid course because most prescriptions are short bursts (asthma flare, gout, poison ivy, etc.) and tripping prophylaxis warnings for those is expensive noise. Some patients are on lifelong immunosuppression from day 1 — solid-organ transplant, autoimmune disease, GVHD — and the prescriber knows immediately the course is chronic. This PR threads a \`chronic\` flag through so those firings happen at prescription time instead of four weeks later.

### Backend changes

- **Migration 0043** adds \`chronic boolean\` to \`medications\`
- **Drizzle schema** + **shared-types Medication interface** + **Zod \`createMedicationSchema\` / \`updateMedicationSchema\`** all pick up the new field
- **\`PatientMedication\`** (ai-oversight) carries \`chronic?: boolean | null\`; \`buildPatientContextForRules\` passes it through from the DB row
- **\`clinical-data\` medication-repo** accepts the field on create + update and returns it on reads
- **CROSS-STEROID-PCP-001** short-circuits the duration gate when \`chronic === true\`; everything else (route gate, dose gate, daily-prednisone-equivalent gate, PCP-prophylaxis check) still applies
- New telemetry helper \`steroidPcpChronicMarked\` surfaces \`metadata.chronic_marked\` so FP-rate analysis can distinguish prescriber-marked firings from duration-gate firings (extends #976)

### Tests

Four new CROSS-STEROID-PCP-001 cases:
- \`chronic=true\` + \`started_at\` within 28 days → flag fires (gate bypassed), \`chronic_marked=true\`
- \`chronic=true\` + no \`started_at\` → flag still fires, \`chronic_marked=true\`
- \`chronic=false\` → duration gate still suppresses the < 28-day burst
- \`chronic=true\` on intranasal corticosteroid → route gate still strips it from the systemic-exposure cohort

Existing three duration-gate tests updated to expect the new \`chronic_marked: false\` field in metadata.

### Out of scope

Prescription form UI for the new flag — tracked as **#1060**.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 904/904 pass (+4 new)
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean
- [x] \`pnpm --filter @carebridge/clinical-data test\` → 46/46 pass
- [x] \`pnpm --filter @carebridge/clinical-data typecheck\` → clean
- [x] \`pnpm --filter @carebridge/shared-types test\` → 214/214 pass

## Migration journal note

Pre-assigned migration idx 47 / tag \`0043_medications_chronic_flag\` so it doesn't collide with parallel migration work. Sole migration in flight.

Closes #1023