### PR TITLE
feat(ai): track APAP content of combo opioids toward acetaminophen daily cap

### DIFF
--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -234,6 +234,60 @@ const DRUG_NAME_ALIASES: Record<string, string> = {
 };
 
 /**
+ * APAP (acetaminophen) content in mg per dose unit for combo opioid
+ * products (#926). The opioid component of these combos is captured by
+ * DRUG_NAME_ALIASES → opioid-canonical for the stricter single-dose
+ * opioid guard. The APAP component is silently ignored by that path
+ * because the alias collapses the name to a single canonical entry.
+ *
+ * This map carries the APAP mg per dose unit for the same brands, so a
+ * daily-rollup rule can sum APAP across a patient's whole medication
+ * list (combo opioids + plain acetaminophen) against the 4000 mg/day
+ * APAP cap.
+ *
+ * Values reflect the post-2014 FDA standard for combo APAP products
+ * (FDA capped combo APAP at 325 mg per dose unit; manufacturers
+ * generally landed on 300–325 mg). Per-formulation strengths vary
+ * (Percocet 5/325, 7.5/325, 10/325; Norco 5/325, 7.5/325, 10/325; etc.)
+ * but the APAP component is standardized within each brand family.
+ *
+ * Keys are lowercased brand strings; values are the mg of APAP per
+ * dose unit (tablet). Unknown brands return undefined and the caller
+ * treats the entry as APAP-free.
+ */
+export const COMBO_OPIOID_APAP_MG: Record<string, number> = {
+  percocet: 325,
+  roxicet: 325,
+  endocet: 325,
+  norco: 325,
+  vicodin: 300,
+  lortab: 325,
+  hydrocet: 325,
+  "tylenol 3": 300,
+  tylenol3: 300,
+  "tylenol 4": 300,
+  tylenol4: 300,
+  "tylenol with codeine": 300,
+  ultracet: 325, // tramadol 37.5 + APAP 325
+  darvocet: 325, // propoxyphene + APAP — discontinued but historical Rx
+};
+
+/**
+ * Look up the APAP content (mg per dose unit) for a combo opioid product.
+ * Accepts the same free-text input shape as {@link getMedicationDoseLimit}
+ * (case-insensitive, tolerates trailing strength / frequency tokens).
+ * Returns undefined when the drug isn't a known combo product, signalling
+ * "no APAP component to track" for that medication. (#926)
+ */
+export function getComboApapMg(drugName: string): number | undefined {
+  for (const key of candidatesFor(drugName)) {
+    const mg = COMBO_OPIOID_APAP_MG[key];
+    if (mg !== undefined) return mg;
+  }
+  return undefined;
+}
+
+/**
  * Strip trailing strength / route / frequency tokens from a free-text
  * drug name so entries like "Ibuprofen 600mg TID" or "Acetaminophen
  * 500mg PO q6h" still resolve to their canonical entry.

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -433,6 +433,235 @@ describe("checkMedicationDailyDose (#235)", () => {
     });
   });
 
+  describe("cumulative APAP across combo opioids + plain acetaminophen (#926)", () => {
+    function multiMedCtx(meds: PatientMedication[]): PatientContext {
+      const triggerEvent: ClinicalEvent = {
+        id: "evt-apap-1",
+        type: "medication.created",
+        patient_id: "p-1",
+        timestamp: "2026-04-18T12:00:00.000Z",
+        data: {
+          resourceId: meds[0]!.id,
+          name: meds[0]!.name,
+          status: "active",
+        },
+      };
+      return {
+        active_diagnoses: [],
+        active_diagnosis_codes: [],
+        active_medications: meds.map((m) => m.name),
+        active_medications_detail: meds,
+        new_symptoms: [],
+        care_team_specialties: [],
+        trigger_event: triggerEvent,
+      };
+    }
+
+    it("Norco 5/325 q6h + Tylenol 650 mg TID → flags APAP cumulative", () => {
+      // Norco: 4 doses/day × 325 mg APAP = 1300 mg APAP/day
+      // Tylenol 650 mg TID: 3 × 650 = 1950 mg APAP/day
+      // Combined: ~3250 mg/day — at the 4000 cap (under, no flag)
+      // Bump Norco to Q4H (6 doses × 325 = 1950) → 1950 + 1950 = 3900 mg/day, still under
+      // Use Q3H to push it over: 8 × 325 = 2600 + 1950 = 4550 mg/day → flags
+      const meds: PatientMedication[] = [
+        {
+          id: "m-norco",
+          name: "Norco",
+          dose_amount: 5, // mg hydrocodone — opioid component
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q3h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+        {
+          id: "m-tylenol",
+          name: "Tylenol",
+          dose_amount: 650,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "tid",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeDefined();
+      expect(apap!.summary).toMatch(/APAP/);
+      expect(apap!.summary).toMatch(/4000 mg\/day/);
+    });
+
+    it("Percocet 10/325 q6h alone (single med) → no APAP combo flag (single-med per-drug flag covers it)", () => {
+      // Percocet 5 mg oxy × 4/day = under oxycodone cap; 325 × 4 = 1300 mg APAP — under
+      // Even at q4h: 6 × 325 = 1950 mg APAP/day — still under 4000
+      const meds: PatientMedication[] = [
+        {
+          id: "m-perc",
+          name: "Percocet",
+          dose_amount: 5,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q6h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeUndefined();
+    });
+
+    it("plain Tylenol alone over-cap → no APAP combo flag (per-drug rule already fires)", () => {
+      // 1500 mg Q4H = 9000 mg/day. The per-drug MED-DAILY-OVER-ACETAMINOPHEN
+      // already fires for this — emitting the combo flag would duplicate.
+      const meds: PatientMedication[] = [
+        {
+          id: "m-tylenol",
+          name: "Acetaminophen",
+          dose_amount: 1500,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q4h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const perDrug = flags.find((f) => f.rule_id?.startsWith("MED-DAILY-OVER-ACETAMINOPHEN"));
+      expect(perDrug).toBeDefined();
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeUndefined();
+    });
+
+    it("Vicodin q4h + Tylenol 1000 q6h → cumulative APAP flags", () => {
+      // Vicodin 300 mg APAP × 6/day = 1800 mg
+      // Tylenol 1000 mg × 4/day = 4000 mg
+      // Total: 5800 mg/day — clearly flags critical (>2× cap? 5800/4000 = 1.45× → warning, not critical)
+      const meds: PatientMedication[] = [
+        {
+          id: "m-vic",
+          name: "Vicodin",
+          dose_amount: 5,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q4h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+        {
+          id: "m-tylenol",
+          name: "Acetaminophen",
+          dose_amount: 1000,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q6h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeDefined();
+      expect(apap!.severity).toBe("warning"); // 1.45×, under critical 2× threshold
+      expect(apap!.rationale).toMatch(/Vicodin/);
+      expect(apap!.rationale).toMatch(/Acetaminophen/);
+    });
+
+    it("critical severity at ≥2× APAP cap (≥8000 mg/day)", () => {
+      const meds: PatientMedication[] = [
+        {
+          id: "m-perc",
+          name: "Percocet",
+          dose_amount: 5,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q2h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+        {
+          id: "m-tylenol",
+          name: "Tylenol",
+          dose_amount: 1000,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q3h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      // Percocet: 325 × 12 = 3900; Tylenol: 1000 × 8 = 8000; total 11900 mg
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeDefined();
+      expect(apap!.severity).toBe("critical");
+    });
+
+    it("fail-open: unparseable frequency on combo opioid drops it from sum", () => {
+      const meds: PatientMedication[] = [
+        {
+          id: "m-norco",
+          name: "Norco",
+          dose_amount: 5,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "when patient asks",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+        {
+          id: "m-tylenol",
+          name: "Tylenol",
+          dose_amount: 1000,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q4h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      // Norco drops out; Tylenol: 1000 × 6 = 6000 mg/day → that fires
+      // the per-drug ACETAMINOPHEN flag but NOT the combo flag (single
+      // med after Norco dropped, so dedup against per-drug kicks in).
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeUndefined();
+    });
+
+    it("non-APAP combo medication (oxycodone IR) does NOT contribute to APAP sum", () => {
+      // Plain oxycodone is opioid-only, no APAP component. Should be
+      // excluded from the APAP rollup entirely.
+      const meds: PatientMedication[] = [
+        {
+          id: "m-oxy",
+          name: "Oxycodone",
+          dose_amount: 10,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q4h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+        {
+          id: "m-tylenol",
+          name: "Tylenol",
+          dose_amount: 500,
+          dose_unit: "mg",
+          route: "oral",
+          frequency: "q6h",
+          max_doses_per_day: null,
+          rxnorm_code: null,
+        },
+      ];
+      // Tylenol alone: 500 × 4 = 2000 mg/day, under cap. Oxycodone doesn't
+      // contribute. Result: no APAP flag.
+      const flags = checkMedicationDailyDose(multiMedCtx(meds));
+      const apap = flags.find((f) => f.rule_id === "MED-DAILY-OVER-APAP-COMBO");
+      expect(apap).toBeUndefined();
+    });
+  });
+
   describe("rule_id conventions", () => {
     it("daily flag rule_id starts with MED-DAILY-OVER-<DRUG>", () => {
       const flags = checkMedicationDailyDose(

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -32,6 +32,7 @@ import {
   parseFrequencyText,
   estimateDailyDose,
   getMedicationDoseLimit,
+  getComboApapMg,
 } from "@carebridge/medical-logic";
 import type { PatientContext, PatientMedication } from "./cross-specialty.js";
 import { createLogger } from "@carebridge/logger";
@@ -332,5 +333,123 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
     });
   }
 
+  // ── Cumulative APAP across combo opioids + plain acetaminophen (#926) ──
+  //
+  // Combo opioids (Percocet, Vicodin, Norco, Tylenol #3, ...) are aliased
+  // in DRUG_NAME_ALIASES to their opioid component for the per-drug
+  // ceiling check above, which is correct because the opioid cap is
+  // generally the binding constraint. But the APAP component of those
+  // same pills is silently dropped — and a patient on, say, Norco 5/325
+  // q6h + supplemental Tylenol 650 mg TID can approach the 4000 mg/day
+  // APAP cap without any single medication tripping its own check.
+  //
+  // Roll the APAP component up across every active medication, sum
+  // against the cap, and emit a flag when the patient exceeds it. Uses
+  // the same fail-open semantics as the per-drug rule: missing dose
+  // amount, unparseable frequency, or unboundable PRN drop out of the
+  // sum quietly rather than over-flag.
+  const apapFlag = checkCumulativeApap(context);
+  if (apapFlag) flags.push(apapFlag);
+
   return flags;
+}
+
+/**
+ * Roll up APAP contribution across the patient's active-medication list.
+ * Sources two streams:
+ *   1. Combo opioid products via {@link getComboApapMg} — APAP mg per
+ *      dose unit, multiplied by daily doses derived from frequency +
+ *      max_doses_per_day.
+ *   2. Plain acetaminophen entries — dose_amount in mg (no per-pill
+ *      lookup needed; the dose IS the APAP mg).
+ *
+ * Compares the daily sum against the FDA 4000 mg/day APAP cap. Returns
+ * a single MED-DAILY-OVER-APAP-COMBO flag when exceeded, undefined
+ * otherwise. Severity matches the existing acetaminophen escalation
+ * shape (1×–2× warning, ≥2× critical).
+ *
+ * Fail-open by design: medications with missing dose_amount, missing
+ * unit, unparseable frequency, or unboundable PRN drop out of the sum
+ * rather than over-flag. Issue #926.
+ */
+function checkCumulativeApap(context: PatientContext): RuleFlag | null {
+  const details = context.active_medications_detail;
+  if (!details || details.length === 0) return null;
+
+  const APAP_CAP_MG = 4000;
+  const contributions: { name: string; mgPerDay: number }[] = [];
+
+  for (const m of details) {
+    if (m.dose_amount == null) continue;
+    const unit = (m.dose_unit ?? "").toLowerCase();
+    if (unit !== "mg") continue;
+
+    const freq = parseFrequencyText(m.frequency);
+    let apapPerDose: number;
+
+    const comboApap = getComboApapMg(m.name);
+    if (comboApap !== undefined) {
+      // Combo opioid: dose_amount is the opioid component; APAP per dose
+      // unit comes from COMBO_OPIOID_APAP_MG.
+      apapPerDose = comboApap;
+    } else {
+      // Plain acetaminophen: dose_amount IS the APAP mg. Resolve by
+      // canonical name match to avoid mis-counting other non-opioid meds.
+      const limit = getMedicationDoseLimit(m.name);
+      if (!limit || limit.displayName !== "Acetaminophen") continue;
+      apapPerDose = m.dose_amount;
+    }
+
+    const dailyDoses = estimateDailyDose(
+      1, // We want raw doses-per-day, not mg-per-day, so pass dose=1.
+      freq,
+      m.max_doses_per_day ?? null,
+    );
+    if (dailyDoses === null || dailyDoses === 0) continue;
+
+    contributions.push({
+      name: m.name,
+      mgPerDay: apapPerDose * dailyDoses,
+    });
+  }
+
+  if (contributions.length === 0) return null;
+  const totalApap = contributions.reduce((s, c) => s + c.mgPerDay, 0);
+  if (totalApap <= APAP_CAP_MG) return null;
+
+  // Skip if a single plain-acetaminophen entry already drives the total
+  // — the per-drug MED-DAILY-OVER-ACETAMINOPHEN flag above covers it and
+  // we don't want duplicate signal.
+  if (
+    contributions.length === 1 &&
+    !getComboApapMg(contributions[0]!.name)
+  ) {
+    return null;
+  }
+
+  const ratio = totalApap / APAP_CAP_MG;
+  const severity: FlagSeverity = ratio >= 2 ? "critical" : "warning";
+  const breakdown = contributions
+    .map((c) => `${c.name} ~${Math.round(c.mgPerDay)} mg/day`)
+    .join("; ");
+
+  return {
+    severity,
+    category: "medication-safety" as FlagCategory,
+    summary: `Cumulative APAP across active medications ~${Math.round(totalApap)} mg/day exceeds the 4000 mg/day ceiling`,
+    rationale:
+      `The acetaminophen component of combo opioid products (Percocet, Vicodin, Norco, Tylenol #3, etc.) ` +
+      `is captured by the brand-alias collapse to the opioid component for the per-drug check, which leaves ` +
+      `the APAP contribution invisible at the single-drug level. Summed across this patient's active ` +
+      `medications (${breakdown}), implied APAP is approximately ${Math.round(totalApap)} mg/day — ` +
+      `${ratio.toFixed(1)}× the 4000 mg/day FDA adult ceiling. Hepatotoxicity risk rises sharply with ` +
+      `chronic exposure above this threshold.`,
+    suggested_action:
+      `Confirm intent. If the combo opioid is the only APAP source and the patient is using <4000 mg/day, ` +
+      `reduce or remove supplemental plain acetaminophen. If chronic APAP >4000 mg/day is unavoidable, ` +
+      `consider switching the opioid component to a non-combo formulation (oxycodone IR, hydromorphone) ` +
+      `and dose plain acetaminophen separately so the daily total is tractable.`,
+    notify_specialties: ["pharmacy", "pain_management"],
+    rule_id: "MED-DAILY-OVER-APAP-COMBO",
+  };
 }


### PR DESCRIPTION
## Summary

\`DRUG_NAME_ALIASES\` collapses combo opioid brands (Percocet, Vicodin, Norco, Tylenol #3, Lortab, Roxicet) to their opioid component for the per-drug ceiling check. That's correct because the opioid cap is the binding constraint in single-dose terms — but it silently drops the APAP component from any daily-rollup. A patient on **Norco 5/325 Q4H + supplemental Tylenol 650 mg TID** can quietly approach the 4000 mg/day APAP ceiling without any individual medication tripping a flag.

This PR rolls the APAP component up across the patient's whole medication list.

### Changes

- **\`packages/medical-logic\`** — new \`COMBO_OPIOID_APAP_MG\` map encodes APAP mg per dose unit for known combo brands (post-2014 FDA-capped 300–325 mg standard). \`getComboApapMg(drugName)\` does the lookup with the same case-insensitive / trailing-token-tolerant rules as \`getMedicationDoseLimit\`.
- **\`services/ai-oversight\` medication-daily-dose** — new \`checkCumulativeApap\` iterates \`active_medications_detail\`, sums APAP from combo brands + plain acetaminophen, compares to 4000 mg/day cap.

### Severity + dedup

- 1×–2× cap → warning; ≥2× cap → critical (mirrors existing acetaminophen escalation shape)
- If the only contributor is a single plain-acetaminophen entry, the per-drug \`MED-DAILY-OVER-ACETAMINOPHEN\` flag already fires and we skip emitting \`MED-DAILY-OVER-APAP-COMBO\` to avoid duplicate signal
- Combo-only over-cap and combo-plus-plain over-cap both still emit

### Fail-open semantics

Missing \`dose_amount\`, missing unit, unparseable frequency, or unboundable PRN drop the medication out of the sum rather than over-flag — same shape as the rest of the rule.

### Tests

7 new tests in \`medication-daily-dose.test.ts\` pinning:
- Norco Q3H + Tylenol TID → flag fires
- Percocet Q6H alone (single med, under cap) → no flag
- Plain Tylenol over-cap → only per-drug flag, no combo flag (dedup)
- Vicodin + Tylenol → cumulative, warning severity (~1.45×)
- Critical severity at ≥2× cap
- Fail-open on unparseable combo frequency
- Non-APAP opioid (plain oxycodone) does not contribute

### Out of scope (per issue body)

- \`max_doses_per_day\` for PRN combos is already wired (PR #1067 / #935)
- LLM context handoff of combo-APAP context — separate prompt-version work, gated on clinical sign-off per \`docs/ai-prompt-editing.md\`

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 907/907 pass (+7 new)
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean
- [x] \`pnpm --filter @carebridge/medical-logic test\` → 431/431 pass
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean

Closes #926