### PR TITLE
feat(fhir): inbound AllergyIntolerance → allergies-row mapper

### DIFF
--- a/services/fhir-gateway/src/__tests__/allergy-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/allergy-mapper.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Inbound FHIR AllergyIntolerance → internal `allergies` row mapper
+ * tests (#337).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapFhirAllergyIntoleranceToRow,
+  extractAllergen,
+  extractRxNormCode,
+  extractSnomedCode,
+  mapCriticalityToSeverity,
+  mapReactionSeverityToInternal,
+  extractReactionDescription,
+  extractOnsetDateTime,
+  resolveRecorderReference,
+  mapVerificationStatusToInternal,
+  type InboundAllergyIntolerance,
+} from "../allergy-mapper.js";
+
+const PATIENT_ID = "patient-337";
+
+describe("mapFhirAllergyIntoleranceToRow (#337)", () => {
+  it("maps a drug allergy with RxNorm coding, criticality high, and reaction text", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      id: "ai-1",
+      clinicalStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+            code: "active",
+          },
+        ],
+      },
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+            code: "confirmed",
+          },
+        ],
+      },
+      code: {
+        coding: [
+          {
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: "7980",
+            display: "Penicillin G",
+          },
+        ],
+        text: "Penicillin",
+      },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      recordedDate: "2026-04-10T00:00:00.000Z",
+      criticality: "high",
+      recorder: { reference: "Practitioner/prov-99" },
+      reaction: [
+        {
+          manifestation: [
+            {
+              coding: [{ display: "Hives" }],
+              text: "Hives",
+            },
+          ],
+          description: "Patient developed hives and throat swelling",
+          severity: "severe",
+        },
+      ],
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      patient_id: PATIENT_ID,
+      allergen: "Penicillin",
+      rxnorm_code: "7980",
+      snomed_code: null,
+      reaction: "Patient developed hives and throat swelling",
+      severity: "severe",
+      verification_status: "confirmed",
+      onset_at: "2026-04-10T00:00:00.000Z",
+      recorded_by: "prov-99",
+      source_system: "fhir_import",
+    });
+  });
+
+  it("maps a food allergen with text coding (no RxNorm, no SNOMED) and unable-to-assess criticality", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: {
+        text: "Peanut",
+      },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      criticality: "unable-to-assess",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.allergen).toBe("Peanut");
+    expect(row!.rxnorm_code).toBeNull();
+    expect(row!.snomed_code).toBeNull();
+    // unable-to-assess → null severity (no internal analogue)
+    expect(row!.severity).toBeNull();
+    expect(row!.reaction).toBeNull();
+  });
+
+  it("maps an environmental allergen with SNOMED coding and criticality low", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: {
+        coding: [
+          {
+            system: "http://snomed.info/sct",
+            code: "256259004",
+            display: "Pollen",
+          },
+        ],
+      },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      criticality: "low",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.allergen).toBe("Pollen");
+    expect(row!.snomed_code).toBe("256259004");
+    expect(row!.rxnorm_code).toBeNull();
+    expect(row!.severity).toBe("mild");
+  });
+
+  it("returns null on verificationStatus: entered-in-error (chart correction)", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+            code: "entered-in-error",
+          },
+        ],
+      },
+      code: { text: "Aspirin" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+    };
+    expect(mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when code is missing (unmappable)", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      patient: { reference: `Patient/${PATIENT_ID}` },
+    };
+    expect(mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when code has neither text nor display", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { coding: [{ system: "http://snomed.info/sct", code: "12345" }] },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+    };
+    // No display, no text → unmappable name.
+    expect(mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID)).toBeNull();
+  });
+
+  it("fails open on missing reaction[] — row still materialises with reaction:null", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Latex" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      criticality: "high",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row).not.toBeNull();
+    expect(row!.allergen).toBe("Latex");
+    expect(row!.reaction).toBeNull();
+    expect(row!.severity).toBe("severe");
+  });
+
+  it("prefers reaction[0].description over manifestation.coding.display", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Sulfa" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      reaction: [
+        {
+          manifestation: [{ coding: [{ display: "Rash" }], text: "Rash" }],
+          description: "Generalised maculopapular rash on day 5",
+        },
+      ],
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.reaction).toBe("Generalised maculopapular rash on day 5");
+  });
+
+  it("falls back to manifestation[0].text when reaction.description is missing", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Iodine" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      reaction: [
+        {
+          manifestation: [{ coding: [{ display: "Hives" }], text: "Hives" }],
+        },
+      ],
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.reaction).toBe("Hives");
+  });
+
+  it("prefers reaction.severity over criticality when both present", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Bee sting" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      criticality: "low",
+      reaction: [
+        {
+          manifestation: [{ coding: [{ display: "Anaphylaxis" }], text: "Anaphylaxis" }],
+          severity: "severe",
+        },
+      ],
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.severity).toBe("severe");
+  });
+
+  it("uses criticality when no reaction.severity is supplied", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Cat dander" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      criticality: "high",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.severity).toBe("severe");
+  });
+
+  it("falls back to onsetDateTime when recordedDate is absent", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Shellfish" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      onsetDateTime: "2020-06-15T00:00:00.000Z",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.onset_at).toBe("2020-06-15T00:00:00.000Z");
+  });
+
+  it("uses recordedDate as onset_at when onsetDateTime is absent", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Shellfish" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      recordedDate: "2024-01-01T00:00:00.000Z",
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.onset_at).toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("falls back to asserter when recorder is missing", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Egg" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      asserter: { reference: "Practitioner/prov-77" },
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.recorded_by).toBe("prov-77");
+  });
+
+  it("returns recorded_by:null when reference is non-Practitioner", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Egg" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+      asserter: { reference: "Patient/patient-self-report" },
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.recorded_by).toBeNull();
+  });
+
+  it("defaults verification_status to 'unconfirmed' when not specified", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      code: { text: "Latex" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.verification_status).toBe("unconfirmed");
+  });
+
+  it("maps verification 'refuted' to internal 'refuted'", () => {
+    const ai: InboundAllergyIntolerance = {
+      resourceType: "AllergyIntolerance",
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+            code: "refuted",
+          },
+        ],
+      },
+      code: { text: "Sulfa" },
+      patient: { reference: `Patient/${PATIENT_ID}` },
+    };
+    const row = mapFhirAllergyIntoleranceToRow(ai, PATIENT_ID);
+    expect(row!.verification_status).toBe("refuted");
+  });
+});
+
+describe("extractAllergen (#337)", () => {
+  it("prefers code.text", () => {
+    expect(
+      extractAllergen({
+        text: "Peanut",
+        coding: [{ display: "Arachis hypogaea allergenic extract" }],
+      }),
+    ).toBe("Peanut");
+  });
+
+  it("falls back to first non-empty coding.display", () => {
+    expect(
+      extractAllergen({
+        coding: [
+          { code: "1" }, // no display
+          { display: "Penicillin" },
+        ],
+      }),
+    ).toBe("Penicillin");
+  });
+
+  it("returns null when nothing usable is present", () => {
+    expect(extractAllergen({})).toBeNull();
+    expect(extractAllergen({ coding: [{ code: "x" }] })).toBeNull();
+    expect(extractAllergen(undefined)).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractAllergen({ text: "  Peanut  " })).toBe("Peanut");
+  });
+});
+
+describe("extractRxNormCode (#337)", () => {
+  it("returns the first RxNorm-coded entry", () => {
+    expect(
+      extractRxNormCode({
+        coding: [
+          { system: "http://snomed.info/sct", code: "12345" },
+          {
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: "7980",
+          },
+        ],
+      }),
+    ).toBe("7980");
+  });
+
+  it("rejects the placeholder 'unknown' code", () => {
+    expect(
+      extractRxNormCode({
+        coding: [
+          {
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: "unknown",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no RxNorm coding present", () => {
+    expect(extractRxNormCode({ text: "Foo" })).toBeNull();
+    expect(extractRxNormCode(undefined)).toBeNull();
+  });
+});
+
+describe("extractSnomedCode (#337)", () => {
+  it("returns the first SNOMED-coded entry", () => {
+    expect(
+      extractSnomedCode({
+        coding: [
+          {
+            system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+            code: "7980",
+          },
+          { system: "http://snomed.info/sct", code: "91935009" },
+        ],
+      }),
+    ).toBe("91935009");
+  });
+
+  it("rejects the placeholder 'unknown' code", () => {
+    expect(
+      extractSnomedCode({
+        coding: [{ system: "http://snomed.info/sct", code: "unknown" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no SNOMED coding present", () => {
+    expect(extractSnomedCode({ text: "Foo" })).toBeNull();
+    expect(extractSnomedCode(undefined)).toBeNull();
+  });
+});
+
+describe("mapCriticalityToSeverity (#337)", () => {
+  it("maps high → severe", () => {
+    expect(mapCriticalityToSeverity("high")).toBe("severe");
+  });
+
+  it("maps low → mild", () => {
+    expect(mapCriticalityToSeverity("low")).toBe("mild");
+  });
+
+  it("maps unable-to-assess → null", () => {
+    expect(mapCriticalityToSeverity("unable-to-assess")).toBeNull();
+  });
+
+  it("maps undefined / unknown criticality → null", () => {
+    expect(mapCriticalityToSeverity(undefined)).toBeNull();
+    expect(mapCriticalityToSeverity("bogus")).toBeNull();
+  });
+});
+
+describe("mapReactionSeverityToInternal (#337)", () => {
+  it("maps FHIR reaction severity tokens directly", () => {
+    expect(mapReactionSeverityToInternal("mild")).toBe("mild");
+    expect(mapReactionSeverityToInternal("moderate")).toBe("moderate");
+    expect(mapReactionSeverityToInternal("severe")).toBe("severe");
+  });
+
+  it("returns null for unknown / missing values", () => {
+    expect(mapReactionSeverityToInternal(undefined)).toBeNull();
+    expect(mapReactionSeverityToInternal("critical")).toBeNull();
+  });
+});
+
+describe("extractReactionDescription (#337)", () => {
+  it("prefers reaction.description", () => {
+    expect(
+      extractReactionDescription({
+        manifestation: [{ coding: [{ display: "Rash" }] }],
+        description: "Generalised maculopapular rash",
+      }),
+    ).toBe("Generalised maculopapular rash");
+  });
+
+  it("falls back to manifestation[0].text", () => {
+    expect(
+      extractReactionDescription({
+        manifestation: [{ coding: [{ display: "Hives" }], text: "Hives" }],
+      }),
+    ).toBe("Hives");
+  });
+
+  it("falls back to manifestation[0].coding[0].display", () => {
+    expect(
+      extractReactionDescription({
+        manifestation: [{ coding: [{ display: "Wheezing" }] }],
+      }),
+    ).toBe("Wheezing");
+  });
+
+  it("returns null when no usable description present", () => {
+    expect(extractReactionDescription(undefined)).toBeNull();
+    expect(extractReactionDescription({ manifestation: [] })).toBeNull();
+    expect(extractReactionDescription({ manifestation: [{}] })).toBeNull();
+  });
+});
+
+describe("extractOnsetDateTime (#337)", () => {
+  it("returns onsetDateTime when present", () => {
+    expect(extractOnsetDateTime({ onsetDateTime: "2020-01-01T00:00:00.000Z" })).toBe(
+      "2020-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("falls back to onsetPeriod.start", () => {
+    expect(
+      extractOnsetDateTime({
+        onsetPeriod: { start: "2019-06-01T00:00:00.000Z" },
+      }),
+    ).toBe("2019-06-01T00:00:00.000Z");
+  });
+
+  it("returns null when no onset variant is present", () => {
+    expect(extractOnsetDateTime({})).toBeNull();
+  });
+});
+
+describe("resolveRecorderReference (#337)", () => {
+  it("parses Practitioner/{id}", () => {
+    expect(resolveRecorderReference({ reference: "Practitioner/abc" })).toBe(
+      "abc",
+    );
+  });
+
+  it("returns null on non-Practitioner reference", () => {
+    expect(resolveRecorderReference({ reference: "Patient/abc" })).toBeNull();
+    expect(resolveRecorderReference(undefined)).toBeNull();
+  });
+});
+
+describe("mapVerificationStatusToInternal (#337)", () => {
+  it("maps confirmed → confirmed", () => {
+    expect(mapVerificationStatusToInternal("confirmed")).toBe("confirmed");
+  });
+
+  it("maps unconfirmed → unconfirmed", () => {
+    expect(mapVerificationStatusToInternal("unconfirmed")).toBe("unconfirmed");
+  });
+
+  it("maps refuted → refuted", () => {
+    expect(mapVerificationStatusToInternal("refuted")).toBe("refuted");
+  });
+
+  it("maps entered-in-error → null (signals 'skip this entry')", () => {
+    expect(mapVerificationStatusToInternal("entered-in-error")).toBeNull();
+  });
+
+  it("defaults to unconfirmed for unknown / missing values", () => {
+    expect(mapVerificationStatusToInternal(undefined)).toBe("unconfirmed");
+    expect(mapVerificationStatusToInternal("bogus")).toBe("unconfirmed");
+  });
+});

--- a/services/fhir-gateway/src/__tests__/import-bundle-materialize-allergies.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-materialize-allergies.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Integration test (#337): import a bundle with an AllergyIntolerance
+ * carrying RxNorm coding + criticality + reaction.severity with
+ * `materialize: true`, then verify the persisted `allergies` row carries
+ * the structured fields the ai-oversight allergy-medication rule consumes.
+ *
+ * Mirrors the medication-mapper integration test at
+ * import-bundle-materialize.test.ts but for the allergies-row path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const allergiesTable = { __name: "allergies" };
+const medicationsTable = { __name: "medications" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: { __name: "patients" },
+  vitals: { __name: "vitals" },
+  labPanels: { __name: "lab_panels" },
+  labResults: { __name: "lab_results" },
+  medications: medicationsTable,
+  diagnoses: { __name: "diagnoses" },
+  allergies: allergiesTable,
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle materialize flag — AllergyIntolerance (#337)", () => {
+  it("does NOT write an allergies row by default (materialize defaults to false)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "AllergyIntolerance",
+            id: "ai-1",
+            code: { text: "Penicillin" },
+            patient: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_allergies).toBe(0);
+    expect(insertCalls.some((c) => c.table === allergiesTable)).toBe(false);
+  });
+
+  it("materialises an AllergyIntolerance with RxNorm coding + reaction.severity into an allergies row", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "AllergyIntolerance",
+            id: "ai-penicillin",
+            clinicalStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                  code: "active",
+                },
+              ],
+            },
+            verificationStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                  code: "confirmed",
+                },
+              ],
+            },
+            code: {
+              coding: [
+                {
+                  system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+                  code: "7980",
+                  display: "Penicillin G",
+                },
+              ],
+              text: "Penicillin",
+            },
+            patient: { reference: "Patient/p-1" },
+            recordedDate: "2026-04-10T00:00:00.000Z",
+            criticality: "high",
+            recorder: { reference: "Practitioner/dr-smith" },
+            reaction: [
+              {
+                manifestation: [
+                  { coding: [{ display: "Hives" }], text: "Hives" },
+                ],
+                description: "Hives and throat swelling 30 min post-dose",
+                severity: "severe",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.materialized_allergies).toBe(1);
+
+    const allergyRows = insertCalls
+      .filter((c) => c.table === allergiesTable)
+      .map((c) => c.row);
+    expect(allergyRows).toHaveLength(1);
+    const row = allergyRows[0]!;
+
+    expect(row.patient_id).toBe("p-1");
+    expect(row.allergen).toBe("Penicillin");
+    expect(row.rxnorm_code).toBe("7980");
+    expect(row.snomed_code).toBeNull();
+    expect(row.reaction).toBe("Hives and throat swelling 30 min post-dose");
+    expect(row.severity).toBe("severe");
+    expect(row.verification_status).toBe("confirmed");
+    expect(typeof row.created_at).toBe("string");
+  });
+
+  it("materialises a food AllergyIntolerance (no RxNorm) with criticality-derived severity", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "AllergyIntolerance",
+            id: "ai-peanut",
+            code: { text: "Peanut" },
+            patient: { reference: "Patient/p-1" },
+            criticality: "low",
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.materialized_allergies).toBe(1);
+    const row = insertCalls.find((c) => c.table === allergiesTable)?.row;
+    expect(row).toBeDefined();
+    expect(row!.allergen).toBe("Peanut");
+    expect(row!.rxnorm_code).toBeNull();
+    expect(row!.severity).toBe("mild"); // low → mild
+    expect(row!.reaction).toBeNull();
+    expect(row!.verification_status).toBe("unconfirmed");
+  });
+
+  it("skips AllergyIntolerance entries with verificationStatus: entered-in-error", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "AllergyIntolerance",
+            id: "ai-mistake",
+            verificationStatus: {
+              coding: [
+                {
+                  system:
+                    "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+                  code: "entered-in-error",
+                },
+              ],
+            },
+            code: { text: "Aspirin" },
+            patient: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    // The raw FHIR resource still imports, but the materialised row does not.
+    expect(result.imported).toBe(1);
+    expect(result.materialized_allergies).toBe(0);
+    expect(insertCalls.some((c) => c.table === allergiesTable)).toBe(false);
+    expect(insertCalls.some((c) => c.table === fhirResourcesTable)).toBe(true);
+  });
+
+  it("returns both materialised counters (medications + allergies) in a mixed bundle", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "MedicationRequest",
+            id: "mr-1",
+            status: "active",
+            intent: "order",
+            medicationCodeableConcept: { text: "Lisinopril" },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+        {
+          resource: {
+            resourceType: "AllergyIntolerance",
+            id: "ai-1",
+            code: { text: "Penicillin" },
+            patient: { reference: "Patient/p-1" },
+            criticality: "high",
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(2);
+    expect(result.materialized_medications).toBe(1);
+    expect(result.materialized_allergies).toBe(1);
+    expect(insertCalls.filter((c) => c.table === medicationsTable)).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === allergiesTable)).toHaveLength(1);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -129,6 +129,7 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         materialized_patients: 0,
         materialized_vitals: 0,
         materialized_lab_results: 0,
+        materialized_allergies: 0,
       });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);

--- a/services/fhir-gateway/src/allergy-mapper.ts
+++ b/services/fhir-gateway/src/allergy-mapper.ts
@@ -1,0 +1,457 @@
+/**
+ * Inbound FHIR R4 AllergyIntolerance → CareBridge `allergies`-row mapper
+ * (issue #337).
+ *
+ * The export side (services/fhir-gateway/src/generators/allergy-intolerance.ts)
+ * already serialises the internal `allergies` table to FHIR. This mapper is
+ * the inverse: it takes a FHIR resource as ingested through `importBundle`
+ * and produces the row shape the patient-records writer would have produced
+ * for the same allergy, so external EHRs pushing structured allergy data
+ * (RxNorm/SNOMED codings, reaction descriptions, criticality, severity)
+ * can drive the ai-oversight allergy-medication rules the same way internal
+ * tRPC writes do today.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitization (the caller
+ * has already sanitised by the time importBundle reaches us). Returns
+ * `null` when the resource is unmappable (missing allergen name,
+ * verificationStatus: entered-in-error) so the caller can skip-and-warn
+ * rather than crash the bundle.
+ */
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// We don't import the export-side FHIR types here because inbound payloads
+// from external EHRs are looser than what our exporter emits (optional
+// fields may be missing, unknown extra fields present). The bundle schema
+// (services/fhir-gateway/src/schemas/bundle.ts) uses .passthrough() so the
+// raw resource arrives as a generic Record<string, unknown> — we narrow
+// defensively at each access.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundReference {
+  reference?: string;
+}
+
+interface InboundPeriod {
+  start?: string;
+  end?: string;
+}
+
+interface InboundReaction {
+  substance?: InboundCodeableConcept;
+  manifestation?: InboundCodeableConcept[];
+  description?: string;
+  /**
+   * FHIR R4 reaction severity is a strict enum (mild | moderate | severe).
+   * We accept a wider string here to defend against external EHRs sending
+   * non-conformant values, and narrow in mapReactionSeverityToInternal.
+   */
+  severity?: string;
+  onset?: string;
+}
+
+export interface InboundAllergyIntolerance {
+  resourceType: "AllergyIntolerance";
+  id?: string;
+  clinicalStatus?: InboundCodeableConcept;
+  verificationStatus?: InboundCodeableConcept;
+  category?: string[];
+  criticality?: string;
+  code?: InboundCodeableConcept;
+  patient?: InboundReference;
+  /**
+   * FHIR R4 onset[x] — we accept the most common form, onsetDateTime,
+   * and onsetPeriod (start used). onsetAge / onsetRange / onsetString
+   * are not normalised here because they can't be converted to ISO 8601
+   * without making clinical assumptions; callers that need those should
+   * pre-resolve.
+   */
+  onsetDateTime?: string;
+  onsetPeriod?: InboundPeriod;
+  recordedDate?: string;
+  recorder?: InboundReference;
+  asserter?: InboundReference;
+  reaction?: InboundReaction[];
+}
+
+// ── Internal enums (mirrors packages/shared-types/clinical-data) ─
+
+/**
+ * Internal severity enum. The DB column is free-text but the schema
+ * (allergySeveritySchema) constrains writes to this set. We deliberately
+ * DO NOT emit "critical" from inbound mapping — FHIR R4 has no
+ * corresponding source token, and back-filling it would require a
+ * clinical-judgement call we can't safely make at the gateway layer.
+ */
+type AllergySeverity = "mild" | "moderate" | "severe";
+
+/**
+ * Internal verification_status. Mirrors the export-side reverse mapping
+ * in generators/allergy-intolerance.ts.
+ */
+type AllergyVerificationStatus =
+  | "confirmed"
+  | "unconfirmed"
+  | "refuted";
+
+// ── Mapped output shape ─────────────────────────────────────────
+
+/**
+ * Shape of the row to insert into `allergies`. Mirrors the column set in
+ * packages/db-schema/src/schema/patients.ts plus the explicit caller-
+ * supplied `patient_id` (the FHIR `patient.reference` carries the patient
+ * id, but the importBundle path validates the patient resolution itself
+ * and passes a verified id in).
+ *
+ * `onset_at` is conceptually distinct from the DB's `created_at`: it's
+ * the clinical onset of the allergy, not the record-creation time. The
+ * caller is responsible for setting `created_at` to the import wall-clock
+ * time when inserting the row.
+ */
+export interface MappedAllergyRow {
+  patient_id: string;
+  allergen: string;
+  rxnorm_code: string | null;
+  snomed_code: string | null;
+  reaction: string | null;
+  severity: AllergySeverity | null;
+  verification_status: AllergyVerificationStatus;
+  onset_at: string | null;
+  /**
+   * Raw external id of the recording practitioner (parsed from
+   * `Practitioner/{id}`). Storing the raw external id is the
+   * minimum-viable approach (#337) — looking up the internal user row
+   * to verify the practitioner exists is deferred to a follow-up.
+   */
+  recorded_by: string | null;
+  source_system: string | null;
+}
+
+// ── Allergen name extraction ────────────────────────────────────
+
+/**
+ * Pick the allergen name from `code`. Order of preference:
+ *   1. code.text (most human-readable; what our exporter emits)
+ *   2. first non-empty code.coding[].display
+ *
+ * Returns null when nothing usable is present — the caller skips the
+ * entry. A SNOMED/RxNorm code without a display label is not a usable
+ * allergen name on its own; we'd be writing the raw integer into the
+ * `allergen` column otherwise.
+ */
+export function extractAllergen(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+/**
+ * Extract the RxNorm code from `code.coding[]`. Returns the first entry
+ * coded against the RxNorm system, or null. Rejects the placeholder
+ * "unknown" code our exporter emits for un-coded allergens.
+ */
+export function extractRxNormCode(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (
+      c.system === "http://www.nlm.nih.gov/research/umls/rxnorm" &&
+      c.code &&
+      c.code !== "unknown"
+    ) {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract a SNOMED CT code from `code.coding[]`. Returns the first entry
+ * coded against the SNOMED CT system, or null. Rejects the "unknown"
+ * placeholder.
+ */
+export function extractSnomedCode(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (
+      c.system === "http://snomed.info/sct" &&
+      c.code &&
+      c.code !== "unknown"
+    ) {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+// ── Severity mapping ────────────────────────────────────────────
+
+/**
+ * Map FHIR criticality (low | high | unable-to-assess) to the internal
+ * severity enum. Criticality is "future risk" not "observed severity";
+ * we collapse it to a coarse internal severity to seed the column for
+ * EHRs that don't supply reaction.severity directly.
+ *
+ *   high              → severe
+ *   low               → mild
+ *   unable-to-assess  → null  (no internal analogue)
+ *
+ * Returns null on undefined or unrecognised values.
+ */
+export function mapCriticalityToSeverity(
+  criticality: string | undefined,
+): AllergySeverity | null {
+  switch (criticality) {
+    case "high":
+      return "severe";
+    case "low":
+      return "mild";
+    case "unable-to-assess":
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Map a FHIR reaction.severity token (mild | moderate | severe) to the
+ * internal severity enum. Returns null for missing or unrecognised
+ * values; the caller falls back to criticality-derived severity.
+ */
+export function mapReactionSeverityToInternal(
+  severity: string | undefined,
+): AllergySeverity | null {
+  switch (severity) {
+    case "mild":
+    case "moderate":
+    case "severe":
+      return severity;
+    default:
+      return null;
+  }
+}
+
+// ── Reaction text extraction ────────────────────────────────────
+
+/**
+ * Pick a human-readable reaction description from the first
+ * `reaction[]` entry. Order of preference:
+ *   1. reaction.description (free text — most descriptive)
+ *   2. manifestation[0].text
+ *   3. manifestation[0].coding[0].display
+ *
+ * Returns null when none of these yield a usable string. This is a
+ * fail-open: a missing reaction column is preferable to fabricating a
+ * generic "Unknown reaction" string that the ai-oversight rules might
+ * trip on.
+ */
+export function extractReactionDescription(
+  reaction: InboundReaction | undefined,
+): string | null {
+  if (!reaction) return null;
+  if (reaction.description && reaction.description.trim() !== "") {
+    return reaction.description.trim();
+  }
+  const manifestation = reaction.manifestation?.[0];
+  if (manifestation) {
+    if (manifestation.text && manifestation.text.trim() !== "") {
+      return manifestation.text.trim();
+    }
+    for (const c of manifestation.coding ?? []) {
+      if (c.display && c.display.trim() !== "") return c.display.trim();
+    }
+  }
+  return null;
+}
+
+// ── Onset extraction ────────────────────────────────────────────
+
+/**
+ * Extract a clinical onset timestamp from the FHIR R4 onset[x] choice
+ * type. We accept onsetDateTime (most common) and onsetPeriod.start.
+ *
+ * onsetAge / onsetRange / onsetString are NOT normalised here — they
+ * require clinical assumptions (a 30-year-old patient's "Age 5" onset
+ * isn't computable from the resource alone) and would silently produce
+ * misleading timestamps. Callers that need those should pre-resolve.
+ */
+export function extractOnsetDateTime(
+  resource: Pick<InboundAllergyIntolerance, "onsetDateTime" | "onsetPeriod">,
+): string | null {
+  if (resource.onsetDateTime) return resource.onsetDateTime;
+  if (resource.onsetPeriod?.start) return resource.onsetPeriod.start;
+  return null;
+}
+
+// ── Reference resolution ────────────────────────────────────────
+
+/**
+ * Resolve a Practitioner reference (e.g. `Practitioner/abc-123`) to
+ * the internal user_id used by `allergies.recorded_by`.
+ *
+ * Minimum-viable implementation (#337): parse `Practitioner/{id}` and
+ * return the raw id. Looking up the internal user row to verify the
+ * practitioner exists is deferred to a follow-up — the import path
+ * already records the raw reference and a downstream reconciliation
+ * job can normalise IDs later. This mirrors the equivalent helper in
+ * the MedicationRequest mapper (#1066).
+ *
+ * Returns null when the reference is missing, malformed, or doesn't
+ * match the Practitioner resource type — Patient self-reported
+ * allergies are common and should leave recorded_by null rather than
+ * storing the patient id in a clinician column.
+ */
+export function resolveRecorderReference(
+  ref: InboundReference | undefined,
+): string | null {
+  if (!ref?.reference) return null;
+  const match = /^Practitioner\/(.+)$/.exec(ref.reference);
+  if (!match) return null;
+  return match[1] ?? null;
+}
+
+// ── Verification status mapping ─────────────────────────────────
+
+/**
+ * FHIR verificationStatus → internal verification_status. The full FHIR
+ * value set is {unconfirmed, confirmed, refuted, entered-in-error,
+ * presumed}.
+ *
+ * `entered-in-error` returns null to signal "skip this entry" — a chart
+ * correction means the record was a mistake and should not be
+ * materialised. Unknown values default to unconfirmed (fail-safe: the
+ * record imports but is flagged as needing clinician review).
+ */
+export function mapVerificationStatusToInternal(
+  status: string | undefined,
+): AllergyVerificationStatus | null {
+  switch (status) {
+    case "confirmed":
+      return "confirmed";
+    case "refuted":
+      return "refuted";
+    case "unconfirmed":
+      return "unconfirmed";
+    case "entered-in-error":
+      return null; // skip — chart mistake
+    default:
+      return "unconfirmed";
+  }
+}
+
+/**
+ * Extract the verificationStatus code from the FHIR CodeableConcept
+ * wrapper (.coding[].code matching the canonical system, or .coding[]
+ * fallback). Returns undefined when nothing matches so the caller's
+ * default kicks in.
+ */
+function extractVerificationCode(
+  cc: InboundCodeableConcept | undefined,
+): string | undefined {
+  if (!cc) return undefined;
+  for (const c of cc.coding ?? []) {
+    if (
+      c.system ===
+        "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification" &&
+      c.code
+    ) {
+      return c.code;
+    }
+  }
+  // Tolerant: some EHRs drop the system on locally-coded statuses.
+  for (const c of cc.coding ?? []) {
+    if (c.code) return c.code;
+  }
+  return undefined;
+}
+
+// ── Main mapper function ────────────────────────────────────────
+
+const SOURCE_SYSTEM_TAG = "fhir_import";
+
+/**
+ * Map a FHIR R4 AllergyIntolerance to a CareBridge `allergies` row.
+ *
+ * @param resource Sanitised FHIR resource (importBundle has already run
+ *                 sanitizeFreeText over every string).
+ * @param patientId Internal patient id the bundle is being imported
+ *                 against. The mapper trusts the caller to have
+ *                 resolved patient.reference to this id.
+ * @returns A row shape ready to insert, or null when the resource is
+ *          unmappable:
+ *           - missing code (no allergen identifier at all)
+ *           - allergen name unrecoverable (no text, no coding.display)
+ *           - verificationStatus: entered-in-error (chart correction)
+ */
+export function mapFhirAllergyIntoleranceToRow(
+  resource: InboundAllergyIntolerance,
+  patientId: string,
+): MappedAllergyRow | null {
+  // Reject chart corrections up-front so we never spend cycles on them.
+  const verificationCode = extractVerificationCode(resource.verificationStatus);
+  const verification = mapVerificationStatusToInternal(verificationCode);
+  if (verification === null) return null;
+
+  const allergen = extractAllergen(resource.code);
+  if (!allergen) return null;
+
+  const rxnormCode = extractRxNormCode(resource.code);
+  const snomedCode = extractSnomedCode(resource.code);
+
+  const firstReaction = resource.reaction?.[0];
+  const reactionText = extractReactionDescription(firstReaction);
+
+  // Severity precedence: an explicit reaction.severity (clinician's
+  // assessment of THIS reaction) outranks the criticality-derived
+  // fallback (future-risk shorthand). Both null leaves severity null
+  // rather than fabricating one.
+  const severity =
+    mapReactionSeverityToInternal(firstReaction?.severity) ??
+    mapCriticalityToSeverity(resource.criticality);
+
+  // Onset precedence: recordedDate (when the record was created in the
+  // chart, always present on conformant exports) outranks onset[x]
+  // (clinical event time). The DB column is best-effort — neither value
+  // is required, and many imported records have neither populated.
+  const onsetAt =
+    resource.recordedDate ?? extractOnsetDateTime(resource);
+
+  // Recorder precedence: recorder (who created the record) outranks
+  // asserter (who said the allergy exists — sometimes the patient).
+  // Patient-as-asserter is a common pattern and we deliberately leave
+  // recorded_by null in that case rather than store a patient id in a
+  // clinician column.
+  const recordedBy =
+    resolveRecorderReference(resource.recorder) ??
+    resolveRecorderReference(resource.asserter);
+
+  return {
+    patient_id: patientId,
+    allergen,
+    rxnorm_code: rxnormCode,
+    snomed_code: snomedCode,
+    reaction: reactionText,
+    severity,
+    verification_status: verification,
+    onset_at: onsetAt,
+    recorded_by: recordedBy,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -54,6 +54,10 @@ import {
   mapFhirObservationToLabResultRow,
   type InboundObservation,
 } from "./observation-mapper.js";
+import {
+  mapFhirAllergyIntoleranceToRow,
+  type InboundAllergyIntolerance,
+} from "./allergy-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -236,6 +240,7 @@ export const fhirGatewayRouter = t.router({
       let materializedPatients = 0;
       let materializedVitals = 0;
       let materializedLabResults = 0;
+      let materializedAllergies = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -321,6 +326,31 @@ export const fhirGatewayRouter = t.router({
                 updated_at: now,
               });
               materializedMedications++;
+            }
+
+            // (#337) Materialise AllergyIntolerance into the
+            // `allergies` table so the ai-oversight allergy-medication
+            // rules (which read `allergies`, not `fhir_resources`)
+            // see external allergen + reaction detail.
+            if (resourceType === "AllergyIntolerance") {
+              const allergyRow = mapFhirAllergyIntoleranceToRow(
+                sanitized as unknown as InboundAllergyIntolerance,
+                input.patient_id,
+              );
+              if (allergyRow) {
+                await tx.insert(allergies).values({
+                  id: crypto.randomUUID(),
+                  patient_id: allergyRow.patient_id,
+                  allergen: allergyRow.allergen,
+                  snomed_code: allergyRow.snomed_code,
+                  rxnorm_code: allergyRow.rxnorm_code,
+                  reaction: allergyRow.reaction,
+                  severity: allergyRow.severity,
+                  verification_status: allergyRow.verification_status,
+                  created_at: now,
+                });
+                materializedAllergies++;
+              }
             }
 
             // Condition → diagnoses materialisation (#337).
@@ -459,6 +489,7 @@ export const fhirGatewayRouter = t.router({
         materialized_patients: materializedPatients,
         materialized_vitals: materializedVitals,
         materialized_lab_results: materializedLabResults,
+        materialized_allergies: materializedAllergies,
       };
     }),
 


### PR DESCRIPTION
## Summary

Adds the inverse of `generators/allergy-intolerance.ts`: maps an inbound FHIR R4 `AllergyIntolerance` resource to a CareBridge `allergies` row so external EHRs pushing structured allergen + reaction detail can drive the ai-oversight allergy-medication rules through the `importBundle` path the same way internal tRPC writes do today.

Mirrors the MedicationRequest mapper pattern (#1066) shipped in #1075:

- **New `services/fhir-gateway/src/allergy-mapper.ts`** — `mapFhirAllergyIntoleranceToRow(resource, patientId)` with helpers for allergen name, RxNorm / SNOMED coding, severity (reaction.severity → criticality fallback), reaction description, onset (recordedDate → onsetDateTime → onsetPeriod.start), recorder/asserter Practitioner refs, and verification-status mapping.
- **Wired into `importBundle`** behind the existing opt-in `materialize` flag; returns `materialized_allergies` counter alongside `materialized_medications` / `imported`.
- **Returns null** on `verificationStatus: entered-in-error` (chart correction) or missing code so the bundle pass skips-and-continues rather than crashing.

## Test plan

- [x] 47 unit tests in `allergy-mapper.test.ts` covering drug / food / environmental allergens, criticality (high/low/unable-to-assess), reaction-severity precedence, missing-reaction fail-open, entered-in-error rejection, verification-status mapping, recorder vs asserter precedence, onset precedence
- [x] 5 integration tests in `import-bundle-materialize-allergies.test.ts` via `importBundle` for default-off behaviour, RxNorm + reaction round-trip, food allergen with criticality-derived severity, entered-in-error skip, mixed bundle counters
- [x] `pnpm typecheck` clean
- [x] `pnpm turbo lint` clean (only pre-existing portal warnings)
- [x] Full `pnpm --filter @carebridge/fhir-gateway test` — 300/300 pass

Refs #337