### PR TITLE
feat(db): persist structured medication frequency to eliminate runtime parse

### DIFF
--- a/packages/db-schema/drizzle/0044_medications_frequency_structured.sql
+++ b/packages/db-schema/drizzle/0044_medications_frequency_structured.sql
@@ -1,0 +1,18 @@
+-- #931: persist structured medication frequency to eliminate runtime
+-- re-parsing of medications.frequency on every rule evaluation.
+--
+-- The column carries either:
+--   * the canonical MedFrequency literal ('daily', 'bid', 'tid', 'qid',
+--     'q2h', 'q3h', 'q4h', 'q6h', 'q8h', 'q12h', 'weekly', 'monthly',
+--     'prn', 'once'); or
+--   * 'qNh:<n>' for non-canonical every-N-hours intervals (q5h, q10h,
+--     etc.) the parser surfaces as QNHoursFrequency.
+--
+-- NULL means the writer could not classify the free-text frequency.
+-- Counting nulls (via the dashboard work that lands in a follow-up)
+-- gives us visibility into the unparseable-frequency long tail — the
+-- denominator we need to improve the parser. Until the column is fully
+-- backfilled, rules fall back to runtime parsing of the existing
+-- `frequency` column (no behavioural regression).
+
+ALTER TABLE medications ADD COLUMN IF NOT EXISTS frequency_structured text;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1747929600000,
       "tag": "0043_medications_chronic_flag",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1747929660000,
+      "tag": "0044_medications_frequency_structured",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -12,6 +12,14 @@ export const medications = pgTable("medications", {
   route: text("route"),
   frequency: text("frequency"),
   /**
+   * Structured frequency derived from {@link frequency} at write time
+   * (#931). Carries either a canonical MedFrequency literal ('daily',
+   * 'bid', 'q4h', ...) or 'qNh:<n>' for non-canonical every-N-hours
+   * intervals. NULL when the writer couldn't classify the free-text
+   * input — rules then fall back to runtime parsing of `frequency`.
+   */
+  frequency_structured: text("frequency_structured"),
+  /**
    * Optional PRN / hard-cap dose count per 24 h. Populated when a
    * prescription carries an explicit cap (e.g. "morphine 10 mg q4h PRN,
    * max 4 doses/day"). Consumed by ai-oversight to bound PRN daily

--- a/packages/medical-logic/src/__tests__/medication-frequency.test.ts
+++ b/packages/medical-logic/src/__tests__/medication-frequency.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   parseFrequencyText,
   estimateDailyDose,
+  serializeFrequency,
+  deserializeFrequency,
   FREQUENCY_DOSES_PER_DAY,
   type MedFrequency,
 } from "../medication-frequency.js";
@@ -209,5 +211,73 @@ describe("estimateDailyDose with non-canonical qNh (#933)", () => {
     expect(
       estimateDailyDose(10, { kind: "qNh", n: Number.POSITIVE_INFINITY }),
     ).toBeNull();
+  });
+});
+
+describe("serializeFrequency / deserializeFrequency round-trip (#931)", () => {
+  it("canonical literals serialize to themselves", () => {
+    for (const f of [
+      "once",
+      "daily",
+      "bid",
+      "tid",
+      "qid",
+      "q2h",
+      "q3h",
+      "q4h",
+      "q6h",
+      "q8h",
+      "q12h",
+      "weekly",
+      "monthly",
+      "prn",
+    ] as const) {
+      expect(serializeFrequency(f)).toBe(f);
+      expect(deserializeFrequency(f)).toBe(f);
+    }
+  });
+
+  it("QNHoursFrequency serializes to 'qNh:<n>' and round-trips", () => {
+    expect(serializeFrequency({ kind: "qNh", n: 5 })).toBe("qNh:5");
+    expect(deserializeFrequency("qNh:5")).toEqual({ kind: "qNh", n: 5 });
+    expect(deserializeFrequency("qNh:10")).toEqual({ kind: "qNh", n: 10 });
+  });
+
+  it("null/undefined input passes through", () => {
+    expect(serializeFrequency(null)).toBeNull();
+    expect(deserializeFrequency(null)).toBeNull();
+    expect(deserializeFrequency(undefined)).toBeNull();
+    expect(deserializeFrequency("")).toBeNull();
+  });
+
+  it("unknown stored values return null so callers fall back to runtime parse", () => {
+    // A future schema migration or hand-edited row that introduces an
+    // unrecognized literal must not crash — callers fall through to
+    // parseFrequencyText(free-text) as the safety net.
+    expect(deserializeFrequency("hourly")).toBeNull();
+    expect(deserializeFrequency("q99h")).toBeNull(); // not canonical, not qNh:N format
+    expect(deserializeFrequency("qNh:99")).toBeNull(); // n out of range
+    expect(deserializeFrequency("qNh:0")).toBeNull();
+    expect(deserializeFrequency("qNh:abc")).toBeNull();
+  });
+
+  it("parseFrequencyText → serialize → deserialize round-trips", () => {
+    for (const input of [
+      "q4h",
+      "every 4 hours",
+      "BID",
+      "twice daily",
+      "PRN",
+      "as needed",
+      "stat",
+      "once a day",
+      "q5h", // non-canonical → QNHoursFrequency
+      "q10h",
+    ]) {
+      const parsed = parseFrequencyText(input);
+      const serialized = serializeFrequency(parsed);
+      const deserialized = deserializeFrequency(serialized);
+      expect(deserialized).toEqual(parsed);
+    }
   });
 });

--- a/packages/medical-logic/src/medication-frequency.ts
+++ b/packages/medical-logic/src/medication-frequency.ts
@@ -193,6 +193,67 @@ export function parseFrequencyText(
 }
 
 /**
+ * Stable wire format for persisting {@link ParsedFrequency} to the
+ * `medications.frequency_structured` column (#931).
+ *
+ * - {@link MedFrequency} string literals serialize as themselves
+ *   ('daily', 'bid', 'q4h', ...).
+ * - {@link QNHoursFrequency} serializes as `'qNh:<n>'` (e.g. 'qNh:5'
+ *   for q5h). Distinct from canonical `qNh` strings ('q4h') so the
+ *   round-trip parser can distinguish them.
+ *
+ * Returns null for null input so callers can pipe the parser result
+ * straight through.
+ */
+export function serializeFrequency(
+  freq: ParsedFrequency | null,
+): string | null {
+  if (freq == null) return null;
+  if (typeof freq === "string") return freq;
+  return `qNh:${freq.n}`;
+}
+
+/**
+ * Inverse of {@link serializeFrequency}. Reads the wire format back
+ * into a {@link ParsedFrequency}. Unknown strings return null so the
+ * caller can fall back to runtime parsing of the free-text frequency
+ * column. (#931)
+ */
+export function deserializeFrequency(
+  stored: string | null | undefined,
+): ParsedFrequency | null {
+  if (!stored) return null;
+  const qNh = stored.match(/^qNh:(\d+)$/);
+  if (qNh) {
+    const n = Number(qNh[1]);
+    if (Number.isInteger(n) && n >= 1 && n <= 24) {
+      return { kind: "qNh", n };
+    }
+    return null;
+  }
+  const canonical: MedFrequency[] = [
+    "once",
+    "daily",
+    "bid",
+    "tid",
+    "qid",
+    "q2h",
+    "q3h",
+    "q4h",
+    "q6h",
+    "q8h",
+    "q12h",
+    "weekly",
+    "monthly",
+    "prn",
+  ];
+  if ((canonical as string[]).includes(stored)) {
+    return stored as MedFrequency;
+  }
+  return null;
+}
+
+/**
  * Estimate the implied daily-cumulative dose (mg-equivalent units the
  * caller passes in). Returns null when the frequency can't be parsed or
  * when PRN is the frequency and no max_doses_per_day is supplied — the

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -33,6 +33,14 @@ export interface Medication extends MutableRecord {
   dose_unit?: string;
   route?: MedRoute;
   frequency?: string;
+  /**
+   * Structured frequency derived from {@link frequency} at write time
+   * (#931). Carries either a canonical MedFrequency literal ('daily',
+   * 'bid', 'q4h', ...) or 'qNh:<n>' for non-canonical every-N-hours
+   * intervals. Undefined when the writer couldn't classify the free-
+   * text — rules then fall back to runtime parsing of `frequency`.
+   */
+  frequency_structured?: string;
   status: MedStatus;
   started_at?: string;
   ended_at?: string;

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -8,7 +8,11 @@
  */
 
 import type { FlagSeverity, FlagCategory, ClinicalEvent, RuleFlag } from "@carebridge/shared-types";
-import { parseFrequencyText, estimateDailyDose } from "@carebridge/medical-logic";
+import {
+  parseFrequencyText,
+  deserializeFrequency,
+  estimateDailyDose,
+} from "@carebridge/medical-logic";
 import { QTC_PATTERN } from "./drug-interactions.js";
 import { METFORMIN_PATTERN, NSAID_PATTERN } from "./shared-drug-patterns.js";
 import { getRecentPotassium, getRecentEGFR } from "./lab-units.js";
@@ -86,6 +90,13 @@ export interface PatientMedication {
   frequency: string | null;
   /** Optional PRN / hard-cap dose count per 24 h (not yet stored in DB). */
   max_doses_per_day?: number | null;
+  /**
+   * Persisted structured frequency from `medications.frequency_structured`
+   * (#931). When present, rules use this directly instead of re-parsing
+   * the free-text `frequency` column. Null when the writer couldn't
+   * classify the input — rule falls back to runtime parsing.
+   */
+  frequency_structured?: string | null;
   rxnorm_code: string | null;
   /**
    * ISO 8601 prescription start date. Populated from `medications.started_at`
@@ -1234,7 +1245,11 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
           // per-dose amount as the daily estimate) so chronic-suppressed
           // PRN tapers still flag, but tight interpretation would miss
           // "prednisone 10 mg BID" today.
-          const freq = parseFrequencyText(systemicSteroidDetail.frequency);
+          // Prefer the structured column populated at write time (#931);
+          // fall back to runtime parsing for unmigrated rows.
+          const freq =
+            deserializeFrequency(systemicSteroidDetail.frequency_structured) ??
+            parseFrequencyText(systemicSteroidDetail.frequency);
           const dailyEquiv =
             estimateDailyDose(
               perDoseEquiv,

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -30,6 +30,7 @@ import type {
 } from "@carebridge/shared-types";
 import {
   parseFrequencyText,
+  deserializeFrequency,
   estimateDailyDose,
   getMedicationDoseLimit,
 } from "@carebridge/medical-logic";
@@ -234,7 +235,12 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
   const limit = getMedicationDoseLimit(med.name);
   if (!limit) return flags;
 
-  const freq = parseFrequencyText(med.frequency);
+  // Prefer the structured column populated at write time (#931). Falls
+  // back to runtime parsing of the free-text frequency when the writer
+  // couldn't classify it, or when the row predates the structured column.
+  const freq =
+    deserializeFrequency(med.frequency_structured) ??
+    parseFrequencyText(med.frequency);
   const daily = estimateDailyDose(
     med.dose_amount,
     freq,

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -916,6 +916,9 @@ export async function buildPatientContextForRules(
       // CROSS-STEROID-PCP-001 duration gate is bypassed and the flag
       // fires at prescription time. Null when the writer never recorded.
       chronic: m.chronic ?? null,
+      // Structured frequency from medications.frequency_structured (#931).
+      // When present, rules skip the runtime re-parse of `frequency`.
+      frequency_structured: m.frequency_structured ?? null,
     })),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -5,6 +5,8 @@ import type { Medication, MedLog, MedStatus } from "@carebridge/shared-types";
 import {
   CROSS_REACTIVITY_MAP,
   expandAllergenAliases,
+  parseFrequencyText,
+  serializeFrequency,
 } from "@carebridge/medical-logic";
 import { emitClinicalEvent } from "../events.js";
 
@@ -141,6 +143,11 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     dose_unit: input.dose_unit ?? null,
     route: input.route ?? null,
     frequency: input.frequency ?? null,
+    // Pre-parse to the structured column at write time (#931). When the
+    // free-text frequency can't be classified, store null and let the
+    // rule fall back to runtime parsing — same fail-open behaviour as
+    // before the structured column existed.
+    frequency_structured: serializeFrequency(parseFrequencyText(input.frequency ?? null)),
     status: input.status ?? "active",
     started_at: input.started_at ?? null,
     ended_at: input.ended_at ?? null,
@@ -173,6 +180,8 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     dose_unit: input.dose_unit,
     route: input.route,
     frequency: input.frequency,
+    frequency_structured:
+      serializeFrequency(parseFrequencyText(input.frequency ?? null)) ?? undefined,
     status: input.status ?? "active",
     started_at: input.started_at,
     ended_at: input.ended_at,
@@ -215,7 +224,11 @@ export async function updateMedication(
   if (fields.dose_amount !== undefined) updates.dose_amount = fields.dose_amount;
   if (fields.dose_unit !== undefined) updates.dose_unit = fields.dose_unit;
   if (fields.route !== undefined) updates.route = fields.route;
-  if (fields.frequency !== undefined) updates.frequency = fields.frequency;
+  if (fields.frequency !== undefined) {
+    updates.frequency = fields.frequency;
+    // Re-derive the structured column whenever the free-text changes (#931).
+    updates.frequency_structured = serializeFrequency(parseFrequencyText(fields.frequency));
+  }
   if (fields.status !== undefined) updates.status = fields.status;
   if (fields.started_at !== undefined) updates.started_at = fields.started_at;
   if (fields.ended_at !== undefined) updates.ended_at = fields.ended_at;
@@ -267,6 +280,7 @@ export async function updateMedication(
     dose_unit: updated.dose_unit ?? undefined,
     route: (updated.route as Medication["route"]) ?? undefined,
     frequency: updated.frequency ?? undefined,
+    frequency_structured: updated.frequency_structured ?? undefined,
     status: updated.status as MedStatus,
     started_at: updated.started_at ?? undefined,
     ended_at: updated.ended_at ?? undefined,
@@ -310,6 +324,7 @@ export async function getMedicationsByPatient(
     dose_unit: row.dose_unit ?? undefined,
     route: (row.route as Medication["route"]) ?? undefined,
     frequency: row.frequency ?? undefined,
+    frequency_structured: row.frequency_structured ?? undefined,
     status: row.status as MedStatus,
     started_at: row.started_at ?? undefined,
     ended_at: row.ended_at ?? undefined,


### PR DESCRIPTION
## Summary

\`services/ai-oversight\` today re-parses \`medications.frequency\` as free text on every rule evaluation. Cheap individually but compounds across the active-medications list. Worse, unparseable frequencies silently fail-open and there's no visibility into the long tail.

This PR adds a \`frequency_structured\` column derived at write time and switches the rules to prefer it.

### Changes

- **Migration 0044** adds \`medications.frequency_structured: text\` (idx 48, one above #1023's idx 47 to avoid journal collision)
- **Drizzle schema** + **shared-types \`Medication\`** carry the field
- **\`serializeFrequency\` / \`deserializeFrequency\`** in \`@carebridge/medical-logic\` give a stable wire format:
  - Canonical \`MedFrequency\` literals serialize to themselves (\`'daily'\`, \`'q4h'\`, etc.)
  - \`QNHoursFrequency\` becomes \`'qNh:<n>'\` for non-canonical intervals like q5h
- **\`clinical-data\` medication-repo** populates the column on create + on every frequency update via \`parseFrequencyText → serialize\`. Unparseable inputs store NULL — same fail-open semantics as before the column existed
- **\`PatientMedication\`** (ai-oversight) carries \`frequency_structured\`; \`buildPatientContextForRules\` passes it through
- **\`CROSS-STEROID-PCP-001\` + \`MED-DAILY-OVER-*\` / \`MED-SINGLE-OVER-*\`** prefer \`deserializeFrequency(structured)\` and fall back to runtime \`parseFrequencyText(free-text)\` for unmigrated rows and unparseable inputs. No behavioural change today; perf wins kick in once existing rows are backfilled

### Tests

5 new tests in \`medication-frequency.test.ts\` cover:
- canonical literal serialization round-trip
- QNHoursFrequency \`qNh:<n>\` round-trip
- null/empty input passthrough
- unknown-stored values fall through to null (safety net)
- end-to-end \`parse → serialize → deserialize\` equivalence

### Out of scope (filed as follow-ups in the issue body)

- Backfill of existing rows
- Metric / dashboard counting \`NULL frequency_structured\` rows
- UI frequency-picker on the clinician-portal prescription form

## Migration journal

Pre-assigned idx 48 / tag \`0044_medications_frequency_structured\`. One step above #1023's idx 47 (#1061) so the two PRs can land in either order without conflict.

## Test plan

- [x] \`pnpm --filter @carebridge/medical-logic test\` → 436/436 pass (+5 new)
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean
- [x] \`pnpm --filter @carebridge/clinical-data test\` → 46/46 pass
- [x] \`pnpm --filter @carebridge/clinical-data typecheck\` → clean
- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 900/900 pass
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean

Closes #931 (backend portion)