### PR TITLE
feat(db): add clinical_flags.metadata column for per-flag telemetry queries

### DIFF
--- a/packages/db-schema/drizzle/0045_clinical_flags_metadata.sql
+++ b/packages/db-schema/drizzle/0045_clinical_flags_metadata.sql
@@ -1,0 +1,16 @@
+-- #1039: clinical_flags.metadata column so RuleFlag.metadata is queryable
+-- per-flag instead of requiring a join through review_jobs.rules_output.
+--
+-- PR #1022 added `RuleFlag.metadata?: Record<string, unknown>` and
+-- CROSS-STEROID-PCP-001 emits `{ duration_known: boolean }` (extended to
+-- `chronic_marked` in #1023). Today that telemetry only survives via
+-- `review_jobs.rules_output` (jsonb<RuleFlag[]>), which forces every
+-- FP-rate query to join clinical_flags → review_jobs.flags_generated and
+-- unnest rules_output. Adding the column to clinical_flags lets dashboards
+-- and ad-hoc analysis filter or group on metadata directly.
+--
+-- Stored as jsonb so future per-rule keys can be added without schema
+-- migrations. Nullable because LLM-path flags currently have no metadata
+-- and existing rows pre-#1039 will be NULL until a backfill runs.
+
+ALTER TABLE clinical_flags ADD COLUMN IF NOT EXISTS metadata jsonb;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1747929660000,
       "tag": "0044_medications_frequency_structured",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1747929720000,
+      "tag": "0045_clinical_flags_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -30,6 +30,13 @@ export const clinicalFlags = pgTable("clinical_flags", {
   prompt_version: text("prompt_version"),
   escalation_count: integer("escalation_count").notNull().default(0),
   last_escalated_at: text("last_escalated_at"),
+  /**
+   * Rule-specific structured telemetry forwarded from RuleFlag.metadata
+   * at flag-creation time (#1039). Queryable per-flag for FP-rate
+   * dashboards without joining through review_jobs.rules_output.
+   * Null for LLM-path flags and historical rows pre-#1039.
+   */
+  metadata: jsonb("metadata").$type<Record<string, unknown>>(),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_flags_patient").on(table.patient_id, table.status),

--- a/packages/shared-types/src/ai-flags.ts
+++ b/packages/shared-types/src/ai-flags.ts
@@ -53,6 +53,12 @@ export interface ClinicalFlag extends BaseRecord {
   escalation_count?: number;
   /** ISO timestamp of the last escalation re-notification. */
   last_escalated_at?: string;
+  /**
+   * Rule-specific structured telemetry forwarded from {@link RuleFlag.metadata}
+   * at flag-creation time (#1039). Queryable per-flag for FP-rate
+   * dashboards. Null for LLM-path flags and historical rows pre-#1039.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 // ─── Rule Engine Output ─────────────────────────────────────────

--- a/services/ai-oversight/src/__tests__/flag-service.test.ts
+++ b/services/ai-oversight/src/__tests__/flag-service.test.ts
@@ -322,4 +322,31 @@ describe("createFlag", () => {
 
     expect(mockEmitNotificationEvent).not.toHaveBeenCalled();
   });
+
+  it("persists metadata into the inserted clinical_flags row (#1039)", async () => {
+    // RuleFlag.metadata forwarded by review-service must land in the
+    // clinical_flags.metadata column so per-flag FP-rate dashboards can
+    // query it without joining review_jobs.rules_output.
+    const flagWithMetadata = {
+      ...baseFlag,
+      rule_id: "CROSS-STEROID-PCP-001",
+      metadata: { duration_known: true, chronic_marked: false },
+    };
+    await createFlag(flagWithMetadata);
+    const inserted = mockValues.mock.calls[0]?.[0];
+    expect(inserted.metadata).toEqual({
+      duration_known: true,
+      chronic_marked: false,
+    });
+  });
+
+  it("omits metadata key entirely when the rule doesn't provide it", async () => {
+    // Rules without buildMetadata (e.g. ONCO-VTE-NEURO-001) call createFlag
+    // without a `metadata` key. The inserted row must reflect that — not
+    // a JSON null, just absence — so downstream consumers can distinguish
+    // "rule had no telemetry" from "rule had explicit-null telemetry".
+    await createFlag(baseFlag);
+    const inserted = mockValues.mock.calls[0]?.[0];
+    expect(Object.prototype.hasOwnProperty.call(inserted, "metadata")).toBe(false);
+  });
 });

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -343,6 +343,10 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
         notify_specialties: ruleFlag.notify_specialties,
         trigger_event_ids: [event.id],
         status: "open",
+        // Forward structured telemetry to the clinical_flags row (#1039).
+        // Null/absent for rules that don't build metadata; included so
+        // FP-rate dashboards don't need to join review_jobs.rules_output.
+        ...(ruleFlag.metadata !== undefined ? { metadata: ruleFlag.metadata } : {}),
       });
       flagIds.push(flag.id);
     }


### PR DESCRIPTION
## Summary

PR #1022 added \`RuleFlag.metadata\` (CROSS-STEROID-PCP-001 emits \`duration_known\`; #1023 adds \`chronic_marked\`). Today that telemetry only survives via \`review_jobs.rules_output\` (\`jsonb<RuleFlag[]>\`), which forces every FP-rate query to join \`clinical_flags\` → \`review_jobs.flags_generated\` and unnest \`rules_output\`.

Persist the field directly on \`clinical_flags\` so per-flag dashboards filter or group on metadata without the join.

### Changes

- **Migration 0045** adds \`clinical_flags.metadata jsonb\` (idx 49 — sequenced one above #1023's idx 47 and #931's idx 48, no journal collision)
- **Drizzle schema** picks up the column with \`$type<Record<string, unknown>>()\`
- **shared-types \`ClinicalFlag\`** interface adds \`metadata?: Record<string, unknown>\` so the typed \`createFlag\` input accepts it
- **\`review-service.ts\`** forwards \`ruleFlag.metadata\` to \`createFlag\` via the same spread-conditional pattern the buildMetadata emitter uses (\`...(metadata !== undefined ? { metadata } : {})\`) — rules without buildMetadata produce a row with the metadata key absent rather than explicitly null

### Tests

- New test pins metadata persistence end-to-end through \`createFlag\`
- New test pins the spread-conditional contract — rules without metadata produce inserted rows where \`hasOwnProperty('metadata')\` is false, not explicit-null

### Out of scope (per issue body)

- Backfill from \`review_jobs.rules_output\` for historical rows
- GIN index on \`metadata\` (defer until FP-rate dashboards become hot)

## Migration journal

Pre-assigned idx 49 / tag \`0045_clinical_flags_metadata\`. Above #1023's idx 47 (#1061) and #931's idx 48 (#1064), so all three migrations can land in any order without conflict.

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 902/902 pass (+2 new)
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean

Closes #1039