### PR TITLE
feat(fhir): inbound MedicationRequest mapper for materialized medications

### DIFF
--- a/services/api-gateway/src/routers/fhir.ts
+++ b/services/api-gateway/src/routers/fhir.ts
@@ -83,6 +83,21 @@ export const fhirRbacRouter = t.router({
         bundle: fhirBundleSchema,
         source_system: z.string(),
         bundle_id: z.string().optional(),
+        /**
+         * Opt-in: materialise inbound MedicationRequest /
+         * MedicationStatement resources into internal `medications`
+         * rows so the ai-oversight rule engine sees external dosing
+         * detail. See #1066. Default false — preserve existing
+         * raw-FHIR-only contract.
+         */
+        materialize: z.boolean().optional(),
+        /**
+         * Internal patient id to associate materialised rows with.
+         * Required when `materialize: true`. Caller is responsible
+         * for resolving the external EHR's Patient.id to the
+         * CareBridge patients.id before invoking importBundle.
+         */
+        patient_id: z.string().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/services/fhir-gateway/src/__tests__/import-bundle-materialize.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-materialize.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Integration test (#1066): import a bundle with a MedicationRequest
+ * carrying Dosage.maxDosePerPeriod = 4/day with `materialize: true`,
+ * then verify the persisted `medications` row carries the structured
+ * fields buildPatientContextForRules consumes — in particular,
+ * `max_doses_per_day: 4`.
+ *
+ * buildPatientContextForRules itself is covered end-to-end by tests in
+ * services/ai-oversight; here we assert the row shape that landed in
+ * the table, which is the exact contract that consumer reads:
+ *   `active_medications_detail[].max_doses_per_day = m.max_doses_per_day ?? null`
+ * (services/ai-oversight/src/services/review-service.ts ~914).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const medicationsTable = { __name: "medications" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: { __name: "patients" },
+  vitals: { __name: "vitals" },
+  labPanels: { __name: "lab_panels" },
+  labResults: { __name: "lab_results" },
+  medications: medicationsTable,
+  diagnoses: { __name: "diagnoses" },
+  allergies: { __name: "allergies" },
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle materialize flag (#1066)", () => {
+  it("does NOT write a medications row by default (materialize defaults to false)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-1",
+            status: "active",
+            intent: "order",
+            medicationCodeableConcept: { text: "Aspirin" },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_medications).toBe(0);
+    expect(insertCalls.some((c) => c.table === medicationsTable)).toBe(false);
+  });
+
+  it("materialises a MedicationRequest with maxDosePerPeriod=4/day into a medications row carrying max_doses_per_day:4", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-prn-morphine",
+            status: "active",
+            intent: "order",
+            medicationCodeableConcept: {
+              coding: [
+                {
+                  system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+                  code: "7052",
+                  display: "Morphine",
+                },
+              ],
+              text: "Morphine",
+            },
+            subject: { reference: "Patient/p-1" },
+            authoredOn: "2026-05-22T10:00:00.000Z",
+            requester: { reference: "Practitioner/dr-smith" },
+            dosageInstruction: [
+              {
+                timing: { code: { text: "q4h PRN" } },
+                route: {
+                  coding: [
+                    {
+                      system: "http://snomed.info/sct",
+                      code: "26643006",
+                      display: "Oral route",
+                    },
+                  ],
+                  text: "oral",
+                },
+                doseAndRate: [
+                  {
+                    doseQuantity: {
+                      value: 10,
+                      unit: "mg",
+                      system: "http://unitsofmeasure.org",
+                      code: "mg",
+                    },
+                  },
+                ],
+                // Dosage.maxDosePerPeriod = 4 doses / 1 day
+                maxDosePerPeriod: {
+                  numerator: { value: 4, unit: "doses" },
+                  denominator: {
+                    value: 1,
+                    unit: "day",
+                    system: "http://unitsofmeasure.org",
+                    code: "d",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.materialized_medications).toBe(1);
+
+    const medRows = insertCalls
+      .filter((c) => c.table === medicationsTable)
+      .map((c) => c.row);
+    expect(medRows).toHaveLength(1);
+    const row = medRows[0]!;
+
+    // The fields buildPatientContextForRules reads when assembling
+    // active_medications_detail[] (services/ai-oversight/src/services/
+    // review-service.ts ~904-925).
+    expect(row.patient_id).toBe("p-1");
+    expect(row.name).toBe("Morphine");
+    expect(row.dose_amount).toBe(10);
+    expect(row.dose_unit).toBe("mg");
+    expect(row.route).toBe("oral");
+    expect(row.frequency).toBe("q4h PRN");
+    // The critical assertion: maxDosePerPeriod=4/day → max_doses_per_day:4
+    // (the rule context flows this straight through to PatientMedication).
+    expect(row.max_doses_per_day).toBe(4);
+    expect(row.status).toBe("active");
+    expect(row.started_at).toBe("2026-05-22T10:00:00.000Z");
+    expect(row.prescribed_by).toBe("dr-smith");
+    expect(row.rxnorm_code).toBe("7052");
+    expect(row.source_system).toBe("fhir_import");
+  });
+
+  it("materialises MedicationStatement entries with no requester (prescribed_by stays null)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "MedicationStatement",
+            id: "ms-1",
+            status: "active",
+            medicationCodeableConcept: { text: "Lisinopril" },
+            subject: { reference: "Patient/p-1" },
+            effectivePeriod: { start: "2025-12-01T00:00:00.000Z" },
+            dosage: [
+              {
+                timing: { code: { text: "daily" } },
+                doseAndRate: [{ doseQuantity: { value: 10, unit: "mg" } }],
+                route: { text: "oral" },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.materialized_medications).toBe(1);
+    const medRow = insertCalls.find((c) => c.table === medicationsTable)?.row;
+    expect(medRow).toBeDefined();
+    expect(medRow!.name).toBe("Lisinopril");
+    expect(medRow!.prescribed_by).toBeNull();
+    expect(medRow!.started_at).toBe("2025-12-01T00:00:00.000Z");
+  });
+
+  it("skips non-medication resources during materialisation but still imports them as raw FHIR", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-1",
+            status: "final",
+            code: { text: "BP" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-skip",
+            status: "entered-in-error", // mapper returns null → skipped
+            medicationCodeableConcept: { text: "Acetaminophen" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(2);
+    expect(result.materialized_medications).toBe(0);
+    // Both raw FHIR resources should still be persisted + audited.
+    expect(
+      insertCalls.filter((c) => c.table === fhirResourcesTable),
+    ).toHaveLength(2);
+    expect(
+      insertCalls.filter((c) => c.table === auditLogTable),
+    ).toHaveLength(2);
+    expect(
+      insertCalls.filter((c) => c.table === medicationsTable),
+    ).toHaveLength(0);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/medication-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/medication-mapper.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Inbound FHIR MedicationRequest / MedicationStatement → internal
+ * `medications` row mapper tests (#1066).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  mapRoute,
+  mapRequestStatusToInternal,
+  mapStatementStatusToInternal,
+  extractMaxDosesPerDay,
+  extractDoseQuantity,
+  extractFrequency,
+  extractMedicationName,
+  extractRxNormCode,
+  resolvePractitionerReference,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+} from "../medication-mapper.js";
+
+const PATIENT_ID = "patient-1066";
+
+describe("mapMedicationRequestToRow (#1066)", () => {
+  it("maps a fully-populated MedicationRequest to a row with every field set", () => {
+    const req: InboundMedicationRequest = {
+      resourceType: "MedicationRequest",
+      id: "mr-1",
+      status: "active",
+      intent: "order",
+      medicationCodeableConcept: {
+        coding: [
+          {
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: "723",
+            display: "Amoxicillin",
+          },
+        ],
+        text: "Amoxicillin",
+      },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      authoredOn: "2026-04-10T00:00:00.000Z",
+      requester: { reference: "Practitioner/prov-99" },
+      dosageInstruction: [
+        {
+          timing: { code: { text: "TID" } },
+          route: {
+            coding: [
+              {
+                system: "http://snomed.info/sct",
+                code: "26643006",
+                display: "Oral route",
+              },
+            ],
+            text: "oral",
+          },
+          doseAndRate: [
+            { doseQuantity: { value: 500, unit: "mg", system: "http://unitsofmeasure.org", code: "mg" } },
+          ],
+        },
+      ],
+    };
+    const row = mapMedicationRequestToRow(req, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      patient_id: PATIENT_ID,
+      name: "Amoxicillin",
+      dose_amount: 500,
+      dose_unit: "mg",
+      route: "oral",
+      frequency: "TID",
+      max_doses_per_day: null,
+      status: "active",
+      started_at: "2026-04-10T00:00:00.000Z",
+      prescribed_by: "prov-99",
+      rxnorm_code: "723",
+      source_system: "fhir_import",
+    });
+  });
+
+  it("returns null when the medication name is missing", () => {
+    const req: InboundMedicationRequest = {
+      resourceType: "MedicationRequest",
+      status: "active",
+    };
+    expect(mapMedicationRequestToRow(req, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when status is entered-in-error (chart correction)", () => {
+    const req: InboundMedicationRequest = {
+      resourceType: "MedicationRequest",
+      status: "entered-in-error",
+      medicationCodeableConcept: { text: "Aspirin" },
+    };
+    expect(mapMedicationRequestToRow(req, PATIENT_ID)).toBeNull();
+  });
+
+  it("preserves dose detail when dosageInstruction has only doseQuantity", () => {
+    const req: InboundMedicationRequest = {
+      resourceType: "MedicationRequest",
+      status: "active",
+      medicationCodeableConcept: { text: "Morphine" },
+      dosageInstruction: [
+        {
+          doseAndRate: [{ doseQuantity: { value: 10, unit: "mg" } }],
+        },
+      ],
+    };
+    const row = mapMedicationRequestToRow(req, PATIENT_ID);
+    expect(row?.dose_amount).toBe(10);
+    expect(row?.dose_unit).toBe("mg");
+    expect(row?.frequency).toBeNull();
+    expect(row?.route).toBeNull();
+  });
+
+  it("falls back to coding.display when medicationCodeableConcept.text is missing", () => {
+    const req: InboundMedicationRequest = {
+      resourceType: "MedicationRequest",
+      status: "active",
+      medicationCodeableConcept: {
+        coding: [{ system: "http://www.nlm.nih.gov/research/umls/rxnorm", code: "1191", display: "Aspirin" }],
+      },
+    };
+    expect(mapMedicationRequestToRow(req, PATIENT_ID)?.name).toBe("Aspirin");
+  });
+});
+
+describe("mapMedicationStatementToRow (#1066)", () => {
+  it("maps a MedicationStatement with no requester to a row with null prescribed_by", () => {
+    const stmt: InboundMedicationStatement = {
+      resourceType: "MedicationStatement",
+      id: "ms-1",
+      status: "active",
+      medicationCodeableConcept: { text: "Lisinopril" },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      effectivePeriod: { start: "2025-12-01T00:00:00.000Z" },
+      dosage: [
+        {
+          timing: { code: { text: "daily" } },
+          route: { text: "oral" },
+          doseAndRate: [{ doseQuantity: { value: 10, unit: "mg" } }],
+        },
+      ],
+    };
+    const row = mapMedicationStatementToRow(stmt, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe("Lisinopril");
+    expect(row!.prescribed_by).toBeNull();
+    expect(row!.started_at).toBe("2025-12-01T00:00:00.000Z");
+    expect(row!.status).toBe("active");
+    expect(row!.dose_amount).toBe(10);
+    expect(row!.route).toBe("oral");
+  });
+
+  it("falls back to dateAsserted when effectivePeriod.start is absent", () => {
+    const stmt: InboundMedicationStatement = {
+      resourceType: "MedicationStatement",
+      status: "active",
+      medicationCodeableConcept: { text: "Vitamin D" },
+      dateAsserted: "2025-11-01T00:00:00.000Z",
+    };
+    const row = mapMedicationStatementToRow(stmt, PATIENT_ID);
+    expect(row?.started_at).toBe("2025-11-01T00:00:00.000Z");
+  });
+
+  it("returns null on entered-in-error statement", () => {
+    const stmt: InboundMedicationStatement = {
+      resourceType: "MedicationStatement",
+      status: "entered-in-error",
+      medicationCodeableConcept: { text: "Acetaminophen" },
+    };
+    expect(mapMedicationStatementToRow(stmt, PATIENT_ID)).toBeNull();
+  });
+});
+
+describe("extractMaxDosesPerDay — per-day Ratio handling (#1066)", () => {
+  it("extracts the numerator value when denominator is per-day (UCUM 'd')", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: {
+          numerator: { value: 4, unit: "doses" },
+          denominator: { value: 1, unit: "day", system: "http://unitsofmeasure.org", code: "d" },
+        },
+      }),
+    ).toBe(4);
+  });
+
+  it("accepts denominator unit='day' without UCUM code", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: {
+          numerator: { value: 6 },
+          denominator: { value: 1, unit: "day" },
+        },
+      }),
+    ).toBe(6);
+  });
+
+  it("accepts the entry when denominator is absent (per-day implicit)", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: {
+          numerator: { value: 3 },
+        },
+      }),
+    ).toBe(3);
+  });
+
+  it("rejects per-week denominator (returns null — fail-open)", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: {
+          numerator: { value: 14 },
+          denominator: { value: 1, unit: "week", code: "wk" },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects denominator value other than 1 (e.g. per-2-days)", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: {
+          numerator: { value: 4 },
+          denominator: { value: 2, code: "d" },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when numerator is missing", () => {
+    expect(extractMaxDosesPerDay({ maxDosePerPeriod: {} })).toBeNull();
+  });
+
+  it("returns null when maxDosePerPeriod is absent", () => {
+    expect(extractMaxDosesPerDay({})).toBeNull();
+    expect(extractMaxDosesPerDay(undefined)).toBeNull();
+  });
+
+  it("floors fractional numerators", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: { numerator: { value: 4.7, unit: "doses" } },
+      }),
+    ).toBe(4);
+  });
+
+  it("rejects zero / negative numerator (no-cap signal)", () => {
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: { numerator: { value: 0 } },
+      }),
+    ).toBeNull();
+    expect(
+      extractMaxDosesPerDay({
+        maxDosePerPeriod: { numerator: { value: -1 } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("mapRoute (#1066)", () => {
+  const cases: Array<[string, string]> = [
+    ["26643006", "oral"],
+    ["47625008", "IV"],
+    ["78421000", "IM"],
+    ["34206005", "subcutaneous"],
+    ["6064005", "topical"],
+    ["418730005", "inhaled"],
+    ["37161004", "rectal"],
+  ];
+  for (const [code, expected] of cases) {
+    it(`maps SNOMED ${code} → ${expected}`, () => {
+      expect(
+        mapRoute({
+          coding: [{ system: "http://snomed.info/sct", code }],
+        }),
+      ).toBe(expected);
+    });
+  }
+
+  it("falls back to free-text 'oral'", () => {
+    expect(mapRoute({ text: "oral" })).toBe("oral");
+    expect(mapRoute({ text: "PO" })).toBe("oral");
+  });
+
+  it("handles common alias text 'subq' / 'SC'", () => {
+    expect(mapRoute({ text: "subq" })).toBe("subcutaneous");
+    expect(mapRoute({ text: "SC" })).toBe("subcutaneous");
+  });
+
+  it("returns null on unknown route", () => {
+    expect(mapRoute({ text: "epidural" })).toBeNull();
+    expect(mapRoute(undefined)).toBeNull();
+  });
+});
+
+describe("status mapping (#1066)", () => {
+  it("MedicationRequest status maps correctly", () => {
+    expect(mapRequestStatusToInternal("active")).toBe("active");
+    expect(mapRequestStatusToInternal("on-hold")).toBe("held");
+    expect(mapRequestStatusToInternal("completed")).toBe("completed");
+    expect(mapRequestStatusToInternal("cancelled")).toBe("discontinued");
+    expect(mapRequestStatusToInternal("stopped")).toBe("discontinued");
+    expect(mapRequestStatusToInternal("entered-in-error")).toBeNull();
+    expect(mapRequestStatusToInternal("draft")).toBe("active");
+    expect(mapRequestStatusToInternal(undefined)).toBe("active");
+    expect(mapRequestStatusToInternal("ACTIVE")).toBe("active");
+  });
+
+  it("MedicationStatement status maps correctly", () => {
+    expect(mapStatementStatusToInternal("active")).toBe("active");
+    expect(mapStatementStatusToInternal("on-hold")).toBe("held");
+    expect(mapStatementStatusToInternal("completed")).toBe("completed");
+    expect(mapStatementStatusToInternal("stopped")).toBe("discontinued");
+    expect(mapStatementStatusToInternal("not-taken")).toBe("discontinued");
+    expect(mapStatementStatusToInternal("intended")).toBe("active");
+    expect(mapStatementStatusToInternal("entered-in-error")).toBeNull();
+    expect(mapStatementStatusToInternal(undefined)).toBe("active");
+  });
+});
+
+describe("name and code extraction helpers (#1066)", () => {
+  it("extractMedicationName prefers text, then coding.display", () => {
+    expect(extractMedicationName({ text: "Aspirin" })).toBe("Aspirin");
+    expect(
+      extractMedicationName({ coding: [{ display: "Aspirin" }] }),
+    ).toBe("Aspirin");
+    expect(extractMedicationName({})).toBeNull();
+    expect(extractMedicationName(undefined)).toBeNull();
+  });
+
+  it("extractRxNormCode returns first RxNorm-coded entry", () => {
+    expect(
+      extractRxNormCode({
+        coding: [
+          { system: "other", code: "X" },
+          { system: "http://www.nlm.nih.gov/research/umls/rxnorm", code: "723" },
+        ],
+      }),
+    ).toBe("723");
+  });
+
+  it("extractRxNormCode rejects the placeholder 'unknown' code", () => {
+    expect(
+      extractRxNormCode({
+        coding: [{ system: "http://www.nlm.nih.gov/research/umls/rxnorm", code: "unknown" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("extractDoseQuantity returns null when value or unit missing", () => {
+    expect(extractDoseQuantity({ doseAndRate: [{ doseQuantity: {} }] })).toBeNull();
+    expect(
+      extractDoseQuantity({ doseAndRate: [{ doseQuantity: { value: 10 } }] }),
+    ).toBeNull();
+  });
+
+  it("extractDoseQuantity uses doseQuantity.code as unit fallback", () => {
+    expect(
+      extractDoseQuantity({
+        doseAndRate: [{ doseQuantity: { value: 5, code: "mg" } }],
+      }),
+    ).toEqual({ amount: 5, unit: "mg" });
+  });
+
+  it("extractFrequency prefers timing.code.text", () => {
+    expect(
+      extractFrequency({ timing: { code: { text: "BID" } } }),
+    ).toBe("BID");
+  });
+
+  it("resolvePractitionerReference parses Practitioner/{id}", () => {
+    expect(
+      resolvePractitionerReference({ reference: "Practitioner/abc-123" }),
+    ).toBe("abc-123");
+    expect(
+      resolvePractitionerReference({ reference: "Patient/abc-123" }),
+    ).toBeNull();
+    expect(resolvePractitionerReference(undefined)).toBeNull();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -120,7 +120,9 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         source_system: "unit-test",
         user_id: adminUser.id,
       });
-      expect(result).toEqual({ imported: 1 });
+      // `materialize` defaults to false (#1066), so the result also
+      // reports `materialized_medications: 0` alongside `imported`.
+      expect(result).toEqual({ imported: 1, materialized_medications: 0 });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);
     });

--- a/services/fhir-gateway/src/medication-mapper.ts
+++ b/services/fhir-gateway/src/medication-mapper.ts
@@ -1,0 +1,517 @@
+/**
+ * Inbound FHIR R4 MedicationRequest / MedicationStatement → CareBridge
+ * `medications`-row mapper (issue #1066).
+ *
+ * The export side (services/fhir-gateway/src/generators/medication-*.ts)
+ * already serialises the internal `medications` table to FHIR. This
+ * mapper is the inverse: it takes a FHIR resource as ingested through
+ * `importBundle` and produces the row shape the clinical-data writer
+ * would have produced for the same prescription, so external EHRs
+ * pushing dosing detail (Dosage.doseQuantity, Dosage.maxDosePerPeriod,
+ * route, frequency, status) can drive the ai-oversight daily-dose rule
+ * the same way internal tRPC writes do today.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitization (the
+ * caller has already sanitised by the time importBundle reaches us).
+ * Returns `null` when the resource is unmappable (missing medication
+ * name, malformed structure) so the caller can skip-and-warn rather
+ * than crash the bundle.
+ */
+
+import type { MedRoute, MedStatus } from "@carebridge/shared-types";
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// We don't import the export-side FHIR types here because inbound
+// payloads from external EHRs are looser than what our exporter emits
+// (optional fields may be missing, unknown extra fields present). The
+// bundle schema (services/fhir-gateway/src/schemas/bundle.ts) uses
+// .passthrough() so the raw resource arrives as a generic
+// Record<string, unknown> — we narrow defensively at each access.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundQuantity {
+  value?: number;
+  unit?: string;
+  system?: string;
+  code?: string;
+}
+
+interface InboundRatio {
+  numerator?: InboundQuantity;
+  denominator?: InboundQuantity;
+}
+
+interface InboundReference {
+  reference?: string;
+}
+
+interface InboundDoseAndRate {
+  doseQuantity?: InboundQuantity;
+  rateQuantity?: InboundQuantity;
+}
+
+interface InboundTimingRepeat {
+  frequency?: number;
+  period?: number;
+  periodUnit?: string;
+}
+
+interface InboundTiming {
+  code?: InboundCodeableConcept;
+  repeat?: InboundTimingRepeat;
+}
+
+interface InboundDosage {
+  text?: string;
+  route?: InboundCodeableConcept;
+  timing?: InboundTiming;
+  doseAndRate?: InboundDoseAndRate[];
+  maxDosePerPeriod?: InboundRatio;
+}
+
+export interface InboundMedicationRequest {
+  resourceType: "MedicationRequest";
+  id?: string;
+  status?: string;
+  intent?: string;
+  medicationCodeableConcept?: InboundCodeableConcept;
+  subject?: InboundReference;
+  authoredOn?: string;
+  requester?: InboundReference;
+  dosageInstruction?: InboundDosage[];
+}
+
+export interface InboundMedicationStatement {
+  resourceType: "MedicationStatement";
+  id?: string;
+  status?: string;
+  medicationCodeableConcept?: InboundCodeableConcept;
+  subject?: InboundReference;
+  effectivePeriod?: { start?: string; end?: string };
+  dateAsserted?: string;
+  informationSource?: InboundReference;
+  dosage?: InboundDosage[];
+}
+
+// ── Mapped output shape ─────────────────────────────────────────
+
+/**
+ * Shape of the row to insert into `medications`. Mirrors
+ * CreateMedicationInput from clinical-data but with `patient_id` as an
+ * explicit caller-supplied value (the FHIR `subject.reference` carries
+ * the patient id, but the importBundle path validates the patient
+ * resolution itself and passes a verified id in).
+ */
+export interface MappedMedicationRow {
+  patient_id: string;
+  name: string;
+  dose_amount: number | null;
+  dose_unit: string | null;
+  route: MedRoute | null;
+  frequency: string | null;
+  max_doses_per_day: number | null;
+  status: MedStatus;
+  started_at: string | null;
+  prescribed_by: string | null;
+  rxnorm_code: string | null;
+  source_system: string | null;
+}
+
+// ── Route mapping ───────────────────────────────────────────────
+
+/**
+ * SNOMED CT route code → internal MedRoute enum. Mirrors the export
+ * side ROUTE_SNOMED table (generators/medication-{request,statement}.ts)
+ * so an exported-then-reimported bundle round-trips losslessly.
+ */
+const ROUTE_BY_SNOMED: Record<string, MedRoute> = {
+  "26643006": "oral",
+  "47625008": "IV",
+  "78421000": "IM",
+  "34206005": "subcutaneous",
+  "6064005": "topical",
+  "418730005": "inhaled",
+  "37161004": "rectal",
+  "284009009": "other",
+};
+
+/**
+ * Free-text route token → internal MedRoute. Case-insensitive,
+ * exact-stem match. Mirrors what the export side writes as
+ * route.text. Returns null on miss so the caller can degrade to a
+ * non-routed row rather than smuggling an invalid enum value into the
+ * DB.
+ */
+function mapRouteText(text: string): MedRoute | null {
+  const t = text.trim().toLowerCase();
+  if (!t) return null;
+  // Direct enum values
+  if (t === "oral" || t === "po") return "oral";
+  if (t === "iv" || t === "intravenous") return "IV";
+  if (t === "im" || t === "intramuscular") return "IM";
+  if (
+    t === "subcutaneous" ||
+    t === "sc" ||
+    t === "subq" ||
+    t === "sq"
+  ) return "subcutaneous";
+  if (t === "topical") return "topical";
+  if (t === "inhaled" || t === "inhalation") return "inhaled";
+  if (t === "rectal" || t === "pr") return "rectal";
+  if (t === "other") return "other";
+  return null;
+}
+
+/**
+ * Extract an internal MedRoute from a FHIR Dosage.route. Prefers
+ * SNOMED coding (the export side always emits one) but falls back
+ * to free-text — external EHRs may send only `text`, only `coding`,
+ * or a heterogeneous mix.
+ */
+export function mapRoute(route: InboundCodeableConcept | undefined): MedRoute | null {
+  if (!route) return null;
+  // 1. Try every SNOMED coding entry first — most reliable signal.
+  for (const c of route.coding ?? []) {
+    if (!c.code) continue;
+    if (
+      c.system === "http://snomed.info/sct" ||
+      // Tolerant: some EHRs drop the system on locally-coded routes.
+      c.system === undefined
+    ) {
+      const mapped = ROUTE_BY_SNOMED[c.code];
+      if (mapped) return mapped;
+    }
+  }
+  // 2. Any coding.display interpreted as free-text.
+  for (const c of route.coding ?? []) {
+    if (c.display) {
+      const m = mapRouteText(c.display);
+      if (m) return m;
+    }
+  }
+  // 3. The free-text `text` field itself.
+  if (route.text) {
+    return mapRouteText(route.text);
+  }
+  return null;
+}
+
+// ── Status mapping ──────────────────────────────────────────────
+
+/**
+ * FHIR MedicationRequest.status → internal MedStatus. The FHIR value
+ * set is wider than the internal enum; values without an internal
+ * analogue (draft/proposal/unknown) map to "active" because the
+ * record was imported into a real patient chart — treating it as
+ * absent would silently drop dosing info from the rule context.
+ *
+ * `entered-in-error` is the one exception: rows with that status are
+ * filtered out of the rule context, so we preserve it as "completed"
+ * is closest in MedStatus terms, BUT we also return null to signal
+ * "skip this entry" — entered-in-error means the chart entry was a
+ * mistake and should not be materialised.
+ */
+export function mapRequestStatusToInternal(status: string | undefined): MedStatus | null {
+  if (!status) return "active";
+  switch (status.toLowerCase()) {
+    case "active":
+      return "active";
+    case "on-hold":
+      return "held";
+    case "completed":
+      return "completed";
+    case "cancelled":
+    case "stopped":
+      return "discontinued";
+    case "entered-in-error":
+      return null; // skip — chart mistake
+    case "draft":
+    case "unknown":
+    default:
+      // Pre-order / unknown still imports as active — the inbound
+      // payload carried dose detail the rule engine should see.
+      return "active";
+  }
+}
+
+/**
+ * FHIR MedicationStatement.status → internal MedStatus. Subset of the
+ * MedicationRequest mapper, plus the statement-only statuses.
+ */
+export function mapStatementStatusToInternal(status: string | undefined): MedStatus | null {
+  if (!status) return "active";
+  switch (status.toLowerCase()) {
+    case "active":
+      return "active";
+    case "on-hold":
+      return "held";
+    case "completed":
+      return "completed";
+    case "stopped":
+    case "not-taken":
+      return "discontinued";
+    case "intended":
+    case "unknown":
+      return "active";
+    case "entered-in-error":
+      return null;
+    default:
+      return "active";
+  }
+}
+
+// ── Medication name extraction ──────────────────────────────────
+
+/**
+ * Pick the medication name from `medicationCodeableConcept`. Order of
+ * preference: `.text` (most human-readable; what our exporter emits),
+ * then the first non-empty `coding[].display`. Returns null when
+ * nothing usable is present — the caller skips the entry.
+ */
+export function extractMedicationName(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+/**
+ * Extract the RxNorm code from `medicationCodeableConcept.coding[]`.
+ * Returns the first entry coded against the RxNorm system, or null.
+ */
+export function extractRxNormCode(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (
+      c.system === "http://www.nlm.nih.gov/research/umls/rxnorm" &&
+      c.code &&
+      c.code !== "unknown"
+    ) {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+// ── Dose extraction ─────────────────────────────────────────────
+
+/**
+ * Extract `dose_amount` + `dose_unit` from `dosageInstruction[0].doseAndRate[0].doseQuantity`.
+ * Both fields are returned together (or both null) so the caller
+ * doesn't have to handle the half-populated case — a unit without a
+ * value is meaningless, and vice versa.
+ */
+export function extractDoseQuantity(
+  dosage: InboundDosage | undefined,
+): { amount: number; unit: string } | null {
+  const dq = dosage?.doseAndRate?.[0]?.doseQuantity;
+  if (!dq) return null;
+  if (typeof dq.value !== "number" || !Number.isFinite(dq.value)) return null;
+  const unit = dq.unit ?? dq.code;
+  if (!unit) return null;
+  return { amount: dq.value, unit };
+}
+
+// ── Frequency extraction ────────────────────────────────────────
+
+/**
+ * Extract free-text frequency from `dosageInstruction[0].timing.code.text`.
+ * Mirrors what the exporter writes; falls back to coding display.
+ * Returns null when neither is present.
+ */
+export function extractFrequency(
+  dosage: InboundDosage | undefined,
+): string | null {
+  const timing = dosage?.timing;
+  if (!timing) return null;
+  if (timing.code?.text && timing.code.text.trim() !== "") {
+    return timing.code.text.trim();
+  }
+  for (const c of timing.code?.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+// ── maxDosePerPeriod extraction ─────────────────────────────────
+
+/**
+ * Convert a FHIR Dosage.maxDosePerPeriod (a Ratio) into the integer
+ * doses-per-day the internal `max_doses_per_day` column expects.
+ *
+ * Per FHIR R4 the numerator is dose count or quantity and the
+ * denominator is the time period. We accept the entry only when:
+ *   - numerator.value is a finite number
+ *   - denominator describes a per-day window (UCUM "d" code, or
+ *     denominator.unit/text matching /day|d/i with value 1, or no
+ *     denominator at all — which most exporters emit when "per day"
+ *     is implicit).
+ *
+ * Anything else (per-week, per-dose, missing) returns null so the
+ * rule context falls back to runtime frequency parsing (the
+ * fail-open behaviour described in #935).
+ *
+ * Returns a positive integer — fractional or zero numerators are
+ * dropped (the daily-dose rule treats them as no-cap and they'd
+ * round to a confusing 0 or 1 in the DB anyway).
+ */
+export function extractMaxDosesPerDay(
+  dosage: InboundDosage | undefined,
+): number | null {
+  const ratio = dosage?.maxDosePerPeriod;
+  if (!ratio?.numerator) return null;
+  const num = ratio.numerator.value;
+  if (typeof num !== "number" || !Number.isFinite(num) || num <= 0) {
+    return null;
+  }
+  const denom = ratio.denominator;
+  if (denom !== undefined) {
+    // Reject explicit non-day denominators.
+    const denomValue = denom.value ?? 1;
+    if (denomValue !== 1) return null;
+    const code = denom.code?.toLowerCase();
+    const unit = denom.unit?.toLowerCase();
+    const isPerDay =
+      code === "d" ||
+      code === "day" ||
+      (unit !== undefined && /^(d|day|days)$/.test(unit));
+    if (!isPerDay) return null;
+  }
+  // Round down: a `4.5 doses/day` numerator is treated as 4 to err
+  // toward not double-counting a partial dose at the rule boundary.
+  return Math.floor(num);
+}
+
+// ── Reference resolution ────────────────────────────────────────
+
+/**
+ * Resolve a Practitioner reference (e.g. `Practitioner/abc-123`) to
+ * the internal user_id used by `medications.prescribed_by`.
+ *
+ * Minimum-viable implementation (#1066): parse `Practitioner/{id}`
+ * and return the raw id. Looking up the internal user row to verify
+ * the practitioner exists is deferred to a follow-up — the import
+ * path already records the raw reference and a downstream
+ * reconciliation job can normalise IDs later.
+ *
+ * Returns null when the reference is missing, malformed, or doesn't
+ * match the Practitioner resource type.
+ */
+export function resolvePractitionerReference(
+  ref: InboundReference | undefined,
+): string | null {
+  if (!ref?.reference) return null;
+  const match = /^Practitioner\/(.+)$/.exec(ref.reference);
+  if (!match) return null;
+  return match[1] ?? null;
+}
+
+// ── Main mapper functions ───────────────────────────────────────
+
+const SOURCE_SYSTEM_TAG = "fhir_import";
+
+/**
+ * Map a FHIR R4 MedicationRequest to a CareBridge `medications` row.
+ *
+ * @param resource Sanitised FHIR resource (importBundle has already
+ *                 run sanitizeFreeText over every string).
+ * @param patientId Internal patient id the bundle is being imported
+ *                 against. The mapper trusts the caller to have
+ *                 resolved subject.reference to this id.
+ * @returns A row shape ready to insert, or null when the resource is
+ *          unmappable (no medication name, entered-in-error status).
+ */
+export function mapMedicationRequestToRow(
+  resource: InboundMedicationRequest,
+  patientId: string,
+): MappedMedicationRow | null {
+  const name = extractMedicationName(resource.medicationCodeableConcept);
+  if (!name) return null;
+  const status = mapRequestStatusToInternal(resource.status);
+  if (status === null) return null;
+
+  const dosage = resource.dosageInstruction?.[0];
+  const dose = extractDoseQuantity(dosage);
+  const frequency = extractFrequency(dosage);
+  const route = mapRoute(dosage?.route);
+  const maxDoses = extractMaxDosesPerDay(dosage);
+  const rxnorm = extractRxNormCode(resource.medicationCodeableConcept);
+  const prescribedBy = resolvePractitionerReference(resource.requester);
+
+  return {
+    patient_id: patientId,
+    name,
+    dose_amount: dose?.amount ?? null,
+    dose_unit: dose?.unit ?? null,
+    route,
+    frequency,
+    max_doses_per_day: maxDoses,
+    status,
+    started_at: resource.authoredOn ?? null,
+    prescribed_by: prescribedBy,
+    rxnorm_code: rxnorm,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+}
+
+/**
+ * Map a FHIR R4 MedicationStatement to a CareBridge `medications` row.
+ *
+ * Statements describe medications the patient is currently taking or
+ * has taken historically — they have no `requester`, a different
+ * status value set, and the dosage live under `dosage[]` instead of
+ * `dosageInstruction[]`. Otherwise mirrors the MedicationRequest
+ * mapper field-for-field.
+ */
+export function mapMedicationStatementToRow(
+  resource: InboundMedicationStatement,
+  patientId: string,
+): MappedMedicationRow | null {
+  const name = extractMedicationName(resource.medicationCodeableConcept);
+  if (!name) return null;
+  const status = mapStatementStatusToInternal(resource.status);
+  if (status === null) return null;
+
+  const dosage = resource.dosage?.[0];
+  const dose = extractDoseQuantity(dosage);
+  const frequency = extractFrequency(dosage);
+  const route = mapRoute(dosage?.route);
+  const maxDoses = extractMaxDosesPerDay(dosage);
+  const rxnorm = extractRxNormCode(resource.medicationCodeableConcept);
+
+  // MedicationStatement has no `requester`; `informationSource` is
+  // used for "who said the patient is on this" rather than who
+  // prescribed it. We don't promote it into `prescribed_by` because
+  // the semantics don't match — statements with a known prescriber
+  // should arrive as a separate MedicationRequest in the same bundle.
+  return {
+    patient_id: patientId,
+    name,
+    dose_amount: dose?.amount ?? null,
+    dose_unit: dose?.unit ?? null,
+    route,
+    frequency,
+    max_doses_per_day: maxDoses,
+    status,
+    started_at: resource.effectivePeriod?.start ?? resource.dateAsserted ?? null,
+    prescribed_by: null,
+    rxnorm_code: rxnorm,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -34,6 +34,12 @@ import {
 } from "./generators/index.js";
 import { fhirBundleSchema } from "./schemas/bundle.js";
 import { sanitizeFreeText } from "@carebridge/phi-sanitizer";
+import {
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+} from "./medication-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -172,12 +178,37 @@ export const fhirGatewayRouter = t.router({
        */
       user_id: z.string(),
       bundle_id: z.string().optional(),
+      /**
+       * Opt-in materialisation flag (#1066). When true, inbound
+       * MedicationRequest and MedicationStatement resources are
+       * additionally mapped to internal `medications` rows so the
+       * ai-oversight rule engine (which reads `medications` not
+       * `fhir_resources`) sees external dosing detail —
+       * Dosage.doseQuantity, Dosage.maxDosePerPeriod, route, status.
+       *
+       * Default false to preserve the raw-FHIR-only contract the
+       * endpoint advertises today; callers that want the FHIR row to
+       * drive the rule engine must explicitly opt in.
+       */
+      materialize: z.boolean().optional().default(false),
+      /**
+       * Patient id to associate materialised medication rows with.
+       * Required when `materialize: true` — the FHIR
+       * MedicationRequest.subject reference may carry a Patient/{id}
+       * pointing at the external EHR's id, which is not the same as
+       * the internal patients.id. Caller (api-gateway RBAC wrapper)
+       * is responsible for the cross-system reconciliation.
+       *
+       * Ignored when `materialize: false`.
+       */
+      patient_id: z.string().optional(),
     }))
     .mutation(async ({ input }) => {
       const db = getDb();
       const now = new Date().toISOString();
       const entries = input.bundle.entry ?? [];
       let imported = 0;
+      let materializedMedications = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -190,6 +221,12 @@ export const fhirGatewayRouter = t.router({
         // imported PHI in fhir_resources with no audit row, defeating the
         // HIPAA § 164.312(b) audit completeness goal.
         // Per Copilot review on PR #378.
+        //
+        // When `materialize: true` (#1066), the same transaction also
+        // inserts a `medications` row for MedicationRequest /
+        // MedicationStatement entries so the raw-FHIR write and the
+        // materialised row are guaranteed atomic — a crash mid-import
+        // can't leave one without the other.
         await db.transaction(async (tx) => {
           await tx.insert(fhirResources).values({
             id: crypto.randomUUID(),
@@ -220,11 +257,49 @@ export const fhirGatewayRouter = t.router({
             ip_address: null,
             timestamp: now,
           });
+
+          // Optional materialisation pass (#1066). The mapper is pure
+          // and returns null for unmappable entries (missing name,
+          // entered-in-error status) — those skip silently.
+          if (input.materialize && input.patient_id) {
+            let row: ReturnType<typeof mapMedicationRequestToRow> = null;
+            if (resourceType === "MedicationRequest") {
+              row = mapMedicationRequestToRow(
+                sanitized as unknown as InboundMedicationRequest,
+                input.patient_id,
+              );
+            } else if (resourceType === "MedicationStatement") {
+              row = mapMedicationStatementToRow(
+                sanitized as unknown as InboundMedicationStatement,
+                input.patient_id,
+              );
+            }
+            if (row) {
+              await tx.insert(medications).values({
+                id: crypto.randomUUID(),
+                patient_id: row.patient_id,
+                name: row.name,
+                dose_amount: row.dose_amount,
+                dose_unit: row.dose_unit,
+                route: row.route,
+                frequency: row.frequency,
+                max_doses_per_day: row.max_doses_per_day,
+                status: row.status,
+                started_at: row.started_at,
+                prescribed_by: row.prescribed_by,
+                rxnorm_code: row.rxnorm_code,
+                source_system: row.source_system ?? input.source_system,
+                created_at: now,
+                updated_at: now,
+              });
+              materializedMedications++;
+            }
+          }
         });
 
         imported++;
       }
-      return { imported };
+      return { imported, materialized_medications: materializedMedications };
     }),
 
   getByPatient: protectedProcedure


### PR DESCRIPTION
## Summary

Adds a FHIR R4 MedicationRequest / MedicationStatement → internal `medications`-row mapper and wires it into `importBundle` behind an opt-in `materialize: true` flag. Surfaces external EHR dosing detail (`Dosage.maxDosePerPeriod`, `doseQuantity`, route, status) to the ai-oversight rule engine.

- New `services/fhir-gateway/src/medication-mapper.ts` — pure, side-effect-free mapper with focused helpers. Returns `null` on unmappable / entered-in-error entries so the caller skip-and-imports the raw FHIR row only.
- `importBundle` accepts `materialize` (default `false` — preserves the raw-FHIR-only contract) and `patient_id` (required when materialising). Materialised rows go in the same atomic transaction as `fhir_resources` + `audit_log` so a crash can't leave them out of sync.
- api-gateway wrapper plumbs the flag through; raw router and gateway router both updated.
- Result shape now includes `materialized_medications` count.

## Behaviour

| Inbound FHIR field                                  | DB column                                |
|-----------------------------------------------------|------------------------------------------|
| `medicationCodeableConcept.text` / `.coding[].display` | `name`                                |
| `medicationCodeableConcept.coding[]` (RxNorm)       | `rxnorm_code`                            |
| `dosageInstruction[0].doseAndRate[0].doseQuantity`  | `dose_amount` + `dose_unit`              |
| `dosageInstruction[0].route` (SNOMED + text)        | `route` (mapped to MedRoute enum)        |
| `dosageInstruction[0].timing.code.text`             | `frequency`                              |
| `dosageInstruction[0].maxDosePerPeriod` (per-day Ratio) | `max_doses_per_day`                  |
| `status` (FHIR R4 value set)                        | `status` (MedStatus enum)                |
| `authoredOn`                                        | `started_at`                             |
| `requester.reference` (`Practitioner/{id}`)         | `prescribed_by`                          |

MedicationStatement mapper mirrors the above with `dosage[]` instead of `dosageInstruction[]`, `effectivePeriod.start` (then `dateAsserted`) for `started_at`, and no requester (statements describe what the patient takes, not who prescribed it).

## Deferred (follow-ups)

- **Practitioner reference resolution** — the mapper parses `Practitioner/{id}` and stores the raw external id verbatim in `prescribed_by`. Looking up the internal `users.id` to verify the practitioner exists is left to a future reconciliation job. Acceptable because nothing in the rule engine reads `prescribed_by` today; downstream we can normalise IDs lazily.
- **FHIR `Patient.id` → internal patients.id resolution** — currently the caller (`api-gateway`) is responsible for supplying the internal id via `patient_id`. A bundle-level reconciliation helper that walks every Patient entry and maps to internal IDs by identifier (MRN) would let the mapper drop the explicit-id requirement.

## Test plan

- [x] Unit: 36 mapper tests cover every field, every status mapping, every route encoding (SNOMED + free-text), every maxDosePerPeriod variant (per-day implicit, per-week reject, fractional floor, zero reject).
- [x] Integration: bundle with `MedicationRequest` + `Dosage.maxDosePerPeriod=4/day` materialises a `medications` row with `max_doses_per_day: 4` — the exact field `buildPatientContextForRules` reads when assembling `active_medications_detail[]` (review-service.ts ~914).
- [x] Default behaviour unchanged — bundles without `materialize: true` write only the raw `fhir_resources` rows.
- [x] Materialisation skips `entered-in-error` entries while still importing them as raw FHIR + audit row.
- [x] Full `pnpm --filter @carebridge/fhir-gateway test` — 248 tests pass.
- [x] Full `pnpm --filter @carebridge/api-gateway test` — 512 tests pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — only pre-existing portal warnings.

Closes #1066