### PR TITLE
feat(fhir): inbound Condition → diagnoses-row mapper

### DIFF
--- a/services/fhir-gateway/src/__tests__/condition-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/condition-mapper.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Inbound FHIR Condition → internal `diagnoses` row mapper tests (#337).
+ *
+ * Mirrors the medication-mapper test layout (see medication-mapper.test.ts)
+ * so the two inbound mappers stay structurally consistent.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapFhirConditionToRow,
+  extractConditionName,
+  extractIcd10Code,
+  extractSnomedCode,
+  mapClinicalStatusToInternal,
+  extractOnsetDateTime,
+  extractRecordedDate,
+  resolveRecorderReference,
+  extractSeverity,
+  isEnteredInError,
+  type InboundCondition,
+} from "../condition-mapper.js";
+
+const PATIENT_ID = "patient-337";
+
+describe("mapFhirConditionToRow (#337)", () => {
+  it("maps a fully-populated Condition to a row with every field set", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      id: "cond-1",
+      clinicalStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/condition-clinical",
+            code: "active",
+          },
+        ],
+      },
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            code: "confirmed",
+          },
+        ],
+      },
+      code: {
+        coding: [
+          {
+            system: "http://hl7.org/fhir/sid/icd-10-cm",
+            code: "C50.911",
+            display: "Malignant neoplasm of breast",
+          },
+          {
+            system: "http://snomed.info/sct",
+            code: "254837009",
+            display: "Malignant neoplasm of breast",
+          },
+        ],
+        text: "Malignant neoplasm of breast",
+      },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      onsetDateTime: "2026-04-10T00:00:00.000Z",
+      recordedDate: "2026-04-11T00:00:00.000Z",
+      recorder: { reference: "Practitioner/prov-99" },
+      severity: {
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "24484000",
+            display: "Severe",
+          },
+        ],
+      },
+    };
+    const row = mapFhirConditionToRow(cond, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      patient_id: PATIENT_ID,
+      description: "Malignant neoplasm of breast",
+      icd10_code: "C50.911",
+      snomed_code: "254837009",
+      status: "active",
+      onset_date: "2026-04-10T00:00:00.000Z",
+      resolved_date: null,
+      diagnosed_by: "prov-99",
+      severity: "severe",
+      recorded_at: "2026-04-11T00:00:00.000Z",
+    });
+  });
+
+  it("returns null when code is missing entirely", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+    };
+    expect(mapFhirConditionToRow(cond, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when code has no text and no coding entries", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: { coding: [] },
+    };
+    expect(mapFhirConditionToRow(cond, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when verificationStatus is entered-in-error (chart correction)", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            code: "entered-in-error",
+          },
+        ],
+      },
+      code: { text: "Hypertension" },
+    };
+    expect(mapFhirConditionToRow(cond, PATIENT_ID)).toBeNull();
+  });
+
+  it("preserves SNOMED-only coding (no ICD-10) and sets icd10_code to null", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: {
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "73211009",
+            display: "Diabetes mellitus",
+          },
+        ],
+      },
+    };
+    const row = mapFhirConditionToRow(cond, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.icd10_code).toBeNull();
+    expect(row!.snomed_code).toBe("73211009");
+    expect(row!.description).toBe("Diabetes mellitus");
+  });
+
+  it("fails open on missing onsetDateTime — row materialises with null onset_date", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: { text: "Hypertension" },
+    };
+    const row = mapFhirConditionToRow(cond, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.onset_date).toBeNull();
+    expect(row!.description).toBe("Hypertension");
+  });
+
+  it("falls back to onsetPeriod.start when onsetDateTime is absent", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: { text: "Asthma" },
+      onsetPeriod: { start: "2024-01-01T00:00:00.000Z" },
+    };
+    expect(mapFhirConditionToRow(cond, PATIENT_ID)?.onset_date).toBe(
+      "2024-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("uses code.text when present, falling back to coding.display", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: {
+        coding: [{ display: "From-coding" }],
+        text: "From-text",
+      },
+    };
+    expect(mapFhirConditionToRow(cond, PATIENT_ID)?.description).toBe(
+      "From-text",
+    );
+  });
+
+  it("treats ICD-10 'icd-10' system shorthand the same as the canonical URL", () => {
+    const cond: InboundCondition = {
+      resourceType: "Condition",
+      code: {
+        coding: [
+          {
+            system: "icd-10",
+            code: "I10",
+            display: "Essential hypertension",
+          },
+        ],
+      },
+    };
+    const row = mapFhirConditionToRow(cond, PATIENT_ID);
+    expect(row?.icd10_code).toBe("I10");
+  });
+});
+
+describe("clinicalStatus mapping (#337)", () => {
+  it("maps active / chronic via the FHIR coded value set", () => {
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "active" }],
+      }),
+    ).toBe("active");
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "recurrence" }],
+      }),
+    ).toBe("active");
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "remission" }],
+      }),
+    ).toBe("chronic");
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "relapse" }],
+      }),
+    ).toBe("active");
+  });
+
+  it("maps resolved / inactive to resolved", () => {
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "resolved" }],
+      }),
+    ).toBe("resolved");
+    expect(
+      mapClinicalStatusToInternal({
+        coding: [{ code: "inactive" }],
+      }),
+    ).toBe("resolved");
+  });
+
+  it("defaults to active when missing or unknown", () => {
+    expect(mapClinicalStatusToInternal(undefined)).toBe("active");
+    expect(mapClinicalStatusToInternal({ coding: [] })).toBe("active");
+    expect(
+      mapClinicalStatusToInternal({ coding: [{ code: "not-a-status" }] }),
+    ).toBe("active");
+  });
+});
+
+describe("isEnteredInError (#337)", () => {
+  it("returns true only for entered-in-error verificationStatus", () => {
+    expect(
+      isEnteredInError({
+        coding: [{ code: "entered-in-error" }],
+      }),
+    ).toBe(true);
+    expect(
+      isEnteredInError({
+        coding: [{ code: "confirmed" }],
+      }),
+    ).toBe(false);
+    expect(isEnteredInError(undefined)).toBe(false);
+  });
+});
+
+describe("code extraction helpers (#337)", () => {
+  it("extractConditionName prefers text, then coding.display", () => {
+    expect(extractConditionName({ text: "Hypertension" })).toBe(
+      "Hypertension",
+    );
+    expect(
+      extractConditionName({
+        coding: [{ display: "Diabetes" }],
+      }),
+    ).toBe("Diabetes");
+    expect(extractConditionName({ coding: [] })).toBeNull();
+    expect(extractConditionName(undefined)).toBeNull();
+  });
+
+  it("extractIcd10Code returns first ICD-10 coded entry", () => {
+    expect(
+      extractIcd10Code({
+        coding: [
+          { system: "http://snomed.info/sct", code: "73211009" },
+          { system: "http://hl7.org/fhir/sid/icd-10-cm", code: "E11.9" },
+        ],
+      }),
+    ).toBe("E11.9");
+  });
+
+  it("extractIcd10Code rejects the export-side 'unknown' placeholder", () => {
+    expect(
+      extractIcd10Code({
+        coding: [
+          {
+            system: "http://hl7.org/fhir/sid/icd-10-cm",
+            code: "unknown",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("extractSnomedCode returns first SNOMED-coded entry", () => {
+    expect(
+      extractSnomedCode({
+        coding: [
+          { system: "http://hl7.org/fhir/sid/icd-10-cm", code: "I10" },
+          { system: "http://snomed.info/sct", code: "59621000" },
+        ],
+      }),
+    ).toBe("59621000");
+  });
+});
+
+describe("date and reference helpers (#337)", () => {
+  it("extractOnsetDateTime prefers onsetDateTime over onsetPeriod.start", () => {
+    expect(
+      extractOnsetDateTime({
+        resourceType: "Condition",
+        onsetDateTime: "2026-01-01T00:00:00.000Z",
+        onsetPeriod: { start: "2020-01-01T00:00:00.000Z" },
+      }),
+    ).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("extractOnsetDateTime falls back to onsetPeriod.start", () => {
+    expect(
+      extractOnsetDateTime({
+        resourceType: "Condition",
+        onsetPeriod: { start: "2020-01-01T00:00:00.000Z" },
+      }),
+    ).toBe("2020-01-01T00:00:00.000Z");
+  });
+
+  it("extractOnsetDateTime returns null when neither is set", () => {
+    expect(
+      extractOnsetDateTime({ resourceType: "Condition" }),
+    ).toBeNull();
+  });
+
+  it("extractRecordedDate returns recordedDate as-is", () => {
+    expect(
+      extractRecordedDate({
+        resourceType: "Condition",
+        recordedDate: "2026-04-11T00:00:00.000Z",
+      }),
+    ).toBe("2026-04-11T00:00:00.000Z");
+    expect(
+      extractRecordedDate({ resourceType: "Condition" }),
+    ).toBeNull();
+  });
+
+  it("resolveRecorderReference parses Practitioner/{id}", () => {
+    expect(
+      resolveRecorderReference({ reference: "Practitioner/abc-123" }),
+    ).toBe("abc-123");
+    expect(
+      resolveRecorderReference({ reference: "Patient/abc-123" }),
+    ).toBeNull();
+    expect(resolveRecorderReference(undefined)).toBeNull();
+  });
+});
+
+describe("extractSeverity (#337)", () => {
+  it("maps SNOMED severity codes to the internal mild/moderate/severe enum", () => {
+    expect(
+      extractSeverity({
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "255604002",
+            display: "Mild",
+          },
+        ],
+      }),
+    ).toBe("mild");
+    expect(
+      extractSeverity({
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "6736007",
+            display: "Moderate",
+          },
+        ],
+      }),
+    ).toBe("moderate");
+    expect(
+      extractSeverity({
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "24484000",
+            display: "Severe",
+          },
+        ],
+      }),
+    ).toBe("severe");
+  });
+
+  it("falls back to display / text token matching", () => {
+    expect(extractSeverity({ text: "mild" })).toBe("mild");
+    expect(extractSeverity({ text: "MODERATE" })).toBe("moderate");
+    expect(
+      extractSeverity({ coding: [{ display: "Severe" }] }),
+    ).toBe("severe");
+  });
+
+  it("returns null on unknown or missing severity", () => {
+    expect(extractSeverity({ text: "fluctuating" })).toBeNull();
+    expect(extractSeverity({ coding: [] })).toBeNull();
+    expect(extractSeverity(undefined)).toBeNull();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/import-bundle-condition.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-condition.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Integration test (#337): import a bundle with a FHIR Condition
+ * carrying ICD-10 + SNOMED codings, clinicalStatus=active and a
+ * recorder reference, then verify the persisted `diagnoses` row
+ * carries the structured fields the patient-records router would
+ * have produced for an internal write.
+ *
+ * Mirrors import-bundle-materialize.test.ts (#1066) so the
+ * Condition mapper integration sits next to the MedicationRequest
+ * mapper integration with the same shape.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const diagnosesTable = { __name: "diagnoses" };
+const medicationsTable = { __name: "medications" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: { __name: "patients" },
+  vitals: { __name: "vitals" },
+  labPanels: { __name: "lab_panels" },
+  labResults: { __name: "lab_results" },
+  medications: medicationsTable,
+  diagnoses: diagnosesTable,
+  allergies: { __name: "allergies" },
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle materialize flag — Condition (#337)", () => {
+  it("does NOT write a diagnoses row by default (materialize defaults to false)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Condition",
+            id: "cond-1",
+            code: { text: "Hypertension" },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_diagnoses).toBe(0);
+    expect(insertCalls.some((c) => c.table === diagnosesTable)).toBe(false);
+  });
+
+  it("materialises a Condition with ICD-10 + SNOMED into a diagnoses row", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Condition",
+            id: "cond-breast-ca",
+            clinicalStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                  code: "active",
+                },
+              ],
+            },
+            verificationStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                  code: "confirmed",
+                },
+              ],
+            },
+            code: {
+              coding: [
+                {
+                  system: "http://hl7.org/fhir/sid/icd-10-cm",
+                  code: "C50.911",
+                  display: "Malignant neoplasm of breast",
+                },
+                {
+                  system: "http://snomed.info/sct",
+                  code: "254837009",
+                  display: "Malignant neoplasm of breast",
+                },
+              ],
+              text: "Malignant neoplasm of breast",
+            },
+            subject: { reference: "Patient/p-1" },
+            onsetDateTime: "2026-04-10T00:00:00.000Z",
+            recordedDate: "2026-04-11T00:00:00.000Z",
+            recorder: { reference: "Practitioner/dr-smith" },
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.materialized_diagnoses).toBe(1);
+
+    const dxRows = insertCalls
+      .filter((c) => c.table === diagnosesTable)
+      .map((c) => c.row);
+    expect(dxRows).toHaveLength(1);
+    const row = dxRows[0]!;
+
+    expect(row.patient_id).toBe("p-1");
+    expect(row.description).toBe("Malignant neoplasm of breast");
+    expect(row.icd10_code).toBe("C50.911");
+    expect(row.snomed_code).toBe("254837009");
+    expect(row.status).toBe("active");
+    expect(row.onset_date).toBe("2026-04-10T00:00:00.000Z");
+    expect(row.resolved_date).toBeNull();
+    expect(row.diagnosed_by).toBe("dr-smith");
+    // External recordedDate is honoured in the persisted created_at.
+    expect(row.created_at).toBe("2026-04-11T00:00:00.000Z");
+  });
+
+  it("skips Condition resources flagged entered-in-error but still imports them as raw FHIR", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Condition",
+            id: "cond-erroneous",
+            verificationStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+                  code: "entered-in-error",
+                },
+              ],
+            },
+            code: { text: "Hypertension" },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_diagnoses).toBe(0);
+    // Raw FHIR resource still persisted + audited even though the
+    // diagnoses materialisation skipped.
+    expect(
+      insertCalls.filter((c) => c.table === fhirResourcesTable),
+    ).toHaveLength(1);
+    expect(
+      insertCalls.filter((c) => c.table === auditLogTable),
+    ).toHaveLength(1);
+    expect(
+      insertCalls.filter((c) => c.table === diagnosesTable),
+    ).toHaveLength(0);
+  });
+
+  it("materialises a SNOMED-only Condition with null icd10_code", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Condition",
+            clinicalStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                  code: "inactive",
+                },
+              ],
+            },
+            code: {
+              coding: [
+                {
+                  system: "http://snomed.info/sct",
+                  code: "73211009",
+                  display: "Diabetes mellitus",
+                },
+              ],
+            },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.materialized_diagnoses).toBe(1);
+    const row = insertCalls.find((c) => c.table === diagnosesTable)?.row;
+    expect(row).toBeDefined();
+    expect(row!.icd10_code).toBeNull();
+    expect(row!.snomed_code).toBe("73211009");
+    expect(row!.status).toBe("resolved");
+    expect(row!.onset_date).toBeNull();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -120,9 +120,14 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         source_system: "unit-test",
         user_id: adminUser.id,
       });
-      // `materialize` defaults to false (#1066), so the result also
-      // reports `materialized_medications: 0` alongside `imported`.
-      expect(result).toEqual({ imported: 1, materialized_medications: 0 });
+      // `materialize` defaults to false (#1066, #337), so the result
+      // also reports `materialized_medications: 0` and
+      // `materialized_diagnoses: 0` alongside `imported`.
+      expect(result).toEqual({
+        imported: 1,
+        materialized_medications: 0,
+        materialized_diagnoses: 0,
+      });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);
     });

--- a/services/fhir-gateway/src/condition-mapper.ts
+++ b/services/fhir-gateway/src/condition-mapper.ts
@@ -1,0 +1,371 @@
+/**
+ * Inbound FHIR R4 Condition → CareBridge `diagnoses`-row mapper (#337).
+ *
+ * The export side (services/fhir-gateway/src/generators/condition.ts)
+ * already serialises the internal `diagnoses` table to FHIR. This
+ * mapper is the inverse: it takes a FHIR Condition resource ingested
+ * through `importBundle` and produces the row shape the patient-records
+ * writer would have produced for the same diagnosis, so external EHRs
+ * pushing condition lists (ICD-10/SNOMED codes, clinical status,
+ * onset/recorded dates) drive the ai-oversight cross-specialty rules
+ * the same way internal tRPC writes do today.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitisation (the
+ * caller has already sanitised by the time importBundle reaches us).
+ * Returns `null` when the resource is unmappable (missing code,
+ * verificationStatus=entered-in-error) so the caller can skip-and-warn
+ * rather than crash the bundle.
+ */
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// We don't import the export-side FHIR types here because inbound
+// payloads from external EHRs are looser than what our exporter emits
+// (optional fields may be missing, unknown extra fields present). The
+// bundle schema (services/fhir-gateway/src/schemas/bundle.ts) uses
+// .passthrough() so the raw resource arrives as a generic
+// Record<string, unknown> — we narrow defensively at each access.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundReference {
+  reference?: string;
+}
+
+interface InboundPeriod {
+  start?: string;
+  end?: string;
+}
+
+export interface InboundCondition {
+  resourceType: "Condition";
+  id?: string;
+  clinicalStatus?: InboundCodeableConcept;
+  verificationStatus?: InboundCodeableConcept;
+  code?: InboundCodeableConcept;
+  subject?: InboundReference;
+  onsetDateTime?: string;
+  onsetPeriod?: InboundPeriod;
+  abatementDateTime?: string;
+  recordedDate?: string;
+  recorder?: InboundReference;
+  severity?: InboundCodeableConcept;
+}
+
+// ── Mapped output shape ─────────────────────────────────────────
+
+/**
+ * Internal `diagnoses` status enum (active | resolved | chronic).
+ * Mirrors `diagnosisStatusSchema` in packages/shared-types.
+ */
+export type DiagnosisStatus = "active" | "resolved" | "chronic";
+
+/**
+ * Internal severity enum returned by the mapper. The `diagnoses` table
+ * itself does not currently store severity, but external EHRs
+ * frequently send it on the Condition resource. The field is extracted
+ * so callers (and a future schema migration) can surface it without a
+ * second pass over the bundle.
+ */
+export type DiagnosisSeverity = "mild" | "moderate" | "severe";
+
+/**
+ * Shape of the row to insert into `diagnoses`. Mirrors the columns of
+ * the `diagnoses` table plus the auxiliary `severity` field described
+ * above. `patient_id` is supplied by the caller (importBundle has
+ * already reconciled FHIR `subject.reference` to the internal id).
+ *
+ * `recorded_at` is exposed separately from a wall-clock `created_at`
+ * so callers preserving external provenance can honour the EHR's
+ * recordedDate when persisting; for the canonical `diagnoses.created_at`
+ * insert, the caller picks `row.recorded_at ?? now`.
+ */
+export interface MappedDiagnosisRow {
+  patient_id: string;
+  description: string;
+  icd10_code: string | null;
+  snomed_code: string | null;
+  status: DiagnosisStatus;
+  onset_date: string | null;
+  resolved_date: string | null;
+  diagnosed_by: string | null;
+  severity: DiagnosisSeverity | null;
+  recorded_at: string | null;
+}
+
+// ── System constants ────────────────────────────────────────────
+
+const ICD10_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm";
+const ICD10_SYSTEM_SHORT = "icd-10";
+const SNOMED_SYSTEM = "http://snomed.info/sct";
+
+// ── Name / code extraction ──────────────────────────────────────
+
+/**
+ * Pick the condition name from `code`. Order of preference:
+ * `.text` (most human-readable; what our exporter emits), then the
+ * first non-empty `coding[].display`. Returns null when nothing
+ * usable is present — the caller skips the entry.
+ */
+export function extractConditionName(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+/**
+ * Extract the ICD-10 code from `code.coding[]`. Accepts both the
+ * canonical HL7 URL and the shorthand "icd-10" some EHRs emit. The
+ * export side writes the placeholder string "unknown" when no real
+ * ICD-10 code is known — that round-trip artefact is rejected.
+ * Returns the first matching entry, or null.
+ */
+export function extractIcd10Code(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (
+      (c.system === ICD10_SYSTEM || c.system === ICD10_SYSTEM_SHORT) &&
+      c.code &&
+      c.code !== "unknown"
+    ) {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the SNOMED CT code from `code.coding[]`. Returns the first
+ * entry coded against the SNOMED system, or null.
+ */
+export function extractSnomedCode(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (c.system === SNOMED_SYSTEM && c.code && c.code !== "unknown") {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+// ── Status mapping ──────────────────────────────────────────────
+
+/**
+ * FHIR Condition.clinicalStatus → internal DiagnosisStatus.
+ *
+ * The HL7 value set is wider than CareBridge's `active | resolved |
+ * chronic` enum. Mapping rules:
+ *   - active / recurrence / relapse → active (currently symptomatic)
+ *   - remission                     → chronic (controlled but ongoing)
+ *   - resolved / inactive           → resolved (no longer active)
+ *
+ * Anything missing or unrecognised defaults to active — diagnoses
+ * imported into a real chart should be visible by default; treating
+ * an unknown status as "absent" would silently drop the row from the
+ * cross-specialty rule context.
+ */
+export function mapClinicalStatusToInternal(
+  cc: InboundCodeableConcept | undefined,
+): DiagnosisStatus {
+  if (!cc) return "active";
+  for (const c of cc.coding ?? []) {
+    const code = c.code?.toLowerCase();
+    if (!code) continue;
+    switch (code) {
+      case "active":
+      case "recurrence":
+      case "relapse":
+        return "active";
+      case "remission":
+        return "chronic";
+      case "resolved":
+      case "inactive":
+        return "resolved";
+    }
+  }
+  return "active";
+}
+
+/**
+ * `verificationStatus` of `entered-in-error` means the chart entry
+ * was a mistake and should not be materialised — the caller skips the
+ * row entirely. Mirrors `mapRequestStatusToInternal` returning null
+ * for the same FHIR value on the medication side.
+ */
+export function isEnteredInError(
+  cc: InboundCodeableConcept | undefined,
+): boolean {
+  if (!cc) return false;
+  for (const c of cc.coding ?? []) {
+    if (c.code?.toLowerCase() === "entered-in-error") return true;
+  }
+  return false;
+}
+
+// ── Date helpers ────────────────────────────────────────────────
+
+/**
+ * Extract the onset timestamp. `onsetDateTime` is the FHIR canonical
+ * single-point value; `onsetPeriod.start` is the next-best signal
+ * when the EHR only knows a date range. Returns null when neither is
+ * set — diagnoses without onset still materialise (fail-open) so the
+ * rule engine sees the presence of the condition.
+ */
+export function extractOnsetDateTime(
+  cond: InboundCondition,
+): string | null {
+  if (cond.onsetDateTime) return cond.onsetDateTime;
+  if (cond.onsetPeriod?.start) return cond.onsetPeriod.start;
+  return null;
+}
+
+/**
+ * Extract the recordedDate (when the diagnosis was first recorded in
+ * the external EHR). Returns null when absent — the caller falls back
+ * to the import wall-clock for `created_at`.
+ */
+export function extractRecordedDate(
+  cond: InboundCondition,
+): string | null {
+  return cond.recordedDate ?? null;
+}
+
+/**
+ * Extract abatement (resolved) timestamp. Currently the FHIR Condition
+ * resource only carries `abatementDateTime` in the export path; we
+ * accept that shape on import. Returns null when not resolved.
+ */
+function extractResolvedDate(cond: InboundCondition): string | null {
+  return cond.abatementDateTime ?? null;
+}
+
+// ── Reference resolution ────────────────────────────────────────
+
+/**
+ * Resolve a Practitioner reference (e.g. `Practitioner/abc-123`) to
+ * the internal user_id used by `diagnoses.diagnosed_by`.
+ *
+ * Minimum-viable implementation (#337): parse `Practitioner/{id}`
+ * and return the raw id. Looking up the internal user row to verify
+ * the practitioner exists is deferred to a follow-up — the import
+ * path records the raw reference and a downstream reconciliation
+ * job can normalise IDs later.
+ *
+ * Returns null when the reference is missing, malformed, or doesn't
+ * match the Practitioner resource type.
+ */
+export function resolveRecorderReference(
+  ref: InboundReference | undefined,
+): string | null {
+  if (!ref?.reference) return null;
+  const match = /^Practitioner\/(.+)$/.exec(ref.reference);
+  if (!match) return null;
+  return match[1] ?? null;
+}
+
+// ── Severity extraction ─────────────────────────────────────────
+
+/**
+ * Map SNOMED severity codes to the internal severity enum. The codes
+ * mirror what the FHIR R4 condition-severity value set publishes so
+ * round-tripping a Condition through the export side (when it
+ * eventually emits severity) lands the same value back.
+ */
+const SEVERITY_BY_SNOMED: Record<string, DiagnosisSeverity> = {
+  "255604002": "mild",
+  "6736007": "moderate",
+  "24484000": "severe",
+};
+
+function mapSeverityText(text: string): DiagnosisSeverity | null {
+  const t = text.trim().toLowerCase();
+  if (!t) return null;
+  if (t === "mild") return "mild";
+  if (t === "moderate") return "moderate";
+  if (t === "severe") return "severe";
+  return null;
+}
+
+/**
+ * Extract a severity enum from a FHIR `severity` CodeableConcept.
+ * Prefers SNOMED coding (single source of truth) and falls back to
+ * coding.display, then top-level .text. Returns null when the value
+ * is missing or unrecognised — the caller treats absent severity as
+ * "unspecified" rather than smuggling a bad enum into the DB.
+ */
+export function extractSeverity(
+  cc: InboundCodeableConcept | undefined,
+): DiagnosisSeverity | null {
+  if (!cc) return null;
+  // 1. SNOMED codes first — single source of truth.
+  for (const c of cc.coding ?? []) {
+    if (!c.code) continue;
+    if (c.system === SNOMED_SYSTEM || c.system === undefined) {
+      const mapped = SEVERITY_BY_SNOMED[c.code];
+      if (mapped) return mapped;
+    }
+  }
+  // 2. Display text on any coding entry.
+  for (const c of cc.coding ?? []) {
+    if (c.display) {
+      const m = mapSeverityText(c.display);
+      if (m) return m;
+    }
+  }
+  // 3. Free-text `text`.
+  if (cc.text) return mapSeverityText(cc.text);
+  return null;
+}
+
+// ── Main mapper ─────────────────────────────────────────────────
+
+/**
+ * Map a FHIR R4 Condition to a CareBridge `diagnoses` row.
+ *
+ * @param resource Sanitised FHIR Condition (importBundle has already
+ *                 run sanitizeFreeText over every string).
+ * @param patientId Internal patient id the bundle is being imported
+ *                 against. The mapper trusts the caller to have
+ *                 resolved subject.reference to this id.
+ * @returns A row shape ready to insert, or null when the resource is
+ *          unmappable (no code, verificationStatus=entered-in-error).
+ */
+export function mapFhirConditionToRow(
+  resource: InboundCondition,
+  patientId: string,
+): MappedDiagnosisRow | null {
+  if (isEnteredInError(resource.verificationStatus)) return null;
+
+  const description = extractConditionName(resource.code);
+  if (!description) return null;
+
+  return {
+    patient_id: patientId,
+    description,
+    icd10_code: extractIcd10Code(resource.code),
+    snomed_code: extractSnomedCode(resource.code),
+    status: mapClinicalStatusToInternal(resource.clinicalStatus),
+    onset_date: extractOnsetDateTime(resource),
+    resolved_date: extractResolvedDate(resource),
+    diagnosed_by: resolveRecorderReference(resource.recorder),
+    severity: extractSeverity(resource.severity),
+    recorded_at: extractRecordedDate(resource),
+  };
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -40,6 +40,10 @@ import {
   type InboundMedicationRequest,
   type InboundMedicationStatement,
 } from "./medication-mapper.js";
+import {
+  mapFhirConditionToRow,
+  type InboundCondition,
+} from "./condition-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -209,6 +213,7 @@ export const fhirGatewayRouter = t.router({
       const entries = input.bundle.entry ?? [];
       let imported = 0;
       let materializedMedications = 0;
+      let materializedDiagnoses = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -258,48 +263,78 @@ export const fhirGatewayRouter = t.router({
             timestamp: now,
           });
 
-          // Optional materialisation pass (#1066). The mapper is pure
-          // and returns null for unmappable entries (missing name,
-          // entered-in-error status) — those skip silently.
+          // Optional materialisation pass (#1066, #337). The mappers
+          // are pure and return null for unmappable entries (missing
+          // name/code, entered-in-error status) — those skip silently.
           if (input.materialize && input.patient_id) {
-            let row: ReturnType<typeof mapMedicationRequestToRow> = null;
+            let medRow: ReturnType<typeof mapMedicationRequestToRow> = null;
             if (resourceType === "MedicationRequest") {
-              row = mapMedicationRequestToRow(
+              medRow = mapMedicationRequestToRow(
                 sanitized as unknown as InboundMedicationRequest,
                 input.patient_id,
               );
             } else if (resourceType === "MedicationStatement") {
-              row = mapMedicationStatementToRow(
+              medRow = mapMedicationStatementToRow(
                 sanitized as unknown as InboundMedicationStatement,
                 input.patient_id,
               );
             }
-            if (row) {
+            if (medRow) {
               await tx.insert(medications).values({
                 id: crypto.randomUUID(),
-                patient_id: row.patient_id,
-                name: row.name,
-                dose_amount: row.dose_amount,
-                dose_unit: row.dose_unit,
-                route: row.route,
-                frequency: row.frequency,
-                max_doses_per_day: row.max_doses_per_day,
-                status: row.status,
-                started_at: row.started_at,
-                prescribed_by: row.prescribed_by,
-                rxnorm_code: row.rxnorm_code,
-                source_system: row.source_system ?? input.source_system,
+                patient_id: medRow.patient_id,
+                name: medRow.name,
+                dose_amount: medRow.dose_amount,
+                dose_unit: medRow.dose_unit,
+                route: medRow.route,
+                frequency: medRow.frequency,
+                max_doses_per_day: medRow.max_doses_per_day,
+                status: medRow.status,
+                started_at: medRow.started_at,
+                prescribed_by: medRow.prescribed_by,
+                rxnorm_code: medRow.rxnorm_code,
+                source_system: medRow.source_system ?? input.source_system,
                 created_at: now,
                 updated_at: now,
               });
               materializedMedications++;
+            }
+
+            // Condition → diagnoses materialisation (#337).
+            if (resourceType === "Condition") {
+              const dxRow = mapFhirConditionToRow(
+                sanitized as unknown as InboundCondition,
+                input.patient_id,
+              );
+              if (dxRow) {
+                await tx.insert(diagnoses).values({
+                  id: crypto.randomUUID(),
+                  patient_id: dxRow.patient_id,
+                  icd10_code: dxRow.icd10_code,
+                  snomed_code: dxRow.snomed_code,
+                  description: dxRow.description,
+                  status: dxRow.status,
+                  onset_date: dxRow.onset_date,
+                  resolved_date: dxRow.resolved_date,
+                  diagnosed_by: dxRow.diagnosed_by,
+                  // Honour the external EHR's recordedDate when present
+                  // so the imported row keeps provenance; otherwise
+                  // use the import wall-clock.
+                  created_at: dxRow.recorded_at ?? now,
+                });
+                materializedDiagnoses++;
+              }
             }
           }
         });
 
         imported++;
       }
-      return { imported, materialized_medications: materializedMedications };
+      return {
+        imported,
+        materialized_medications: materializedMedications,
+        materialized_diagnoses: materializedDiagnoses,
+      };
     }),
 
   getByPatient: protectedProcedure


### PR DESCRIPTION
## Summary
- Adds `services/fhir-gateway/src/condition-mapper.ts`, the inverse of the existing outbound Condition generator (`generators/condition.ts`). Same template as the MedicationRequest/MedicationStatement mapper shipped in #1075 — pure, side-effect-free helper that converts a sanitised inbound FHIR R4 Condition into the row the patient-records writer would have produced for an internal diagnosis create.
- Wires the mapper into `importBundle` dispatch. When `materialize: true` and a `patient_id` is supplied, Condition entries materialise into the `diagnoses` table inside the same transaction as the raw `fhir_resources` + `audit_log` insert. The return payload gains a `materialized_diagnoses` counter alongside the existing `materialized_medications`.
- Honours external `recordedDate` provenance by using it (when present) as the persisted `diagnoses.created_at` instead of the import wall-clock.

## Mapper behaviour
- `description` ← `code.text` then `code.coding[].display`
- `icd10_code` ← first coding matching `http://hl7.org/fhir/sid/icd-10-cm` or the `icd-10` shorthand; the export side's `unknown` placeholder is rejected so round-tripped bundles don't store it
- `snomed_code` ← first SNOMED-coded entry
- `status` ← `clinicalStatus` (`active`/`recurrence`/`relapse` → `active`, `remission` → `chronic`, `resolved`/`inactive` → `resolved`, default `active` fail-open)
- `onset_date` ← `onsetDateTime` then `onsetPeriod.start`
- `resolved_date` ← `abatementDateTime`
- `diagnosed_by` ← parsed from `recorder` `Practitioner/{id}` reference
- `severity` ← SNOMED `255604002`/`6736007`/`24484000` plus text fallback
- Returns `null` on `verificationStatus: entered-in-error` or missing `code` so the bundle skip-and-warns rather than crashing.

## Test plan
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 277 pass (29 net new: 25 unit + 4 integration)
- [x] `pnpm typecheck` — 36/36 tasks pass
- [x] `pnpm turbo lint` — 20/20 tasks pass (no new warnings)
- [x] Round-trip with `generators/condition.ts`: ICD-10 + SNOMED dual coding extracted; `unknown` placeholder code dropped

Refs #337