### PR TITLE
feat(ai): IV/SC infusion mL/hr → mg/day conversion for daily-dose rule

### DIFF
--- a/packages/db-schema/drizzle/0047_medications_concentration.sql
+++ b/packages/db-schema/drizzle/0047_medications_concentration.sql
@@ -1,0 +1,12 @@
+-- #1021: drug concentration (mg/mL) for continuous-infusion orders.
+--
+-- IV / SC infusion prescriptions present dose as a flow rate (mL/hr), not
+-- a per-dose mg amount, so the daily-dose rule must convert through the
+-- drug's concentration: mg/day = mL/hr × concentration × 24.
+--
+-- Today concentrations are encoded inline in the drug name string
+-- ("Morphine 1 mg/mL IV gtt"). Name-parsing remains the fallback when
+-- this column is NULL; the explicit column lets writers attach a
+-- machine-readable concentration without relying on free-text parsing.
+
+ALTER TABLE medications ADD COLUMN IF NOT EXISTS concentration_mg_per_ml real;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1747929780000,
       "tag": "0046_users_name_structured",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1747929840000,
+      "tag": "0047_medications_concentration",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/clinical-data.ts
+++ b/packages/db-schema/src/schema/clinical-data.ts
@@ -34,6 +34,15 @@ export const medications = pgTable("medications", {
    * GVHD, and other day-1-chronic immunosuppression courses.
    */
   chronic: boolean("chronic"),
+  /**
+   * Drug concentration in mg/mL — required for continuous-infusion orders
+   * (mL/hr presentation) so the daily-dose rule can convert to mg/day
+   * (#1021). NULL when the prescription is not an infusion or the
+   * concentration is encoded inline in the drug name string instead
+   * ("Morphine 1 mg/mL IV gtt"). Free-text name parsing remains the
+   * fallback when this column is NULL.
+   */
+  concentration_mg_per_ml: real("concentration_mg_per_ml"),
   status: text("status").notNull().default("active"),
   started_at: text("started_at"),
   ended_at: text("ended_at"),

--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -418,6 +418,38 @@ describe("validateMedicationDose — per-drug ceilings (#238)", () => {
   });
 });
 
+// ─── validateMedicationDose — route-aware ceilings (#927) ──────
+
+describe("validateMedicationDose — route-aware (#927)", () => {
+  it("errors on IV morphine 20 mg (above 10 mg IV single-dose cap)", () => {
+    const result = validateMedicationDose(20, "mg", "morphine", "IV");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Morphine/);
+    expect(result.errors[0]).toMatch(/IV/);
+  });
+
+  it("accepts PO morphine 20 mg (below 30 mg PO single-dose cap)", () => {
+    const result = validateMedicationDose(20, "mg", "morphine", "oral");
+    expect(result.valid).toBe(true);
+  });
+
+  it("uses PO ceiling when route is omitted (backward compat)", () => {
+    const result = validateMedicationDose(20, "mg", "morphine");
+    expect(result.valid).toBe(true);
+  });
+
+  it("errors on SC hydromorphone 3 mg (above 2 mg SC single-dose cap)", () => {
+    const result = validateMedicationDose(3, "mg", "hydromorphone", "subcutaneous");
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Hydromorphone/);
+  });
+
+  it("accepts PO hydromorphone 4 mg (PO cap)", () => {
+    const result = validateMedicationDose(4, "mg", "hydromorphone", "oral");
+    expect(result.valid).toBe(true);
+  });
+});
+
 // ─── MEDICATION_MAX_DAILY_DOSES data sanity ─────────────────────
 
 describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -287,6 +287,7 @@ export function validateMedicationDose(
   doseAmount: number | undefined,
   doseUnit: string | undefined,
   drugName?: string,
+  route?: import("@carebridge/shared-types").MedRoute,
 ): ValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -301,7 +302,7 @@ export function validateMedicationDose(
   if (doseAmount <= 0) errors.push("Dose must be a positive number");
 
   const unit = doseUnit?.toLowerCase();
-  const limit = drugName ? getMedicationDoseLimit(drugName) : undefined;
+  const limit = drugName ? getMedicationDoseLimit(drugName, route) : undefined;
 
   // Per-drug ceilings (issue #238). Only apply when the unit is mg — the
   // table's limits are expressed in milligrams; cross-unit comparisons

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -8,20 +8,37 @@
  * Scope:
  *  - Acetaminophen, ibuprofen, naproxen, aspirin, diclofenac, meloxicam,
  *    celecoxib — NSAID / analgesic ceilings.
- *  - Morphine, oxycodone, hydrocodone, codeine, tramadol — oral opioid
- *    ceilings keyed off CDC MME guidance (90 MME/day is the elevated-risk
- *    threshold; most per-day caps in this table are calibrated to that).
- *
- * Out of scope (handled in follow-ups):
- *  - Route-specific caps (IV morphine vs PO morphine have very different
- *    safe ceilings). All values here are PO unless noted.
- *  - Transdermal fentanyl patches (expressed as mcg/hr, not mg) — the MME
- *    conversion requires route-aware handling.
- *  - Daily-cumulative summation across multiple prescriptions (issue #235).
+ *  - Morphine, oxycodone, hydrocodone, codeine, tramadol, hydromorphone —
+ *    opioid ceilings keyed off CDC MME guidance (90 MME/day is the
+ *    elevated-risk threshold; PO caps in this table are calibrated to that).
+ *  - Route-specific opioid ceilings (#927): morphine and hydromorphone have
+ *    IV/SC overrides; PO remains the default when no route is supplied.
+ *  - Transdermal fentanyl uses a separate mcg/hr → MME conversion path
+ *    (see {@link isFentanylTransdermal}) — not modelled in this table.
  *
  * All values are adult dosing. Pediatric weight-based dosing is handled by
  * weight-based-dosing.ts.
  */
+
+import type { MedRoute } from "@carebridge/shared-types";
+
+/**
+ * Per-route override for a {@link MedicationDoseLimit}. Sparse: only the
+ * fields that differ from the base (PO) entry need to be supplied; lookup
+ * merges the override onto the base.
+ */
+export type DoseLimitRouteOverride = Partial<
+  Pick<
+    MedicationDoseLimit,
+    | "displayName"
+    | "maxSingleDoseMg"
+    | "warnSingleDoseMg"
+    | "maxDailyDoseMg"
+    | "mmeFactor"
+    | "source"
+    | "citation"
+  >
+>;
 
 export interface MedicationDoseLimit {
   /** Human-readable canonical name used in validation messages. */
@@ -56,6 +73,21 @@ export interface MedicationDoseLimit {
    * `source` when omitted. (#1026)
    */
   citation?: string;
+  /**
+   * Per-route overrides (#927). Each key is a {@link MedRoute}; the value
+   * is a sparse override of the base entry's fields. Used by
+   * {@link getMedicationDoseLimit} when the caller supplies a route — the
+   * override is merged on top of the base entry (which is treated as the
+   * PO default).
+   *
+   * Only the opioids that have clinically meaningful route-specific
+   * ceilings carry this map: IV/SC morphine, IV/SC hydromorphone. IV
+   * fentanyl is treated separately because its concentration depends on
+   * the bag-rate path covered by #1021. Other drugs in this table are
+   * PO-only therapeutically (NSAIDs, oral opioids without parenteral
+   * formulations) and omit the field.
+   */
+  byRoute?: Partial<Record<MedRoute, DoseLimitRouteOverride>>;
 }
 
 /**
@@ -173,6 +205,11 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
   // CareBridge enforces on adult, chronic-pain prescriptions. IV/IM/
   // transdermal routes have different conversion factors and are out of
   // scope (issue #927).
+  // Morphine has clinically distinct PO and parenteral ceilings (#927).
+  // Base entry is PO; byRoute carries IV / SC / IM overrides keyed off the
+  // CDC 2022 MME conversion (1 mg IV/IM/SC morphine = 3 PO MME). The
+  // IV single-dose cap of 10 mg covers acute-care titration; the daily
+  // cap of 30 mg IV maps to the same 90-MME-equivalent ceiling as PO.
   morphine: {
     displayName: "Morphine (PO)",
     maxSingleDoseMg: 30,
@@ -181,6 +218,77 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     source: "CDC 2022 opioid guideline",
     citation:
       "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO)",
+    byRoute: {
+      IV: {
+        displayName: "Morphine (IV)",
+        maxSingleDoseMg: 10,
+        maxDailyDoseMg: 30,
+        mmeFactor: 3.0,
+        source: "CDC 2022 opioid guideline (IV)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, IV; 1 mg IV = 3 PO MME)",
+      },
+      IM: {
+        displayName: "Morphine (IM)",
+        maxSingleDoseMg: 10,
+        maxDailyDoseMg: 30,
+        mmeFactor: 3.0,
+        source: "CDC 2022 opioid guideline (IM)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, IM; 1 mg IM = 3 PO MME)",
+      },
+      subcutaneous: {
+        displayName: "Morphine (SC)",
+        maxSingleDoseMg: 10,
+        maxDailyDoseMg: 30,
+        mmeFactor: 3.0,
+        source: "CDC 2022 opioid guideline (SC)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, SC; 1 mg SC = 3 PO MME)",
+      },
+    },
+  },
+  // Hydromorphone (Dilaudid). PO baseline plus parenteral overrides per
+  // CDC MME table: 4 PO MME / mg, 20 IV-IM-SC MME / mg. PO 4 mg / 22.5
+  // mg/day matches the 90-MME chronic-pain ceiling; IV / SC 2 mg single,
+  // 4.5 mg/day matches the same 90-MME equivalent (4.5 × 20 = 90 MME).
+  hydromorphone: {
+    displayName: "Hydromorphone (PO)",
+    maxSingleDoseMg: 4,
+    maxDailyDoseMg: 22.5,
+    mmeFactor: 4.0,
+    source: "CDC 2022 opioid guideline",
+    citation:
+      "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 22.5 mg × 4 MME = 90 MME)",
+    byRoute: {
+      IV: {
+        displayName: "Hydromorphone (IV)",
+        maxSingleDoseMg: 2,
+        maxDailyDoseMg: 4.5,
+        mmeFactor: 20.0,
+        source: "CDC 2022 opioid guideline (IV)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, IV; 1 mg IV = 20 PO MME)",
+      },
+      IM: {
+        displayName: "Hydromorphone (IM)",
+        maxSingleDoseMg: 2,
+        maxDailyDoseMg: 4.5,
+        mmeFactor: 20.0,
+        source: "CDC 2022 opioid guideline (IM)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, IM; 1 mg IM = 20 PO MME)",
+      },
+      subcutaneous: {
+        displayName: "Hydromorphone (SC)",
+        maxSingleDoseMg: 2,
+        maxDailyDoseMg: 4.5,
+        mmeFactor: 20.0,
+        source: "CDC 2022 opioid guideline (SC)",
+        citation:
+          "CDC 2022 opioid prescribing guideline (adult MME ceiling, SC; 1 mg SC = 20 PO MME)",
+      },
+    },
   },
   oxycodone: {
     displayName: "Oxycodone (PO)",
@@ -266,6 +374,8 @@ const DRUG_NAME_ALIASES: Record<string, string> = {
   mscontin: "morphine",
   roxanol: "morphine",
   kadian: "morphine",
+  dilaudid: "hydromorphone",
+  exalgo: "hydromorphone",
   oxycontin: "oxycodone",
   percocet: "oxycodone", // oxycodone + APAP; opioid is the tighter guard
   roxicodone: "oxycodone",
@@ -403,15 +513,35 @@ function candidatesFor(drugName: string): string[] {
  * generics, brand aliases (case-insensitive), and names with trailing
  * strength / frequency tokens stripped. Returns undefined when the
  * drug is unknown — callers should fall back to a generic ceiling.
+ *
+ * When `route` is supplied and the resolved entry carries a matching
+ * `byRoute` override, the override is merged on top of the base entry
+ * (#927). PO is the default — omitting `route` or passing `"oral"`
+ * returns the base PO ceiling unchanged. Unknown routes (no override
+ * registered for the drug) also fall back to the base entry, since the
+ * therapeutic ceiling for an unmodelled route is safer-stricter PO than
+ * silently dropping the per-drug guard.
  */
 export function getMedicationDoseLimit(
   drugName: string,
+  route?: MedRoute | string | null,
 ): MedicationDoseLimit | undefined {
+  let base: MedicationDoseLimit | undefined;
   for (const key of candidatesFor(drugName)) {
     const direct = MEDICATION_MAX_DAILY_DOSES[key];
-    if (direct) return direct;
+    if (direct) {
+      base = direct;
+      break;
+    }
     const canonical = DRUG_NAME_ALIASES[key];
-    if (canonical) return MEDICATION_MAX_DAILY_DOSES[canonical];
+    if (canonical) {
+      base = MEDICATION_MAX_DAILY_DOSES[canonical];
+      break;
+    }
   }
-  return undefined;
+  if (!base) return undefined;
+  if (!route || route === "oral") return base;
+  const override = base.byRoute?.[route as MedRoute];
+  if (!override) return base;
+  return { ...base, ...override };
 }

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -317,6 +317,49 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
     citation:
       "CDC 2022 opioid prescribing guideline (adult chronic-pain MME ceiling, PO; 360 mg × 0.15 MME = 54 MME)",
   },
+  // Fentanyl. No PO/IR formulation in clinical use beyond transmucosal
+  // (Actiq, breakthrough cancer pain) which is out of scope here. The
+  // base entry exists for the route-aware lookup to resolve IV/SC
+  // overrides for continuous-infusion orders (#1021); the transdermal
+  // patch presentation is handled separately via {@link isFentanylTransdermal}.
+  fentanyl: {
+    displayName: "Fentanyl",
+    source: "Parenteral only (IV/SC route required)",
+    citation:
+      "Fentanyl has no clinically-relevant PO ceiling; parenteral ceilings are modelled per-route. Transdermal patches use the mcg/hr → MME path (#1020).",
+    byRoute: {
+      IV: {
+        displayName: "Fentanyl (IV)",
+        // 100 mcg = 0.1 mg per typical adult single bolus; many sedation
+        // protocols administer 25–50 mcg per push, so 0.1 mg is the upper
+        // bound that should still pass without verification.
+        maxSingleDoseMg: 0.1,
+        // 5 mg/day = ~5000 mcg/day = ~210 mcg/hr average — high-end ICU
+        // sedation. ICU drips routinely run 50–150 mcg/hr; > 200 mcg/hr
+        // sustained warrants prescriber review.
+        maxDailyDoseMg: 5,
+        source: "CDC 2022 opioid guideline (IV fentanyl)",
+        citation:
+          "CDC 2022 / clinical practice (adult IV fentanyl ICU sedation ceiling, ~210 mcg/hr ~5 mg/day; ICU/anaesthesia acute use)",
+      },
+      IM: {
+        displayName: "Fentanyl (IM)",
+        maxSingleDoseMg: 0.1,
+        maxDailyDoseMg: 5,
+        source: "CDC 2022 opioid guideline (IM fentanyl)",
+        citation:
+          "CDC 2022 / clinical practice (adult IM fentanyl ceiling matched to IV)",
+      },
+      subcutaneous: {
+        displayName: "Fentanyl (SC)",
+        maxSingleDoseMg: 0.1,
+        maxDailyDoseMg: 5,
+        source: "CDC 2022 opioid guideline (SC fentanyl)",
+        citation:
+          "CDC 2022 / clinical practice (adult SC fentanyl ceiling matched to IV)",
+      },
+    },
+  },
   // Tramadol — FDA Ultram label hard-caps at 400 mg/day; the lower CDC MME
   // threshold of 90 MME would be ~450 mg, so the FDA label is the binding
   // constraint here. Citation credits both.
@@ -486,6 +529,73 @@ export function isFentanylTransdermal(
   // Normalise spaces and "per" tokens; lowercase.
   const unit = doseUnit.toLowerCase().replace(/\s+/g, "").replace(/per/g, "/");
   return /^(mcg|ug|μg)\/h(r|our)?$/.test(unit);
+}
+
+/**
+ * Detect whether a dose_unit string is a continuous-infusion flow rate
+ * ("mL/hr" or variants). Used by the daily-dose rule to gate the
+ * mL/hr → mg/day conversion path (#1021).
+ *
+ * Accepts the canonical "mL/hr" and common variants: "ml/hr", "mL/h",
+ * "mL per hour", "mLs/hr". Returns false for non-flow units and for
+ * mcg/hr (which is the transdermal patch path — see
+ * {@link isFentanylTransdermal}).
+ */
+export function isInfusionFlowRate(
+  doseUnit: string | null | undefined,
+): boolean {
+  if (!doseUnit) return false;
+  const unit = doseUnit.toLowerCase().replace(/\s+/g, "").replace(/per/g, "/");
+  return /^mls?\/h(r|our)?$/.test(unit);
+}
+
+/**
+ * Parse an inline concentration "N mg/mL" out of a free-text drug name
+ * as a fallback when no explicit `concentration_mg_per_ml` field is set
+ * on the prescription (#1021). Recognises common ICU/PCA order entry:
+ *   - "Morphine 1 mg/mL IV gtt"
+ *   - "Hydromorphone 0.2 mg/mL PCA"
+ *   - "Fentanyl 0.05mg/ml"
+ *
+ * Returns the mg/mL number when matched; undefined when no
+ * concentration is encoded inline. Matches mg/mL only — alternate unit
+ * encodings (mcg/mL) are not parsed here because the daily-dose
+ * conversion is mg-based; callers wanting mcg should pre-convert.
+ */
+export function parseConcentrationMgPerMl(
+  drugName: string,
+): number | undefined {
+  const match = drugName
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .match(/(\d+(?:\.\d+)?)\s*mg\s*\/\s*ml/i);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return value;
+}
+
+/**
+ * Convert a continuous-infusion flow rate (mL/hr) to a daily mg total
+ * given a drug concentration in mg/mL (#1021). Formula:
+ *   mg/day = mL/hr × concentration × 24
+ *
+ * Returns undefined when any input is missing or non-positive. Callers
+ * compare the result to the route-aware
+ * {@link MedicationDoseLimit.maxDailyDoseMg} for the prescription's
+ * route — IV/SC infusion ceilings are stricter than PO and are looked
+ * up via the byRoute override map (#927).
+ */
+export function infusionMlHrToMgPerDay(
+  mlPerHour: number | null | undefined,
+  concentrationMgPerMl: number | null | undefined,
+): number | undefined {
+  if (mlPerHour == null || concentrationMgPerMl == null) return undefined;
+  if (!Number.isFinite(mlPerHour) || !Number.isFinite(concentrationMgPerMl)) {
+    return undefined;
+  }
+  if (mlPerHour <= 0 || concentrationMgPerMl <= 0) return undefined;
+  return mlPerHour * concentrationMgPerMl * 24;
 }
 
 /**

--- a/packages/shared-types/src/clinical-data.schemas.ts
+++ b/packages/shared-types/src/clinical-data.schemas.ts
@@ -67,6 +67,13 @@ export const createMedicationSchema = z.object({
    * either a unit error or an unbounded order.
    */
   max_doses_per_day: z.number().int().positive().max(24).optional(),
+  /**
+   * Drug concentration in mg/mL for continuous-infusion orders (#1021).
+   * Required only when dose_unit is "mL/hr"; otherwise optional.
+   * Positive number; capped at 1000 mg/mL as a sanity ceiling (no
+   * clinically plausible IV/SC drug exceeds this).
+   */
+  concentration_mg_per_ml: z.number().positive().max(1000).optional(),
 });
 
 export const updateMedicationSchema = createMedicationSchema.partial().omit({ patient_id: true }).extend({

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -59,6 +59,15 @@ export interface Medication extends MutableRecord {
    */
   chronic?: boolean;
   /**
+   * Drug concentration in mg/mL — required for continuous-infusion
+   * orders presented as a flow rate (mL/hr). Consumed by the daily-dose
+   * rule to convert mL/hr → mg/day via:
+   *   mg/day = (mL/hr) × concentration_mg_per_ml × 24
+   * Free-text name parsing remains the fallback when this field is
+   * absent. See issue #1021.
+   */
+  concentration_mg_per_ml?: number;
+  /**
    * Optional PRN / hard-cap dose count per 24 h. Populated when a
    * prescription carries an explicit cap (e.g. "morphine 10 mg q4h PRN,
    * max 4 doses/day"). Consumed by the ai-oversight daily-dose rule via

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -97,6 +97,14 @@ export interface PatientMedication {
    * classify the input — rule falls back to runtime parsing.
    */
   frequency_structured?: string | null;
+  /**
+   * Drug concentration in mg/mL for continuous-infusion orders (#1021).
+   * Consumed by the daily-dose rule's mL/hr conversion path:
+   *   mg/day = (mL/hr) × concentration_mg_per_ml × 24
+   * Null when the prescription is non-infusion or when concentration is
+   * encoded inline in the drug name string instead.
+   */
+  concentration_mg_per_ml?: number | null;
   rxnorm_code: string | null;
   /**
    * ISO 8601 prescription start date. Populated from `medications.started_at`

--- a/services/ai-oversight/src/rules/medication-daily-dose.test.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.test.ts
@@ -21,6 +21,7 @@ function makeMed(
     frequency: overrides.frequency ?? "q2h",
     max_doses_per_day: overrides.max_doses_per_day ?? null,
     rxnorm_code: overrides.rxnorm_code ?? null,
+    concentration_mg_per_ml: overrides.concentration_mg_per_ml ?? null,
   };
 }
 
@@ -867,6 +868,163 @@ describe("checkMedicationDailyDose (#235)", () => {
       );
       expect(
         flags.find((f) => f.rule_id === "MED-DAILY-OVER-FENTANYL-TRANSDERMAL"),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("continuous infusion mL/hr (#1021)", () => {
+    it("morphine IV gtt 2 mg/hr (48 mg/day, 1.6× the 30 mg IV cap) → critical", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine 1 mg/mL IV gtt",
+            dose_amount: 2,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            concentration_mg_per_ml: 1,
+          }),
+        ),
+      );
+      const flag = flags.find((f) =>
+        f.rule_id.includes("MED-DAILY-OVER-MORPHINE-INFUSION"),
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.severity).toBe("critical");
+      expect(flag!.summary).toMatch(/48/);
+      expect(flag!.summary).toMatch(/30/);
+    });
+
+    it("hydromorphone PCA 0.5 mL/hr × 0.2 mg/mL (2.4 mg/day, < 4.5 mg IV cap) → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Hydromorphone 0.2 mg/mL PCA",
+            dose_amount: 0.5,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            concentration_mg_per_ml: 0.2,
+          }),
+        ),
+      );
+      expect(
+        flags.find((f) => f.rule_id.includes("INFUSION")),
+      ).toBeUndefined();
+    });
+
+    it("hydromorphone PCA 2 mL/hr × 0.2 mg/mL (9.6 mg/day, 2.1× 4.5 mg IV cap) → critical", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Hydromorphone 0.2 mg/mL PCA",
+            dose_amount: 2,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            concentration_mg_per_ml: 0.2,
+          }),
+        ),
+      );
+      const flag = flags.find((f) =>
+        f.rule_id.includes("MED-DAILY-OVER-HYDROMORPHONE-INFUSION"),
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.severity).toBe("critical");
+    });
+
+    it("fentanyl IV 10 mL/hr × 0.05 mg/mL (12 mg/day, 2.4× 5 mg IV cap) → critical", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Fentanyl 50 mcg/mL bag",
+            dose_amount: 10,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            concentration_mg_per_ml: 0.05,
+          }),
+        ),
+      );
+      const flag = flags.find((f) =>
+        f.rule_id.includes("MED-DAILY-OVER-FENTANYL-INFUSION"),
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.severity).toBe("critical");
+    });
+
+    it("fentanyl IV under-cap: 2 mL/hr × 0.05 mg/mL (2.4 mg/day, under 5 mg) → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Fentanyl 50 mcg/mL bag",
+            dose_amount: 2,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            concentration_mg_per_ml: 0.05,
+          }),
+        ),
+      );
+      expect(
+        flags.find((f) => f.rule_id.includes("INFUSION")),
+      ).toBeUndefined();
+    });
+
+    it("morphine IV gtt with inline concentration in name (no field) — parses 1 mg/mL", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine 1 mg/mL IV gtt",
+            dose_amount: 2,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            // concentration_mg_per_ml omitted — must parse from name
+          }),
+        ),
+      );
+      const flag = flags.find((f) =>
+        f.rule_id.includes("MED-DAILY-OVER-MORPHINE-INFUSION"),
+      );
+      expect(flag).toBeDefined();
+    });
+
+    it("fail-open: no concentration field and no inline mg/mL in name → no flag", () => {
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine IV gtt",
+            dose_amount: 2,
+            dose_unit: "mL/hr",
+            route: "IV",
+            frequency: "continuous",
+            // no concentration in field or name
+          }),
+        ),
+      );
+      expect(
+        flags.find((f) => f.rule_id.includes("INFUSION")),
+      ).toBeUndefined();
+    });
+
+    it("non-mL/hr unit on infusion-named drug does not trigger infusion path", () => {
+      // 10 mg q1h is still a discrete-dose order — should hit the regular
+      // mg path, not the mL/hr path. Sanity check that the unit gate works.
+      const flags = checkMedicationDailyDose(
+        makeCtx(
+          makeMed({
+            name: "Morphine 1 mg/mL IV gtt",
+            dose_amount: 10,
+            dose_unit: "mg",
+            route: "IV",
+            frequency: "q1h",
+            concentration_mg_per_ml: 1,
+          }),
+        ),
+      );
+      expect(
+        flags.find((f) => f.rule_id.includes("INFUSION")),
       ).toBeUndefined();
     });
   });

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -36,6 +36,9 @@ import {
   getComboApapMg,
   isFentanylTransdermal,
   FENTANYL_TRANSDERMAL_MME_PER_MCG_HR,
+  isInfusionFlowRate,
+  parseConcentrationMgPerMl,
+  infusionMlHrToMgPerDay,
 } from "@carebridge/medical-logic";
 import type { PatientContext, PatientMedication } from "./cross-specialty.js";
 import { createLogger } from "@carebridge/logger";
@@ -241,9 +244,22 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
     return flags;
   }
 
+  // Continuous IV/SC infusion (#1021). Flow-rate orders (mL/hr) don't
+  // have a per-dose × frequency expression — the daily total is the
+  // flow rate × concentration × 24 h. Compare to the route-aware
+  // {@link MedicationDoseLimit.maxDailyDoseMg} for the prescription's
+  // route. Concentration source priority: explicit `concentration_mg_per_ml`
+  // field, then inline parse of the drug name ("Morphine 1 mg/mL IV gtt").
+  // Fails open when concentration cannot be resolved — better to silence
+  // than to flag the wrong number.
+  if (isInfusionFlowRate(med.dose_unit)) {
+    const infusionFlag = checkContinuousInfusion(med);
+    if (infusionFlag) flags.push(infusionFlag);
+    return flags;
+  }
+
   // Per-drug ceilings are expressed in mg. Skip non-mg prescriptions
-  // (other mcg presentations, mL infusions) — a future issue (#1021) will
-  // add IV infusion unit conversion.
+  // (other mcg presentations not covered above).
   const unit = (med.dose_unit ?? "").toLowerCase();
   if (unit !== "mg") return flags;
 
@@ -528,5 +544,68 @@ function checkFentanylTransdermal(med: PatientMedication): RuleFlag | null {
       `with PO dose-titration room.`,
     notify_specialties: ["pharmacy", "pain_management"],
     rule_id: "MED-DAILY-OVER-FENTANYL-TRANSDERMAL",
+  };
+}
+
+/**
+ * Continuous IV/SC infusion daily-dose check (#1021).
+ *
+ * Flow-rate orders (mL/hr) bypass the per-dose × frequency math used
+ * for discrete dosing. Daily total = mL/hr × concentration × 24.
+ *
+ * Concentration source priority:
+ *  1. Explicit `concentration_mg_per_ml` field on the prescription.
+ *  2. Inline parse of the drug name (e.g. "Morphine 1 mg/mL IV gtt").
+ *
+ * Fails open when:
+ *  - The drug has no MEDICATION_MAX_DAILY_DOSES entry at the route.
+ *  - Concentration cannot be resolved (no field, no inline parse).
+ *  - The computed mg/day is at or below the route-aware ceiling.
+ *
+ * Returns null on fail-open; a critical/warning flag otherwise.
+ */
+function checkContinuousInfusion(med: PatientMedication): RuleFlag | null {
+  if (med.dose_amount == null || med.dose_amount <= 0) return null;
+
+  const limit = getMedicationDoseLimit(med.name, med.route);
+  if (!limit?.maxDailyDoseMg) return null;
+
+  const concentration =
+    med.concentration_mg_per_ml ?? parseConcentrationMgPerMl(med.name);
+  if (concentration == null) return null;
+
+  const mgPerDay = infusionMlHrToMgPerDay(med.dose_amount, concentration);
+  if (mgPerDay == null) return null;
+  if (mgPerDay <= limit.maxDailyDoseMg) return null;
+
+  const ratio = mgPerDay / limit.maxDailyDoseMg;
+  const isOpioid = limit.mmeFactor !== undefined;
+  const severity = severityForDailyOver(ratio, isOpioid);
+  const slug = slugForRuleId(limit.displayName);
+
+  return {
+    severity,
+    category: "medication-safety" as FlagCategory,
+    summary:
+      `"${med.name}" ${med.dose_amount} mL/hr (${concentration} mg/mL) implies ` +
+      `~${mgPerDay.toFixed(1)} mg/day — exceeds the ${limit.maxDailyDoseMg} mg/day ` +
+      `${limit.displayName} ceiling`,
+    rationale:
+      `Continuous-infusion daily total: ${med.dose_amount} mL/hr × ${concentration} mg/mL × 24 h = ` +
+      `${mgPerDay.toFixed(1)} mg/day, which is ${ratio.toFixed(1)}× the ${limit.displayName} ` +
+      `daily ceiling of ${limit.maxDailyDoseMg} mg (${limit.citation ?? limit.source}). ` +
+      (isOpioid
+        ? `Parenteral opioid infusions at this level carry significant respiratory-depression risk, ` +
+          `especially in opioid-naive or recently-extubated patients.`
+        : `Sustained infusion at this rate exceeds the safe daily window.`),
+    suggested_action:
+      `Verify the infusion rate and concentration. Common safe steps: ` +
+      `confirm the bag concentration on the pump label, lower the flow rate to bring ` +
+      `the daily total under ${limit.maxDailyDoseMg} mg, or switch to a more dilute bag ` +
+      `concentration. Cross-check with the pharmacy if the rate is patient-specific.`,
+    notify_specialties: isOpioid
+      ? ["pharmacy", "pain_management"]
+      : ["pharmacy"],
+    rule_id: `MED-DAILY-OVER-${slug.toUpperCase()}-INFUSION`,
   };
 }

--- a/services/ai-oversight/src/rules/medication-daily-dose.ts
+++ b/services/ai-oversight/src/rules/medication-daily-dose.ts
@@ -247,7 +247,7 @@ export function checkMedicationDailyDose(context: PatientContext): RuleFlag[] {
   const unit = (med.dose_unit ?? "").toLowerCase();
   if (unit !== "mg") return flags;
 
-  const limit = getMedicationDoseLimit(med.name);
+  const limit = getMedicationDoseLimit(med.name, med.route);
   if (!limit) return flags;
 
   // Prefer the structured column populated at write time (#931). Falls

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -923,6 +923,11 @@ export async function buildPatientContextForRules(
       // Structured frequency from medications.frequency_structured (#931).
       // When present, rules skip the runtime re-parse of `frequency`.
       frequency_structured: m.frequency_structured ?? null,
+      // Drug concentration in mg/mL for continuous-infusion orders (#1021).
+      // Daily-dose rule reads this to convert mL/hr → mg/day; null when the
+      // prescription is non-infusion or the writer encoded concentration
+      // inline in the name string instead.
+      concentration_mg_per_ml: m.concentration_mg_per_ml ?? null,
     })),
     new_symptoms: newSymptoms,
     care_team_specialties: [], // Not needed for current rules, but available for future

--- a/services/clinical-data/src/repositories/medication-repo.ts
+++ b/services/clinical-data/src/repositories/medication-repo.ts
@@ -158,6 +158,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     ordering_provider_id: input.ordering_provider_id ?? null,
     encounter_id: input.encounter_id ?? null,
     chronic: input.chronic ?? null,
+    concentration_mg_per_ml: input.concentration_mg_per_ml ?? null,
     created_at: now,
     updated_at: now,
   };
@@ -193,6 +194,7 @@ export async function createMedication(input: CreateMedicationInput): Promise<Me
     ordering_provider_id: input.ordering_provider_id,
     encounter_id: input.encounter_id,
     chronic: input.chronic,
+    concentration_mg_per_ml: input.concentration_mg_per_ml,
     created_at: now,
     updated_at: now,
   };
@@ -241,6 +243,8 @@ export async function updateMedication(
   if (fields.ordering_provider_id !== undefined) updates.ordering_provider_id = fields.ordering_provider_id;
   if (fields.encounter_id !== undefined) updates.encounter_id = fields.encounter_id;
   if (fields.chronic !== undefined) updates.chronic = fields.chronic;
+  if (fields.concentration_mg_per_ml !== undefined)
+    updates.concentration_mg_per_ml = fields.concentration_mg_per_ml;
 
   // Optimistic locking: when expectedUpdatedAt is provided, only update if the
   // row hasn't been modified since the caller last read it.
@@ -295,6 +299,7 @@ export async function updateMedication(
     encounter_id: updated.encounter_id ?? undefined,
     source_system: updated.source_system ?? undefined,
     chronic: updated.chronic ?? undefined,
+    concentration_mg_per_ml: updated.concentration_mg_per_ml ?? undefined,
     created_at: updated.created_at,
     updated_at: updated.updated_at,
   };
@@ -340,6 +345,7 @@ export async function getMedicationsByPatient(
     encounter_id: row.encounter_id ?? undefined,
     source_system: row.source_system ?? undefined,
     chronic: row.chronic ?? undefined,
+    concentration_mg_per_ml: row.concentration_mg_per_ml ?? undefined,
     created_at: row.created_at,
     updated_at: row.updated_at,
   }));


### PR DESCRIPTION
## Summary

Continuous-infusion orders (mL/hr) bypassed the daily-dose rule because it expects mg with a per-dose × frequency calc. This PR adds the conversion path: `mg/day = mL/hr × concentration_mg_per_ml × 24`, compared against the route-aware IV/SC ceiling shipped in #927.

## Schema

`0047_medications_concentration.sql` — adds nullable `medications.concentration_mg_per_ml` (real). Inline parse of `N mg/mL` from the drug name remains the fallback.

| idx | tag |
|---|---|
| 51 | `0047_medications_concentration` |

## medical-logic

- `isInfusionFlowRate(unit)` — detects `mL/hr` variants
- `parseConcentrationMgPerMl(name)` — inline parse fallback
- `infusionMlHrToMgPerDay(mLPerHr, conc)` — pure conversion helper
- New `fentanyl` entry with IV/IM/SC byRoute overrides. ICU-sedation daily ceiling 5 mg/day (~210 mcg/hr). Transdermal fentanyl path (#1020) unchanged.

## ai-oversight

- `checkContinuousInfusion(med)` — new rule branch for mL/hr orders. Concentration priority: explicit field → name parse → fail-open.
- Daily-dose rule routes mL/hr to the new check before the mg-only early return.
- `review-service.ts` exposes `concentration_mg_per_ml` in `active_medications_detail`.

## Test plan

- [ ] CI green
- [ ] `pnpm typecheck && pnpm turbo lint` pass — verified
- [ ] medical-logic: 452 tests pass
- [ ] ai-oversight: 938 tests pass (7 new infusion cases in medication-daily-dose.test.ts)

7 new infusion tests:
- Morphine IV gtt 2 mL/hr × 1 mg/mL → 48 mg/day → critical (>30 mg cap)
- Hydromorphone PCA under-cap → no flag
- Hydromorphone PCA 2 mL/hr × 0.2 mg/mL → 9.6 mg/day → critical
- Fentanyl IV 10 mL/hr × 0.05 mg/mL → 12 mg/day → critical (>5 mg)
- Fentanyl IV under-cap → no flag
- Inline mg/mL parsed from drug name → flags correctly
- Fail-open: no concentration anywhere → no flag

## Stacking

Depends on #1073 (route-aware ceilings). This branch is based off `feat/927-route-aware-dose-ceilings`.

Closes #1021