### PR TITLE
feat(ai): surface combo-product disambiguation warning at validation

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -450,6 +450,75 @@ describe("validateMedicationDose — route-aware (#927)", () => {
   });
 });
 
+// ─── validateMedicationDose — combo-product disambiguation (#929) ──
+
+describe("validateMedicationDose — combo-product disambiguation (#929)", () => {
+  it("Percocet 5 mg passes opioid ceiling but warns it's a combo", () => {
+    const result = validateMedicationDose(5, "mg", "Percocet");
+    expect(result.valid).toBe(true);
+    expect(
+      result.warnings.some((w) =>
+        w.match(/combination product.*oxycodone.*acetaminophen/),
+      ),
+    ).toBe(true);
+  });
+
+  it("Vicodin 5 mg warns it's hydrocodone + APAP combo", () => {
+    const result = validateMedicationDose(5, "mg", "Vicodin");
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes("hydrocodone") &&
+          w.includes("acetaminophen") &&
+          w.includes("300 mg"),
+      ),
+    ).toBe(true);
+  });
+
+  it("Norco warns and resolves to hydrocodone opioid ceiling", () => {
+    const result = validateMedicationDose(15, "mg", "Norco");
+    // Hydrocodone single ceiling is 10 mg — 15 mg errors on the opioid
+    // component AND warns it's a combo product.
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/Hydrocodone/);
+    expect(
+      result.warnings.some((w) => w.includes("combination product")),
+    ).toBe(true);
+  });
+
+  it("Tylenol 3 warns it's codeine + APAP", () => {
+    const result = validateMedicationDose(30, "mg", "Tylenol 3");
+    expect(
+      result.warnings.some(
+        (w) => w.includes("codeine") && w.includes("acetaminophen"),
+      ),
+    ).toBe(true);
+  });
+
+  it("Single-ingredient acetaminophen does NOT trigger combo warning", () => {
+    const result = validateMedicationDose(500, "mg", "acetaminophen");
+    expect(
+      result.warnings.some((w) => w.includes("combination product")),
+    ).toBe(false);
+  });
+
+  it("Single-ingredient oxycodone (OxyContin) does NOT trigger combo warning", () => {
+    const result = validateMedicationDose(10, "mg", "OxyContin");
+    expect(
+      result.warnings.some((w) => w.includes("combination product")),
+    ).toBe(false);
+  });
+
+  it("Combo warning is suppressed when unit is not mg", () => {
+    // mcg-unit on a combo brand: numerically nonsensical, but the
+    // combo warning would mislead the prescriber. Skip when unit isn't mg.
+    const result = validateMedicationDose(500, "mcg", "Percocet");
+    expect(
+      result.warnings.some((w) => w.includes("combination product")),
+    ).toBe(false);
+  });
+});
+
 // ─── MEDICATION_MAX_DAILY_DOSES data sanity ─────────────────────
 
 describe("MEDICATION_MAX_DAILY_DOSES reference data (#238)", () => {

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -5,7 +5,10 @@
 
 import type { VitalType } from "@carebridge/shared-types";
 import { COMMON_LAB_TESTS } from "@carebridge/shared-types";
-import { getMedicationDoseLimit } from "./medication-max-doses.js";
+import {
+  getMedicationDoseLimit,
+  lookupComboBrand,
+} from "./medication-max-doses.js";
 
 export interface VitalRange {
   min: number;
@@ -303,6 +306,24 @@ export function validateMedicationDose(
 
   const unit = doseUnit?.toLowerCase();
   const limit = drugName ? getMedicationDoseLimit(drugName, route) : undefined;
+  const combo = drugName ? lookupComboBrand(drugName) : undefined;
+
+  // Combo-product disambiguation warning (#929). When the caller supplies
+  // a combo brand name (Percocet, Vicodin, Norco, Tylenol 3, etc.), the
+  // alias collapses to the opioid component because the opioid ceiling
+  // is the tighter guard. Anyone writing `dose_amount` intending the
+  // acetaminophen component would silently get a numerically-wrong
+  // validation. Emit a warning so the prescriber sees the disambiguation
+  // explicitly. The opioid-component ceiling still applies via `limit`.
+  if (combo && unit === "mg") {
+    warnings.push(
+      `"${drugName}" is a combination product (${combo.opioidComponent} ` +
+        `+ ${combo.nonOpioidComponent} ${combo.nonOpioidMgPerDose} mg per ` +
+        `dose unit). The encoded ${doseAmount} mg is being validated against ` +
+        `the ${combo.opioidComponent} ceiling — for per-component accuracy, ` +
+        `prescribe with the ingredient name instead of the brand.`,
+    );
+  }
 
   // Per-drug ceilings (issue #238). Only apply when the unit is mg — the
   // table's limits are expressed in milligrams; cross-unit comparisons

--- a/packages/medical-logic/src/medication-max-doses.ts
+++ b/packages/medical-logic/src/medication-max-doses.ts
@@ -335,6 +335,11 @@ export const MEDICATION_MAX_DAILY_DOSES: Record<string, MedicationDoseLimit> = {
  * Brand → generic aliases. Combo products (e.g. Percocet = oxycodone +
  * acetaminophen) are aliased to the opioid component — the more tightly
  * bounded drug — so the lookup returns the stricter of the two caps.
+ *
+ * Combo brands ALSO appear in {@link COMBO_OPIOID_APAP_MG} (for the APAP
+ * roll-up rule in #926) and are surfaced as
+ * {@link ComboBrandInfo} via {@link lookupComboBrand} so the prescriber
+ * sees an explicit disambiguation warning at validation time (#929).
  */
 const DRUG_NAME_ALIASES: Record<string, string> = {
   // Acetaminophen
@@ -439,6 +444,64 @@ export function getComboApapMg(drugName: string): number | undefined {
   for (const key of candidatesFor(drugName)) {
     const mg = COMBO_OPIOID_APAP_MG[key];
     if (mg !== undefined) return mg;
+  }
+  return undefined;
+}
+
+/**
+ * Combo-product identification (#929).
+ *
+ * Combo brands (Percocet, Vicodin, Norco, Tylenol 3/4, Ultracet, etc.)
+ * pack two ingredients into a single dose unit — typically an opioid +
+ * acetaminophen. The medications schema stores ONE `dose_amount` /
+ * `dose_unit`, so the encoded number can refer to either component.
+ *
+ * The historical behaviour aliased combo brands to their opioid
+ * component because the opioid ceiling is the tighter guard. That is
+ * still the right thing to do for safety, but callers who write
+ * `dose_amount` intending the APAP component (a real prescriber error
+ * surface) would get a silently-mis-validated record.
+ *
+ * `lookupComboBrand` exposes the combo information so:
+ *  - {@link validateMedicationDose} can warn that the brand is a combo
+ *    product and the encoded mg is being interpreted as the opioid
+ *    component;
+ *  - APAP cumulative checks (#926) can read the non-opioid mg without
+ *    having to grep the alias table.
+ */
+export interface ComboBrandInfo {
+  /** Canonicalised brand key (lowercase) that matched the input. */
+  brand: string;
+  /** Opioid canonical name — same as DRUG_NAME_ALIASES[brand]. */
+  opioidComponent: string;
+  /**
+   * Non-opioid co-ingredient. All currently-encoded combo brands pair
+   * an opioid with acetaminophen; future combos (e.g. ibuprofen +
+   * hydrocodone) would land here.
+   */
+  nonOpioidComponent: string;
+  /** Non-opioid mg per dose unit (from COMBO_OPIOID_APAP_MG). */
+  nonOpioidMgPerDose: number;
+}
+
+/**
+ * Look up combo-product information for a free-text drug name. Returns
+ * undefined when the input is a single-ingredient drug or unknown.
+ * Combo brands are identified by intersecting DRUG_NAME_ALIASES and
+ * COMBO_OPIOID_APAP_MG — anything present in both is a combo.
+ */
+export function lookupComboBrand(drugName: string): ComboBrandInfo | undefined {
+  for (const key of candidatesFor(drugName)) {
+    const opioid = DRUG_NAME_ALIASES[key];
+    const nonOpioidMg = COMBO_OPIOID_APAP_MG[key];
+    if (opioid && nonOpioidMg !== undefined) {
+      return {
+        brand: key,
+        opioidComponent: opioid,
+        nonOpioidComponent: "acetaminophen",
+        nonOpioidMgPerDose: nonOpioidMg,
+      };
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Combo opioid brands (Percocet, Vicodin, Norco, Tylenol 3/4, Ultracet) historically aliased silently to their opioid component because the opioid ceiling is the tighter guard. Anyone writing \`dose_amount\` intending the APAP component would get a numerically-wrong validation with no signal. This PR tightens the contract without restructuring the schema:

- New \`ComboBrandInfo\` interface + \`lookupComboBrand(name)\` helper. Recognises a brand as a combo by intersecting \`DRUG_NAME_ALIASES\` with \`COMBO_OPIOID_APAP_MG\` — anything in both is a combo.
- \`validateMedicationDose\` emits a warning when the input is a combo brand and \`dose_unit\` is mg, naming both components and the APAP per-dose-unit content.
- The opioid-component ceiling check still applies (preserves #238 single-dose safety).

## Example warning

```
"Percocet" is a combination product (oxycodone + acetaminophen 325 mg per
dose unit). The encoded 5 mg is being validated against the oxycodone
ceiling — for per-component accuracy, prescribe with the ingredient name
instead of the brand.
```

## Out of scope

- **Multi-ingredient schema refactor** (\`components[]: {ingredient, dose_mg}\` on \`patient_medications\`) — large surface (DB, types, repo, rules). The disambiguation warning ships the prescriber feedback now with no schema churn; the structural change is a deferred follow-up if/when richer rule logic needs to read per-component dosing directly.
- **APAP cumulative cap check** is already shipped in #926 / #1070 (\`checkCumulativeApap\` rolls APAP across combo opioids + plain Tylenol vs the 4 g/day cap).

## Test plan

- [ ] CI green
- [ ] \`pnpm typecheck && pnpm turbo lint\` pass — verified
- [ ] medical-logic: 454 tests pass (7 new combo-disambiguation cases)

7 new tests:
- Percocet 5 mg passes ceiling but warns (oxycodone + APAP)
- Vicodin 5 mg warns (hydrocodone + APAP 300 mg)
- Norco 15 mg errors on opioid AND warns combo
- Tylenol 3 warns (codeine + APAP)
- Plain acetaminophen: no combo warning
- OxyContin (single-ingredient): no combo warning
- mcg-unit on combo brand: combo warning suppressed (cross-unit mismatch)

Closes #929