### PR TITLE
feat(ai): fentanyl transdermal patch (mcg/hr) unit-conversion for daily-dose rule

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -1037,3 +1037,39 @@ describe("checkSystolicBP", () => {
     expect(checkSystolicBP(200)).toBe("critical");
   });
 });
+
+describe("isFentanylTransdermal (#1020)", () => {
+  it("matches Fentanyl patch with mcg/hr", async () => {
+    const { isFentanylTransdermal } = await import("../medication-max-doses.js");
+    expect(isFentanylTransdermal("Fentanyl transdermal patch", "mcg/hr")).toBe(true);
+    expect(isFentanylTransdermal("Duragesic", "mcg/hr")).toBe(true);
+    expect(isFentanylTransdermal("FENTANYL PATCH", "MCG/HR")).toBe(true);
+  });
+
+  it("accepts unit aliases mcg/h, ug/hr, μg/hr", async () => {
+    const { isFentanylTransdermal } = await import("../medication-max-doses.js");
+    expect(isFentanylTransdermal("Fentanyl patch", "mcg/h")).toBe(true);
+    expect(isFentanylTransdermal("Fentanyl patch", "ug/hr")).toBe(true);
+    expect(isFentanylTransdermal("Fentanyl patch", "μg/hr")).toBe(true);
+    expect(isFentanylTransdermal("Fentanyl patch", "mcg per hour")).toBe(true);
+  });
+
+  it("rejects IV fentanyl (mcg unit, no rate)", async () => {
+    const { isFentanylTransdermal } = await import("../medication-max-doses.js");
+    expect(isFentanylTransdermal("Fentanyl", "mcg")).toBe(false);
+    expect(isFentanylTransdermal("Fentanyl", "mg")).toBe(false);
+  });
+
+  it("rejects non-fentanyl drugs even with mcg/hr unit", async () => {
+    const { isFentanylTransdermal } = await import("../medication-max-doses.js");
+    expect(isFentanylTransdermal("Clonidine patch", "mcg/hr")).toBe(false);
+    expect(isFentanylTransdermal("Nitroglycerin patch", "mcg/hr")).toBe(false);
+  });
+
+  it("returns false for missing unit", async () => {
+    const { isFentanylTransdermal } = await import("../medication-max-doses.js");
+    expect(isFentanylTransdermal("Fentanyl patch", null)).toBe(false);
+    expect(isFentanylTransdermal("Fentanyl patch", undefined)).toBe(false);
+    expect(isFentanylTransdermal("Fentanyl patch", "")).toBe(false);
+  });
+});

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -334,6 +334,51 @@ export function getComboApapMg(drugName: string): number | undefined {
 }
 
 /**
+ * MME-per-day-per-(mcg/hr) factor for transdermal fentanyl patches
+ * (Duragesic) (#1020).
+ *
+ * Per CDC 2022 opioid prescribing guideline and the FDA Duragesic
+ * label, transdermal fentanyl delivers continuously and the
+ * conversion to oral morphine equivalent is:
+ *
+ *   MME/day = (mcg/hr) × 2.4
+ *
+ * Reference points used by the daily-dose rule:
+ *   - 12 mcg/hr → 28.8 MME/day (sub-threshold; common starter)
+ *   - 25 mcg/hr → 60 MME/day (under 90 MME cap)
+ *   - 37.5 mcg/hr → 90 MME/day (at CDC threshold)
+ *   - 50 mcg/hr → 120 MME/day (1.33× cap → critical at default 1.2×)
+ *   - 100 mcg/hr → 240 MME/day (2.67× cap → critical)
+ *
+ * IV/IM fentanyl uses a different conversion factor (route-aware
+ * lookup tracked separately in #927/#1021) and is NOT covered here —
+ * this helper applies ONLY to the transdermal patch presentation.
+ */
+export const FENTANYL_TRANSDERMAL_MME_PER_MCG_HR = 2.4;
+
+/**
+ * Detect whether a free-text drug name + dose_unit combination is a
+ * transdermal fentanyl patch order (#1020). True only when both:
+ *   - name matches /fentanyl|duragesic/i, AND
+ *   - dose_unit is the patch delivery rate ("mcg/hr" or variants)
+ *
+ * Returns false for IV/IM fentanyl (which uses "mcg" or "mg" units)
+ * or for any non-fentanyl medication. Callers use the boolean to
+ * gate the mcg/hr → MME/day conversion.
+ */
+export function isFentanylTransdermal(
+  drugName: string,
+  doseUnit: string | null | undefined,
+): boolean {
+  if (!/fentanyl|duragesic/i.test(drugName)) return false;
+  if (!doseUnit) return false;
+  // Accept "mcg/hr", "mcg/h", "mcg per hr", "mcg per hour", "ug/hr", "μg/hr".
+  // Normalise spaces and "per" tokens; lowercase.
+  const unit = doseUnit.toLowerCase().replace(/\s+/g, "").replace(/per/g, "/");
+  return /^(mcg|ug|μg)\/h(r|our)?$/.test(unit);
+}
+
+/**
  * Strip trailing strength / route / frequency tokens from a free-text
  * drug name so entries like "Ibuprofen 600mg TID" or "Acetaminophen
  * 500mg PO q6h" still resolve to their canonical entry.

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -743,6 +743,134 @@ describe("checkMedicationDailyDose (#235)", () => {
     });
   });
 
+  describe("fentanyl transdermal patch (mcg/hr) (#1020)", () => {
+    function makeFentanylPatch(mcgHr: number, unit = "mcg/hr"): PatientMedication {
+      return makeMed({
+        name: "Fentanyl transdermal patch",
+        dose_amount: mcgHr,
+        dose_unit: unit,
+        route: "topical",
+        frequency: "q72h", // patch is replaced every 72h; rule reads the rate
+      });
+    }
+
+    it("12 mcg/hr → no flag (28.8 MME/day, well under 90 cap)", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(12)));
+      expect(
+        flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+
+    it("25 mcg/hr → no flag (60 MME/day, under cap)", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(25)));
+      expect(
+        flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+
+    it("40 mcg/hr → warning (96 MME/day, 1.07× cap, below 1.2× critical)", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(40)));
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe("warning");
+      expect(f!.summary).toMatch(/96 MME/);
+    });
+
+    it("50 mcg/hr → critical (120 MME/day, 1.33× cap)", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(50)));
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe("critical");
+      expect(f!.summary).toMatch(/120 MME/);
+    });
+
+    it("100 mcg/hr → critical (240 MME/day, 2.67× cap)", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(100)));
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe("critical");
+      expect(f!.summary).toMatch(/240 MME/);
+    });
+
+    it("Duragesic brand resolves to fentanyl transdermal", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({
+          name: "Duragesic",
+          dose_amount: 75,
+          dose_unit: "mcg/hr",
+          route: "topical",
+          frequency: "q72h",
+        })),
+      );
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+      expect(f!.severity).toBe("critical"); // 75 × 2.4 = 180 MME → 2× cap
+    });
+
+    it("unit alias 'mcg/h' (no r) is accepted", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(50, "mcg/h")));
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+    });
+
+    it("unit alias 'ug/hr' (micro abbrev) is accepted", () => {
+      const flags = checkMedicationDailyDose(makeCtx(makeFentanylPatch(50, "ug/hr")));
+      const f = flags.find((x) => x.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL");
+      expect(f).toBeDefined();
+    });
+
+    it("IV fentanyl (mcg, not mcg/hr) → does NOT trigger transdermal path", () => {
+      // IV fentanyl uses a different conversion factor — out of scope here.
+      // The mcg-only branch should fall through to the existing non-mg
+      // path (no flag, fail-open) rather than convert at the transdermal
+      // factor. Future issue #1021 adds IV unit conversion.
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({
+          name: "Fentanyl",
+          dose_amount: 100,
+          dose_unit: "mcg",
+          route: "IV",
+          frequency: "q4h",
+        })),
+      );
+      expect(
+        flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+
+    it("non-fentanyl drug with mcg/hr unit does NOT match", () => {
+      // Some other continuous-release drug expressed in mcg/hr — must
+      // not be mistakenly treated as fentanyl.
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({
+          name: "Clonidine patch",
+          dose_amount: 100,
+          dose_unit: "mcg/hr",
+          route: "topical",
+          frequency: "weekly",
+        })),
+      );
+      expect(
+        flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+
+    it("missing dose_amount → no flag (fail-open)", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(makeMed({
+          name: "Fentanyl patch",
+          dose_amount: null,
+          dose_unit: "mcg/hr",
+          route: "topical",
+          frequency: "q72h",
+        })),
+      );
+      expect(
+        flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+  });
+
   describe("rule_id conventions", () => {
     it("daily flag rule_id starts with MED-DAILY-OVER-<DRUG>", () => {
       const flags = checkMedicationDailyDose(

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -34,6 +34,8 @@ import {
   estimateDailyDose,
   getMedicationDoseLimit,
   getComboApapMg,
+  isFentanylTransdermal,
+  FENTANYL_TRANSDERMAL_MME_PER_MCG_HR,
 } from "@carebridge/medical-logic";
 import type { PatientContext, PatientMedication } from "./cross-specialty.js";
 import { createLogger } from "@carebridge/logger";
@@ -228,8 +230,20 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
   if (!med) return flags;
 
   if (med.dose_amount == null) return flags;
+
+  // Fentanyl transdermal patch (#1020). Continuous-release delivery
+  // expressed in mcg/hr — bypass the mg-only single/daily ceilings
+  // (mcg-based caps would be 1000× wrong) and convert directly to MME/day
+  // via the CDC 2022 transdermal factor (2.4 MME per mcg/hr).
+  if (isFentanylTransdermal(med.name, med.dose_unit)) {
+    const fentanylFlag = checkFentanylTransdermal(med);
+    if (fentanylFlag) flags.push(fentanylFlag);
+    return flags;
+  }
+
   // Per-drug ceilings are expressed in mg. Skip non-mg prescriptions
-  // (mcg patches, mL infusions) — a future issue will add unit conversion.
+  // (other mcg presentations, mL infusions) — a future issue (#1021) will
+  // add IV infusion unit conversion.
   const unit = (med.dose_unit ?? "").toLowerCase();
   if (unit !== "mg") return flags;
 
@@ -457,5 +471,62 @@ function checkCumulativeApap(context: PatientContext): RuleFlag | null {
       `and dose plain acetaminophen separately so the daily total is tractable.`,
     notify_specialties: ["pharmacy", "pain_management"],
     rule_id: "MED-DAILY-OVER-APAP-COMBO",
+  };
+}
+
+/**
+ * Compute MME/day from a transdermal-fentanyl patch order and flag when
+ * the dose exceeds the CDC 90 MME/day elevated-risk threshold (#1020).
+ *
+ * Conversion: MME/day = (mcg/hr) × 2.4. Severity follows the same warning
+ * vs critical escalation as the main mg-based opioid path — under cap →
+ * no flag; over cap → warning until ratio reaches OPIOID_CRITICAL_RATIO
+ * (default 1.2×), at which point → critical.
+ *
+ * Fail-open: PRN frequency on a continuous-release patch is non-sensical
+ * but tolerated as a typo — the patch delivers continuously regardless
+ * of the frequency field, so we compute MME purely from the mcg/hr rate.
+ */
+function checkFentanylTransdermal(med: PatientMedication): RuleFlag | null {
+  if (med.dose_amount == null || med.dose_amount <= 0) return null;
+  const mmePerDay = med.dose_amount * FENTANYL_TRANSDERMAL_MME_PER_MCG_HR;
+  const cap = 90; // CDC 2022 elevated-risk threshold (MME/day)
+  if (mmePerDay <= cap) return null;
+
+  const ratio = mmePerDay / cap;
+  const severity = severityForDailyOver(ratio, true);
+
+  // Surface override note in the rationale when the operator has tuned
+  // the opioid critical ratio away from CDC default (same pattern as
+  // the main MED-DAILY-OVER opioid path).
+  const isOverridden = OPIOID_CRITICAL_RATIO !== OPIOID_CRITICAL_RATIO_DEFAULT;
+  const overrideNote = isOverridden
+    ? ` Active critical-escalation ratio: ${OPIOID_CRITICAL_RATIO}× (deployment override; CDC default ${OPIOID_CRITICAL_RATIO_DEFAULT}×).`
+    : "";
+
+  return {
+    severity,
+    category: "medication-safety" as FlagCategory,
+    summary:
+      `"${med.name}" ${med.dose_amount} mcg/hr transdermal patch implies ` +
+      `~${Math.round(mmePerDay)} MME/day — exceeds the 90 MME/day CDC threshold`,
+    rationale:
+      `Transdermal fentanyl delivers continuously at the labelled mcg/hr ` +
+      `rate; the CDC 2022 conversion factor for the patch presentation is ` +
+      `${FENTANYL_TRANSDERMAL_MME_PER_MCG_HR} MME per mcg/hr. ${med.dose_amount} mcg/hr × ` +
+      `${FENTANYL_TRANSDERMAL_MME_PER_MCG_HR} = ~${Math.round(mmePerDay)} MME/day, ` +
+      `which is ${ratio.toFixed(1)}× the 90 MME/day elevated-risk threshold. ` +
+      `Over-prescription at this level is a leading driver of respiratory ` +
+      `depression and overdose, especially in opioid-naive or recently-` +
+      `rotated patients.` + overrideNote,
+    suggested_action:
+      `Verify opioid tolerance and clinical context. Common safe steps: ` +
+      `confirm the patch strength is appropriate for the patient's baseline ` +
+      `MME load (transdermal initiation in opioid-naive patients is contra-` +
+      `indicated by the Duragesic label), step down to a lower-strength ` +
+      `patch (25 → 12 mcg/hr), or rotate to a different long-acting opioid ` +
+      `with PO dose-titration room.`,
+    notify_specialties: ["pharmacy", "pain_management"],
+    rule_id: "MED-DAILY-OVER-FENTANYL-TRANSDERMAL",
   };
 }


### PR DESCRIPTION
## Summary

\`services/ai-oversight/src/rules/medication-daily-dose.ts\` bails on non-mg units because the per-drug ceilings in \`MEDICATION_MAX_DAILY_DOSES\` are all mg-denominated. **Transdermal fentanyl patches (Duragesic) are expressed in mcg/hr** and would silently slip past the rule without a dedicated branch — a 100 mcg/hr patch is 240 MME/day, almost 3× the CDC 90 MME/day elevated-risk threshold.

This PR adds a special-case fentanyl-transdermal path that bypasses the mg ceiling check and converts directly to MME/day:

\`\`\`
MME/day = (mcg/hr) × 2.4   (CDC 2022 transdermal conversion factor)
\`\`\`

### Threshold ladder (tested)

| mcg/hr | MME/day | Ratio vs 90 cap | Outcome |
|---|---|---|---|
| 12 | 28.8 | 0.32× | no flag |
| 25 | 60 | 0.67× | no flag |
| 40 | 96 | 1.07× | warning |
| 50 | 120 | 1.33× | critical |
| 75 | 180 | 2.00× | critical |
| 100 | 240 | 2.67× | critical |

Severity escalation follows the same warning vs critical mechanic as the main mg-based opioid path — under cap → no flag; over cap → warning until ratio reaches \`OPIOID_CRITICAL_RATIO\` (default 1.2×), at which point critical. Override-rationale surfacing reuses the existing pattern so a deployment that has tuned the ratio sees the adjusted threshold in the audit trail.

### Changes

- **\`medical-logic\`** — new \`isFentanylTransdermal(name, doseUnit)\` helper + \`FENTANYL_TRANSDERMAL_MME_PER_MCG_HR\` constant. Detects fentanyl/Duragesic by name AND mcg/hr-shape unit (accepts \`mcg/h\`, \`ug/hr\`, \`μg/hr\`, \`mcg per hour\`). IV fentanyl (mcg, no /hr) is correctly excluded — its conversion factor is different and tracked in #1021
- **\`ai-oversight\` rule** — special-case branch before the mg-only short-circuit. New \`checkFentanylTransdermal\` emits a single \`MED-DAILY-OVER-FENTANYL-TRANSDERMAL\` flag

### Tests

- **11 new tests** in \`medication-daily-dose.test.ts\` cover the threshold ladder, brand alias (Duragesic), unit aliases (\`mcg/h\`, \`ug/hr\`), exclusion of IV fentanyl and other non-fentanyl mcg/hr patches (clonidine), and fail-open on missing dose_amount
- **5 new tests** in \`medical-validation.test.ts\` pin \`isFentanylTransdermal\` directly

### Out of scope

- IV fentanyl mcg-to-MME conversion (different factor, #1021)
- Daily-sum across multiple fentanyl patches on the same patient (unusual prescribing pattern; covered by the existing rule when a single patch already over-caps)

## Test plan

- [x] \`pnpm --filter @carebridge/ai-oversight test\` → 911/911 pass (+11 new)
- [x] \`pnpm --filter @carebridge/ai-oversight typecheck\` → clean
- [x] \`pnpm --filter @carebridge/medical-logic test\` → 436/436 pass (+5 new)
- [x] \`pnpm --filter @carebridge/medical-logic typecheck\` → clean

Closes #1020