### PR TITLE
test(medical-logic): add SMOG + Gunning-Fog complements + multilingual plan

### DIFF
--- a/docs/patient-education-readability.md
+++ b/docs/patient-education-readability.md
@@ -1,0 +1,141 @@
+# Patient-education readability — design and multilingual plan
+
+CareBridge surfaces clinician-authored patient-education cards (diagnoses,
+medications) in the patient portal. The reading level of those cards is
+guarded by a lock test: every PR that touches `patient-education.ts`
+must keep the cards within reading-level ceilings.
+
+This doc covers two things:
+
+1. The current English-only guard (PR #962, extended in PR for #975).
+2. How the guard extends once translated cards land.
+
+## Current guard — English
+
+The lock test lives at
+`packages/medical-logic/src/__tests__/patient-education-reading-level.test.ts`.
+Every `summary`, joined `self_care`, and joined `when_to_contact_provider`
+block from `DIAGNOSIS_EDUCATION_TABLE` and `MEDICATION_EDUCATION_TABLE`
+is graded against **three independent metrics**:
+
+| Metric          | What it measures                                          | Ceiling | Why we use it                                                                 |
+|-----------------|-----------------------------------------------------------|---------|-------------------------------------------------------------------------------|
+| Flesch-Kincaid  | Sentence length × syllable density                        | 11.0    | Standard patient-education benchmark (HHS Office of Minority Health 6–8th).   |
+| SMOG            | Polysyllable count, normalized to 30 sentences            | 13.0    | Stable on short bullet lists where FK gets noisy (words/sentences collapses). |
+| Gunning-Fog     | Sentence length + hard-word density (3+ syllables)        | 13.0    | Combines both signals; tends to read 1–2 grades above FK on the same text.   |
+
+A card must clear **all three** ceilings to pass. FK alone can be gamed
+by short fragments; SMOG alone misses long-but-simple prose; Gunning-Fog
+alone is sensitive to sentence punctuation. The intersection catches
+each failure mode.
+
+All three formulas are inlined as small pure functions in the test
+file — no runtime dep. Syllables use a vowel-group heuristic that is
+"close enough for a guard" (we're catching four-syllable jargon, not
+doing comma-level linguistic precision).
+
+### Targets vs ceilings
+
+Ceilings are intentionally above target. HHS targets 6th–8th grade for
+consumer-health material; our ceilings are 11.0 (FK) / 13.0 (SMOG) /
+13.0 (Fog). The gap exists because legitimate medical terms
+(`hypertension`, `immunosuppressant`, `anticoagulation`) push the
+metrics up by 2–3 grades regardless of how plain the surrounding
+prose is. A ceiling at 8.0 would flake the suite on every clinically
+correct card.
+
+If the guard catches a PR, it means the *new* content drifted
+significantly above already-loose ceilings — worth re-wording, not
+worth fighting the metric.
+
+## Multilingual plan — coming with Spanish first
+
+Flesch-Kincaid, SMOG, and Gunning-Fog are all **English-specific**.
+Their formulas are calibrated to English syllable patterns and the
+distribution of polysyllables in English text. Applying them to a
+Spanish card produces meaningless numbers — Spanish words average more
+syllables than English ones, so a perfectly clear Spanish summary
+would score "12th grade" by FK and fail the guard.
+
+When translated cards land, the guard needs to know the locale of each
+block and route to a language-appropriate metric.
+
+### Per-language metric map
+
+| Language | Metric                                  | Notes                                                           |
+|----------|-----------------------------------------|-----------------------------------------------------------------|
+| English  | Flesch-Kincaid + SMOG + Gunning-Fog     | Current intersection. Keep as-is.                                |
+| Spanish  | Fernández-Huerta + Szigriszt-Pazos       | Fernández-Huerta is the FK analog; Szigriszt is the modernized form. Score ranges differ from FK — Spanish reading-ease "very easy" is ~80–90, English FK grade level reads inverted. |
+| German   | LIX + Wiener Sachtextformel             | LIX is sentence-length + long-word density; Wiener is the German-specific grade-level analog. |
+| French   | Kandel-Moles                            | French FK analog. Calibrated against French primary-school content. |
+
+Per-language syllable counters need to live next to the metric
+functions. The current English `countSyllables` won't carry over —
+Spanish has rules for diphthongs and tildes; German has umlauts and
+compound-word boundaries.
+
+### Where the code lives
+
+Extract the shared scaffolding (`tokenizeWords`, `countSentences`,
+metric dispatch by locale) into a new module:
+
+```
+packages/medical-logic/src/readability/
+  index.ts              # public surface
+  english.ts            # FK, SMOG, Fog + English syllables
+  spanish.ts            # Fernández-Huerta, Szigriszt + Spanish syllables (when needed)
+  german.ts             # LIX, Wiener (when needed)
+  french.ts             # Kandel-Moles (when needed)
+  __tests__/readability.test.ts
+```
+
+The lock-test imports from `readability` and dispatches per card based
+on the locale tag on the card. Test file becomes thin — it iterates
+cards, asks the readability module for a verdict, and asserts pass.
+
+### Lock-test policy when locale ≠ English
+
+Two options:
+
+1. **Per-locale lock test, identical structure.** Each language gets
+   its own metric+ceiling tuned the same way English's is — generous
+   enough to clear legitimate medical terms in that language. This is
+   the right end-state; it requires native-speaker calibration for
+   each language we add.
+
+2. **Language-agnostic fallback for languages we haven't calibrated.**
+   Sentence-length cap (no sentence > 25 words) + typographic checks
+   (no walls of all-caps, no abbreviation soup). Catches obvious
+   regressions without claiming a grade-level number we can't defend.
+
+Plan: ship option 1 for any language we ship cards in; keep option 2
+as the safety net for any locale where the metric module hasn't been
+written yet, so a card in a new language doesn't bypass the guard
+entirely.
+
+## Acceptance for the first non-English translation
+
+Before the first translated card merges:
+
+- [ ] Decide which locale(s) to support first (likely Spanish per
+      patient population).
+- [ ] Implement the per-language metric(s) and ceiling under
+      `packages/medical-logic/src/readability/<lang>.ts`.
+- [ ] Calibrate the ceiling on a small corpus of native-speaker
+      patient-education samples (e.g. CDC Spanish materials, NIH
+      MedlinePlus Spanish), aiming for the same "loose-enough that
+      clinical terms pass" headroom the English guard has.
+- [ ] Add the locale tag to the card data and route the lock test
+      through `readability` module.
+- [ ] Update this doc with the chosen ceiling and a one-line summary
+      of the calibration corpus.
+
+## References
+
+- PR [#962](https://github.com/blamechris/carebridge/pull/962) — original Flesch-Kincaid lock test
+- Issue [#975](https://github.com/blamechris/carebridge/issues/975) — multi-metric extension + this plan
+- HHS Office of Minority Health — Plain Language guidelines (6th–8th grade target)
+- McLaughlin (1969) — SMOG Readability Formula
+- Gunning (1952) — Technique of Clear Writing (Fog Index)
+- Fernández-Huerta (1959) — Medidas sencillas de lecturabilidad (Spanish)
+- Bamberger & Vanecek (1984) — Wiener Sachtextformel (German)

--- a/packages/medical-logic/src/__tests__/patient-education-reading-level.test.ts
+++ b/packages/medical-logic/src/__tests__/patient-education-reading-level.test.ts
@@ -6,24 +6,48 @@ import {
 } from "../patient-education.js";
 
 /**
- * Lock-test for patient-education reading level (#949).
+ * Lock-test for patient-education reading level (#949, extended in #975).
  *
- * Targets ~8th-grade / plain-language reading level. We use Flesch-Kincaid
- * grade level because it's the standard patient-education benchmark (HHS
- * Office of Minority Health targets 6th–8th for consumer health material).
+ * Targets ~8th-grade / plain-language reading level. We use three
+ * independent grade-level metrics so the guard is robust to gaming any
+ * single formula:
  *
- * A small pure-function implementation — no runtime dep. Syllables are
- * counted with a vowel-group heuristic that is close enough for a guard
- * test: we're catching "this sentence has four-syllable jargon", not
+ *   - Flesch-Kincaid (FK)  — standard patient-education benchmark.
+ *     Sensitive to sentence length and syllable density.
+ *     HHS Office of Minority Health targets 6th–8th for consumer health
+ *     material.
+ *
+ *   - SMOG Index           — McLaughlin 1969. Focuses on polysyllable
+ *     density and is stable on short bullet lists where FK gets noisy
+ *     because words/sentences collapses to a tiny ratio.
+ *
+ *   - Gunning-Fog          — Gunning 1952. Combines sentence length and
+ *     hard-word density; tends to read 1–2 grades above FK on the same
+ *     text and complements both FK and SMOG.
+ *
+ * ALL THREE must be at or below ceiling for the card to pass. FK alone
+ * can be gamed by short fragments; SMOG alone misses long-but-simple
+ * prose; Gunning-Fog alone is sensitive to sentence punctuation. The
+ * intersection catches each failure mode.
+ *
+ * Pure-function implementations — no runtime deps. Syllables are counted
+ * with a vowel-group heuristic that is close enough for a guard test:
+ * we're catching "this sentence has four-syllable jargon", not
  * comma-level precision.
  *
- * The limit is deliberately loose (grade ≤ 11.0) so legitimate technical
- * terms (hypertension, immunosuppressant) don't flake the suite. If this
- * catches a PR it means the card has slid meaningfully above 11th grade,
- * which is worth re-wording.
+ * Ceilings are deliberately loose so legitimate technical terms
+ * (hypertension, immunosuppressant) don't flake the suite. If any of the
+ * three catches a PR it means the card has slid meaningfully above
+ * mid-high-school reading level — worth re-wording.
+ *
+ * Multilingual roadmap is documented in
+ * `docs/patient-education-readability.md`; until non-English cards land,
+ * these English-tuned formulas are the only guard.
  */
 
 const FK_GRADE_CEILING = 11.0;
+const SMOG_GRADE_CEILING = 13.0;
+const FOG_GRADE_CEILING = 13.0;
 
 /** Count syllables in a single word (lowercased). Vowel-group heuristic. */
 function countSyllables(word: string): number {
@@ -62,11 +86,61 @@ function fleschKincaidGrade(text: string): number {
   );
 }
 
+/**
+ * SMOG Index (McLaughlin 1969). Returns a grade-level estimate based on
+ * polysyllable density and sentence count.
+ *
+ *   SMOG grade = 1.0430 × √(polysyllables × 30 / sentences) + 3.1291
+ *
+ * Polysyllable = a word with 3 or more syllables. The canonical formula
+ * is calibrated to a sample of 30 sentences; for short content we apply
+ * the formula with the actual sentence count, which is the standard
+ * approximation. (#975)
+ */
+function smogGrade(text: string): number {
+  const tokens = tokenizeWords(text);
+  if (tokens.length === 0) return 0;
+  const sentences = countSentences(text);
+  const polysyllables = tokens.filter((w) => countSyllables(w) >= 3).length;
+  return (
+    1.0430 * Math.sqrt((polysyllables * 30) / sentences) + 3.1291
+  );
+}
+
+/**
+ * Gunning-Fog Index (Gunning 1952). Combines sentence length with the
+ * density of "hard" words (3+ syllables, excluding common -es / -ed /
+ * -ing inflections which the original heuristic also dropped).
+ *
+ *   Fog = 0.4 × ((words / sentences) + 100 × (hard_words / words))
+ *
+ * (#975)
+ */
+function gunningFogGrade(text: string): number {
+  const tokens = tokenizeWords(text);
+  const words = tokens.length;
+  if (words === 0) return 0;
+  const sentences = countSentences(text);
+  const hardWords = tokens.filter((w) => {
+    const lower = w.toLowerCase();
+    // Strip common inflectional endings before counting syllables —
+    // "process" is hard, "processed" / "processes" / "processing" are
+    // treated as the same word per Gunning's original definition.
+    const stripped = lower
+      .replace(/(?:ed|es|ing)$/i, "")
+      .replace(/[^a-z]/g, "");
+    return countSyllables(stripped) >= 3;
+  }).length;
+  return 0.4 * (words / sentences + 100 * (hardWords / words));
+}
+
 interface GradedText {
   ownerKey: string;
   field: string;
   text: string;
-  grade: number;
+  fk: number;
+  smog: number;
+  fog: number;
 }
 
 /**
@@ -81,25 +155,20 @@ function gradeEveryBlock(
 ): GradedText[] {
   const selfCareJoined = content.self_care.join(" ");
   const whenJoined = content.when_to_contact_provider.join(" ");
+  function score(field: string, text: string): GradedText {
+    return {
+      ownerKey: key,
+      field,
+      text,
+      fk: fleschKincaidGrade(text),
+      smog: smogGrade(text),
+      fog: gunningFogGrade(text),
+    };
+  }
   return [
-    {
-      ownerKey: key,
-      field: "summary",
-      text: content.summary,
-      grade: fleschKincaidGrade(content.summary),
-    },
-    {
-      ownerKey: key,
-      field: "self_care",
-      text: selfCareJoined,
-      grade: fleschKincaidGrade(selfCareJoined),
-    },
-    {
-      ownerKey: key,
-      field: "when_to_contact_provider",
-      text: whenJoined,
-      grade: fleschKincaidGrade(whenJoined),
-    },
+    score("summary", content.summary),
+    score("self_care", selfCareJoined),
+    score("when_to_contact_provider", whenJoined),
   ];
 }
 
@@ -121,16 +190,50 @@ describe("patient-education reading level (#949)", () => {
   });
 
   for (const g of graded) {
-    it(`${g.ownerKey}.${g.field}: grade ${g.grade.toFixed(1)} ≤ ${FK_GRADE_CEILING}`, () => {
-      if (g.grade > FK_GRADE_CEILING) {
+    it(`${g.ownerKey}.${g.field}: FK ${g.fk.toFixed(1)} ≤ ${FK_GRADE_CEILING}, SMOG ${g.smog.toFixed(1)} ≤ ${SMOG_GRADE_CEILING}, Fog ${g.fog.toFixed(1)} ≤ ${FOG_GRADE_CEILING}`, () => {
+      if (
+        g.fk > FK_GRADE_CEILING ||
+        g.smog > SMOG_GRADE_CEILING ||
+        g.fog > FOG_GRADE_CEILING
+      ) {
         // Surface the offending block so content PRs get a clear fix.
         console.log(
-          `[reading-level] ${g.ownerKey}.${g.field} reads at grade ${g.grade.toFixed(1)}: "${g.text}"`,
+          `[reading-level] ${g.ownerKey}.${g.field}: FK=${g.fk.toFixed(1)} SMOG=${g.smog.toFixed(1)} Fog=${g.fog.toFixed(1)}: "${g.text}"`,
         );
       }
-      expect(g.grade).toBeLessThanOrEqual(FK_GRADE_CEILING);
+      expect(g.fk, `${g.ownerKey}.${g.field} FK`).toBeLessThanOrEqual(FK_GRADE_CEILING);
+      expect(g.smog, `${g.ownerKey}.${g.field} SMOG`).toBeLessThanOrEqual(SMOG_GRADE_CEILING);
+      expect(g.fog, `${g.ownerKey}.${g.field} Fog`).toBeLessThanOrEqual(FOG_GRADE_CEILING);
     });
   }
+});
+
+describe("smogGrade sanity (#975)", () => {
+  it("elementary writing scores in single digits", () => {
+    const s = smogGrade("The dog ran fast. The cat sat. Birds fly high.");
+    expect(s).toBeLessThan(8);
+  });
+
+  it("polysyllable-dense prose scores meaningfully higher", () => {
+    const s = smogGrade(
+      "Immunosuppressant pharmacotherapy necessitates stringent immunological surveillance in transplantation recipients.",
+    );
+    expect(s).toBeGreaterThan(10);
+  });
+});
+
+describe("gunningFogGrade sanity (#975)", () => {
+  it("elementary writing scores in single digits", () => {
+    const f = gunningFogGrade("The dog ran fast. The cat sat. Birds fly high.");
+    expect(f).toBeLessThan(8);
+  });
+
+  it("polysyllable-dense prose scores meaningfully higher", () => {
+    const f = gunningFogGrade(
+      "Immunosuppressant pharmacotherapy necessitates stringent immunological surveillance in transplantation recipients.",
+    );
+    expect(f).toBeGreaterThan(15);
+  });
 });
 
 describe("fleschKincaidGrade sanity (#949)", () => {


### PR DESCRIPTION
## Summary

PR #962 added a Flesch-Kincaid lock test on every patient-education card, but FK alone can be gamed — short fragments collapse the words/sentences ratio even when the vocabulary is dense. This PR extends the guard with two independent complement metrics so the intersection catches each formula's failure mode.

### Test changes

\`packages/medical-logic/src/__tests__/patient-education-reading-level.test.ts\`:

- **\`smogGrade()\`** — SMOG Index (McLaughlin 1969). Polysyllable density normalized to 30 sentences. Stable on short bullet lists where FK gets noisy.
- **\`gunningFogGrade()\`** — Gunning-Fog Index (Gunning 1952). Sentence length + 3+-syllable hard-word density, with the standard -es/-ed/-ing inflection-stripping.
- Per-card assertions now require **all three** (FK ≤ 11.0, SMOG ≤ 13.0, Fog ≤ 13.0). Ceilings are deliberately loose so legitimate medical jargon (hypertension, immunosuppressant) doesn't flake the suite.
- Sanity tests pinning elementary-vs-jargon scoring for both new formulas.

### New doc

\`docs/patient-education-readability.md\`:

- Documents the three-metric intersection design and the rationale for the loose ceilings.
- Per-language metric map (Spanish: Fernández-Huerta + Szigriszt; German: LIX + Wiener; French: Kandel-Moles). FK / SMOG / Fog are English-specific and would produce meaningless numbers on other languages, so the guard needs locale-aware dispatch before the first translation lands.
- Proposed \`packages/medical-logic/src/readability/\` module layout for when that dispatch is needed.
- Two-tier fallback policy (per-locale ceiling where calibrated; sentence-length / typographic checks as the safety net for uncalibrated locales).
- Acceptance checklist for the first non-English translation.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` → 435/435 pass (+3 new sanity, +existing per-card now check 3 metrics)
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean

Closes #975