### PR TITLE
feat(fhir): add structured name columns to users for authoritative Practitioner export

### DIFF
--- a/packages/db-schema/drizzle/0046_users_name_structured.sql
+++ b/packages/db-schema/drizzle/0046_users_name_structured.sql
@@ -1,0 +1,24 @@
+-- #972: structured name columns on users for authoritative FHIR Practitioner export.
+--
+-- The `users.name` free-text column is adequate for display but ambiguous
+-- for FHIR — `parseName` in services/fhir-gateway/src/generators/practitioner.ts
+-- runs a particle-aware heuristic at export time (Hispanic two-part surnames,
+-- particle-prefixed families like "de Klerk", middle-initial Anglo names).
+-- The heuristic is correct in the common case but inevitably miscategorises
+-- edge cases (full middle names, hyphenated surnames with particles, etc.).
+--
+-- Authoritative structure on the row eliminates the guess: writers
+-- populate the structured columns explicitly, and toFhirPractitioner reads
+-- them when present. The free-text `name` column stays for display and as
+-- a fallback for unbackfilled rows.
+--
+-- Backfill is a separate one-shot script that runs the existing parseName
+-- over every users row and queues Hispanic / particle / hyphenated names
+-- for admin review (tracked separately). Once the backfill completes and
+-- all clinical roles have non-null name_family + name_given, a follow-up
+-- migration will flip the columns to NOT NULL and parseName is removed.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS name_family text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS name_given text[];
+ALTER TABLE users ADD COLUMN IF NOT EXISTS name_prefix text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS name_suffix text;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1747929720000,
       "tag": "0045_clinical_flags_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1747929780000,
+      "tag": "0046_users_name_structured",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/auth.ts
+++ b/packages/db-schema/src/schema/auth.ts
@@ -6,6 +6,24 @@ export const users = pgTable("users", {
   email: text("email").notNull().unique(),
   password_hash: text("password_hash").notNull(),
   name: text("name").notNull(),
+  /**
+   * Structured name columns (#972). Populated authoritatively by writers
+   * and preferred by FHIR Practitioner export. `parseName` in
+   * services/fhir-gateway/src/generators/practitioner.ts remains as a
+   * fallback for rows where the structured columns are still null.
+   *
+   * `name_family` carries the full family name including particles
+   * (e.g. "de Klerk", "van der Berg") and two-part Hispanic surnames
+   * (e.g. "García López"). `name_given` is the ordered list of given
+   * names including middle names. Prefix is honorifics ("Dr.", "Mrs.");
+   * suffix is credentials ("MD", "RN", "PhD", "III").
+   *
+   * Nullable until a one-shot backfill populates every clinical-role row.
+   */
+  name_family: text("name_family"),
+  name_given: text("name_given").array(),
+  name_prefix: text("name_prefix"),
+  name_suffix: text("name_suffix"),
   role: text("role").notNull(), // patient, nurse, physician, specialist, admin, family_caregiver
   patient_id: text("patient_id"), // links patient users to their patient record
   specialty: text("specialty"),

--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -145,4 +145,78 @@ describe("toFhirPractitioner (#388)", () => {
     expect(p.name?.[0]?.family).toBe("Quincy Adams");
     expect(p.name?.[0]?.given).toEqual(["John", "Robert"]);
   });
+
+  describe("structured name columns take precedence over parseName heuristic (#972)", () => {
+    it("name_family + name_given populate HumanName exactly, bypassing parseName", () => {
+      // Free-text "Sarah Marie Jones" would heuristic to family="Marie Jones".
+      // When the structured columns are populated, they win — Marie is the
+      // middle given name as the writer recorded.
+      const p = toFhirPractitioner(
+        makeUser({
+          name: "Sarah Marie Jones",
+          name_family: "Jones",
+          name_given: ["Sarah", "Marie"],
+        }),
+      );
+      expect(p.name?.[0]?.family).toBe("Jones");
+      expect(p.name?.[0]?.given).toEqual(["Sarah", "Marie"]);
+    });
+
+    it("falls back to parseName when name_family is null (unbackfilled row)", () => {
+      const p = toFhirPractitioner(
+        makeUser({
+          name: "Sarah Jones",
+          name_family: null,
+          name_given: null,
+        }),
+      );
+      // Heuristic two-token result.
+      expect(p.name?.[0]?.family).toBe("Jones");
+      expect(p.name?.[0]?.given).toEqual(["Sarah"]);
+    });
+
+    it("structured columns carry through name_prefix and name_suffix", () => {
+      const p = toFhirPractitioner(
+        makeUser({
+          name: "Dr. Sarah Jones, MD",
+          name_family: "Jones",
+          name_given: ["Sarah"],
+          name_prefix: "Dr.",
+          name_suffix: "MD",
+        }),
+      );
+      expect(p.name?.[0]?.family).toBe("Jones");
+      expect(p.name?.[0]?.given).toEqual(["Sarah"]);
+      expect(p.name?.[0]?.prefix).toEqual(["Dr."]);
+      expect(p.name?.[0]?.suffix).toEqual(["MD"]);
+    });
+
+    it("structured columns preserve particles and two-part surnames verbatim", () => {
+      // "Sarah de Klerk" → parseName produces family="de Klerk" via the
+      // particle heuristic. The structured path doesn't run the heuristic —
+      // the writer records family="de Klerk" directly.
+      const p = toFhirPractitioner(
+        makeUser({
+          name: "Sarah de Klerk",
+          name_family: "de Klerk",
+          name_given: ["Sarah"],
+        }),
+      );
+      expect(p.name?.[0]?.family).toBe("de Klerk");
+      expect(p.name?.[0]?.given).toEqual(["Sarah"]);
+    });
+
+    it("empty name_given array does not produce an empty `given` field", () => {
+      // Mononymic case via structured columns ("Plato" with name_given=[]).
+      const p = toFhirPractitioner(
+        makeUser({
+          name: "Plato",
+          name_family: "Plato",
+          name_given: [],
+        }),
+      );
+      expect(p.name?.[0]?.family).toBe("Plato");
+      expect(p.name?.[0]?.given).toBeUndefined();
+    });
+  });
 });

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -159,6 +159,39 @@ function parseName(fullName: string): HumanName {
   };
 }
 
+/**
+ * Build the FHIR HumanName from a user row, preferring the authoritative
+ * structured columns (#972) when populated. Falls back to the parseName
+ * heuristic over the free-text `name` column for rows that haven't been
+ * backfilled yet.
+ *
+ * The structured path is exact — no guessing about Hispanic two-part
+ * surnames vs middle names, no particle-absorption heuristics. Writers
+ * have already classified the name correctly.
+ */
+function buildPractitionerName(user: UserRow): HumanName {
+  if (user.name_family) {
+    const name: HumanName = {
+      text: user.name,
+      family: user.name_family,
+    };
+    if (user.name_given && user.name_given.length > 0) {
+      name.given = user.name_given;
+    }
+    if (user.name_prefix) {
+      name.prefix = [user.name_prefix];
+    }
+    if (user.name_suffix) {
+      name.suffix = [user.name_suffix];
+    }
+    return name;
+  }
+  // Fallback: heuristic parse of the free-text `name` column. Removed
+  // once the backfill completes and the structured columns flip to NOT
+  // NULL — see #972.
+  return parseName(user.name);
+}
+
 export function toFhirPractitioner(user: UserRow): FhirPractitioner {
   const resource: FhirPractitioner = {
     resourceType: "Practitioner",
@@ -169,7 +202,7 @@ export function toFhirPractitioner(user: UserRow): FhirPractitioner {
         value: user.id,
       },
     ],
-    name: [parseName(user.name)],
+    name: [buildPractitionerName(user)],
   };
 
   // Qualification / specialty — surfaced as a text-only CodeableConcept.

--- a/services/fhir-gateway/src/types/fhir-r4.ts
+++ b/services/fhir-gateway/src/types/fhir-r4.ts
@@ -45,6 +45,10 @@ export interface HumanName {
   text?: string;
   family?: string;
   given?: string[];
+  /** Honorifics (e.g. "Dr.", "Mrs."). FHIR R4 HumanName.prefix. */
+  prefix?: string[];
+  /** Credentials / generational (e.g. "MD", "RN", "PhD", "III"). FHIR R4 HumanName.suffix. */
+  suffix?: string[];
 }
 
 export interface Meta {


### PR DESCRIPTION
## Summary

\`services/fhir-gateway/src/generators/practitioner.ts::parseName\` today runs a particle-aware heuristic over \`users.name\` to split it into FHIR \`HumanName\`'s \`family\` + \`given\` fields. The heuristic handles Hispanic two-part surnames, particle-prefixed families (\`de Klerk\`, \`van der Berg\`), and middle-initial Anglo names — but it inevitably miscategorises edge cases (full middle names heuristic to \"Marie Jones\" as family, etc.).

Adds authoritative structured columns on \`users\` so writers can record the canonical split explicitly. \`parseName\` remains as a fallback for unbackfilled rows.

### Changes

- **Migration 0046** adds nullable \`name_family text\`, \`name_given text[]\`, \`name_prefix text\`, \`name_suffix text\` (idx 50 — one above #1039's idx 49 to avoid journal collision)
- **Drizzle schema** and \`users.$inferSelect\` pick up the new columns
- **\`toFhirPractitioner\`** gains \`buildPractitionerName\`: prefers structured columns when \`name_family\` is populated, falls back to \`parseName\` otherwise. The structured path emits prefix/suffix arrays too (HumanName interface extended)
- **\`HumanName\`** type adds \`prefix?: string[]\` and \`suffix?: string[]\`

### Tests

5 new tests pin the structured-takes-precedence contract:
- structured columns bypass the \`parseName\` heuristic exactly
- null \`name_family\` falls back to \`parseName\`
- prefix + suffix propagate to FHIR HumanName arrays
- structured family preserves particles verbatim (\"de Klerk\")
- empty \`name_given\` array does NOT produce an empty \`given\` field

### Out of scope (filed as follow-ups)

- Backfill script for existing rows (one-shot tooling)
- Admin review queue for Hispanic / particle / hyphenated names flagged by the heuristic during backfill
- Clinician profile edit UI for structured fields
- NOT NULL flip + \`parseName\` removal once backfill completes

## Migration journal

Pre-assigned idx 50 / tag \`0046_users_name_structured\`. One above #1039's idx 49 (#1065), so all four in-flight migrations (#1023/#1061 idx 47, #931/#1064 idx 48, #1039/#1065 idx 49, this idx 50) can land in any order without conflict.

## Test plan

- [x] \`pnpm --filter @carebridge/fhir-gateway test\` → 206/206 pass (+5 new)
- [x] \`pnpm --filter @carebridge/fhir-gateway typecheck\` → clean
- [x] \`pnpm --filter @carebridge/db-schema build\` → clean

Closes #972 (column + reader portion)