### PR TITLE
feat(fhir): inbound Patient → patients-row mapper

### DIFF
--- a/services/fhir-gateway/src/__tests__/import-bundle-materialize-patient.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-materialize-patient.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration test (#337): import a bundle containing FHIR Patient
+ * resources with `materialize: true`, then verify the persisted
+ * `patients` rows carry the demographic fields the patient-records
+ * service expects — name, date_of_birth, biological_sex, mrn,
+ * source_system.
+ *
+ * Mirrors the structure of import-bundle-materialize.test.ts (#1066)
+ * which covers the MedicationRequest materialisation path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const patientsTable = { __name: "patients" };
+const medicationsTable = { __name: "medications" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  // hmacForIndex stub — the real impl HMACs with a key but for the
+  // materialiser test we only need a deterministic non-empty string so
+  // the writer code can stash it in `mrn_hmac` / `name_hmac`.
+  hmacForIndex: (v: string) => `hmac:${v}`,
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: patientsTable,
+  vitals: { __name: "vitals" },
+  labPanels: { __name: "lab_panels" },
+  labResults: { __name: "lab_results" },
+  medications: medicationsTable,
+  diagnoses: { __name: "diagnoses" },
+  allergies: { __name: "allergies" },
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle materialize=true → patients row (#337)", () => {
+  it("does NOT write a patients row when materialize is false (default)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-1",
+            name: [{ use: "official", text: "Jane Doe", family: "Doe", given: ["Jane"] }],
+            birthDate: "1980-05-12",
+            gender: "female",
+            identifier: [
+              {
+                type: {
+                  coding: [
+                    {
+                      system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      code: "MR",
+                    },
+                  ],
+                },
+                value: "MRN-12345",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_patients).toBe(0);
+    expect(insertCalls.some((c) => c.table === patientsTable)).toBe(false);
+    // Raw FHIR insert + audit_log row still happen.
+    expect(
+      insertCalls.filter((c) => c.table === fhirResourcesTable),
+    ).toHaveLength(1);
+  });
+
+  it("materialises a Patient with name, dob, sex, and MRN", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-jane-doe",
+            active: true,
+            name: [
+              {
+                use: "official",
+                family: "Doe",
+                given: ["Jane", "Marie"],
+                text: "Jane Marie Doe",
+              },
+            ],
+            birthDate: "1980-05-12",
+            gender: "female",
+            identifier: [
+              {
+                use: "usual",
+                type: {
+                  coding: [
+                    {
+                      system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                      code: "MR",
+                      display: "Medical Record Number",
+                    },
+                  ],
+                },
+                system: "https://carebridge.dev/fhir/sid/mrn",
+                value: "MRN-42",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.materialized_patients).toBe(1);
+
+    const patientRows = insertCalls
+      .filter((c) => c.table === patientsTable)
+      .map((c) => c.row);
+    expect(patientRows).toHaveLength(1);
+    const row = patientRows[0]!;
+
+    expect(row.name).toBe("Jane Marie Doe");
+    expect(row.date_of_birth).toBe("1980-05-12");
+    expect(row.biological_sex).toBe("female");
+    expect(row.mrn).toBe("MRN-42");
+    // `patients` table has no `source_system` column today (unlike the
+    // `medications` table) — the mapper still produces a source_system
+    // tag for callers / logging, but it isn't persisted into the row.
+    expect(row.source_system).toBeUndefined();
+    // Server-assigned fields are present.
+    expect(typeof row.id).toBe("string");
+    expect(typeof row.created_at).toBe("string");
+    expect(typeof row.updated_at).toBe("string");
+    // HMAC columns are populated for searchable fields.
+    expect(row.name_hmac).toBe("hmac:Jane Marie Doe");
+    expect(row.mrn_hmac).toBe("hmac:MRN-42");
+  });
+
+  it("skips materialisation when Patient.active is false", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-retired",
+            active: false,
+            name: [{ family: "Retired", text: "Retired Patient" }],
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+    });
+    // Raw FHIR insert + audit still happen (we don't drop the FHIR
+    // resource itself just because we won't materialise a patient row).
+    expect(result.imported).toBe(1);
+    expect(result.materialized_patients).toBe(0);
+    expect(insertCalls.some((c) => c.table === patientsTable)).toBe(false);
+  });
+
+  it("skips materialisation when Patient has no name and no MRN", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-anon",
+            gender: "unknown",
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_patients).toBe(0);
+    expect(insertCalls.some((c) => c.table === patientsTable)).toBe(false);
+  });
+
+  it("leaves mrn_hmac unset when the Patient has no MRN", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-no-mrn",
+            name: [{ family: "Smith", given: ["John"] }],
+            gender: "male",
+          },
+        },
+      ],
+    };
+    await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+    });
+    const row = insertCalls.find((c) => c.table === patientsTable)?.row;
+    expect(row).toBeDefined();
+    expect(row!.mrn).toBeNull();
+    expect(row!.mrn_hmac).toBeNull();
+    expect(row!.name).toBe("John Smith");
+  });
+
+  it("materialises multiple Patient entries in one bundle", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-a",
+            name: [{ text: "Alice Adams" }],
+            gender: "female",
+          },
+        },
+        {
+          resource: {
+            resourceType: "Patient",
+            id: "pat-b",
+            name: [{ text: "Bob Brown" }],
+            gender: "male",
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+    });
+    expect(result.imported).toBe(2);
+    expect(result.materialized_patients).toBe(2);
+    expect(
+      insertCalls.filter((c) => c.table === patientsTable),
+    ).toHaveLength(2);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/patient-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/patient-mapper.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Inbound FHIR Patient → internal `patients` row mapper tests (#337).
+ *
+ * Mirrors the structure of medication-mapper.test.ts: full-resource happy
+ * path, missing fields, identifier-only, entered-in-error skip, and the
+ * gender → biological_sex enum mapping.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapFhirPatientToRow,
+  extractPatientName,
+  extractMrn,
+  mapGenderToSex,
+  type InboundPatient,
+} from "../patient-mapper.js";
+
+describe("mapFhirPatientToRow (#337)", () => {
+  it("maps a fully-populated Patient to a row with every field set", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      id: "pat-1",
+      identifier: [
+        {
+          use: "usual",
+          type: {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                code: "MR",
+                display: "Medical Record Number",
+              },
+            ],
+          },
+          system: "https://carebridge.dev/fhir/sid/mrn",
+          value: "MRN-12345",
+        },
+      ],
+      name: [
+        {
+          use: "official",
+          family: "Doe",
+          given: ["Jane", "Marie"],
+          text: "Jane Marie Doe",
+        },
+      ],
+      birthDate: "1980-05-12",
+      gender: "female",
+    };
+    const row = mapFhirPatientToRow(resource);
+    expect(row).not.toBeNull();
+    expect(row!).toEqual({
+      name: "Jane Marie Doe",
+      date_of_birth: "1980-05-12",
+      biological_sex: "female",
+      mrn: "MRN-12345",
+      source_system: "fhir_import",
+    });
+  });
+
+  it("returns null when the resource has no name and no identifier", () => {
+    // A Patient with no name AND no MRN is unidentifiable — refuse to
+    // create a row rather than landing an anonymous patient in the table.
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      id: "pat-empty",
+    };
+    expect(mapFhirPatientToRow(resource)).toBeNull();
+  });
+
+  it("uses identifier as a placeholder name when only the MRN is present", () => {
+    // Identifier-only Patient — the FHIR resource carries a real MRN
+    // but no demographic name. We materialise with the MRN string as the
+    // placeholder so the row is still identifiable downstream.
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      identifier: [
+        {
+          type: {
+            coding: [
+              { system: "http://terminology.hl7.org/CodeSystem/v2-0203", code: "MR" },
+            ],
+          },
+          value: "MRN-99999",
+        },
+      ],
+    };
+    const row = mapFhirPatientToRow(resource);
+    expect(row).not.toBeNull();
+    expect(row!.mrn).toBe("MRN-99999");
+    expect(row!.name).toBe("MRN-99999");
+  });
+
+  it("returns null when active=false (entered-in-error equivalent)", () => {
+    // FHIR Patient has no `entered-in-error` status enum, but active=false
+    // is the equivalent "do not materialise" signal — the chart entry has
+    // been retired and should not propagate into the internal patient set.
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      active: false,
+      name: [{ family: "Ghost" }],
+      gender: "unknown",
+    };
+    expect(mapFhirPatientToRow(resource)).toBeNull();
+  });
+
+  it("composes name from family + given when text is missing", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [{ family: "Smith", given: ["John", "Q"] }],
+    };
+    const row = mapFhirPatientToRow(resource);
+    expect(row?.name).toBe("John Q Smith");
+  });
+
+  it("uses single-token family-only when given is missing", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [{ family: "Cher" }],
+    };
+    expect(mapFhirPatientToRow(resource)?.name).toBe("Cher");
+  });
+
+  it("prefers official use over usual when both are present", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [
+        { use: "usual", text: "Johnny Smith" },
+        { use: "official", text: "Jonathan Smith" },
+      ],
+    };
+    expect(mapFhirPatientToRow(resource)?.name).toBe("Jonathan Smith");
+  });
+
+  it("falls back to first name entry when no official/usual present", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [
+        { use: "nickname", text: "JD" },
+        { use: "old", text: "Old Name" },
+      ],
+    };
+    expect(mapFhirPatientToRow(resource)?.name).toBe("JD");
+  });
+
+  it("birthDate stays in YYYY-MM-DD form", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [{ family: "Doe" }],
+      birthDate: "1980-05-12",
+    };
+    expect(mapFhirPatientToRow(resource)?.date_of_birth).toBe("1980-05-12");
+  });
+
+  it("birthDate left null when absent", () => {
+    const resource: InboundPatient = {
+      resourceType: "Patient",
+      name: [{ family: "Doe" }],
+    };
+    expect(mapFhirPatientToRow(resource)?.date_of_birth).toBeNull();
+  });
+});
+
+describe("extractPatientName (#337)", () => {
+  it("returns null when name array is absent or empty", () => {
+    expect(extractPatientName(undefined)).toBeNull();
+    expect(extractPatientName([])).toBeNull();
+  });
+
+  it("prefers entries with use='official' over 'usual'", () => {
+    expect(
+      extractPatientName([
+        { use: "usual", text: "Usual Smith" },
+        { use: "official", text: "Official Smith" },
+      ]),
+    ).toBe("Official Smith");
+  });
+
+  it("falls back to use='usual' when no official entry", () => {
+    expect(
+      extractPatientName([
+        { use: "nickname", text: "Nick" },
+        { use: "usual", text: "Usual Smith" },
+      ]),
+    ).toBe("Usual Smith");
+  });
+
+  it("prefers .text over composed family+given", () => {
+    expect(
+      extractPatientName([
+        {
+          use: "official",
+          text: "Dr. Jane M. Doe Jr.",
+          family: "Doe",
+          given: ["Jane", "M."],
+        },
+      ]),
+    ).toBe("Dr. Jane M. Doe Jr.");
+  });
+
+  it("composes 'given... family' when text missing", () => {
+    expect(
+      extractPatientName([{ family: "Doe", given: ["Jane", "Marie"] }]),
+    ).toBe("Jane Marie Doe");
+  });
+
+  it("returns null when an entry has neither text nor family nor given", () => {
+    expect(extractPatientName([{ use: "official" }])).toBeNull();
+  });
+
+  it("returns given-only name when family missing", () => {
+    expect(extractPatientName([{ given: ["Madonna"] }])).toBe("Madonna");
+  });
+
+  it("trims whitespace from composed result", () => {
+    expect(extractPatientName([{ given: ["  John  "], family: " Smith " }]))
+      .toBe("John Smith");
+  });
+});
+
+describe("extractMrn (#337)", () => {
+  it("returns null when identifier array is absent", () => {
+    expect(extractMrn(undefined)).toBeNull();
+    expect(extractMrn([])).toBeNull();
+  });
+
+  it("picks the identifier with type.coding.code='MR'", () => {
+    expect(
+      extractMrn([
+        {
+          type: { coding: [{ code: "SS", system: "ssn" }] },
+          value: "111-22-3333",
+        },
+        {
+          type: {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                code: "MR",
+              },
+            ],
+          },
+          value: "MRN-9000",
+        },
+      ]),
+    ).toBe("MRN-9000");
+  });
+
+  it("falls back to system matching the CareBridge MRN system", () => {
+    expect(
+      extractMrn([
+        {
+          system: "https://carebridge.dev/fhir/sid/mrn",
+          value: "MRN-CB-1",
+        },
+      ]),
+    ).toBe("MRN-CB-1");
+  });
+
+  it("returns null when no identifier has MR type or MRN system", () => {
+    expect(
+      extractMrn([
+        { type: { coding: [{ code: "SS" }] }, value: "111-22-3333" },
+        { value: "no-type-no-system" },
+      ]),
+    ).toBeNull();
+  });
+
+  it("skips identifiers with no value even if MR-typed", () => {
+    expect(
+      extractMrn([
+        { type: { coding: [{ code: "MR" }] } },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("mapGenderToSex (#337)", () => {
+  it("maps FHIR genders to internal biological_sex enum", () => {
+    expect(mapGenderToSex("male")).toBe("male");
+    expect(mapGenderToSex("female")).toBe("female");
+    // The internal enum is `male | female | unknown`; FHIR's `other`
+    // collapses to `unknown` rather than coining a new value.
+    expect(mapGenderToSex("other")).toBe("unknown");
+    expect(mapGenderToSex("unknown")).toBe("unknown");
+  });
+
+  it("treats undefined and empty string as unknown", () => {
+    expect(mapGenderToSex(undefined)).toBe("unknown");
+    expect(mapGenderToSex("")).toBe("unknown");
+  });
+
+  it("is case-insensitive", () => {
+    expect(mapGenderToSex("MALE")).toBe("male");
+    expect(mapGenderToSex("Female")).toBe("female");
+  });
+
+  it("falls back to unknown for unrecognised values", () => {
+    expect(mapGenderToSex("nonsense")).toBe("unknown");
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -121,12 +121,12 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         user_id: adminUser.id,
       });
       // `materialize` defaults to false (#1066, #337), so the result
-      // also reports `materialized_medications: 0` and
-      // `materialized_diagnoses: 0` alongside `imported`.
+      // also reports all materialised counters at 0 alongside `imported`.
       expect(result).toEqual({
         imported: 1,
         materialized_medications: 0,
         materialized_diagnoses: 0,
+        materialized_patients: 0,
       });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);

--- a/services/fhir-gateway/src/patient-mapper.ts
+++ b/services/fhir-gateway/src/patient-mapper.ts
@@ -1,0 +1,310 @@
+/**
+ * Inbound FHIR R4 Patient → CareBridge `patients`-row mapper (issue #337).
+ *
+ * The export side (services/fhir-gateway/src/generators/patient.ts)
+ * already serialises the internal `patients` table to FHIR. This mapper
+ * is the inverse: it takes a FHIR Patient resource as ingested through
+ * `importBundle` and produces the row shape the patient-records writer
+ * would have produced for the same demographic record, so external EHRs
+ * pushing patient identity (name, DOB, gender, MRN) materialise as a
+ * real `patients` row rather than living only in the raw `fhir_resources`
+ * table.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitization (the
+ * caller has already sanitised by the time importBundle reaches us).
+ * Returns `null` when the resource is unmappable (no name AND no MRN,
+ * or `active: false` flagging the patient record as retired) so the
+ * caller can skip-and-warn rather than crash the bundle.
+ *
+ * Mirrors the medication-mapper.ts pattern (#1066) field-for-field:
+ *   - InboundPatient is loose (passthrough JSON), narrowed defensively
+ *   - small focused extract* helpers per logical field
+ *   - main `mapFhirPatientToRow` orchestrates the helpers
+ *   - `source_system: "fhir_import"` tags the row for downstream filtering
+ */
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// As with the medication mapper, we intentionally don't import the
+// export-side `FhirPatient` type — inbound payloads from external EHRs
+// are looser (optional fields missing, unknown extras present). The
+// bundle schema (services/fhir-gateway/src/schemas/bundle.ts) uses
+// .passthrough() so the raw resource arrives as a generic record. We
+// narrow defensively at each access.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundIdentifier {
+  use?: string;
+  type?: InboundCodeableConcept;
+  system?: string;
+  value?: string;
+}
+
+interface InboundHumanName {
+  use?: string;
+  text?: string;
+  family?: string;
+  given?: string[];
+  prefix?: string[];
+  suffix?: string[];
+}
+
+export interface InboundPatient {
+  resourceType: "Patient";
+  id?: string;
+  /**
+   * FHIR Patient.active. `false` signals the patient record has been
+   * retired (the closest analogue to MedicationRequest.entered-in-error)
+   * — we refuse to materialise so a corrected/duplicated patient record
+   * doesn't slip into the live patient set.
+   */
+  active?: boolean;
+  identifier?: InboundIdentifier[];
+  name?: InboundHumanName[];
+  birthDate?: string;
+  gender?: string;
+}
+
+// ── Mapped output shape ─────────────────────────────────────────
+
+/**
+ * Shape of the row to insert into `patients`. Mirrors the column set
+ * the patient-records writer would produce (services/patient-records/
+ * src/router.ts `create`), minus the server-assigned fields (`id`,
+ * `created_at`, `updated_at`) which the importBundle caller fills in
+ * at write time.
+ *
+ * `name_hmac` / `mrn_hmac` are derived from `name` / `mrn` via
+ * `hmacForIndex` at write time — they aren't carried in the mapper
+ * output to keep this module pure (no key access, no encryption side
+ * effects).
+ */
+export interface MappedPatientRow {
+  name: string;
+  date_of_birth: string | null;
+  biological_sex: "male" | "female" | "unknown";
+  mrn: string | null;
+  source_system: string;
+}
+
+// ── Gender mapping ──────────────────────────────────────────────
+
+/**
+ * Internal biological_sex enum. The shared-types `biologicalSexSchema`
+ * (packages/shared-types/src/patient.schemas.ts) is the source of
+ * truth: `"male" | "female" | "unknown"`. The FHIR Patient.gender
+ * value set is wider (also includes "other"); we collapse "other" to
+ * "unknown" rather than coining a new internal value.
+ */
+type InternalSex = "male" | "female" | "unknown";
+
+/**
+ * Map FHIR Patient.gender → internal biological_sex.
+ *
+ * Case-insensitive. Unrecognised inputs (including "other") fall back
+ * to "unknown" rather than throwing — the caller would rather land a
+ * row with unknown sex than drop the patient entirely.
+ */
+export function mapGenderToSex(gender: string | undefined): InternalSex {
+  if (!gender) return "unknown";
+  const g = gender.trim().toLowerCase();
+  if (g === "male") return "male";
+  if (g === "female") return "female";
+  // FHIR's "other" and "unknown" both collapse to internal "unknown".
+  return "unknown";
+}
+
+// ── Name extraction ─────────────────────────────────────────────
+
+/**
+ * Pick the best HumanName entry from a Patient.name[] list.
+ *
+ * Order of preference:
+ *   1. use === "official" — the legal/canonical name
+ *   2. use === "usual"    — the everyday name (still authoritative)
+ *   3. first entry in the array
+ *
+ * Returns null when the entry has nothing usable (no text, no family,
+ * no given) so the caller can fall back to the MRN as a placeholder
+ * name or skip the resource entirely.
+ */
+function pickBestNameEntry(
+  names: InboundHumanName[],
+): InboundHumanName | null {
+  if (names.length === 0) return null;
+  const byUse = (target: string) =>
+    names.find((n) => n.use?.toLowerCase() === target);
+  return byUse("official") ?? byUse("usual") ?? names[0] ?? null;
+}
+
+/**
+ * Render a HumanName entry as a single internal name string.
+ *
+ * Prefers `text` (what our exporter emits, and what external EHRs
+ * often populate for display). Falls back to `given` joined with
+ * spaces followed by `family` — the inverse of the outbound
+ * `parseName` in generators/patient.ts, so an exported-then-reimported
+ * patient round-trips losslessly.
+ *
+ * Returns null when nothing usable is present.
+ */
+function renderName(entry: InboundHumanName): string | null {
+  if (entry.text && entry.text.trim() !== "") return entry.text.trim();
+  const given = (entry.given ?? [])
+    .map((g) => g.trim())
+    .filter((g) => g !== "");
+  const family = entry.family?.trim() ?? "";
+  const composed = [...given, family].filter((p) => p !== "").join(" ");
+  if (composed === "") return null;
+  return composed;
+}
+
+/**
+ * Extract a display name from a FHIR Patient.name[].
+ *
+ * Public surface so unit tests can exercise the picker independently
+ * of the main mapper.
+ */
+export function extractPatientName(
+  names: InboundHumanName[] | undefined,
+): string | null {
+  if (!names || names.length === 0) return null;
+  const best = pickBestNameEntry(names);
+  if (!best) return null;
+  return renderName(best);
+}
+
+// ── MRN extraction ──────────────────────────────────────────────
+
+/**
+ * Canonical CareBridge MRN system URL (mirrors generators/patient.ts).
+ * The export side stamps every MRN with this `system` so a round-trip
+ * import recognises it. We also accept any identifier carrying the
+ * HL7 v2-0203 "MR" type code regardless of system, so MRNs from
+ * external EHRs (Epic, Cerner) are picked up too.
+ */
+const CAREBRIDGE_MRN_SYSTEM = "https://carebridge.dev/fhir/sid/mrn";
+const HL7_V2_0203_SYSTEM = "http://terminology.hl7.org/CodeSystem/v2-0203";
+
+/**
+ * Pull the MRN out of a Patient.identifier[] list.
+ *
+ * Strategy:
+ *   1. First identifier with type.coding.code === "MR" (the HL7 v2-0203
+ *      Medical Record Number code — universally used by major EHRs).
+ *   2. First identifier whose system matches CAREBRIDGE_MRN_SYSTEM
+ *      (covers the case where a round-trip drops the type coding).
+ *
+ * Identifiers without a `value` are skipped — an empty MRN is no MRN.
+ *
+ * Returns null when no MRN-shaped identifier is found.
+ */
+export function extractMrn(
+  identifiers: InboundIdentifier[] | undefined,
+): string | null {
+  if (!identifiers || identifiers.length === 0) return null;
+
+  // Pass 1: any identifier with type.coding[].code === "MR".
+  for (const ident of identifiers) {
+    if (!ident.value) continue;
+    for (const c of ident.type?.coding ?? []) {
+      if (c.code === "MR") {
+        // Optional system tightening: when system is present, require
+        // it to be the HL7 v2-0203 codesystem. Most external EHRs
+        // populate this; some omit it, and we tolerate the omission.
+        if (c.system === undefined || c.system === HL7_V2_0203_SYSTEM) {
+          return ident.value;
+        }
+      }
+    }
+  }
+
+  // Pass 2: identifier whose `system` matches the CareBridge MRN
+  // namespace (handles type-coding-stripped round-trips).
+  for (const ident of identifiers) {
+    if (!ident.value) continue;
+    if (ident.system === CAREBRIDGE_MRN_SYSTEM) return ident.value;
+  }
+
+  return null;
+}
+
+// ── birthDate extraction ────────────────────────────────────────
+
+/**
+ * Normalise Patient.birthDate to the YYYY-MM-DD shape the internal
+ * `patients.date_of_birth` column expects. FHIR R4 birthDate is
+ * already date-only in conformant payloads, but defensively strip
+ * any time component if an external EHR included one.
+ *
+ * Returns null when birthDate is absent or doesn't start with a
+ * recognisable date prefix.
+ */
+function extractBirthDate(birthDate: string | undefined): string | null {
+  if (!birthDate) return null;
+  // Accept "1980-05-12" or "1980-05-12T00:00:00.000Z" — slice to date
+  // prefix and validate the basic shape.
+  const datePart = birthDate.slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return null;
+  return datePart;
+}
+
+// ── Main mapper ─────────────────────────────────────────────────
+
+const SOURCE_SYSTEM_TAG = "fhir_import";
+
+/**
+ * Map a FHIR R4 Patient to a CareBridge `patients` row.
+ *
+ * @param resource Sanitised FHIR Patient (importBundle has already
+ *                 run sanitizeFreeText over every string).
+ * @returns A row shape ready to insert, or null when the resource is
+ *          unmappable (no name AND no MRN, or active=false flagging
+ *          the patient record as retired).
+ *
+ * Note: this does NOT assign an internal id. The importBundle caller
+ * either generates one (`crypto.randomUUID()`) or reconciles to an
+ * existing internal patient via a separate code path. Keeping the id
+ * out of the mapper preserves the pure-function contract and lets
+ * the materialisation pass run inside the same transaction as the
+ * raw FHIR insert without coupling to id-allocation strategy.
+ */
+export function mapFhirPatientToRow(
+  resource: InboundPatient,
+): MappedPatientRow | null {
+  // active=false → patient record retired by source. Skip materialisation
+  // to mirror the medication-mapper's entered-in-error behaviour.
+  if (resource.active === false) return null;
+
+  const mrn = extractMrn(resource.identifier);
+  const nameFromHuman = extractPatientName(resource.name);
+
+  // Refuse anonymous rows: a Patient with neither a name nor an MRN is
+  // unidentifiable. Returning null lets the caller emit a structured
+  // warning and continue with the rest of the bundle.
+  if (!nameFromHuman && !mrn) return null;
+
+  // When the FHIR Patient carries an MRN but no demographic name, use
+  // the MRN string as the placeholder name so the row is still
+  // identifiable in downstream UI. The MRN is encrypted at rest just
+  // like a real name, so this carries the same PHI characteristics.
+  const name = nameFromHuman ?? mrn;
+  if (!name) return null; // unreachable per the check above; satisfies TS
+
+  return {
+    name,
+    date_of_birth: extractBirthDate(resource.birthDate),
+    biological_sex: mapGenderToSex(resource.gender),
+    mrn,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -1,6 +1,6 @@
 import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { getDb } from "@carebridge/db-schema";
+import { getDb, hmacForIndex } from "@carebridge/db-schema";
 import {
   fhirResources,
   auditLog,
@@ -44,6 +44,10 @@ import {
   mapFhirConditionToRow,
   type InboundCondition,
 } from "./condition-mapper.js";
+import {
+  mapFhirPatientToRow,
+  type InboundPatient,
+} from "./patient-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -197,11 +201,16 @@ export const fhirGatewayRouter = t.router({
       materialize: z.boolean().optional().default(false),
       /**
        * Patient id to associate materialised medication rows with.
-       * Required when `materialize: true` — the FHIR
-       * MedicationRequest.subject reference may carry a Patient/{id}
-       * pointing at the external EHR's id, which is not the same as
-       * the internal patients.id. Caller (api-gateway RBAC wrapper)
-       * is responsible for the cross-system reconciliation.
+       * Required when `materialize: true` AND the bundle contains
+       * MedicationRequest/MedicationStatement entries — the FHIR
+       * subject reference may carry a Patient/{id} pointing at the
+       * external EHR's id, which is not the same as the internal
+       * patients.id. Caller (api-gateway RBAC wrapper) is responsible
+       * for the cross-system reconciliation.
+       *
+       * NOT required for Patient resource materialisation (#337) —
+       * the Patient resource itself defines the patient identity, so
+       * the materialiser mints a fresh internal id at write time.
        *
        * Ignored when `materialize: false`.
        */
@@ -214,6 +223,7 @@ export const fhirGatewayRouter = t.router({
       let imported = 0;
       let materializedMedications = 0;
       let materializedDiagnoses = 0;
+      let materializedPatients = 0;
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -227,11 +237,12 @@ export const fhirGatewayRouter = t.router({
         // HIPAA § 164.312(b) audit completeness goal.
         // Per Copilot review on PR #378.
         //
-        // When `materialize: true` (#1066), the same transaction also
-        // inserts a `medications` row for MedicationRequest /
-        // MedicationStatement entries so the raw-FHIR write and the
-        // materialised row are guaranteed atomic — a crash mid-import
-        // can't leave one without the other.
+        // When `materialize: true` (#1066, #337), the same transaction
+        // also inserts a `medications` row for MedicationRequest /
+        // MedicationStatement entries and a `patients` row for Patient
+        // entries, so the raw-FHIR write and the materialised row are
+        // guaranteed atomic — a crash mid-import can't leave one without
+        // the other.
         await db.transaction(async (tx) => {
           await tx.insert(fhirResources).values({
             id: crypto.randomUUID(),
@@ -326,6 +337,38 @@ export const fhirGatewayRouter = t.router({
               }
             }
           }
+
+          // Patient materialisation (#337). Unlike medications, Patient
+          // resources do NOT need an external `input.patient_id` — the
+          // FHIR Patient resource IS the patient identity, so we mint a
+          // fresh internal id on insert. The mapper returns null for
+          // unmappable entries (active=false, no name AND no MRN);
+          // those skip silently and the raw FHIR row is still imported.
+          if (input.materialize && resourceType === "Patient") {
+            const patientRow = mapFhirPatientToRow(
+              sanitized as unknown as InboundPatient,
+            );
+            if (patientRow) {
+              await tx.insert(patients).values({
+                id: crypto.randomUUID(),
+                name: patientRow.name,
+                // HMAC indexes for searchable encrypted columns. Mirrors
+                // the patient-records create path so a materialised
+                // import and a manual create produce structurally
+                // identical rows.
+                name_hmac: hmacForIndex(patientRow.name),
+                date_of_birth: patientRow.date_of_birth,
+                biological_sex: patientRow.biological_sex,
+                mrn: patientRow.mrn,
+                mrn_hmac: patientRow.mrn
+                  ? hmacForIndex(patientRow.mrn)
+                  : null,
+                created_at: now,
+                updated_at: now,
+              });
+              materializedPatients++;
+            }
+          }
         });
 
         imported++;
@@ -334,6 +377,7 @@ export const fhirGatewayRouter = t.router({
         imported,
         materialized_medications: materializedMedications,
         materialized_diagnoses: materializedDiagnoses,
+        materialized_patients: materializedPatients,
       };
     }),
 


### PR DESCRIPTION
## Summary

Adds the inbound counterpart to `services/fhir-gateway/src/generators/patient.ts`: a pure mapper that takes a FHIR R4 Patient resource and returns the row shape `patient-records` would produce for the same demographic record. Wires it into `importBundle` so Patient resources land as real `patients` rows when `materialize: true`, with the raw FHIR insert and the materialised row committed in a single transaction.

Mirrors the medication-mapper pattern (#1066, PR #1075) field-for-field:

- Focused extractor helpers: `extractPatientName`, `extractMrn`, `mapGenderToSex`, plus internal `pickBestNameEntry`, `renderName`, `extractBirthDate`
- `InboundPatient` is loose (passthrough JSON) and narrowed defensively at each access — external EHRs may omit fields our exporter populates
- Returns `null` on unmappable entries (`active: false`, or no name AND no MRN) so the raw FHIR row still imports but the materialise pass skips silently
- Name extraction prefers `use="official"` → `use="usual"` → first entry, then `.text` → composed `given... family`
- MRN extraction prefers `type.coding.code === "MR"` (HL7 v2-0203 universal MR code) then falls back to `system === CAREBRIDGE_MRN_SYSTEM`
- Gender mapping collapses FHIR's `"other"` to internal `"unknown"` since the shared-types `biologicalSexSchema` is `"male" | "female" | "unknown"`
- Result type adds `materialized_patients: number` alongside `imported` and `materialized_medications`

Note: the `patients` table has no `source_system` column today; the mapper still emits a `source_system: "fhir_import"` tag for callers / logging but it isn't persisted.

**Expected merge conflicts** with parallel #337 PRs (Observation/Condition/AllergyIntolerance/DiagnosticReport mappers) on the `importBundle` dispatch block and the `materialized_*` counters — minor mechanical resolution.

Refs #337

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test` — 281 tests pass (27 new unit, 6 new integration, all existing including router-auth + import-bundle-materialize)
- [x] `pnpm typecheck` — clean
- [x] `pnpm turbo lint` — clean (no new warnings)
- [ ] Manual smoke: import a real Epic-sandbox bundle with Patient + MedicationRequest, confirm both materialise in the same transaction