### PR TITLE
feat(med): wire max_doses_per_day through writer + FHIR export

### DIFF
--- a/packages/shared-types/src/clinical-data.schemas.ts
+++ b/packages/shared-types/src/clinical-data.schemas.ts
@@ -61,6 +61,12 @@ export const createMedicationSchema = z.object({
    * (transplant, autoimmune, GVHD).
    */
   chronic: z.boolean().optional(),
+  /**
+   * Optional PRN / hard-cap dose count per 24 h (#935). Capped at 24
+   * because the dosing-cycle ceiling is q1h × 24h — anything above is
+   * either a unit error or an unbounded order.
+   */
+  max_doses_per_day: z.number().int().positive().max(24).optional(),
 });
 
 export const updateMedicationSchema = createMedicationSchema.partial().omit({ patient_id: true }).extend({

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -58,6 +58,14 @@ export interface Medication extends MutableRecord {
    * autoimmune, GVHD). See issue #1023.
    */
   chronic?: boolean;
+  /**
+   * Optional PRN / hard-cap dose count per 24 h. Populated when a
+   * prescription carries an explicit cap (e.g. "morphine 10 mg q4h PRN,
+   * max 4 doses/day"). Consumed by the ai-oversight daily-dose rule via
+   * estimateDailyDose to bound otherwise-unboundable PRN regimens.
+   * See issues #235 and #935.
+   */
+  max_doses_per_day?: number;
 }
 
 export interface MedLog extends BaseRecord {

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -148,6 +148,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     // rule fall back to runtime parsing — same fail-open behaviour as
     // before the structured column existed.
     frequency_structured: serializeFrequency(parseFrequencyText(input.frequency ?? null)),
+    max_doses_per_day: input.max_doses_per_day ?? null,
     status: input.status ?? "active",
     started_at: input.started_at ?? null,
     ended_at: input.ended_at ?? null,
@@ -182,6 +183,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     frequency: input.frequency,
     frequency_structured:
       serializeFrequency(parseFrequencyText(input.frequency ?? null)) ?? undefined,
+    max_doses_per_day: input.max_doses_per_day,
     status: input.status ?? "active",
     started_at: input.started_at,
     ended_at: input.ended_at,
@@ -229,6 +231,7 @@ export async function updateMedication(
     // Re-derive the structured column whenever the free-text changes (#931).
     updates.frequency_structured = serializeFrequency(parseFrequencyText(fields.frequency));
   }
+  if (fields.max_doses_per_day !== undefined) updates.max_doses_per_day = fields.max_doses_per_day;
   if (fields.status !== undefined) updates.status = fields.status;
   if (fields.started_at !== undefined) updates.started_at = fields.started_at;
   if (fields.ended_at !== undefined) updates.ended_at = fields.ended_at;
@@ -281,6 +284,7 @@ export async function updateMedication(
     route: (updated.route as Medication["route"]) ?? undefined,
     frequency: updated.frequency ?? undefined,
     frequency_structured: updated.frequency_structured ?? undefined,
+    max_doses_per_day: updated.max_doses_per_day ?? undefined,
     status: updated.status as MedStatus,
     started_at: updated.started_at ?? undefined,
     ended_at: updated.ended_at ?? undefined,
@@ -325,6 +329,7 @@ export async function getMedicationsByPatient(
     route: (row.route as Medication["route"]) ?? undefined,
     frequency: row.frequency ?? undefined,
     frequency_structured: row.frequency_structured ?? undefined,
+    max_doses_per_day: row.max_doses_per_day ?? undefined,
     status: row.status as MedStatus,
     started_at: row.started_at ?? undefined,
     ended_at: row.ended_at ?? undefined,

--- a/services/fhir-gateway/src/__tests__/medication-request.test.ts
+++ b/services/fhir-gateway/src/__tests__/medication-request.test.ts
@@ -146,4 +146,32 @@ describe("toFhirMedicationRequest (#388)", () => {
     );
     expect(r.dosageInstruction).toBeUndefined();
   });
+
+  describe("Dosage.maxDosePerPeriod (#935)", () => {
+    it("emits maxDosePerPeriod as a per-day Ratio when max_doses_per_day is set", () => {
+      const r = toFhirMedicationRequest(
+        makeMed({
+          frequency: "Q4H PRN",
+          max_doses_per_day: 4,
+        }),
+        "p1",
+      );
+      const cap = r.dosageInstruction?.[0]?.maxDosePerPeriod;
+      expect(cap).toBeDefined();
+      expect(cap?.numerator?.value).toBe(4);
+      expect(cap?.numerator?.unit).toBe("doses");
+      expect(cap?.denominator?.value).toBe(1);
+      expect(cap?.denominator?.unit).toBe("day");
+      expect(cap?.denominator?.system).toBe("http://unitsofmeasure.org");
+      expect(cap?.denominator?.code).toBe("d");
+    });
+
+    it("omits maxDosePerPeriod when max_doses_per_day is null", () => {
+      const r = toFhirMedicationRequest(
+        makeMed({ max_doses_per_day: null }),
+        "p1",
+      );
+      expect(r.dosageInstruction?.[0]?.maxDosePerPeriod).toBeUndefined();
+    });
+  });
 });

--- a/services/fhir-gateway/src/generators/medication-request.ts
+++ b/services/fhir-gateway/src/generators/medication-request.ts
@@ -167,6 +167,25 @@ export function toFhirMedicationRequest(
     hasDosage = true;
   }
 
+  // Emit Dosage.maxDosePerPeriod when the prescription carries an explicit
+  // PRN ceiling — gives external EHRs the same daily-cap signal the
+  // ai-oversight daily-dose rule uses to bound PRN regimens (#935).
+  if (medication.max_doses_per_day != null) {
+    dosage.maxDosePerPeriod = {
+      numerator: {
+        value: medication.max_doses_per_day,
+        unit: "doses",
+      },
+      denominator: {
+        value: 1,
+        unit: "day",
+        system: "http://unitsofmeasure.org",
+        code: "d",
+      },
+    };
+    hasDosage = true;
+  }
+
   if (hasDosage) {
     const parts: string[] = [];
     if (medication.dose_amount != null && medication.dose_unit) {

--- a/services/fhir-gateway/src/generators/medication-statement.ts
+++ b/services/fhir-gateway/src/generators/medication-statement.ts
@@ -48,6 +48,21 @@ interface FhirDosage {
       code?: string;
     };
   }[];
+  /**
+   * Dosage.maxDosePerPeriod (#935) — explicit PRN ceiling carried as a
+   * FHIR Ratio (count / time unit). External EHRs ingesting the
+   * exported MedicationStatement see the same daily-cap signal that
+   * the ai-oversight daily-dose rule uses internally.
+   */
+  maxDosePerPeriod?: {
+    numerator?: { value: number; unit: string };
+    denominator?: {
+      value: number;
+      unit: string;
+      system?: string;
+      code?: string;
+    };
+  };
 }
 
 interface FhirMedicationStatement {
@@ -191,6 +206,25 @@ export function toFhirMedicationStatement(
         ),
       },
     ];
+    hasDosage = true;
+  }
+
+  // Emit Dosage.maxDosePerPeriod when an explicit PRN ceiling is set.
+  // Mirrors medication-request.ts so the two exports carry the same
+  // daily-cap signal external EHRs can ingest. (#935)
+  if (medication.max_doses_per_day != null) {
+    dosage.maxDosePerPeriod = {
+      numerator: {
+        value: medication.max_doses_per_day,
+        unit: "doses",
+      },
+      denominator: {
+        value: 1,
+        unit: "day",
+        system: "http://unitsofmeasure.org",
+        code: "d",
+      },
+    };
     hasDosage = true;
   }
 

--- a/services/fhir-gateway/src/types/fhir-r4.ts
+++ b/services/fhir-gateway/src/types/fhir-r4.ts
@@ -111,11 +111,24 @@ export interface DoseAndRate {
   rateQuantity?: Quantity;
 }
 
+export interface Ratio {
+  numerator?: Quantity;
+  denominator?: Quantity;
+}
+
 export interface DosageInstruction {
   text?: string;
   route?: CodeableConcept;
   timing?: Timing;
   doseAndRate?: DoseAndRate[];
+  /**
+   * Upper bound on the cumulative dose administered over a period
+   * (e.g. "max 4 doses/day"). FHIR R4 Dosage.maxDosePerPeriod is a
+   * Ratio — numerator is the dose count or quantity, denominator is
+   * the time unit. Used by the daily-dose rule to bound PRN regimens
+   * via {@link extractMaxDosesPerDay}. (#935)
+   */
+  maxDosePerPeriod?: Ratio;
 }
 
 // ─── Patient resource ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Backend completion of #935. The \`medications.max_doses_per_day\` column shipped in #1041, and the rule already consumes it via \`buildPatientContextForRules\`. What was missing: writer-side accept/persist + FHIR-export representation.

### Changes

- **\`shared-types Medication\`** adds \`max_doses_per_day?: number\`
- **\`createMedicationSchema\` / \`updateMedicationSchema\`** (Zod) accept it with a max-24 cap (q1h × 24h is the dosing-cycle ceiling)
- **\`clinical-data\` medication-repo** accepts the field on create + update and returns it on reads
- **FHIR generators** (\`medication-request\`, \`medication-statement\`) emit \`Dosage.maxDosePerPeriod\` as a per-day \`Ratio\` when the column is set, giving external EHRs the same daily-cap signal the internal rule uses
- **\`DosageInstruction\`** type gains the \`maxDosePerPeriod\` field

### Tests

2 new tests in \`medication-request.test.ts\` pin the Ratio shape (4 doses / 1 day) and the omit-when-null behaviour.

### Out of scope — filed as #1066

FHIR ingest extraction of \`Dosage.maxDosePerPeriod\` from external bundles. The current \`importBundle\` path stores raw FHIR JSON in \`fhir_resources\` but does NOT materialize MedicationRequest into internal \`medications\` rows — that mapping is a separate architectural piece. Tracked in #1066.

## Test plan

- [x] \`pnpm --filter @carebridge/clinical-data test\` → 46/46 pass
- [x] \`pnpm --filter @carebridge/clinical-data typecheck\` → clean
- [x] \`pnpm --filter @carebridge/fhir-gateway test\` → 203/203 pass (+2 new)
- [x] \`pnpm --filter @carebridge/fhir-gateway typecheck\` → clean
- [x] \`pnpm --filter @carebridge/shared-types test\` → 214/214 pass

Closes #935 (backend writer + export portion; inbound mapping in #1066)