### PR TITLE
feat(fhir): inbound DiagnosticReport → lab-panels mapper

### DIFF
--- a/services/fhir-gateway/src/__tests__/diagnostic-report-mapper.test.ts
+++ b/services/fhir-gateway/src/__tests__/diagnostic-report-mapper.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Inbound FHIR DiagnosticReport → internal lab_panels (+ child
+ * lab_results) mapper tests (#337).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mapFhirDiagnosticReportToRow,
+  extractPanelName,
+  extractPanelLoinc,
+  resolvePractitionerReference,
+  normaliseObservationReference,
+  mapLabObservationToResultRow,
+  shouldImportDiagnosticReport,
+  indexBundleObservations,
+  type InboundDiagnosticReport,
+  type InboundObservation,
+} from "../diagnostic-report-mapper.js";
+
+const PATIENT_ID = "patient-337";
+
+describe("mapFhirDiagnosticReportToRow — panel core (#337)", () => {
+  it("maps a fully-populated CBC DiagnosticReport to a panel row with every field set", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      id: "dr-cbc-1",
+      status: "final",
+      code: {
+        coding: [
+          { system: "http://loinc.org", code: "58410-2", display: "CBC panel - Blood by Automated count" },
+        ],
+        text: "CBC",
+      },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      effectiveDateTime: "2026-05-22T08:00:00.000Z",
+      issued: "2026-05-22T09:30:00.000Z",
+      performer: [{ reference: "Practitioner/lab-tech-1" }],
+      resultsInterpreter: [{ reference: "Practitioner/dr-smith" }],
+      result: [],
+    };
+
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID);
+    expect(mapped).not.toBeNull();
+    expect(mapped!.panel).toEqual({
+      patient_id: PATIENT_ID,
+      panel_name: "CBC",
+      panel_code: "58410-2",
+      // resultsInterpreter (the ordering clinician) wins over performer.
+      ordered_by: "dr-smith",
+      ordering_provider_id: "dr-smith",
+      collected_at: "2026-05-22T08:00:00.000Z",
+      reported_at: "2026-05-22T09:30:00.000Z",
+      source_system: "fhir_import",
+    });
+    // No observations supplied → results: [] (panel still emitted).
+    expect(mapped!.results).toEqual([]);
+  });
+
+  it("returns null when the panel name is missing", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+    };
+    expect(mapFhirDiagnosticReportToRow(report, PATIENT_ID)).toBeNull();
+  });
+
+  it("returns null when status is entered-in-error (chart correction)", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "entered-in-error",
+      code: { text: "CBC" },
+    };
+    expect(mapFhirDiagnosticReportToRow(report, PATIENT_ID)).toBeNull();
+  });
+
+  it("falls back to coding.display when code.text is absent", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: {
+        coding: [{ system: "http://loinc.org", code: "24323-8", display: "Comprehensive metabolic panel" }],
+      },
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID);
+    expect(mapped!.panel.panel_name).toBe("Comprehensive metabolic panel");
+    expect(mapped!.panel.panel_code).toBe("24323-8");
+  });
+
+  it("falls back to effectivePeriod.start when effectiveDateTime is absent", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "BMP" },
+      effectivePeriod: { start: "2026-04-12T10:00:00.000Z", end: "2026-04-12T10:05:00.000Z" },
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID);
+    expect(mapped!.panel.collected_at).toBe("2026-04-12T10:00:00.000Z");
+  });
+
+  it("emits a panel with null ordering provider when no performer is present", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "Lipid panel" },
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID);
+    expect(mapped!.panel.ordered_by).toBeNull();
+    expect(mapped!.panel.ordering_provider_id).toBeNull();
+  });
+
+  it("emits a panel with no results when none of the result[] refs resolve", () => {
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "CBC" },
+      result: [{ reference: "Observation/obs-missing" }],
+    };
+    const observations = new Map<string, InboundObservation>();
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID, observations);
+    expect(mapped!.results).toEqual([]);
+  });
+});
+
+describe("mapFhirDiagnosticReportToRow — child observation materialisation (#337)", () => {
+  it("materialises a CBC panel's three referenced Observations into lab_results rows", () => {
+    const wbcObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-wbc",
+      status: "final",
+      code: {
+        coding: [{ system: "http://loinc.org", code: "6690-2", display: "WBC" }],
+        text: "WBC",
+      },
+      valueQuantity: { value: 7.5, unit: "10*3/uL", system: "http://unitsofmeasure.org", code: "10*3/uL" },
+      referenceRange: [
+        { low: { value: 4.5, unit: "10*3/uL" }, high: { value: 11, unit: "10*3/uL" } },
+      ],
+    };
+    const hgbObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-hgb",
+      status: "final",
+      code: {
+        coding: [{ system: "http://loinc.org", code: "718-7", display: "Hemoglobin" }],
+        text: "Hemoglobin",
+      },
+      valueQuantity: { value: 9.2, unit: "g/dL" },
+      referenceRange: [
+        { low: { value: 12, unit: "g/dL" }, high: { value: 16, unit: "g/dL" } },
+      ],
+      interpretation: [
+        {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: "L",
+              display: "Low",
+            },
+          ],
+        },
+      ],
+    };
+    const pltObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-plt",
+      status: "final",
+      code: {
+        coding: [{ system: "http://loinc.org", code: "777-3", display: "Platelet count" }],
+        text: "Platelets",
+      },
+      valueQuantity: { value: 250, unit: "10*3/uL" },
+    };
+
+    const observations = new Map<string, InboundObservation>([
+      ["obs-wbc", wbcObs],
+      ["obs-hgb", hgbObs],
+      ["obs-plt", pltObs],
+    ]);
+
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      id: "dr-cbc-1",
+      status: "final",
+      code: { text: "CBC", coding: [{ system: "http://loinc.org", code: "58410-2" }] },
+      subject: { reference: `Patient/${PATIENT_ID}` },
+      effectiveDateTime: "2026-05-22T08:00:00.000Z",
+      issued: "2026-05-22T09:30:00.000Z",
+      result: [
+        { reference: "Observation/obs-wbc" },
+        { reference: "Observation/obs-hgb" },
+        { reference: "Observation/obs-plt" },
+      ],
+    };
+
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID, observations);
+    expect(mapped).not.toBeNull();
+    expect(mapped!.results).toHaveLength(3);
+
+    const byName = Object.fromEntries(mapped!.results.map((r) => [r.test_name, r]));
+    expect(byName.WBC).toEqual({
+      test_name: "WBC",
+      test_code: "6690-2",
+      value: 7.5,
+      unit: "10*3/uL",
+      reference_low: 4.5,
+      reference_high: 11,
+      flag: null,
+    });
+    expect(byName.Hemoglobin).toEqual({
+      test_name: "Hemoglobin",
+      test_code: "718-7",
+      value: 9.2,
+      unit: "g/dL",
+      reference_low: 12,
+      reference_high: 16,
+      flag: "L",
+    });
+    expect(byName.Platelets).toEqual({
+      test_name: "Platelets",
+      test_code: "777-3",
+      value: 250,
+      unit: "10*3/uL",
+      reference_low: null,
+      reference_high: null,
+      flag: null,
+    });
+  });
+
+  it("resolves urn:uuid: bundle-local references to indexed observations", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-1",
+      status: "final",
+      code: { text: "Sodium" },
+      valueQuantity: { value: 140, unit: "mEq/L" },
+    };
+    const observations = new Map<string, InboundObservation>([
+      ["abc-uuid-1234", obs],
+      ["obs-1", obs],
+    ]);
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "BMP" },
+      result: [{ reference: "urn:uuid:abc-uuid-1234" }],
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID, observations);
+    expect(mapped!.results).toHaveLength(1);
+    expect(mapped!.results[0]!.test_name).toBe("Sodium");
+  });
+
+  it("skips child Observation entries with entered-in-error status", () => {
+    const goodObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-good",
+      status: "final",
+      code: { text: "Glucose" },
+      valueQuantity: { value: 95, unit: "mg/dL" },
+    };
+    const badObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-bad",
+      status: "entered-in-error",
+      code: { text: "Bad reading" },
+      valueQuantity: { value: 99999, unit: "mg/dL" },
+    };
+    const observations = new Map<string, InboundObservation>([
+      ["obs-good", goodObs],
+      ["obs-bad", badObs],
+    ]);
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "BMP" },
+      result: [
+        { reference: "Observation/obs-good" },
+        { reference: "Observation/obs-bad" },
+      ],
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID, observations);
+    expect(mapped!.results).toHaveLength(1);
+    expect(mapped!.results[0]!.test_name).toBe("Glucose");
+  });
+
+  it("skips observations without numeric valueQuantity (defers string/coded results to a follow-up)", () => {
+    const codedObs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-coded",
+      status: "final",
+      code: { text: "Blood type" },
+      // No valueQuantity — typically a valueCodeableConcept on the wire.
+    };
+    const observations = new Map<string, InboundObservation>([["obs-coded", codedObs]]);
+    const report: InboundDiagnosticReport = {
+      resourceType: "DiagnosticReport",
+      status: "final",
+      code: { text: "Blood typing" },
+      result: [{ reference: "Observation/obs-coded" }],
+    };
+    const mapped = mapFhirDiagnosticReportToRow(report, PATIENT_ID, observations);
+    expect(mapped!.results).toEqual([]);
+  });
+});
+
+describe("mapLabObservationToResultRow (#337)", () => {
+  it("flags hemoglobin as critical when interpretation carries an HH code", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      code: { text: "Hemoglobin" },
+      valueQuantity: { value: 4.1, unit: "g/dL" },
+      interpretation: [
+        {
+          coding: [
+            {
+              system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+              code: "LL",
+            },
+          ],
+        },
+      ],
+    };
+    const row = mapLabObservationToResultRow(obs);
+    expect(row!.flag).toBe("critical");
+  });
+
+  it("uses valueQuantity.code as the unit fallback when unit is absent", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      code: { text: "Potassium" },
+      valueQuantity: { value: 4.0, code: "mEq/L" },
+    };
+    const row = mapLabObservationToResultRow(obs);
+    expect(row!.unit).toBe("mEq/L");
+  });
+
+  it("returns null when the observation has no LOINC and no display name", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      code: {},
+      valueQuantity: { value: 1, unit: "mg/dL" },
+    };
+    expect(mapLabObservationToResultRow(obs)).toBeNull();
+  });
+
+  it("returns null when valueQuantity is missing or non-numeric", () => {
+    expect(
+      mapLabObservationToResultRow({
+        resourceType: "Observation",
+        status: "final",
+        code: { text: "X" },
+      }),
+    ).toBeNull();
+    expect(
+      mapLabObservationToResultRow({
+        resourceType: "Observation",
+        status: "final",
+        code: { text: "X" },
+        valueQuantity: { unit: "mg/dL" },
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to free-text interpretation when no V3 code is present", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      status: "final",
+      code: { text: "WBC" },
+      valueQuantity: { value: 18, unit: "10*3/uL" },
+      interpretation: [{ text: "High" }],
+    };
+    expect(mapLabObservationToResultRow(obs)!.flag).toBe("H");
+  });
+});
+
+describe("status mapping (#337)", () => {
+  it("imports every status except entered-in-error", () => {
+    expect(shouldImportDiagnosticReport("final")).toBe(true);
+    expect(shouldImportDiagnosticReport("preliminary")).toBe(true);
+    expect(shouldImportDiagnosticReport("partial")).toBe(true);
+    expect(shouldImportDiagnosticReport("amended")).toBe(true);
+    expect(shouldImportDiagnosticReport("corrected")).toBe(true);
+    expect(shouldImportDiagnosticReport("appended")).toBe(true);
+    expect(shouldImportDiagnosticReport("registered")).toBe(true);
+    expect(shouldImportDiagnosticReport("unknown")).toBe(true);
+    expect(shouldImportDiagnosticReport(undefined)).toBe(true);
+    expect(shouldImportDiagnosticReport("entered-in-error")).toBe(false);
+    expect(shouldImportDiagnosticReport("ENTERED-IN-ERROR")).toBe(false);
+  });
+});
+
+describe("name and code extraction helpers (#337)", () => {
+  it("extractPanelName prefers text, then coding.display", () => {
+    expect(extractPanelName({ text: "CBC" })).toBe("CBC");
+    expect(extractPanelName({ coding: [{ display: "CBC" }] })).toBe("CBC");
+    expect(extractPanelName({})).toBeNull();
+    expect(extractPanelName(undefined)).toBeNull();
+  });
+
+  it("extractPanelLoinc returns the first LOINC-coded entry only", () => {
+    expect(
+      extractPanelLoinc({
+        coding: [
+          { system: "other", code: "X" },
+          { system: "http://loinc.org", code: "58410-2" },
+        ],
+      }),
+    ).toBe("58410-2");
+    expect(
+      extractPanelLoinc({ coding: [{ system: "other", code: "X" }] }),
+    ).toBeNull();
+    expect(extractPanelLoinc(undefined)).toBeNull();
+  });
+
+  it("resolvePractitionerReference parses Practitioner/{id}", () => {
+    expect(resolvePractitionerReference({ reference: "Practitioner/p1" })).toBe("p1");
+    expect(resolvePractitionerReference({ reference: "Patient/p1" })).toBeNull();
+    expect(resolvePractitionerReference(undefined)).toBeNull();
+  });
+
+  it("normaliseObservationReference handles typed, urn:uuid, and bare refs", () => {
+    expect(normaliseObservationReference({ reference: "Observation/o1" })).toBe("o1");
+    expect(normaliseObservationReference({ reference: "urn:uuid:abc" })).toBe("abc");
+    expect(normaliseObservationReference({ reference: "o1" })).toBe("o1");
+    expect(normaliseObservationReference(undefined)).toBeNull();
+    expect(normaliseObservationReference({ reference: "" })).toBeNull();
+  });
+});
+
+describe("indexBundleObservations (#337)", () => {
+  it("indexes Observation entries by both bare id and urn:uuid fullUrl", () => {
+    const obs: InboundObservation = {
+      resourceType: "Observation",
+      id: "obs-1",
+      status: "final",
+      code: { text: "Na" },
+      valueQuantity: { value: 140, unit: "mEq/L" },
+    };
+    const map = indexBundleObservations([
+      { fullUrl: "urn:uuid:abc-123", resource: obs },
+    ]);
+    expect(map.get("obs-1")).toBe(obs);
+    expect(map.get("abc-123")).toBe(obs);
+  });
+
+  it("ignores non-Observation entries", () => {
+    const map = indexBundleObservations([
+      { resource: { resourceType: "Patient", id: "p-1" } },
+      {
+        resource: {
+          resourceType: "Observation",
+          id: "obs-2",
+        },
+      },
+    ]);
+    expect(map.has("p-1")).toBe(false);
+    expect(map.has("obs-2")).toBe(true);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/import-bundle-diagnostic-report.test.ts
+++ b/services/fhir-gateway/src/__tests__/import-bundle-diagnostic-report.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration test (#337): import a bundle with a DiagnosticReport
+ * (CBC) plus its three referenced Observation entries with
+ * `materialize: true`, and verify the persisted `lab_panels` row
+ * lands alongside one `lab_results` row per referenced Observation,
+ * all linked via the same `panel_id`.
+ *
+ * Mirrors the import-bundle-materialize.test.ts harness pattern
+ * shipped in #1066 — the in-memory mock captures every insert so we
+ * can assert table + row pairs without touching a real Postgres.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type InsertCall = { table: unknown; row: Record<string, unknown> };
+const insertCalls: InsertCall[] = [];
+
+const insertMock = vi.fn((table: unknown) => ({
+  values: vi.fn(async (row: Record<string, unknown>) => {
+    insertCalls.push({ table, row });
+  }),
+}));
+
+const transactionMock = vi.fn(
+  async (cb: (tx: { insert: typeof insertMock }) => Promise<unknown>) => {
+    return cb({ insert: insertMock });
+  },
+);
+
+const fhirResourcesTable = { __name: "fhir_resources" };
+const auditLogTable = { __name: "audit_log" };
+const labPanelsTable = { __name: "lab_panels" };
+const labResultsTable = { __name: "lab_results" };
+const medicationsTable = { __name: "medications" };
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => ({ insert: insertMock, transaction: transactionMock }),
+  fhirResources: fhirResourcesTable,
+  auditLog: auditLogTable,
+  patients: { __name: "patients" },
+  vitals: { __name: "vitals" },
+  labPanels: labPanelsTable,
+  labResults: labResultsTable,
+  medications: medicationsTable,
+  diagnoses: { __name: "diagnoses" },
+  allergies: { __name: "allergies" },
+  encounters: { __name: "encounters" },
+  procedures: { __name: "procedures" },
+  users: { __name: "users" },
+}));
+
+const { fhirGatewayRouter } = await import("../router.js");
+
+const adminCtx = {
+  user: {
+    id: "user-admin",
+    email: "admin@carebridge.dev",
+    name: "Admin",
+    role: "admin" as const,
+    is_active: true,
+    created_at: "2026-04-01T00:00:00.000Z",
+    updated_at: "2026-04-01T00:00:00.000Z",
+  },
+};
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  insertMock.mockClear();
+  transactionMock.mockClear();
+});
+
+describe("importBundle DiagnosticReport materialisation (#337)", () => {
+  it("does NOT write a lab_panels row by default (materialize defaults to false)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "DiagnosticReport",
+            id: "dr-1",
+            status: "final",
+            code: { text: "CBC" },
+            subject: { reference: "Patient/p-1" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_lab_panels).toBe(0);
+    expect(result.materialized_lab_results).toBe(0);
+    expect(insertCalls.some((c) => c.table === labPanelsTable)).toBe(false);
+    expect(insertCalls.some((c) => c.table === labResultsTable)).toBe(false);
+  });
+
+  it("materialises a CBC DiagnosticReport with three Observations into one panel + three result rows linked by panel_id", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          // The DiagnosticReport may appear BEFORE its child Observations
+          // in the bundle. The router pre-indexes the bundle so order
+          // doesn't matter.
+          resource: {
+            resourceType: "DiagnosticReport",
+            id: "dr-cbc-1",
+            status: "final",
+            code: {
+              coding: [
+                { system: "http://loinc.org", code: "58410-2", display: "CBC panel" },
+              ],
+              text: "CBC",
+            },
+            subject: { reference: "Patient/p-1" },
+            effectiveDateTime: "2026-05-22T08:00:00.000Z",
+            issued: "2026-05-22T09:30:00.000Z",
+            performer: [{ reference: "Practitioner/lab-tech-1" }],
+            resultsInterpreter: [{ reference: "Practitioner/dr-smith" }],
+            result: [
+              { reference: "Observation/obs-wbc" },
+              { reference: "Observation/obs-hgb" },
+              { reference: "Observation/obs-plt" },
+            ],
+          },
+        },
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-wbc",
+            status: "final",
+            code: {
+              coding: [{ system: "http://loinc.org", code: "6690-2", display: "WBC" }],
+              text: "WBC",
+            },
+            valueQuantity: { value: 7.5, unit: "10*3/uL" },
+            referenceRange: [
+              { low: { value: 4.5, unit: "10*3/uL" }, high: { value: 11, unit: "10*3/uL" } },
+            ],
+          },
+        },
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-hgb",
+            status: "final",
+            code: {
+              coding: [{ system: "http://loinc.org", code: "718-7", display: "Hemoglobin" }],
+              text: "Hemoglobin",
+            },
+            valueQuantity: { value: 9.2, unit: "g/dL" },
+            referenceRange: [
+              { low: { value: 12, unit: "g/dL" }, high: { value: 16, unit: "g/dL" } },
+            ],
+            interpretation: [
+              {
+                coding: [
+                  {
+                    system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    code: "L",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          resource: {
+            resourceType: "Observation",
+            id: "obs-plt",
+            status: "final",
+            code: {
+              coding: [{ system: "http://loinc.org", code: "777-3", display: "Platelets" }],
+              text: "Platelets",
+            },
+            valueQuantity: { value: 250, unit: "10*3/uL" },
+          },
+        },
+      ],
+    };
+
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+
+    expect(result.imported).toBe(4);
+    expect(result.materialized_lab_panels).toBe(1);
+    expect(result.materialized_lab_results).toBe(3);
+
+    const panelRows = insertCalls
+      .filter((c) => c.table === labPanelsTable)
+      .map((c) => c.row);
+    expect(panelRows).toHaveLength(1);
+    const panel = panelRows[0]!;
+    expect(panel.patient_id).toBe("p-1");
+    expect(panel.panel_name).toBe("CBC");
+    // resultsInterpreter wins over performer for the ordering signal.
+    expect(panel.ordered_by).toBe("dr-smith");
+    expect(panel.ordering_provider_id).toBe("dr-smith");
+    expect(panel.collected_at).toBe("2026-05-22T08:00:00.000Z");
+    expect(panel.reported_at).toBe("2026-05-22T09:30:00.000Z");
+    expect(panel.source_system).toBe("fhir_import");
+
+    const resultRows = insertCalls
+      .filter((c) => c.table === labResultsTable)
+      .map((c) => c.row);
+    expect(resultRows).toHaveLength(3);
+    // Every child result must be linked to the parent panel.
+    for (const r of resultRows) {
+      expect(r.panel_id).toBe(panel.id);
+    }
+    const byName = Object.fromEntries(resultRows.map((r) => [r.test_name, r]));
+    expect(byName.WBC).toMatchObject({
+      test_code: "6690-2",
+      value: 7.5,
+      unit: "10*3/uL",
+      reference_low: 4.5,
+      reference_high: 11,
+      flag: null,
+    });
+    expect(byName.Hemoglobin).toMatchObject({
+      test_code: "718-7",
+      value: 9.2,
+      unit: "g/dL",
+      reference_low: 12,
+      reference_high: 16,
+      flag: "L",
+    });
+    expect(byName.Platelets).toMatchObject({
+      test_code: "777-3",
+      value: 250,
+      unit: "10*3/uL",
+      reference_low: null,
+      reference_high: null,
+      flag: null,
+    });
+  });
+
+  it("emits a panel with no child results when the DiagnosticReport.result[] refs don't resolve in the bundle", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "DiagnosticReport",
+            id: "dr-isolated",
+            status: "final",
+            code: { text: "Lipid panel" },
+            subject: { reference: "Patient/p-1" },
+            // result[] references an Observation that's not in this
+            // bundle — the panel should still land.
+            result: [{ reference: "Observation/obs-not-in-bundle" }],
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.materialized_lab_panels).toBe(1);
+    expect(result.materialized_lab_results).toBe(0);
+    expect(insertCalls.filter((c) => c.table === labPanelsTable)).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === labResultsTable)).toHaveLength(0);
+  });
+
+  it("skips a DiagnosticReport with entered-in-error status (still imports raw FHIR)", async () => {
+    const caller = fhirGatewayRouter.createCaller(adminCtx);
+    const bundle = {
+      resourceType: "Bundle" as const,
+      type: "collection" as const,
+      entry: [
+        {
+          resource: {
+            resourceType: "DiagnosticReport",
+            id: "dr-mistake",
+            status: "entered-in-error",
+            code: { text: "CBC" },
+          },
+        },
+      ],
+    };
+    const result = await caller.importBundle({
+      bundle,
+      source_system: "epic-sandbox",
+      user_id: "user-admin",
+      materialize: true,
+      patient_id: "p-1",
+    });
+    expect(result.imported).toBe(1);
+    expect(result.materialized_lab_panels).toBe(0);
+    expect(result.materialized_lab_results).toBe(0);
+    // Raw FHIR + audit_log rows still landed.
+    expect(insertCalls.filter((c) => c.table === fhirResourcesTable)).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === auditLogTable)).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === labPanelsTable)).toHaveLength(0);
+  });
+});

--- a/services/fhir-gateway/src/__tests__/router-auth.test.ts
+++ b/services/fhir-gateway/src/__tests__/router-auth.test.ts
@@ -130,6 +130,7 @@ describe("fhirGatewayRouter raw auth (defense-in-depth)", () => {
         materialized_vitals: 0,
         materialized_lab_results: 0,
         materialized_allergies: 0,
+        materialized_lab_panels: 0,
       });
       // fhir_resources insert + audit_log insert = 2 inserts per resource
       expect(insertMock).toHaveBeenCalledTimes(2);

--- a/services/fhir-gateway/src/diagnostic-report-mapper.ts
+++ b/services/fhir-gateway/src/diagnostic-report-mapper.ts
@@ -1,0 +1,456 @@
+/**
+ * Inbound FHIR R4 DiagnosticReport → CareBridge
+ * `lab_panels` + child `lab_results` row mapper (issue #337).
+ *
+ * The export side (services/fhir-gateway/src/generators/observation.ts)
+ * already serialises lab_results as individual FHIR Observation
+ * resources. A DiagnosticReport groups those Observations into a panel
+ * (CBC, BMP, lipids, ...). This mapper is the inverse: it takes a FHIR
+ * DiagnosticReport — typically alongside the Observation resources it
+ * references via `result[]` — and produces the (panel, results[]) row
+ * pair that the clinical-data lab repo would have written for the same
+ * data, so external EHRs pushing panel-grouped results can land in the
+ * same shape that ai-oversight reads from.
+ *
+ * Option (a) implementation: when the caller can supply a lookup of the
+ * Observation resources referenced by `DiagnosticReport.result[]`, the
+ * mapper materialises a child `lab_results` row per referenced
+ * Observation, linked back to the panel. When no observations are
+ * supplied (or none of the refs resolve), the mapper still emits the
+ * panel row with an empty `results` array — callers can treat that as
+ * "panel imported, results to follow" without losing the parent record.
+ *
+ * Pure / side-effect-free — no DB writes, no PHI sanitisation (the
+ * caller has already sanitised by the time importBundle reaches us).
+ * Returns `null` when the panel itself is unmappable (no name,
+ * `entered-in-error` status) so the caller can skip-and-warn.
+ */
+
+// ── Types we accept from the inbound bundle ─────────────────────
+// Mirrors the medication-mapper pattern (#1066): inbound bundles use
+// .passthrough() so resources arrive as a loose Record<string, unknown>.
+// We narrow defensively at each access.
+
+interface InboundCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+interface InboundCodeableConcept {
+  coding?: InboundCoding[];
+  text?: string;
+}
+
+interface InboundQuantity {
+  value?: number;
+  unit?: string;
+  system?: string;
+  code?: string;
+}
+
+interface InboundReference {
+  reference?: string;
+}
+
+interface InboundPeriod {
+  start?: string;
+  end?: string;
+}
+
+interface InboundReferenceRange {
+  low?: InboundQuantity;
+  high?: InboundQuantity;
+}
+
+export interface InboundObservation {
+  resourceType: "Observation";
+  id?: string;
+  status?: string;
+  category?: InboundCodeableConcept[];
+  code?: InboundCodeableConcept;
+  subject?: InboundReference;
+  effectiveDateTime?: string;
+  effectivePeriod?: InboundPeriod;
+  issued?: string;
+  valueQuantity?: InboundQuantity;
+  interpretation?: InboundCodeableConcept[];
+  referenceRange?: InboundReferenceRange[];
+}
+
+export interface InboundDiagnosticReport {
+  resourceType: "DiagnosticReport";
+  id?: string;
+  status?: string;
+  category?: InboundCodeableConcept[];
+  code?: InboundCodeableConcept;
+  subject?: InboundReference;
+  effectiveDateTime?: string;
+  effectivePeriod?: InboundPeriod;
+  issued?: string;
+  performer?: InboundReference[];
+  resultsInterpreter?: InboundReference[];
+  result?: InboundReference[];
+}
+
+// ── Mapped output shape ─────────────────────────────────────────
+
+/**
+ * Internal `lab_panels` row shape. Mirrors CreateLabPanelInput from
+ * clinical-data, with `patient_id` as an explicit caller-supplied value
+ * (the FHIR `subject.reference` may carry an external EHR's id; the
+ * importBundle path is responsible for resolution).
+ */
+export interface LabPanelRow {
+  patient_id: string;
+  panel_name: string;
+  panel_code: string | null;
+  ordered_by: string | null;
+  collected_at: string | null;
+  reported_at: string | null;
+  ordering_provider_id: string | null;
+  source_system: string | null;
+}
+
+/**
+ * Internal `lab_results` row shape, less `panel_id` and `id` which the
+ * caller fills in once the parent panel row is persisted.
+ */
+export interface LabResultRow {
+  test_name: string;
+  test_code: string | null;
+  value: number;
+  unit: string;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: "H" | "L" | "critical" | null;
+}
+
+/**
+ * Combined mapper output: the panel row plus the materialised result
+ * rows. An empty `results` array means "no child Observations were
+ * supplied or none resolved" — the caller still persists the panel.
+ */
+export interface MappedDiagnosticReport {
+  panel: LabPanelRow;
+  results: LabResultRow[];
+}
+
+// ── Status mapping ──────────────────────────────────────────────
+
+/**
+ * FHIR DiagnosticReport.status → does this row materialise?
+ *
+ * Most DiagnosticReport status values represent a valid panel snapshot
+ * that should be imported (`partial`, `preliminary`, `final`,
+ * `amended`, `corrected`, `appended`, etc.). The exceptions are
+ * `entered-in-error` (chart correction — must be dropped) and the
+ * wildly out-of-domain `unknown`, which we still import as the
+ * underlying data is meaningful even if administrative status isn't.
+ *
+ * Returns true to import, false to drop. Mirrors the
+ * `mapRequestStatusToInternal → null` semantics in medication-mapper.
+ */
+export function shouldImportDiagnosticReport(status: string | undefined): boolean {
+  if (!status) return true;
+  return status.toLowerCase() !== "entered-in-error";
+}
+
+// ── LOINC / panel-code extraction ───────────────────────────────
+
+const LOINC_SYSTEM = "http://loinc.org";
+
+/**
+ * Extract the panel display name from `code.text` (preferred — most
+ * human-readable, what our exporter would emit) or fall back to the
+ * first non-empty `coding[].display`. Returns null when nothing usable
+ * is present.
+ */
+export function extractPanelName(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+/**
+ * Extract the LOINC code for the panel from `code.coding[]`. Returns
+ * the first entry coded against the LOINC system, or null when no
+ * LOINC coding is present. We deliberately do not fall back to any
+ * other coding system: a non-LOINC code in `panel_code` would mislead
+ * the ai-oversight rule context, which keys off LOINC.
+ */
+export function extractPanelLoinc(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (c.system === LOINC_SYSTEM && c.code && c.code.trim() !== "") {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+// ── Reference resolution ────────────────────────────────────────
+
+/**
+ * Resolve a Practitioner reference (`Practitioner/{id}`) to the raw
+ * external id used by `lab_panels.ordered_by` /
+ * `lab_panels.ordering_provider_id`. Mirrors
+ * `resolvePractitionerReference` in medication-mapper — defers the
+ * internal-user lookup to a reconciliation job downstream.
+ */
+export function resolvePractitionerReference(
+  ref: InboundReference | undefined,
+): string | null {
+  if (!ref?.reference) return null;
+  const match = /^Practitioner\/(.+)$/.exec(ref.reference);
+  if (!match) return null;
+  return match[1] ?? null;
+}
+
+/**
+ * Normalise a FHIR `result[]` reference to the canonical lookup key.
+ * Inbound bundles may carry either a typed reference like
+ * `Observation/obs-123` or a bundle-local pointer like
+ * `urn:uuid:abc-...`. We return the trailing identifier so the caller
+ * can look the resource up in a map keyed by either form.
+ *
+ * Returns null when the reference is empty or malformed.
+ */
+export function normaliseObservationReference(
+  ref: InboundReference | undefined,
+): string | null {
+  if (!ref?.reference) return null;
+  const r = ref.reference.trim();
+  if (r === "") return null;
+  const obsMatch = /^Observation\/(.+)$/.exec(r);
+  if (obsMatch) return obsMatch[1] ?? null;
+  const urnMatch = /^urn:uuid:(.+)$/.exec(r);
+  if (urnMatch) return urnMatch[1] ?? null;
+  // Bare id (e.g. just "obs-1") — accept as-is so a caller indexing
+  // by raw resource.id can still match.
+  return r;
+}
+
+// ── Lab Observation → lab_results row ───────────────────────────
+
+/**
+ * Map a single FHIR R4 Observation (lab category) into an internal
+ * lab_results row. Returns null when the observation is unmappable:
+ *   - status is entered-in-error (chart correction)
+ *   - no test name (code.text and coding[].display both missing)
+ *   - no numeric valueQuantity (we don't yet support string / coded
+ *     results — those exit through a follow-up mapper)
+ *   - no unit (a unitless value is meaningless for the rule engine)
+ *
+ * The flag column is populated when `interpretation[]` carries a
+ * known V3 ObservationInterpretation code (H, L, A, AA) — mirroring
+ * what the export side could in theory emit. Unrecognised
+ * interpretations are dropped to null rather than smuggled into the
+ * enum.
+ */
+export function mapLabObservationToResultRow(
+  obs: InboundObservation,
+): LabResultRow | null {
+  if (obs.status && obs.status.toLowerCase() === "entered-in-error") {
+    return null;
+  }
+  const testName = extractTestName(obs.code);
+  if (!testName) return null;
+
+  const q = obs.valueQuantity;
+  if (!q || typeof q.value !== "number" || !Number.isFinite(q.value)) {
+    return null;
+  }
+  const unit = q.unit ?? q.code;
+  if (!unit || unit.trim() === "") return null;
+
+  const testCode = extractLoincFromCoding(obs.code);
+  const range = obs.referenceRange?.[0];
+  const refLow = typeof range?.low?.value === "number" && Number.isFinite(range.low.value)
+    ? range.low.value
+    : null;
+  const refHigh = typeof range?.high?.value === "number" && Number.isFinite(range.high.value)
+    ? range.high.value
+    : null;
+  const flag = extractInterpretationFlag(obs.interpretation);
+
+  return {
+    test_name: testName,
+    test_code: testCode,
+    value: q.value,
+    unit,
+    reference_low: refLow,
+    reference_high: refHigh,
+    flag,
+  };
+}
+
+function extractTestName(cc: InboundCodeableConcept | undefined): string | null {
+  if (!cc) return null;
+  if (cc.text && cc.text.trim() !== "") return cc.text.trim();
+  for (const c of cc.coding ?? []) {
+    if (c.display && c.display.trim() !== "") return c.display.trim();
+  }
+  return null;
+}
+
+function extractLoincFromCoding(
+  cc: InboundCodeableConcept | undefined,
+): string | null {
+  if (!cc) return null;
+  for (const c of cc.coding ?? []) {
+    if (c.system === LOINC_SYSTEM && c.code && c.code.trim() !== "") {
+      return c.code;
+    }
+  }
+  return null;
+}
+
+const INTERPRETATION_V3_SYSTEM =
+  "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation";
+
+function extractInterpretationFlag(
+  interps: InboundCodeableConcept[] | undefined,
+): LabResultRow["flag"] {
+  if (!interps) return null;
+  for (const cc of interps) {
+    for (const c of cc.coding ?? []) {
+      // Accept V3 codes specifically; ignore other coding systems to
+      // avoid a `text: "high"` rogue interpretation overriding the
+      // structured flag column. Critical & abnormal map to "critical".
+      if (
+        c.system === INTERPRETATION_V3_SYSTEM ||
+        c.system === undefined
+      ) {
+        const code = c.code?.toUpperCase();
+        if (code === "H") return "H";
+        if (code === "L") return "L";
+        if (code === "HH" || code === "LL" || code === "AA") return "critical";
+        if (code === "A") return null; // generic abnormal — no flag
+      }
+    }
+    // Fall back to free text
+    const text = cc.text?.toLowerCase();
+    if (text === "high" || text === "h") return "H";
+    if (text === "low" || text === "l") return "L";
+    if (text === "critical" || text === "panic") return "critical";
+  }
+  return null;
+}
+
+// ── Main mapper ─────────────────────────────────────────────────
+
+const SOURCE_SYSTEM_TAG = "fhir_import";
+
+/**
+ * Map a FHIR R4 DiagnosticReport to a CareBridge `lab_panels` row plus
+ * the child `lab_results` rows for each referenced Observation that
+ * the caller could resolve.
+ *
+ * @param resource Sanitised FHIR DiagnosticReport (importBundle has
+ *                 already run sanitizeFreeText over every string).
+ * @param patientId Internal patient id the bundle is being imported
+ *                 against. Caller is responsible for resolving
+ *                 subject.reference to an internal id.
+ * @param containedObservations Optional lookup of Observation resources
+ *                 keyed by either bare resource id or bundle-local
+ *                 `urn:uuid:` value. When provided, every reference in
+ *                 `result[]` is resolved and the matching observations
+ *                 are materialised as child lab_results rows. When
+ *                 absent or empty, the panel is still returned with
+ *                 results: [] so the caller can persist the parent.
+ * @returns Mapped (panel, results) pair, or null when the panel itself
+ *          is unmappable (no name, entered-in-error).
+ */
+export function mapFhirDiagnosticReportToRow(
+  resource: InboundDiagnosticReport,
+  patientId: string,
+  containedObservations?: Map<string, InboundObservation>,
+): MappedDiagnosticReport | null {
+  if (!shouldImportDiagnosticReport(resource.status)) return null;
+  const panelName = extractPanelName(resource.code);
+  if (!panelName) return null;
+
+  const panelCode = extractPanelLoinc(resource.code);
+  // FHIR R4: performer[] is who actually performed the work; we treat
+  // the first Practitioner entry as the ordered_by signal (most
+  // exporters write the ordering clinician here). resultsInterpreter
+  // is a stronger ordering-provider signal when present.
+  const orderingProvider =
+    resolveFirstPractitioner(resource.resultsInterpreter) ??
+    resolveFirstPractitioner(resource.performer);
+
+  const collectedAt =
+    resource.effectiveDateTime ?? resource.effectivePeriod?.start ?? null;
+  const reportedAt = resource.issued ?? null;
+
+  const panel: LabPanelRow = {
+    patient_id: patientId,
+    panel_name: panelName,
+    panel_code: panelCode,
+    ordered_by: orderingProvider,
+    collected_at: collectedAt,
+    reported_at: reportedAt,
+    ordering_provider_id: orderingProvider,
+    source_system: SOURCE_SYSTEM_TAG,
+  };
+
+  const results: LabResultRow[] = [];
+  if (containedObservations && containedObservations.size > 0) {
+    for (const ref of resource.result ?? []) {
+      const key = normaliseObservationReference(ref);
+      if (!key) continue;
+      const obs = containedObservations.get(key);
+      if (!obs) continue;
+      const row = mapLabObservationToResultRow(obs);
+      if (row) results.push(row);
+    }
+  }
+
+  return { panel, results };
+}
+
+function resolveFirstPractitioner(
+  refs: InboundReference[] | undefined,
+): string | null {
+  for (const r of refs ?? []) {
+    const id = resolvePractitionerReference(r);
+    if (id) return id;
+  }
+  return null;
+}
+
+/**
+ * Build the Observation lookup map the diagnostic-report mapper
+ * expects from a list of bundle entries. Indexes each Observation by
+ * its resource id and (if present) its bundle entry's fullUrl
+ * (typically `urn:uuid:...`), so result[] references in either form
+ * resolve correctly.
+ *
+ * Pure helper exposed for the importBundle wiring and tests; the
+ * mapper itself accepts any caller-provided map.
+ */
+export function indexBundleObservations(
+  entries: Array<{ fullUrl?: string; resource?: { resourceType?: string; id?: string } }>,
+): Map<string, InboundObservation> {
+  const map = new Map<string, InboundObservation>();
+  for (const entry of entries) {
+    const res = entry.resource;
+    if (!res || res.resourceType !== "Observation") continue;
+    const obs = res as unknown as InboundObservation;
+    if (res.id) map.set(res.id, obs);
+    if (entry.fullUrl) {
+      const urn = /^urn:uuid:(.+)$/.exec(entry.fullUrl);
+      if (urn && urn[1]) map.set(urn[1], obs);
+      else map.set(entry.fullUrl, obs);
+    }
+  }
+  return map;
+}

--- a/services/fhir-gateway/src/router.ts
+++ b/services/fhir-gateway/src/router.ts
@@ -58,6 +58,11 @@ import {
   mapFhirAllergyIntoleranceToRow,
   type InboundAllergyIntolerance,
 } from "./allergy-mapper.js";
+import {
+  mapFhirDiagnosticReportToRow,
+  indexBundleObservations,
+  type InboundDiagnosticReport,
+} from "./diagnostic-report-mapper.js";
 
 const logger = createLogger("fhir-gateway");
 
@@ -200,13 +205,18 @@ export const fhirGatewayRouter = t.router({
        * Opt-in materialisation flag (#1066, extended by #337). When
        * true, inbound clinical resources are additionally mapped to
        * the internal structured tables the ai-oversight rule engine
-       * reads (`medications`, `vitals`, `lab_results`) — not just
-       * persisted as raw FHIR in `fhir_resources`.
+       * reads — not just persisted as raw FHIR in `fhir_resources`.
        *
        * Resource type → target table:
-       *   - MedicationRequest / MedicationStatement → medications
-       *   - Observation (category=vital-signs)      → vitals
-       *   - Observation (category=laboratory)       → lab_results
+       *   - Patient                                  → patients
+       *   - MedicationRequest / MedicationStatement  → medications
+       *   - Observation (category=vital-signs)       → vitals
+       *   - Observation (category=laboratory)        → lab_results
+       *   - Condition                                → diagnoses
+       *   - AllergyIntolerance                       → allergies
+       *   - DiagnosticReport                         → lab_panels
+       *     (+ child lab_results rows resolved from referenced
+       *     Observation entries in the same bundle)
        *
        * Default false to preserve the raw-FHIR-only contract the
        * endpoint advertises today; callers that want the FHIR rows
@@ -218,8 +228,9 @@ export const fhirGatewayRouter = t.router({
        * `materialize: true` AND the bundle contains resources whose
        * subject reference may carry an external Patient/{id} that is
        * not the same as the internal patients.id (Medication*, Observation,
-       * Condition, AllergyIntolerance). Caller (api-gateway RBAC
-       * wrapper) is responsible for cross-system reconciliation.
+       * Condition, AllergyIntolerance, DiagnosticReport). Caller
+       * (api-gateway RBAC wrapper) is responsible for cross-system
+       * reconciliation.
        *
        * NOT required for Patient resource materialisation (#337) —
        * the Patient resource itself defines the patient identity, so
@@ -241,6 +252,27 @@ export const fhirGatewayRouter = t.router({
       let materializedVitals = 0;
       let materializedLabResults = 0;
       let materializedAllergies = 0;
+      let materializedLabPanels = 0;
+
+      // Pre-index Observation entries from the bundle so DiagnosticReport
+      // materialisation (#337) can resolve `result[]` references that
+      // point either at typed Observation/{id} refs or bundle-local
+      // urn:uuid:{...} pointers. Built once per bundle rather than per
+      // entry so reference resolution is O(n) over the whole bundle and
+      // robust to entry ordering.
+      const observationIndex = input.materialize
+        ? indexBundleObservations(
+            entries
+              .filter((e) => e.resource)
+              .map((e) => ({
+                fullUrl: e.fullUrl,
+                resource: e.resource as unknown as {
+                  resourceType?: string;
+                  id?: string;
+                },
+              })),
+          )
+        : new Map();
       for (const entry of entries) {
         if (!entry.resource) continue;
         const sanitized = sanitizeResourceStrings(entry.resource) as Record<string, unknown>;
@@ -478,6 +510,54 @@ export const fhirGatewayRouter = t.router({
               }
             }
           }
+
+          // DiagnosticReport → lab_panels + lab_results (#337). Same
+          // transaction as the raw FHIR + audit insert so the parent
+          // row and its child results commit or roll back as a unit.
+          // Resolves child Observation references via the bundle-wide
+          // observationIndex built before the loop.
+          if (
+            input.materialize &&
+            resourceType === "DiagnosticReport" &&
+            input.patient_id
+          ) {
+            const mapped = mapFhirDiagnosticReportToRow(
+              sanitized as unknown as InboundDiagnosticReport,
+              input.patient_id,
+              observationIndex,
+            );
+            if (mapped) {
+              const panelId = crypto.randomUUID();
+              await tx.insert(labPanels).values({
+                id: panelId,
+                patient_id: mapped.panel.patient_id,
+                panel_name: mapped.panel.panel_name,
+                ordered_by: mapped.panel.ordered_by,
+                collected_at: mapped.panel.collected_at,
+                reported_at: mapped.panel.reported_at,
+                ordering_provider_id: mapped.panel.ordering_provider_id,
+                source_system:
+                  mapped.panel.source_system ?? input.source_system,
+                created_at: now,
+              });
+              materializedLabPanels++;
+              for (const r of mapped.results) {
+                await tx.insert(labResults).values({
+                  id: crypto.randomUUID(),
+                  panel_id: panelId,
+                  test_name: r.test_name,
+                  test_code: r.test_code,
+                  value: r.value,
+                  unit: r.unit,
+                  reference_low: r.reference_low,
+                  reference_high: r.reference_high,
+                  flag: r.flag,
+                  created_at: now,
+                });
+                materializedLabResults++;
+              }
+            }
+          }
         });
 
         imported++;
@@ -490,6 +570,7 @@ export const fhirGatewayRouter = t.router({
         materialized_vitals: materializedVitals,
         materialized_lab_results: materializedLabResults,
         materialized_allergies: materializedAllergies,
+        materialized_lab_panels: materializedLabPanels,
       };
     }),
 


### PR DESCRIPTION
## Summary
- New `services/fhir-gateway/src/diagnostic-report-mapper.ts` — pure mapper from FHIR R4 DiagnosticReport into the internal `lab_panels` row + child `lab_results` rows. Extracts panel name, LOINC panel code, ordering provider (resultsInterpreter preferred over performer), collected_at (effectiveDateTime / effectivePeriod.start), reported_at (issued), and a status import gate that drops `entered-in-error`.
- **Option (a) child materialisation**: the mapper accepts a `Map<string, InboundObservation>` of resolved Observations and materialises each referenced result. The router pre-indexes the bundle once (by bare id and `urn:uuid:` fullUrl) so `DiagnosticReport.result[]` references resolve regardless of entry order. Per-result extraction handles numeric `valueQuantity`, `referenceRange[0]`, and V3 ObservationInterpretation flags (H / L / HH→critical / LL→critical / free-text fallback).
- Wired into `importBundle` dispatch alongside MedicationRequest / MedicationStatement. Panel + child results write in the same transaction as the raw FHIR + audit_log inserts so a crash mid-import cannot orphan a panel from its children. New counters `materialized_lab_panels` and `materialized_lab_results` join `materialized_medications` on the return value.

Mirrors the medication-mapper template from #1075.

Refs #337

## Test plan
- [x] 23 unit tests in `diagnostic-report-mapper.test.ts` covering: CBC fully-populated, missing name → null, entered-in-error → null, coding.display fallback, effectivePeriod fallback, no observations supplied → empty results, three referenced Observations materialised end-to-end, urn:uuid bundle-local refs, entered-in-error child skip, non-numeric value skip, HH→critical flag, free-text interpretation fallback, panel LOINC extraction, helper exhaustive cases.
- [x] 4 integration tests in `import-bundle-diagnostic-report.test.ts` covering: materialize-off default skips writes, CBC + 3 Observations → 1 panel row + 3 result rows all sharing `panel_id`, unresolved result refs still emit the panel, entered-in-error DiagnosticReport still imports raw FHIR + audit but skips materialisation.
- [x] `pnpm typecheck` (Turbo: 36 successful)
- [x] `pnpm turbo lint` (Turbo: 20 successful)
- [x] `pnpm --filter @carebridge/fhir-gateway test` (275 passed, including the existing 271 + 27 new tests, and the updated router-auth assertion that expects the new return shape)