### PR TITLE
feat(fhir): inbound Observation → vitals/lab_results mapper

### DIFF
--- a/services/fhir-gateway/src/__tests__/import-bundle-observation-materialize.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-observation-materialize.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Integration test (#337): import a mixed bundle of vital-sign and
+ * laboratory Observations with `materialize: true`, then verify both
+ * tables receive the structured rows the rule engine consumes.
+ *
+ * The materialisation contract this test pins down:
+ *   - Observation(category=vital-signs) → exactly one `vitals` row
+ *     (panel-style BP collapses to a single row with value_secondary).
+ *   - Observation(category=laboratory)  → one `lab_panels` row +
+ *     one `lab_results` row (per-Observation panel — batching peer
+ *     results under one panel is a follow-up).
+ *   - Observation with no category falls through, raw FHIR persisted
+ *     but neither vitals nor lab_results written.
+ *   - status=entered-in-error is skipped by both mappers.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const medicationsTable = { __name: "medications" };
+const vitalsTable = { __name: "vitals" };
+const labPanelsTable = { __name: "lab_panels" };
+const labResultsTable = { __name: "lab_results" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: { __name: "patients" },
+  vitals: vitalsTable,
+  labPanels: labPanelsTable,
+  labResults: labResultsTable,
+  medications: medicationsTable,
+  diagnoses: { __name: "diagnoses" },
+  allergies: { __name: "allergies" },
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle Observation materialisation (#337)", () => {
+  it("materialises a mixed bundle: vitals + lab_results land in their own tables", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        // Heart rate
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-hr",
+            status: "final",
+            category: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/observation-category",
+                    code: "vital-signs",
+                  },
+                ],
+              },
+            ],
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8867-4",
+                  display: "Heart rate",
+                },
+              ],
+            },
+            subject: { reference: "Patient/p-1" },
+            effectiveDateTime: "2026-05-22T10:00:00.000Z",
+            valueQuantity: { value: 72, unit: "bpm", code: "/min" },
+          },
+        },
+        // Blood pressure with component[]
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-bp",
+            status: "final",
+            category: [{ coding: [{ code: "vital-signs" }] }],
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "85354-9",
+                  display: "Blood pressure panel",
+                },
+              ],
+            },
+            subject: { reference: "Patient/p-1" },
+            effectiveDateTime: "2026-05-22T10:01:00.000Z",
+            component: [
+              {
+                code: {
+                  coding: [
+                    { system: "http://loinc.org", code: "8480-6" },
+                  ],
+                },
+                valueQuantity: { value: 122, unit: "mmHg" },
+              },
+              {
+                code: {
+                  coding: [
+                    { system: "http://loinc.org", code: "8462-4" },
+                  ],
+                },
+                valueQuantity: { value: 78, unit: "mmHg" },
+              },
+            ],
+          },
+        },
+        // Glucose lab result with reference range and H flag
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-glu",
+            status: "final",
+            category: [{ coding: [{ code: "laboratory" }] }],
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "2339-0",
+                  display: "Glucose",
+                },
+              ],
+              text: "Glucose",
+            },
+            subject: { reference: "Patient/p-1" },
+            effectiveDateTime: "2026-05-22T10:05:00.000Z",
+            valueQuantity: { value: 145, unit: "mg/dL" },
+            referenceRange: [
+              {
+                low: { value: 70, unit: "mg/dL" },
+                high: { value: 100, unit: "mg/dL" },
+              },
+            ],
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: "H",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+
+    expect(result.imported).toBe(3);
+    expect(result.materialized_vitals).toBe(2);
+    expect(result.materialized_lab_results).toBe(1);
+
+    // ── vitals assertions ───────────────────────────────────
+    const vitalRows = insertCalls
+      .filter((c) => c.table === vitalsTable)
+      .map((c) => c.row);
+    expect(vitalRows).toHaveLength(2);
+
+    const hr = vitalRows.find((r) => r.type === "heart_rate")!;
+    expect(hr).toBeDefined();
+    expect(hr.patient_id).toBe("p-1");
+    expect(hr.loinc_code).toBe("8867-4");
+    expect(hr.value_primary).toBe(72);
+    expect(hr.value_secondary).toBeNull();
+    expect(hr.unit).toBe("bpm");
+    expect(hr.recorded_at).toBe("2026-05-22T10:00:00.000Z");
+    expect(hr.source_system).toBe("fhir_import");
+
+    const bp = vitalRows.find((r) => r.type === "blood_pressure")!;
+    expect(bp).toBeDefined();
+    expect(bp.value_primary).toBe(122);
+    expect(bp.value_secondary).toBe(78);
+    expect(bp.unit).toBe("mmHg");
+
+    // ── lab_results + lab_panels assertions ─────────────────
+    const labRows = insertCalls
+      .filter((c) => c.table === labResultsTable)
+      .map((c) => c.row);
+    const panelRows = insertCalls
+      .filter((c) => c.table === labPanelsTable)
+      .map((c) => c.row);
+    expect(labRows).toHaveLength(1);
+    expect(panelRows).toHaveLength(1);
+
+    const labRow = labRows[0]!;
+    const panelRow = panelRows[0]!;
+    expect(labRow.test_name).toBe("Glucose");
+    expect(labRow.test_code).toBe("2339-0");
+    expect(labRow.value).toBe(145);
+    expect(labRow.unit).toBe("mg/dL");
+    expect(labRow.reference_low).toBe(70);
+    expect(labRow.reference_high).toBe(100);
+    expect(labRow.flag).toBe("H");
+    // panel_id must thread through from the sidecar lab_panels row
+    expect(labRow.panel_id).toBe(panelRow.id);
+    expect(panelRow.patient_id).toBe("p-1");
+    expect(panelRow.panel_name).toBe("Glucose");
+    expect(panelRow.collected_at).toBe("2026-05-22T10:05:00.000Z");
+
+    // No medications row should have been written.
+    expect(
+      insertCalls.filter((c) => c.table === medicationsTable),
+    ).toHaveLength(0);
+  });
+
+  it("skips Observations without a recognised category (raw FHIR still persisted)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-no-cat",
+            status: "final",
+            // No category[]
+            code: {
+              coding: [{ system: "http://loinc.org", code: "8867-4" }],
+            },
+            effectiveDateTime: "2026-05-22T10:00:00.000Z",
+            valueQuantity: { value: 72, unit: "bpm" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_vitals).toBe(0);
+    expect(result.materialized_lab_results).toBe(0);
+    expect(
+      insertCalls.filter((c) => c.table === fhirResourcesTable),
+    ).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === vitalsTable)).toHaveLength(0);
+    expect(insertCalls.filter((c) => c.table === labResultsTable)).toHaveLength(
+      0,
+    );
+  });
+
+  it("skips entered-in-error Observations from materialisation but still imports raw", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-err",
+            status: "entered-in-error",
+            category: [{ coding: [{ code: "vital-signs" }] }],
+            code: {
+              coding: [{ system: "http://loinc.org", code: "8867-4" }],
+            },
+            effectiveDateTime: "2026-05-22T10:00:00.000Z",
+            valueQuantity: { value: 72, unit: "bpm" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_vitals).toBe(0);
+    expect(insertCalls.filter((c) => c.table === vitalsTable)).toHaveLength(0);
+    expect(
+      insertCalls.filter((c) => c.table === fhirResourcesTable),
+    ).toHaveLength(1);
+  });
+
+  it("does NOT materialise Observations by default (materialize defaults to false)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-hr",
+            status: "final",
+            category: [{ coding: [{ code: "vital-signs" }] }],
+            code: {
+              coding: [{ system: "http://loinc.org", code: "8867-4" }],
+            },
+            effectiveDateTime: "2026-05-22T10:00:00.000Z",
+            valueQuantity: { value: 72, unit: "bpm" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_vitals).toBe(0);
+    expect(result.materialized_lab_results).toBe(0);
+    expect(insertCalls.filter((c) => c.table === vitalsTable)).toHaveLength(0);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/observation-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/observation-mapper.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Inbound FHIR Observation → internal vitals / lab_results row mapper
+ * tests (#337).
+ *
+ * Observation is the trickiest inbound mapper because the same FHIR
+ * resource type routes to two different internal tables based on
+ * Observation.category[].coding[].code:
+ *   - vital-signs  → vitals
+ *   - laboratory   → lab_results
+ *
+ * The mapper exposes:
+ *   - classifyObservationCategory: returns the routing decision (or null
+ *     when the category is missing — caller-decided fallback).
+ *   - mapFhirObservationToVitalRow:      → MappedVitalRow | null
+ *   - mapFhirObservationToLabResultRow:  → MappedLabResultRow | null
+ *
+ * Both row mappers return null on:
+ *   - missing LOINC code / value
+ *   - status: entered-in-error
+ *   - unmappable resource (no effective time, etc.)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  extractEffectiveTime,
+  extractLoincCode,
+  extractValueQuantity,
+  type InboundObservation,
+} from "../observation-mapper.js";
+
+const PATIENT_ID = "patient-337";
+
+// ── classifyObservationCategory ────────────────────────────────
+
+describe("classifyObservationCategory (#337)", () => {
+  it("returns 'vital-signs' when category coding contains the canonical vital-signs code", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [
+        {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/observation-category",
+              code: "vital-signs",
+              display: "Vital Signs",
+            },
+          ],
+        },
+      ],
+      code: { text: "BP" },
+    };
+    expect(classifyObservationCategory(obs)).toBe("vital-signs");
+  });
+
+  it("returns 'laboratory' when category coding contains the laboratory code", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [
+        {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/observation-category",
+              code: "laboratory",
+              display: "Laboratory",
+            },
+          ],
+        },
+      ],
+      code: { text: "Glucose" },
+    };
+    expect(classifyObservationCategory(obs)).toBe("laboratory");
+  });
+
+  it("ignores category coding system when only the code is present (tolerant)", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { text: "HR" },
+    };
+    expect(classifyObservationCategory(obs)).toBe("vital-signs");
+  });
+
+  it("returns null when category is missing (caller decides fallback)", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      code: { text: "Unknown" },
+    };
+    expect(classifyObservationCategory(obs)).toBeNull();
+  });
+
+  it("returns null when category has no recognised coding", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "social-history" }] }],
+      code: { text: "Smoking" },
+    };
+    expect(classifyObservationCategory(obs)).toBeNull();
+  });
+
+  it("picks vital-signs when multiple categories include it", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [
+        { coding: [{ code: "exam" }] },
+        { coding: [{ code: "vital-signs" }] },
+      ],
+      code: { text: "HR" },
+    };
+    expect(classifyObservationCategory(obs)).toBe("vital-signs");
+  });
+});
+
+// ── helpers ────────────────────────────────────────────────────
+
+describe("extractLoincCode (#337)", () => {
+  it("returns the LOINC-coded entry", () => {
+    expect(
+      extractLoincCode({
+        code: {
+          coding: [
+            { system: "other", code: "X" },
+            { system: "http://loinc.org", code: "8867-4", display: "Heart rate" },
+          ],
+        },
+      }),
+    ).toBe("8867-4");
+  });
+
+  it("returns null when no LOINC coding is present", () => {
+    expect(
+      extractLoincCode({ code: { coding: [{ system: "other", code: "X" }] } }),
+    ).toBeNull();
+    expect(extractLoincCode({ code: { text: "free text only" } })).toBeNull();
+  });
+
+  it("returns null when the code field is absent", () => {
+    expect(extractLoincCode({} as unknown as InboundObservation)).toBeNull();
+  });
+});
+
+describe("extractValueQuantity (#337)", () => {
+  it("returns value + unit when both present", () => {
+    expect(
+      extractValueQuantity({
+        valueQuantity: { value: 72, unit: "bpm", code: "/min" },
+      }),
+    ).toEqual({ value: 72, unit: "bpm" });
+  });
+
+  it("falls back to code as unit when unit is absent", () => {
+    expect(
+      extractValueQuantity({ valueQuantity: { value: 100, code: "mg/dL" } }),
+    ).toEqual({ value: 100, unit: "mg/dL" });
+  });
+
+  it("returns null when value is missing", () => {
+    expect(extractValueQuantity({ valueQuantity: { unit: "bpm" } })).toBeNull();
+  });
+
+  it("returns null when valueQuantity is absent", () => {
+    expect(extractValueQuantity({})).toBeNull();
+  });
+});
+
+describe("extractEffectiveTime (#337)", () => {
+  it("returns effectiveDateTime when present", () => {
+    expect(
+      extractEffectiveTime({
+        effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      } as InboundObservation),
+    ).toBe("2026-05-22T10:00:00.000Z");
+  });
+
+  it("falls back to effectivePeriod.start", () => {
+    expect(
+      extractEffectiveTime({
+        effectivePeriod: { start: "2026-05-22T09:00:00.000Z" },
+      } as InboundObservation),
+    ).toBe("2026-05-22T09:00:00.000Z");
+  });
+
+  it("returns null when neither is set", () => {
+    expect(extractEffectiveTime({} as InboundObservation)).toBeNull();
+  });
+});
+
+// ── mapFhirObservationToVitalRow ───────────────────────────────
+
+describe("mapFhirObservationToVitalRow (#337)", () => {
+  it("maps a heart-rate Observation to a vitals row", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-hr",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: {
+        coding: [
+          { system: "http://loinc.org", code: "8867-4", display: "Heart rate" },
+        ],
+        text: "Heart rate",
+      },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 72, unit: "bpm", code: "/min" },
+    };
+    const row = mapFhirObservationToVitalRow(obs, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      patient_id: PATIENT_ID,
+      type: "heart_rate",
+      loinc_code: "8867-4",
+      value_primary: 72,
+      value_secondary: null,
+      unit: "bpm",
+      recorded_at: "2026-05-22T10:00:00.000Z",
+      source_system: "fhir_import",
+    });
+  });
+
+  it("maps an O2 sat Observation", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: {
+        coding: [{ system: "http://loinc.org", code: "59408-5" }],
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 98, unit: "%", code: "%" },
+    };
+    const row = mapFhirObservationToVitalRow(obs, PATIENT_ID);
+    expect(row?.type).toBe("o2_sat");
+    expect(row?.value_primary).toBe(98);
+    expect(row?.unit).toBe("%");
+  });
+
+  it("maps a blood-pressure Observation with component[] (systolic + diastolic)", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: {
+        coding: [
+          { system: "http://loinc.org", code: "85354-9", display: "Blood pressure panel" },
+        ],
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      component: [
+        {
+          code: {
+            coding: [
+              { system: "http://loinc.org", code: "8480-6", display: "Systolic" },
+            ],
+          },
+          valueQuantity: { value: 120, unit: "mmHg", code: "mm[Hg]" },
+        },
+        {
+          code: {
+            coding: [
+              { system: "http://loinc.org", code: "8462-4", display: "Diastolic" },
+            ],
+          },
+          valueQuantity: { value: 80, unit: "mmHg", code: "mm[Hg]" },
+        },
+      ],
+    };
+    const row = mapFhirObservationToVitalRow(obs, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.type).toBe("blood_pressure");
+    expect(row!.value_primary).toBe(120);
+    expect(row!.value_secondary).toBe(80);
+    expect(row!.unit).toBe("mmHg");
+  });
+
+  it("returns null on status: entered-in-error", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "entered-in-error",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { coding: [{ system: "http://loinc.org", code: "8867-4" }] },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 72, unit: "bpm" },
+    };
+    expect(mapFhirObservationToVitalRow(obs, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when LOINC code does not map to a VitalType", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { coding: [{ system: "http://loinc.org", code: "99999-9" }] },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 1, unit: "x" },
+    };
+    expect(mapFhirObservationToVitalRow(obs, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when value is missing", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { coding: [{ system: "http://loinc.org", code: "8867-4" }] },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+    };
+    expect(mapFhirObservationToVitalRow(obs, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when effective time is missing", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { coding: [{ system: "http://loinc.org", code: "8867-4" }] },
+      valueQuantity: { value: 72, unit: "bpm" },
+    };
+    expect(mapFhirObservationToVitalRow(obs, PATIENT_ID)).toBeNull();
+  });
+
+  it("falls back to effectivePeriod.start when effectiveDateTime absent", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "vital-signs" }] }],
+      code: { coding: [{ system: "http://loinc.org", code: "8867-4" }] },
+      effectivePeriod: { start: "2026-05-21T08:00:00.000Z" },
+      valueQuantity: { value: 65, unit: "bpm" },
+    };
+    expect(mapFhirObservationToVitalRow(obs, PATIENT_ID)?.recorded_at).toBe(
+      "2026-05-21T08:00:00.000Z",
+    );
+  });
+});
+
+// ── mapFhirObservationToLabResultRow ───────────────────────────
+
+describe("mapFhirObservationToLabResultRow (#337)", () => {
+  it("maps a glucose Observation to a lab_results row", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-glu",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: {
+        coding: [
+          { system: "http://loinc.org", code: "2339-0", display: "Glucose" },
+        ],
+        text: "Glucose",
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 95, unit: "mg/dL", code: "mg/dL" },
+    };
+    const row = mapFhirObservationToLabResultRow(obs);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      test_name: "Glucose",
+      test_code: "2339-0",
+      value: 95,
+      unit: "mg/dL",
+      reference_low: null,
+      reference_high: null,
+      flag: null,
+      recorded_at: "2026-05-22T10:00:00.000Z",
+    });
+  });
+
+  it("extracts reference range low and high", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: {
+        coding: [
+          { system: "http://loinc.org", code: "6690-2", display: "WBC" },
+        ],
+        text: "WBC",
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 7.5, unit: "K/uL", code: "10*3/uL" },
+      referenceRange: [
+        {
+          low: { value: 4.5, unit: "K/uL" },
+          high: { value: 11.0, unit: "K/uL" },
+        },
+      ],
+    };
+    const row = mapFhirObservationToLabResultRow(obs);
+    expect(row?.reference_low).toBe(4.5);
+    expect(row?.reference_high).toBe(11.0);
+  });
+
+  it("maps interpretation H/L/critical flags", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: {
+        coding: [{ system: "http://loinc.org", code: "2339-0" }],
+        text: "Glucose",
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 250, unit: "mg/dL" },
+      interpretation: [
+        {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: "H",
+            },
+          ],
+        },
+      ],
+    };
+    expect(mapFhirObservationToLabResultRow(obs)?.flag).toBe("H");
+  });
+
+  it("falls back to code.text when no LOINC code is present", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: { text: "Custom assay" },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 1, unit: "x" },
+    };
+    const row = mapFhirObservationToLabResultRow(obs);
+    expect(row?.test_name).toBe("Custom assay");
+    expect(row?.test_code).toBeNull();
+  });
+
+  it("returns null on status: entered-in-error", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "entered-in-error",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: {
+        coding: [{ system: "http://loinc.org", code: "2339-0" }],
+        text: "Glucose",
+      },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 95, unit: "mg/dL" },
+    };
+    expect(mapFhirObservationToLabResultRow(obs)).toBeNull();
+  });
+
+  it("returns null when value is missing", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: { text: "Glucose" },
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+    };
+    expect(mapFhirObservationToLabResultRow(obs)).toBeNull();
+  });
+
+  it("returns null when test name cannot be resolved", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      category: [{ coding: [{ code: "laboratory" }] }],
+      code: {},
+      effectiveDateTime: "2026-05-22T10:00:00.000Z",
+      valueQuantity: { value: 1, unit: "x" },
+    };
+    expect(mapFhirObservationToLabResultRow(obs)).toBeNull();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -121,12 +121,14 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         user_id: adminUser.id,
       });
       // `materialize` defaults to false (#1066, #337), so the result
-      // also reports all materialised counters at 0 alongside `imported`.
+      // reports 0 for every materialised-row count alongside `imported`.
       expect(result).toEqual({
         imported: 1,
         materialized_medications: 0,
         materialized_diagnoses: 0,
         materialized_patients: 0,
+        materialized_vitals: 0,
+        materialized_lab_results: 0,
       });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);

--- a/services/fhir-gateway/src/observation-mapper.ts
+++ b/services/fhir-gateway/src/observation-mapper.ts
@@ -1,0 +1,422 @@
+/**
+ * Inbound FHIR R4 Observation → CareBridge row mapper (issue #337).
+ *
+ * Unlike MedicationRequest/Statement, a single FHIR Observation resource
+ * type fans out to TWO internal tables based on
+ * Observation.category[].coding[].code:
+ *
+ *   - "vital-signs" → `vitals`         (mapFhirObservationToVitalRow)
+ *   - "laboratory"  → `lab_results`    (mapFhirObservationToLabResultRow)
+ *
+ * The caller (importBundle in router.ts) first calls
+ * `classifyObservationCategory` to decide which target table the entry
+ * routes to, then invokes the matching row mapper. Both mappers return
+ * `null` when the resource is unmappable (missing LOINC, missing value,
+ * status: entered-in-error) so the caller can skip-and-continue rather
+ * than crash the bundle.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitisation (the
+ * caller has already sanitised by the time importBundle reaches us).
+ */
+
+import { VITAL_LOINC_CODES, type VitalType, type LabFlag } from "@carebridge/shared-types";
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// The bundle schema (services/fhir-gateway/src/schemas/bundle.ts) uses
+// .passthrough() so resources arrive as generic objects. We narrow
+// defensively at each access; unknown extra fields are ignored.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundQuantity {
+  value?: number;
+  unit?: string;
+  system?: string;
+  code?: string;
+}
+
+interface InboundReference {
+  reference?: string;
+}
+
+interface InboundObservationComponent {
+  code?: InboundCodeableConcept;
+  valueQuantity?: InboundQuantity;
+}
+
+interface InboundReferenceRange {
+  low?: InboundQuantity;
+  high?: InboundQuantity;
+}
+
+export interface InboundObservation {
+  resourceType: "Observation";
+  id?: string;
+  status?: string;
+  category?: InboundCodeableConcept[];
+  code?: InboundCodeableConcept;
+  subject?: InboundReference;
+  effectiveDateTime?: string;
+  effectivePeriod?: { start?: string; end?: string };
+  valueQuantity?: InboundQuantity;
+  component?: InboundObservationComponent[];
+  referenceRange?: InboundReferenceRange[];
+  interpretation?: InboundCodeableConcept[];
+}
+
+// ── Mapped output shapes ───────────────────────────────────────
+
+/**
+ * Shape of the row to insert into `vitals`. Mirrors CreateVitalInput
+ * from clinical-data; the caller supplies `patient_id` from the verified
+ * import context (Observation.subject may reference an external EHR's
+ * patient id, which is NOT the internal patients.id).
+ */
+export interface MappedVitalRow {
+  patient_id: string;
+  type: VitalType;
+  loinc_code: string | null;
+  value_primary: number;
+  value_secondary: number | null;
+  unit: string;
+  recorded_at: string;
+  source_system: string | null;
+}
+
+/**
+ * Shape of the row to insert into `lab_results`. The `panel_id` column
+ * is mandatory at the schema level but is supplied by the caller (the
+ * importBundle path creates a synthetic lab_panels row per Observation,
+ * or batches multiple results under one panel — that orchestration lives
+ * in the router, not here).
+ *
+ * `recorded_at` is carried explicitly so the caller can decide whether
+ * to write it into `lab_panels.collected_at` (canonical) or use it as
+ * `lab_results.created_at` directly.
+ */
+export interface MappedLabResultRow {
+  test_name: string;
+  test_code: string | null;
+  value: number;
+  unit: string;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: LabFlag | null;
+  recorded_at: string;
+}
+
+// ── Category classification ────────────────────────────────────
+
+const OBSERVATION_CATEGORY_SYSTEM =
+  "http://terminology.hl7.org/CodeSystem/observation-category";
+
+export type ObservationCategory = "vital-signs" | "laboratory";
+
+/**
+ * Read Observation.category[].coding[] and return the first recognised
+ * routing code. Tolerant of missing `system` (some EHRs locally-code the
+ * category without the URL); strict on the `code` enum. Returns null
+ * when no category — or no recognised category — is present, leaving
+ * the routing decision (drop / fail-open / default) to the caller.
+ *
+ * If multiple categories are listed (e.g. ["exam", "vital-signs"]), the
+ * first recognised one wins. vital-signs and laboratory are mutually
+ * exclusive in practice so the iteration order doesn't matter.
+ */
+export function classifyObservationCategory(
+  resource: InboundObservation,
+): ObservationCategory | null {
+  const cats = resource.category;
+  if (!cats || cats.length === 0) return null;
+  for (const cat of cats) {
+    for (const c of cat.coding ?? []) {
+      if (!c.code) continue;
+      // Accept either the canonical observation-category system or no
+      // system at all. Reject other systems to avoid collisions with
+      // unrelated terminologies that happen to use the same codes.
+      if (
+        c.system !== undefined &&
+        c.system !== OBSERVATION_CATEGORY_SYSTEM
+      ) {
+        continue;
+      }
+      if (c.code === "vital-signs") return "vital-signs";
+      if (c.code === "laboratory") return "laboratory";
+    }
+  }
+  return null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+const LOINC_SYSTEM = "http://loinc.org";
+const SOURCE_SYSTEM_TAG = "fhir_import";
+
+/**
+ * Pull the first LOINC-coded entry out of Observation.code.coding[].
+ * Returns null when no LOINC entry is present — the caller falls back
+ * to free-text test name (lab) or rejects the row (vitals).
+ */
+export function extractLoincCode(
+  resource: Pick<InboundObservation, "code">,
+): string | null {
+  const code = resource.code;
+  if (!code) return null;
+  for (const c of code.coding ?? []) {
+    if (c.system === LOINC_SYSTEM && c.code) {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract value + unit from valueQuantity. unit prefers `.unit` and
+ * falls back to `.code`; one-of-them missing makes the entry
+ * unmappable (a unit without a value is meaningless and vice versa).
+ */
+export function extractValueQuantity(
+  resource: Pick<InboundObservation, "valueQuantity">,
+): { value: number; unit: string } | null {
+  const q = resource.valueQuantity;
+  if (!q) return null;
+  if (typeof q.value !== "number" || !Number.isFinite(q.value)) return null;
+  const unit = q.unit ?? q.code;
+  if (!unit) return null;
+  return { value: q.value, unit };
+}
+
+/**
+ * Extract the effective time the observation pertains to. Prefers
+ * `effectiveDateTime` (the most common form) and falls back to
+ * `effectivePeriod.start` (used by some EHRs for continuously-monitored
+ * vitals). Returns null when neither is present — vitals without a
+ * timestamp are rejected because the rule engine indexes by time.
+ */
+export function extractEffectiveTime(
+  resource: InboundObservation,
+): string | null {
+  if (resource.effectiveDateTime) return resource.effectiveDateTime;
+  if (resource.effectivePeriod?.start) return resource.effectivePeriod.start;
+  return null;
+}
+
+// ── LOINC → VitalType resolution ───────────────────────────────
+
+/**
+ * Inverse of VITAL_LOINC_CODES. Built once at module load — VitalType
+ * is a closed enum and the LOINC code → type direction has no
+ * ambiguity (each vital type uses a single LOINC code).
+ *
+ * For blood pressure, the panel LOINC (85354-9) maps to blood_pressure;
+ * the component codes 8480-6 (systolic) and 8462-4 (diastolic) are
+ * handled inline by mapFhirObservationToVitalRow.
+ */
+const LOINC_TO_VITAL_TYPE: Record<string, VitalType> = Object.fromEntries(
+  (Object.entries(VITAL_LOINC_CODES) as Array<[VitalType, string | null]>)
+    .filter((entry): entry is [VitalType, string] => entry[1] !== null)
+    .map(([k, v]) => [v, k]),
+);
+
+const SYSTOLIC_BP_LOINC = "8480-6";
+const DIASTOLIC_BP_LOINC = "8462-4";
+
+/**
+ * Extract systolic + diastolic from Observation.component[]. Returns
+ * `null` when both components aren't present — a BP Observation
+ * missing either half is incomplete and rejected.
+ */
+function extractBloodPressureComponents(
+  resource: InboundObservation,
+): { systolic: number; diastolic: number; unit: string } | null {
+  const components = resource.component;
+  if (!components || components.length === 0) return null;
+  let systolic: { value: number; unit: string } | null = null;
+  let diastolic: { value: number; unit: string } | null = null;
+  for (const comp of components) {
+    const loinc = extractLoincCode({ code: comp.code });
+    if (!loinc) continue;
+    const value = extractValueQuantity({ valueQuantity: comp.valueQuantity });
+    if (!value) continue;
+    if (loinc === SYSTOLIC_BP_LOINC) systolic = value;
+    else if (loinc === DIASTOLIC_BP_LOINC) diastolic = value;
+  }
+  if (!systolic || !diastolic) return null;
+  // Both halves share the same UCUM unit in practice (mmHg/mm[Hg]);
+  // we pick systolic's unit as the canonical value since the parent
+  // `vitals.unit` column carries one string.
+  return {
+    systolic: systolic.value,
+    diastolic: diastolic.value,
+    unit: systolic.unit,
+  };
+}
+
+// ── Interpretation flag mapping ────────────────────────────────
+
+/**
+ * FHIR v3 ObservationInterpretation code → internal LabFlag. The full
+ * value set is large; we accept only the common subset clinical-data's
+ * `lab_results.flag` column carries today.
+ */
+function mapInterpretationFlag(
+  interpretations: InboundCodeableConcept[] | undefined,
+): LabFlag | null {
+  if (!interpretations) return null;
+  for (const i of interpretations) {
+    for (const c of i.coding ?? []) {
+      const code = c.code?.toUpperCase();
+      if (!code) continue;
+      // Critical first — overrides plain H/L when both are present.
+      if (code === "HH" || code === "LL" || code === "AA") return "critical";
+      if (code === "H" || code === ">") return "H";
+      if (code === "L" || code === "<") return "L";
+    }
+  }
+  return null;
+}
+
+// ── Main mappers ───────────────────────────────────────────────
+
+/**
+ * Map a FHIR R4 Observation (category=vital-signs) to a CareBridge
+ * `vitals` row.
+ *
+ * @param resource Sanitised FHIR Observation. The caller is expected to
+ *                 have already classified the category via
+ *                 classifyObservationCategory and verified it equals
+ *                 "vital-signs"; this function does NOT re-check
+ *                 category to keep the logic single-responsibility.
+ * @param patientId Internal patient id the bundle is being imported
+ *                 against. Trusted from the caller's resolution of
+ *                 subject.reference.
+ * @returns A row shape ready to insert, or null when the resource is
+ *          unmappable (no LOINC → VitalType match, missing value,
+ *          missing effective time, entered-in-error status).
+ */
+export function mapFhirObservationToVitalRow(
+  resource: InboundObservation,
+  patientId: string,
+): MappedVitalRow | null {
+  if (resource.status === "entered-in-error") return null;
+  const recordedAt = extractEffectiveTime(resource);
+  if (!recordedAt) return null;
+
+  const loinc = extractLoincCode(resource);
+  if (!loinc) return null;
+
+  const vitalType = LOINC_TO_VITAL_TYPE[loinc];
+  if (!vitalType) return null;
+
+  if (vitalType === "blood_pressure") {
+    const bp = extractBloodPressureComponents(resource);
+    if (!bp) return null;
+    return {
+      patient_id: patientId,
+      type: "blood_pressure",
+      loinc_code: loinc,
+      value_primary: bp.systolic,
+      value_secondary: bp.diastolic,
+      unit: bp.unit,
+      recorded_at: recordedAt,
+      source_system: SOURCE_SYSTEM_TAG,
+    };
+  }
+
+  const value = extractValueQuantity(resource);
+  if (!value) return null;
+
+  return {
+    patient_id: patientId,
+    type: vitalType,
+    loinc_code: loinc,
+    value_primary: value.value,
+    value_secondary: null,
+    unit: value.unit,
+    recorded_at: recordedAt,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+}
+
+/**
+ * Map a FHIR R4 Observation (category=laboratory) to a CareBridge
+ * `lab_results` row shape.
+ *
+ * Note the returned shape carries `recorded_at` rather than the
+ * panel/created_at split — the caller (importBundle) is responsible for
+ * constructing the synthetic `lab_panels` row that anchors the result
+ * via `panel_id`. We don't generate panel rows here because the same
+ * Observation could be batched with peers under one synthetic panel
+ * (e.g. a CBC bundle), and that batching decision belongs in the router.
+ *
+ * @param resource Sanitised FHIR Observation. The caller is expected to
+ *                 have already classified the category as "laboratory".
+ * @returns A row shape ready for the caller to attach a panel_id +
+ *          id + created_at to, or null when unmappable.
+ */
+export function mapFhirObservationToLabResultRow(
+  resource: InboundObservation,
+): MappedLabResultRow | null {
+  if (resource.status === "entered-in-error") return null;
+  const recordedAt = extractEffectiveTime(resource);
+  if (!recordedAt) return null;
+
+  const value = extractValueQuantity(resource);
+  if (!value) return null;
+
+  // Prefer LOINC code; test_name prefers code.text, then the LOINC
+  // entry's display, then the first non-empty coding.display.
+  const loinc = extractLoincCode(resource);
+  const testName = extractLabTestName(resource);
+  if (!testName) return null;
+
+  const range = resource.referenceRange?.[0];
+  const refLow =
+    typeof range?.low?.value === "number" && Number.isFinite(range.low.value)
+      ? range.low.value
+      : null;
+  const refHigh =
+    typeof range?.high?.value === "number" && Number.isFinite(range.high.value)
+      ? range.high.value
+      : null;
+
+  const flag = mapInterpretationFlag(resource.interpretation);
+
+  return {
+    test_name: testName,
+    test_code: loinc,
+    value: value.value,
+    unit: value.unit,
+    reference_low: refLow,
+    reference_high: refHigh,
+    flag,
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Pick a human-readable lab test name from Observation.code. Order of
+ * preference mirrors extractMedicationName: `.text` first, then any
+ * non-empty coding.display. Returns null when nothing usable is
+ * present — without a name the result has no key for trending / lookup.
+ */
+function extractLabTestName(
+  resource: Pick<InboundObservation, "code">,
+): string | null {
+  const cc = resource.code;
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -48,6 +48,12 @@ import {
   mapFhirPatientToRow,
   type InboundPatient,
 } from "./patient-mapper.js";
+import {
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  type InboundObservation,
+} from "./observation-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -187,32 +193,36 @@ export const fhirGatewayRouter = t.router({
       user_id: z.string(),
       bundle_id: z.string().optional(),
       /**
-       * Opt-in materialisation flag (#1066). When true, inbound
-       * MedicationRequest and MedicationStatement resources are
-       * additionally mapped to internal `medications` rows so the
-       * ai-oversight rule engine (which reads `medications` not
-       * `fhir_resources`) sees external dosing detail —
-       * Dosage.doseQuantity, Dosage.maxDosePerPeriod, route, status.
+       * Opt-in materialisation flag (#1066, extended by #337). When
+       * true, inbound clinical resources are additionally mapped to
+       * the internal structured tables the ai-oversight rule engine
+       * reads (`medications`, `vitals`, `lab_results`) — not just
+       * persisted as raw FHIR in `fhir_resources`.
+       *
+       * Resource type → target table:
+       *   - MedicationRequest / MedicationStatement → medications
+       *   - Observation (category=vital-signs)      → vitals
+       *   - Observation (category=laboratory)       → lab_results
        *
        * Default false to preserve the raw-FHIR-only contract the
-       * endpoint advertises today; callers that want the FHIR row to
-       * drive the rule engine must explicitly opt in.
+       * endpoint advertises today; callers that want the FHIR rows
+       * to drive the rule engine must explicitly opt in.
        */
       materialize: z.boolean().optional().default(false),
       /**
-       * Patient id to associate materialised medication rows with.
-       * Required when `materialize: true` AND the bundle contains
-       * MedicationRequest/MedicationStatement entries — the FHIR
-       * subject reference may carry a Patient/{id} pointing at the
-       * external EHR's id, which is not the same as the internal
-       * patients.id. Caller (api-gateway RBAC wrapper) is responsible
-       * for the cross-system reconciliation.
+       * Patient id to associate materialised rows with. Required when
+       * `materialize: true` AND the bundle contains resources whose
+       * subject reference may carry an external Patient/{id} that is
+       * not the same as the internal patients.id (Medication*, Observation,
+       * Condition, AllergyIntolerance). Caller (api-gateway RBAC
+       * wrapper) is responsible for cross-system reconciliation.
        *
        * NOT required for Patient resource materialisation (#337) —
        * the Patient resource itself defines the patient identity, so
        * the materialiser mints a fresh internal id at write time.
        *
-       * Ignored when `materialize: false`.
+       * Applies to every materialised target (medications, vitals,
+       * lab_results, diagnoses). Ignored when `materialize: false`.
        */
       patient_id: z.string().optional(),
     }))
@@ -224,6 +234,8 @@ export const fhirGatewayRouter = t.router({
       let materializedMedications = 0;
       let materializedDiagnoses = 0;
       let materializedPatients = 0;
+      let materializedVitals = 0;
+      let materializedLabResults = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -369,6 +381,73 @@ export const fhirGatewayRouter = t.router({
               materializedPatients++;
             }
           }
+
+          // Observation routing (#337). The same FHIR resource type
+          // fans out to two internal tables based on category:
+          //   - vital-signs → `vitals`
+          //   - laboratory  → `lab_results` (via a synthetic
+          //                  `lab_panels` row anchoring panel_id)
+          // Resources with no recognised category fall through
+          // unmaterialised — the raw_fhir row is still persisted
+          // above so no data is dropped silently.
+          if (input.materialize && resourceType === "Observation" && input.patient_id) {
+            const obs = sanitized as unknown as InboundObservation;
+            const category = classifyObservationCategory(obs);
+            if (category === "vital-signs") {
+              const vitalRow = mapFhirObservationToVitalRow(
+                obs,
+                input.patient_id,
+              );
+              if (vitalRow) {
+                await tx.insert(vitals).values({
+                  id: crypto.randomUUID(),
+                  patient_id: vitalRow.patient_id,
+                  recorded_at: vitalRow.recorded_at,
+                  type: vitalRow.type,
+                  loinc_code: vitalRow.loinc_code,
+                  value_primary: vitalRow.value_primary,
+                  value_secondary: vitalRow.value_secondary,
+                  unit: vitalRow.unit,
+                  source_system: vitalRow.source_system ?? input.source_system,
+                  created_at: now,
+                });
+                materializedVitals++;
+              }
+            } else if (category === "laboratory") {
+              const labRow = mapFhirObservationToLabResultRow(obs);
+              if (labRow) {
+                // lab_results.panel_id is NOT NULL — every imported
+                // lab Observation needs a sidecar lab_panels row.
+                // We create one per Observation here; future work
+                // could batch peer Observations under a single
+                // panel (e.g. a CBC panel arriving as 11 separate
+                // Observations with a shared encounter).
+                const panelId = crypto.randomUUID();
+                await tx.insert(labPanels).values({
+                  id: panelId,
+                  patient_id: input.patient_id,
+                  panel_name: labRow.test_name,
+                  collected_at: labRow.recorded_at,
+                  reported_at: labRow.recorded_at,
+                  source_system: input.source_system,
+                  created_at: now,
+                });
+                await tx.insert(labResults).values({
+                  id: crypto.randomUUID(),
+                  panel_id: panelId,
+                  test_name: labRow.test_name,
+                  test_code: labRow.test_code,
+                  value: labRow.value,
+                  unit: labRow.unit,
+                  reference_low: labRow.reference_low,
+                  reference_high: labRow.reference_high,
+                  flag: labRow.flag,
+                  created_at: labRow.recorded_at,
+                });
+                materializedLabResults++;
+              }
+            }
+          }
         });
 
         imported++;
@@ -378,6 +457,8 @@ export const fhirGatewayRouter = t.router({
         materialized_medications: materializedMedications,
         materialized_diagnoses: materializedDiagnoses,
         materialized_patients: materializedPatients,
+        materialized_vitals: materializedVitals,
+        materialized_lab_results: materializedLabResults,
       };
     }),
 


### PR DESCRIPTION
## Summary

Adds the inbound FHIR R4 Observation → CareBridge mapper (one of the
5 parallel inbound mappers for issue #337). Observation is the only
inbound FHIR resource type that routes to **two** internal tables
based on `Observation.category[].coding[].code`:

- `vital-signs` → `vitals` (BP component[] collapsed into value_primary + value_secondary)
- `laboratory` → `lab_results` (with a synthetic `lab_panels` sidecar anchoring panel_id)

Wired into `importBundle`'s opt-in materialise path alongside the
existing medication materialiser (#1066). The mutation now returns
`materialized_vitals` + `materialized_lab_results` in addition to
`materialized_medications`.

Refs #337.

## Scope

- `services/fhir-gateway/src/observation-mapper.ts` — pure mapper (372 lines)
  - `classifyObservationCategory(resource)` → `"vital-signs" | "laboratory" | null`
  - `mapFhirObservationToVitalRow(resource, patientId)` → `MappedVitalRow | null`
  - `mapFhirObservationToLabResultRow(resource)` → `MappedLabResultRow | null`
  - Helpers: `extractLoincCode`, `extractValueQuantity`, `extractEffectiveTime`
- `services/fhir-gateway/src/router.ts` — Observation dispatch inside `importBundle`
- 31 unit tests + 4 integration tests

## Edge cases covered

- BP `component[]` with systolic 8480-6 + diastolic 8462-4 → single vitals row
- `effectiveDateTime` vs `effectivePeriod.start` fallback
- LOINC code resolution (inverted from `VITAL_LOINC_CODES`)
- Reference range low/high extraction for lab results
- v3 ObservationInterpretation H / L / HH-LL-AA → critical mapping
- `entered-in-error` skipped by both mappers (raw FHIR still persists)
- Missing category falls through (fail-open, raw FHIR persisted)

## Deferred

Multi-Observation panel batching (a CBC arriving as 11 Observations
that should collapse to one `lab_panels` row with 11 results) — today
each lab Observation generates its own sidecar panel. Documented
inline; worth a follow-up issue.

## Test plan

- [x] `pnpm typecheck` (clean)
- [x] `pnpm turbo lint` (clean — only pre-existing clinician-portal warnings)
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 283/283 passing
- [ ] Round-trip test against real Epic sandbox bundle (deferred to issue #337 integration phase)