### PR TITLE
feat(epic): SMART Backend Services authentication

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,6 +628,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
 
+  services/epic-connector:
+    dependencies:
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@carebridge/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
+
   services/fhir-gateway:
     dependencies:
       '@carebridge/clinical-data':

--- a/services/epic-connector/README.md
+++ b/services/epic-connector/README.md
@@ -1,0 +1,59 @@
+# @carebridge/epic-connector
+
+Epic SMART on FHIR integration for CareBridge.
+
+Issue #389 ships the authentication layer — RS384 client-assertion JWT,
+OAuth 2.0 client-credentials token exchange, expiry-aware caching, and
+SMART configuration discovery. Follow-ups will add the typed FHIR
+client (#390), sync worker (#391), App Launch (#392), and outbound
+flag push (#393).
+
+## First-time setup
+
+```bash
+# 1. Generate an RS384 keypair and grab the public JWK
+pnpm --filter @carebridge/epic-connector epic:keygen
+
+# Output includes:
+#   - private key path  (default: ~/.carebridge/epic-private.pem, 0600)
+#   - kid               (UUID to embed in JWT assertions)
+#   - public JWK        (paste at open.epic.com → App Settings → Public Keys)
+#   - .env.local snippet
+
+# 2. Register the public JWK at open.epic.com.
+#    App Settings → Public Keys → "Add" → paste the JWK output.
+
+# 3. Add to .env.local (already gitignored):
+#    EPIC_CLIENT_ID=<your Non-Production Client ID>
+#    EPIC_PRIVATE_KEY_PATH=~/.carebridge/epic-private.pem
+#    EPIC_JWT_KID=<the kid from step 1>
+
+# Defaults to fhir.epic.com sandbox. Override EPIC_TOKEN_URL and
+# EPIC_FHIR_BASE_URL for production.
+```
+
+## Use
+
+```ts
+import { loadEpicConfig, EpicTokenClient } from "@carebridge/epic-connector";
+
+const config = loadEpicConfig();
+const client = new EpicTokenClient(config);
+
+const token = await client.getAccessToken();
+// → use as Authorization: Bearer ${token} on FHIR requests
+```
+
+The token client caches the response and refreshes 60s before expiry.
+Call `client.invalidate()` after a 401 to force a fresh assertion.
+
+## Test
+
+```bash
+pnpm --filter @carebridge/epic-connector test
+```
+
+Tests are offline: JWT signatures verify against an ephemeral keypair,
+token exchange uses a mocked fetch, JWK conversion round-trips through
+Node's crypto. The end-to-end sandbox test is intentionally not in CI
+— it requires real Epic credentials and runs locally when present.

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@carebridge/epic-connector",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
+  "bin": {
+    "carebridge-epic-keygen": "dist/bin/keygen.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "epic:keygen": "tsx src/bin/keygen.ts"
+  },
+  "dependencies": {
+    "@carebridge/logger": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@carebridge/test-utils": "workspace:*",
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/services/epic-connector/src/__tests__/capability.test.ts
+++ b/services/epic-connector/src/__tests__/capability.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for SMART configuration discovery (#389).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchSmartConfiguration,
+  smartConfigurationUrl,
+} from "../capability.js";
+
+describe("smartConfigurationUrl (#389)", () => {
+  it("appends /.well-known/smart-configuration to a base URL", () => {
+    expect(
+      smartConfigurationUrl("https://fhir.example.com/api/FHIR/R4/"),
+    ).toBe("https://fhir.example.com/api/FHIR/R4/.well-known/smart-configuration");
+  });
+
+  it("normalises trailing slashes", () => {
+    expect(
+      smartConfigurationUrl("https://fhir.example.com/api/FHIR/R4////"),
+    ).toBe("https://fhir.example.com/api/FHIR/R4/.well-known/smart-configuration");
+  });
+});
+
+describe("fetchSmartConfiguration (#389)", () => {
+  it("returns the parsed JSON on 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token_endpoint: "https://fhir.example.com/oauth2/token",
+          grant_types_supported: ["client_credentials"],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const cfg = await fetchSmartConfiguration(
+      "https://fhir.example.com/api/FHIR/R4/",
+      fetchMock,
+    );
+    expect(cfg.token_endpoint).toBe("https://fhir.example.com/oauth2/token");
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+    await expect(
+      fetchSmartConfiguration(
+        "https://fhir.example.com/api/FHIR/R4/",
+        fetchMock,
+      ),
+    ).rejects.toThrow(/SMART configuration discovery failed: 404/);
+  });
+
+  it("throws when token_endpoint is missing from the response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ grant_types_supported: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(
+      fetchSmartConfiguration(
+        "https://fhir.example.com/api/FHIR/R4/",
+        fetchMock,
+      ),
+    ).rejects.toThrow(/missing token_endpoint/);
+  });
+});

--- a/services/epic-connector/src/__tests__/config.test.ts
+++ b/services/epic-connector/src/__tests__/config.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for Epic config loading (#389).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  loadEpicConfig,
+  EPIC_SANDBOX_TOKEN_URL,
+  EPIC_SANDBOX_FHIR_BASE_URL,
+} from "../config.js";
+
+let tmpDir: string;
+let pemPath: string;
+let privatePem: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "carebridge-epic-config-"));
+  pemPath = join(tmpDir, "epic-private.pem");
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  writeFileSync(pemPath, privatePem, "utf8");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadEpicConfig (#389)", () => {
+  it("loads from a complete env with explicit file path", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.clientId).toBe("abc-123");
+    expect(cfg.jwtKid).toBe("kid-001");
+    expect(cfg.privateKeyPem).toBe(privatePem);
+  });
+
+  it("defaults to sandbox URLs when EPIC_TOKEN_URL / EPIC_FHIR_BASE_URL absent", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.tokenUrl).toBe(EPIC_SANDBOX_TOKEN_URL);
+    expect(cfg.fhirBaseUrl).toBe(EPIC_SANDBOX_FHIR_BASE_URL);
+  });
+
+  it("honours explicit EPIC_TOKEN_URL override (e.g. production)", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+      EPIC_TOKEN_URL: "https://prod.example.com/oauth2/token",
+      EPIC_FHIR_BASE_URL: "https://prod.example.com/api/FHIR/R4/",
+    });
+    expect(cfg.tokenUrl).toBe("https://prod.example.com/oauth2/token");
+    expect(cfg.fhirBaseUrl).toBe("https://prod.example.com/api/FHIR/R4/");
+  });
+
+  it("throws when EPIC_CLIENT_ID is missing", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_PRIVATE_KEY_PATH: pemPath,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow();
+  });
+
+  it("throws when EPIC_JWT_KID is missing", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: pemPath,
+      }),
+    ).toThrow();
+  });
+
+  it("throws when neither PATH nor PEM is set", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/EPIC_PRIVATE_KEY_PATH or EPIC_PRIVATE_KEY_PEM/);
+  });
+
+  it("throws when PATH points at a non-existent file", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: join(tmpDir, "does-not-exist.pem"),
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/Failed to read EPIC_PRIVATE_KEY_PATH/);
+  });
+
+  it("accepts inline PEM when PATH is absent", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PEM: privatePem,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(privatePem);
+  });
+
+  it("prefers PATH over PEM when both are set", () => {
+    const altPem =
+      "-----BEGIN PRIVATE KEY-----\nfake-different-key\n-----END PRIVATE KEY-----";
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_PRIVATE_KEY_PEM: altPem,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(privatePem); // came from PATH, not PEM
+  });
+
+  it("rejects a key that isn't a PEM-encoded RSA private key", () => {
+    const bogus = join(tmpDir, "not-a-key.pem");
+    writeFileSync(bogus, "this is not a key", "utf8");
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: bogus,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/private key must be a PEM/);
+  });
+});

--- a/services/epic-connector/src/__tests__/jwt-assertion.test.ts
+++ b/services/epic-connector/src/__tests__/jwt-assertion.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the RS384 JWT assertion builder (#389).
+ *
+ * These verify the JWT against a fixture keypair generated inside the
+ * test (no Epic call). The verification step uses Node's crypto with
+ * the matching public key to confirm the signature is RS384 and that
+ * the payload claims are spec-compliant.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  generateKeyPairSync,
+  createVerify,
+  KeyObject,
+  randomUUID,
+} from "node:crypto";
+import {
+  buildClientAssertion,
+  decodeAssertionForTest,
+} from "../jwt-assertion.js";
+
+describe("buildClientAssertion (#389)", () => {
+  let privateKeyPem: string;
+  let publicKey: KeyObject;
+
+  beforeAll(() => {
+    const { privateKey, publicKey: pub } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    publicKey = pub;
+  });
+
+  function makeArgs(overrides: Partial<Parameters<typeof buildClientAssertion>[0]> = {}) {
+    return {
+      clientId: "test-client-id-123",
+      tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+      kid: "test-kid-abc",
+      privateKeyPem,
+      ...overrides,
+    };
+  }
+
+  it("emits a compact JWS with three segments", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("uses RS384 algorithm and includes the kid in the header", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { header } = decodeAssertionForTest(jwt);
+    expect(header.alg).toBe("RS384");
+    expect(header.typ).toBe("JWT");
+    expect(header.kid).toBe("test-kid-abc");
+  });
+
+  it("sets iss and sub to the client_id per Backend Services spec", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.iss).toBe("test-client-id-123");
+    expect(payload.sub).toBe("test-client-id-123");
+  });
+
+  it("binds aud to the token endpoint URL", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.aud).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    );
+  });
+
+  it("sets exp to iat + 240s by default (under Epic's 5-minute ceiling)", () => {
+    const fixedNow = 1_700_000_000;
+    const jwt = buildClientAssertion(makeArgs({ now: () => fixedNow }));
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.iat).toBe(fixedNow);
+    expect(payload.exp).toBe(fixedNow + 240);
+  });
+
+  it("honours the expiresInSec override", () => {
+    const fixedNow = 1_700_000_000;
+    const jwt = buildClientAssertion(
+      makeArgs({ now: () => fixedNow, expiresInSec: 60 }),
+    );
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.exp).toBe(fixedNow + 60);
+  });
+
+  it("includes a unique jti claim", () => {
+    const a = decodeAssertionForTest(buildClientAssertion(makeArgs()));
+    const b = decodeAssertionForTest(buildClientAssertion(makeArgs()));
+    expect(a.payload.jti).toBeDefined();
+    expect(b.payload.jti).toBeDefined();
+    expect(a.payload.jti).not.toBe(b.payload.jti);
+  });
+
+  it("honours an injected jti", () => {
+    const jti = randomUUID();
+    const jwt = buildClientAssertion(makeArgs({ jti }));
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.jti).toBe(jti);
+  });
+
+  it("produces an RS384 signature verifiable with the matching public key", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const [header, payload, signature] = jwt.split(".") as [string, string, string];
+    const signingInput = `${header}.${payload}`;
+
+    const sigBuf = Buffer.from(
+      signature.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (signature.length % 4)) % 4),
+      "base64",
+    );
+
+    const verifier = createVerify("RSA-SHA384");
+    verifier.update(signingInput);
+    verifier.end();
+    const ok = verifier.verify(publicKey, sigBuf);
+    expect(ok).toBe(true);
+  });
+
+  it("the same signature does NOT verify under RS256 (algorithm-strict)", () => {
+    // Defends against accidental algorithm downgrade — Epic rejects RS256
+    // for Backend Services so we must produce RS384 specifically.
+    const jwt = buildClientAssertion(makeArgs());
+    const [header, payload, signature] = jwt.split(".") as [string, string, string];
+    const signingInput = `${header}.${payload}`;
+    const sigBuf = Buffer.from(
+      signature.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (signature.length % 4)) % 4),
+      "base64",
+    );
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(signingInput);
+    verifier.end();
+    expect(verifier.verify(publicKey, sigBuf)).toBe(false);
+  });
+});

--- a/services/epic-connector/src/__tests__/keygen.test.ts
+++ b/services/epic-connector/src/__tests__/keygen.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the RS384 keypair generator (#389).
+ *
+ * These exercise the JWK conversion against a known-good RSA keypair
+ * and verify the file-permissions / structure of the on-disk output.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  generateKeyPairSync,
+  createSign,
+  createVerify,
+  createPublicKey,
+} from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeypair, publicKeyFingerprint } from "../keygen.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "carebridge-epic-keygen-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("generateKeypair (#389)", () => {
+  it("writes the private key to the requested path", () => {
+    const out = join(tmpDir, "epic-private.pem");
+    const result = generateKeypair({ privateKeyPath: out });
+    expect(result.privateKeyPath).toBe(out);
+    const pem = readFileSync(out, "utf8");
+    expect(pem).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("sets the private key file mode to 0600 (owner-only)", () => {
+    const out = join(tmpDir, "epic-private.pem");
+    generateKeypair({ privateKeyPath: out });
+    const mode = statSync(out).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("creates intermediate directories", () => {
+    const out = join(tmpDir, "nested", "dir", "epic-private.pem");
+    generateKeypair({ privateKeyPath: out });
+    expect(readFileSync(out, "utf8")).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("returns a JWK with kty=RSA, alg=RS384, use=sig", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    expect(result.publicJwk.kty).toBe("RSA");
+    expect(result.publicJwk.alg).toBe("RS384");
+    expect(result.publicJwk.use).toBe("sig");
+  });
+
+  it("uses the provided kid", () => {
+    const kid = "my-rotation-2026-01";
+    const result = generateKeypair({
+      privateKeyPath: join(tmpDir, "k.pem"),
+      kid,
+    });
+    expect(result.publicJwk.kid).toBe(kid);
+    expect(result.kid).toBe(kid);
+  });
+
+  it("generates a JWK that verifies signatures made with the private key", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    const privatePem = readFileSync(result.privateKeyPath, "utf8");
+
+    // Sign arbitrary data with the generated private key, then verify
+    // with a public key reconstructed from the JWK. This is the
+    // round-trip Epic does server-side when it receives our assertion.
+    const signer = createSign("RSA-SHA384");
+    signer.update("test-payload");
+    signer.end();
+    const sig = signer.sign(privatePem);
+
+    const publicKey = createPublicKey({
+      key: { ...result.publicJwk } as Record<string, string>,
+      format: "jwk",
+    });
+    const verifier = createVerify("RSA-SHA384");
+    verifier.update("test-payload");
+    verifier.end();
+    expect(verifier.verify(publicKey, sig)).toBe(true);
+  });
+
+  it("emits base64url-encoded n and e (no padding, URL-safe alphabet)", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    // base64url: A-Z, a-z, 0-9, -, _ — no =, +, /
+    expect(result.publicJwk.n).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(result.publicJwk.e).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("honours an injected generator (test injection)", () => {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privatePem = privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString();
+    const publicPem = publicKey
+      .export({ type: "spki", format: "pem" })
+      .toString();
+
+    const result = generateKeypair({
+      privateKeyPath: join(tmpDir, "k.pem"),
+      generator: () => ({ privatePem, publicPem }),
+    });
+
+    // Writing the injected private key should produce a JWK whose
+    // public key matches the injected public key.
+    const reconstructed = createPublicKey({
+      key: { ...result.publicJwk } as Record<string, string>,
+      format: "jwk",
+    });
+    const reconstructedPem = reconstructed
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    expect(reconstructedPem).toBe(publicPem);
+  });
+});
+
+describe("publicKeyFingerprint (#389)", () => {
+  it("returns a 16-char hex prefix of the SHA-256 DER fingerprint", () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const fp = publicKeyFingerprint(pem);
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is deterministic for the same key", () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    expect(publicKeyFingerprint(pem)).toBe(publicKeyFingerprint(pem));
+  });
+});

--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for EpicTokenClient (#389).
+ *
+ * Mocks fetch so the tests run offline. Real-Epic integration is gated
+ * on EPIC_CLIENT_ID and runs locally when the user has credentials.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicTokenClient, DEFAULT_SYSTEM_SCOPES } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client-id-xyz",
+    tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+function tokenResponse(opts: { expires_in?: number; access_token?: string } = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: opts.access_token ?? "fake-access-token",
+      expires_in: opts.expires_in ?? 3600,
+      token_type: "Bearer",
+      scope: DEFAULT_SYSTEM_SCOPES.join(" "),
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("EpicTokenClient (#389)", () => {
+  let privatePem: string;
+
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  it("requests a token via client_credentials with a JWT assertion", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    );
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("client_assertion_type")).toBe(
+      "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    );
+    expect(body.get("client_assertion")).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(body.get("scope")).toBe(DEFAULT_SYSTEM_SCOPES.join(" "));
+  });
+
+  it("returns the parsed access_token from a 200 response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      tokenResponse({ access_token: "abc-123" }),
+    );
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+    const token = await client.getAccessToken();
+    expect(token).toBe("abc-123");
+  });
+
+  it("caches the token and serves subsequent calls without re-fetching", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+    await client.getAccessToken();
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("re-requests when the cached token has less than 60s of lifetime left", async () => {
+    let now = 1_700_000_000_000;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () => tokenResponse({ expires_in: 100 }));
+    const client = new EpicTokenClient(
+      makeConfig(privatePem),
+      fetchMock,
+      () => now,
+    );
+
+    await client.getAccessToken();
+    // Jump forward 50 seconds — still within the 60s refresh buffer
+    // window (100 - 50 = 50 remaining ≤ 60 → re-request).
+    now += 50_000;
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT re-request when cache still has > 60s of lifetime", async () => {
+    let now = 1_700_000_000_000;
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse({ expires_in: 3600 }));
+    const client = new EpicTokenClient(
+      makeConfig(privatePem),
+      fetchMock,
+      () => now,
+    );
+
+    await client.getAccessToken();
+    now += 600_000; // 10 min later — token still has ~50 min left
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("invalidate() forces a fresh token on next call", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+    client.invalidate();
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on non-2xx response without leaking the assertion body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("invalid_client_assertion_or_signature", { status: 400 }),
+    );
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await expect(client.getAccessToken()).rejects.toThrow(/Epic token endpoint returned 400/);
+  });
+
+  it("accepts custom scope override", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken(["system/Patient.read"]);
+
+    const body = new URLSearchParams(
+      fetchMock.mock.calls[0]![1].body as string,
+    );
+    expect(body.get("scope")).toBe("system/Patient.read");
+  });
+});

--- a/services/epic-connector/src/bin/keygen.ts
+++ b/services/epic-connector/src/bin/keygen.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * `carebridge-epic-keygen` — one-shot RS384 keypair setup (#389).
+ *
+ * Usage:
+ *   pnpm epic:keygen [--out <path>] [--kid <id>]
+ *
+ * Defaults:
+ *   --out  ~/.carebridge/epic-private.pem
+ *   --kid  fresh UUID v4
+ *
+ * On success, prints:
+ *  1. The path the private key was written to (chmod 0600).
+ *  2. The kid to set as EPIC_JWT_KID.
+ *  3. The public JWK to paste into open.epic.com → App Settings →
+ *     Public Keys.
+ *  4. The .env snippet to copy into your local .env.local.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { generateKeypair, publicKeyFingerprint } from "../keygen.js";
+
+interface Args {
+  out: string;
+  kid?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    out: join(homedir(), ".carebridge", "epic-private.pem"),
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out" || arg === "-o") {
+      const next = argv[++i];
+      if (!next) throw new Error("--out requires a path argument");
+      args.out = next;
+    } else if (arg === "--kid") {
+      const next = argv[++i];
+      if (!next) throw new Error("--kid requires an id argument");
+      args.kid = next;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `Usage: carebridge-epic-keygen [--out <path>] [--kid <id>]\n\n` +
+      `Generates an RS384 keypair for Epic SMART Backend Services and\n` +
+      `prints the public JWK for upload at open.epic.com.\n\n` +
+      `Options:\n` +
+      `  --out, -o   Path to write the private key PEM (chmod 0600).\n` +
+      `              Default: ~/.carebridge/epic-private.pem\n` +
+      `  --kid       Key id to embed in the JWK. Default: fresh UUID.\n` +
+      `  --help, -h  Show this help.\n`,
+  );
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const result = generateKeypair({
+    privateKeyPath: args.out,
+    kid: args.kid,
+  });
+
+  const fingerprint = publicKeyFingerprint(result.publicKeyPem);
+
+  /* eslint-disable no-console */
+  console.log("\n=== Epic SMART Backend Services keypair generated ===\n");
+  console.log(`Private key:    ${result.privateKeyPath}  (chmod 0600)`);
+  console.log(`Key id (kid):   ${result.kid}`);
+  console.log(`Fingerprint:    sha256:${fingerprint}\n`);
+  console.log("Public JWK — paste this at open.epic.com → App Settings → Public Keys:\n");
+  console.log(JSON.stringify(result.publicJwk, null, 2));
+  console.log("\n.env.local snippet:\n");
+  console.log(`EPIC_CLIENT_ID=<paste your Non-Production Client ID here>`);
+  console.log(`EPIC_PRIVATE_KEY_PATH=${result.privateKeyPath}`);
+  console.log(`EPIC_JWT_KID=${result.kid}\n`);
+  console.log(
+    "Defaults to Epic's sandbox (fhir.epic.com). Override " +
+      "EPIC_TOKEN_URL and EPIC_FHIR_BASE_URL for production.",
+  );
+  /* eslint-enable no-console */
+}
+
+try {
+  main();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `epic-keygen failed: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+}

--- a/services/epic-connector/src/capability.ts
+++ b/services/epic-connector/src/capability.ts
@@ -31,13 +31,14 @@ export interface SmartConfiguration {
 }
 
 /**
- * Build the well-known URL for the given FHIR base URL. The well-known
- * doc lives at the server root, NOT under the FHIR base, so we strip
- * any /FHIR/R4 suffix before appending.
+ * Build the well-known URL for the given FHIR base URL. Per SMART App
+ * Launch §Discovery, the conformance document MAY be served from the
+ * FHIR base or from the server root — Epic's interconnect deployments
+ * serve it from the FHIR base, so we keep the path intact and just
+ * append `.well-known/smart-configuration`. Hosts that require root-
+ * level discovery can pass the root URL directly.
  */
 export function smartConfigurationUrl(fhirBaseUrl: string): string {
-  // Strip a trailing FHIR-version path segment if present, then append
-  // .well-known/smart-configuration per the spec.
   const trimmed = fhirBaseUrl.replace(/\/+$/, "");
   return `${trimmed}/.well-known/smart-configuration`;
 }

--- a/services/epic-connector/src/capability.ts
+++ b/services/epic-connector/src/capability.ts
@@ -1,0 +1,81 @@
+/**
+ * SMART configuration discovery (#389).
+ *
+ * Per the SMART App Launch spec §Discovery, a FHIR server publishes a
+ * JSON document at `/.well-known/smart-configuration` describing its
+ * OAuth2 endpoints, supported scopes, and capabilities.
+ *
+ * Used at startup to resolve the token endpoint when it isn't pinned in
+ * config, and to confirm the server advertises `client-credentials`
+ * grant support before we attempt a backend-services token exchange.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#smart-configuration
+ */
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-capability");
+
+export interface SmartConfiguration {
+  /** OAuth2 token endpoint — what the assertion's `aud` claim binds to. */
+  token_endpoint: string;
+  /** OAuth2 authorisation endpoint (used by SMART App Launch, not Backend Services). */
+  authorization_endpoint?: string;
+  /** JWKS URI Epic uses to validate the assertion's signature. */
+  jwks_uri?: string;
+  /** Capabilities advertised by the server (e.g. "client-confidential-asymmetric"). */
+  capabilities?: string[];
+  /** Grant types supported (we require "client_credentials"). */
+  grant_types_supported?: string[];
+  /** Scopes supported (subset of what we request). */
+  scopes_supported?: string[];
+}
+
+/**
+ * Build the well-known URL for the given FHIR base URL. The well-known
+ * doc lives at the server root, NOT under the FHIR base, so we strip
+ * any /FHIR/R4 suffix before appending.
+ */
+export function smartConfigurationUrl(fhirBaseUrl: string): string {
+  // Strip a trailing FHIR-version path segment if present, then append
+  // .well-known/smart-configuration per the spec.
+  const trimmed = fhirBaseUrl.replace(/\/+$/, "");
+  return `${trimmed}/.well-known/smart-configuration`;
+}
+
+/**
+ * Fetch and parse the SMART configuration. Throws on network failure,
+ * non-2xx response, or malformed JSON. Callers should cache the result
+ * — these documents change rarely and a refetch per token request is
+ * wasted network.
+ */
+export async function fetchSmartConfiguration(
+  fhirBaseUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SmartConfiguration> {
+  const url = smartConfigurationUrl(fhirBaseUrl);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `SMART configuration discovery failed: ${response.status} ${response.statusText} at ${url}`,
+    );
+  }
+  const parsed = (await response.json()) as SmartConfiguration;
+  if (!parsed.token_endpoint) {
+    throw new Error(
+      `SMART configuration at ${url} is missing token_endpoint`,
+    );
+  }
+  if (
+    parsed.grant_types_supported &&
+    !parsed.grant_types_supported.includes("client_credentials")
+  ) {
+    log.warn(
+      "SMART configuration does not advertise client_credentials grant",
+      { url, grants: parsed.grant_types_supported },
+    );
+  }
+  return parsed;
+}

--- a/services/epic-connector/src/config.ts
+++ b/services/epic-connector/src/config.ts
@@ -12,10 +12,11 @@
  *                               sandbox default when absent).
  *   EPIC_FHIR_BASE_URL        — FHIR R4 base URL for read operations.
  *   EPIC_PRIVATE_KEY_PATH     — Filesystem path to the RS384 private-key
- *                               PEM. Mutually exclusive with PEM env.
- *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Takes precedence over
- *                               PATH only when PATH is absent — explicit
- *                               PATH preferred for ease of rotation.
+ *                               PEM. Takes precedence when set.
+ *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Used only when
+ *                               EPIC_PRIVATE_KEY_PATH is unset. Setting
+ *                               both is allowed but PATH wins — explicit
+ *                               PATH is preferred for ease of rotation.
  *   EPIC_JWT_KID              — Key id matching the JWK uploaded at
  *                               open.epic.com. Required so Epic can
  *                               select the right public key when the

--- a/services/epic-connector/src/config.ts
+++ b/services/epic-connector/src/config.ts
@@ -1,0 +1,88 @@
+/**
+ * Epic connector configuration (#389).
+ *
+ * Resolves Epic credentials from environment, validates required fields,
+ * and loads the RS384 private key used to sign JWT client assertions for
+ * the SMART Backend Services flow.
+ *
+ * Env vars:
+ *   EPIC_CLIENT_ID            — Non-Production / Production Client ID issued
+ *                               by open.epic.com after app registration.
+ *   EPIC_TOKEN_URL            — OAuth2 token endpoint (resolved from the
+ *                               sandbox default when absent).
+ *   EPIC_FHIR_BASE_URL        — FHIR R4 base URL for read operations.
+ *   EPIC_PRIVATE_KEY_PATH     — Filesystem path to the RS384 private-key
+ *                               PEM. Mutually exclusive with PEM env.
+ *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Takes precedence over
+ *                               PATH only when PATH is absent — explicit
+ *                               PATH preferred for ease of rotation.
+ *   EPIC_JWT_KID              — Key id matching the JWK uploaded at
+ *                               open.epic.com. Required so Epic can
+ *                               select the right public key when the
+ *                               registered JWKS has more than one entry.
+ */
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+const SANDBOX_TOKEN_URL =
+  "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token";
+const SANDBOX_FHIR_BASE_URL =
+  "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+
+const configSchema = z.object({
+  clientId: z.string().min(1, "EPIC_CLIENT_ID is required"),
+  tokenUrl: z.string().url(),
+  fhirBaseUrl: z.string().url(),
+  privateKeyPem: z
+    .string()
+    .min(1)
+    .refine(
+      (pem) =>
+        pem.includes("BEGIN RSA PRIVATE KEY") ||
+        pem.includes("BEGIN PRIVATE KEY"),
+      "private key must be a PEM-encoded RSA key",
+    ),
+  jwtKid: z.string().min(1, "EPIC_JWT_KID is required"),
+});
+
+export type EpicConfig = z.infer<typeof configSchema>;
+
+function readPrivateKey(env: NodeJS.ProcessEnv): string {
+  const inlinePem = env.EPIC_PRIVATE_KEY_PEM;
+  const path = env.EPIC_PRIVATE_KEY_PATH;
+
+  if (path) {
+    try {
+      return readFileSync(path, "utf8");
+    } catch (err) {
+      throw new Error(
+        `Failed to read EPIC_PRIVATE_KEY_PATH "${path}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  if (inlinePem) return inlinePem;
+  throw new Error(
+    "Either EPIC_PRIVATE_KEY_PATH or EPIC_PRIVATE_KEY_PEM must be set",
+  );
+}
+
+/**
+ * Resolve the Epic connector configuration from process env. Throws on
+ * missing required values or a malformed private key — fail loudly at
+ * boot rather than at first token request.
+ */
+export function loadEpicConfig(env: NodeJS.ProcessEnv = process.env): EpicConfig {
+  const parsed = configSchema.parse({
+    clientId: env.EPIC_CLIENT_ID,
+    tokenUrl: env.EPIC_TOKEN_URL ?? SANDBOX_TOKEN_URL,
+    fhirBaseUrl: env.EPIC_FHIR_BASE_URL ?? SANDBOX_FHIR_BASE_URL,
+    privateKeyPem: readPrivateKey(env),
+    jwtKid: env.EPIC_JWT_KID,
+  });
+  return parsed;
+}
+
+export const EPIC_SANDBOX_TOKEN_URL = SANDBOX_TOKEN_URL;
+export const EPIC_SANDBOX_FHIR_BASE_URL = SANDBOX_FHIR_BASE_URL;

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -15,7 +15,6 @@ export {
 } from "./config.js";
 export {
   buildClientAssertion,
-  decodeAssertionForTest,
   type BuildAssertionArgs,
 } from "./jwt-assertion.js";
 export {

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @carebridge/epic-connector — Epic SMART on FHIR integration.
+ *
+ * #389 ships SMART Backend Services authentication: RS384 JWT
+ * assertion, OAuth2 client-credentials token exchange, expiry-aware
+ * caching, and SMART configuration discovery.
+ *
+ * Follow-ups will add the typed FHIR client (#390), sync worker (#391),
+ * App Launch (#392), and outbound flag push (#393).
+ */
+export { loadEpicConfig, type EpicConfig } from "./config.js";
+export {
+  EPIC_SANDBOX_TOKEN_URL,
+  EPIC_SANDBOX_FHIR_BASE_URL,
+} from "./config.js";
+export {
+  buildClientAssertion,
+  decodeAssertionForTest,
+  type BuildAssertionArgs,
+} from "./jwt-assertion.js";
+export {
+  EpicTokenClient,
+  DEFAULT_SYSTEM_SCOPES,
+  type TokenResponse,
+} from "./token-client.js";
+export {
+  fetchSmartConfiguration,
+  smartConfigurationUrl,
+  type SmartConfiguration,
+} from "./capability.js";
+export {
+  generateKeypair,
+  publicKeyFingerprint,
+  type GeneratedKeyPair,
+  type PublicJwk,
+  type GenerateOptions,
+} from "./keygen.js";

--- a/services/epic-connector/src/jwt-assertion.ts
+++ b/services/epic-connector/src/jwt-assertion.ts
@@ -90,8 +90,10 @@ export function buildClientAssertion(args: BuildAssertionArgs): string {
 }
 
 /**
- * Decode the JWT header + payload without verification. Test helper —
- * production code never inspects its own signed JWTs; Epic does that.
+ * Decode the JWT header + payload without verification. Internal test
+ * helper — intentionally NOT re-exported from the package entrypoint.
+ * Production code never inspects its own signed JWTs; Epic does that.
+ * Import from `./jwt-assertion.js` directly within tests.
  */
 export function decodeAssertionForTest(jwt: string): {
   header: Record<string, unknown>;

--- a/services/epic-connector/src/jwt-assertion.ts
+++ b/services/epic-connector/src/jwt-assertion.ts
@@ -1,0 +1,114 @@
+/**
+ * RS384-signed JWT client assertion for SMART Backend Services (#389).
+ *
+ * Per the SMART App Launch spec §Backend Services, the client_assertion
+ * is a JWT signed with the client's registered private key. Epic requires
+ * RS384 (RSA + SHA-384) — NOT the default RS256 most JWT libraries use.
+ *
+ * Claims per the spec:
+ *   iss  — client_id
+ *   sub  — client_id (same value; system-to-system, no user subject)
+ *   aud  — token endpoint URL (the resource the assertion authorises)
+ *   exp  — issued-at + 5 min (Epic rejects anything longer)
+ *   jti  — unique id (Epic rejects re-use within the exp window)
+ *
+ * Uses Node's crypto rather than a JWT library to keep the dependency
+ * surface small and so the algorithm choice is explicit at the call site.
+ */
+import { createSign, randomUUID } from "node:crypto";
+
+export interface BuildAssertionArgs {
+  clientId: string;
+  /** Epic token endpoint URL — the `aud` claim. */
+  tokenUrl: string;
+  /** Key id matching the JWK uploaded at open.epic.com. */
+  kid: string;
+  /** RS384 private key in PEM format. */
+  privateKeyPem: string;
+  /**
+   * Lifetime of the assertion in seconds. Defaults to 4 minutes (240s)
+   * — well under Epic's 5-minute ceiling but long enough to tolerate
+   * modest clock skew between this host and Epic.
+   */
+  expiresInSec?: number;
+  /**
+   * Override `iat` / `exp` time source for tests. Defaults to Date.now().
+   */
+  now?: () => number;
+  /**
+   * Override `jti` for tests. Defaults to crypto.randomUUID().
+   */
+  jti?: string;
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input) : input;
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/**
+ * Build an RS384-signed JWT client assertion. Returns the compact JWS
+ * (header.payload.signature) ready to plug into the
+ * client_assertion form parameter of a token request.
+ */
+export function buildClientAssertion(args: BuildAssertionArgs): string {
+  const now = args.now?.() ?? Math.floor(Date.now() / 1000);
+  const expiresInSec = args.expiresInSec ?? 240;
+  const jti = args.jti ?? randomUUID();
+
+  const header = {
+    alg: "RS384",
+    typ: "JWT",
+    kid: args.kid,
+  };
+  const payload = {
+    iss: args.clientId,
+    sub: args.clientId,
+    aud: args.tokenUrl,
+    exp: now + expiresInSec,
+    iat: now,
+    jti,
+  };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  // RSA-SHA384 sign. Node's createSign("RSA-SHA384") is the explicit RS384
+  // path — important because most generic crypto.sign callers default to
+  // RS256 which Epic rejects.
+  const signer = createSign("RSA-SHA384");
+  signer.update(signingInput);
+  signer.end();
+  const signature = base64UrlEncode(signer.sign(args.privateKeyPem));
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Decode the JWT header + payload without verification. Test helper —
+ * production code never inspects its own signed JWTs; Epic does that.
+ */
+export function decodeAssertionForTest(jwt: string): {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signature: string;
+} {
+  const [h, p, s] = jwt.split(".");
+  if (!h || !p || !s) throw new Error("malformed JWT");
+  const fromB64Url = (input: string): string =>
+    Buffer.from(
+      input.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (input.length % 4)) % 4),
+      "base64",
+    ).toString("utf8");
+  return {
+    header: JSON.parse(fromB64Url(h)) as Record<string, unknown>,
+    payload: JSON.parse(fromB64Url(p)) as Record<string, unknown>,
+    signature: s,
+  };
+}

--- a/services/epic-connector/src/keygen.ts
+++ b/services/epic-connector/src/keygen.ts
@@ -154,8 +154,8 @@ export interface GenerateOptions {
   privateKeyPath: string;
   /**
    * Override the kid. Defaults to a fresh UUID — fine for first-time
-   * setup. Rotations should pass the prior kid so server-side caches
-   * don't have to refetch the JWKS.
+   * setup. Rotations typically generate a NEW kid so the previous JWKS
+   * entry can be retained alongside the new one until Epic re-fetches.
    */
   kid?: string;
   /**
@@ -170,7 +170,7 @@ export interface GenerateOptions {
  * public JWK + kid for upload to open.epic.com.
  */
 export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
-  const kid = options.kid ?? randomUUIDv5Stable();
+  const kid = options.kid ?? generateKid();
   const generated =
     options.generator?.() ??
     (() => {
@@ -188,10 +188,19 @@ export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
     })();
 
   mkdirSync(dirname(options.privateKeyPath), { recursive: true });
-  writeFileSync(options.privateKeyPath, generated.privatePem, "utf8");
-  // Tighten permissions so the private key isn't world-readable. The
-  // openssl-generated default leaves 0644 on macOS — easy to leak via
-  // a misconfigured backup.
+  // Create the file with 0600 from the start. `writeFileSync` accepts a
+  // `mode` option that's applied at open() time, closing the race window
+  // where a separate chmod after writeFileSync would leave the key
+  // world-readable for the few syscalls in between. The `flag: "w"`
+  // matches the default but is explicit for the security audit trail.
+  writeFileSync(options.privateKeyPath, generated.privatePem, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: "w",
+  });
+  // Belt-and-braces: chmod after the write in case an existing file
+  // was overwritten and the new mode wasn't applied (older Node
+  // versions did NOT update mode on overwrite of an existing file).
   chmodSync(options.privateKeyPath, 0o600);
 
   const publicJwk = rsaPublicPemToJwk(generated.publicPem, kid);
@@ -204,10 +213,12 @@ export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
 }
 
 /**
- * Stable kid generator — uses crypto.randomUUID under the hood. Kept
- * factorable so tests can stub kid generation.
+ * Default kid generator — emits a fresh UUID v4 from crypto.randomUUID
+ * per invocation. Factored out so tests can stub kid generation for
+ * deterministic fixtures. The name was previously misleading; this is
+ * NOT a UUID v5 (no namespacing) and is NOT stable across invocations.
  */
-function randomUUIDv5Stable(): string {
+function generateKid(): string {
   return randomUUID();
 }
 

--- a/services/epic-connector/src/keygen.ts
+++ b/services/epic-connector/src/keygen.ts
@@ -1,0 +1,222 @@
+/**
+ * RS384 keypair generator for Epic SMART Backend Services (#389).
+ *
+ * Generates an RSA 2048-bit keypair (Epic's minimum), writes the private
+ * key as PEM to disk, and converts the public key to JWK form ready for
+ * upload at open.epic.com → App Settings → Public Keys.
+ *
+ * Why a custom helper instead of `openssl genrsa` + manual JWK conversion:
+ *  - Single command sets correct file permissions (0600) on the private
+ *    key, hard to get wrong with `openssl` defaults.
+ *  - JWK output already includes the `alg: "RS384"` and `kid` fields
+ *    Epic expects, with the right base64url encoding (not base64).
+ *  - No openssl version differences (LibreSSL on macOS vs OpenSSL on
+ *    Linux produce subtly different PEM headers).
+ */
+import { generateKeyPairSync, createHash, randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface GeneratedKeyPair {
+  /** Filesystem path the private key PEM was written to. */
+  privateKeyPath: string;
+  /** Public key as a JWK ready to paste into open.epic.com. */
+  publicJwk: PublicJwk;
+  /** Key id — matches the `kid` claim in JWT assertions. */
+  kid: string;
+  /**
+   * Public key in SPKI PEM form. Exposed alongside the JWK so callers
+   * can pass it through helpers expecting PEM (e.g. fingerprint
+   * printing) without having to re-derive it from the on-disk private
+   * key.
+   */
+  publicKeyPem: string;
+}
+
+export interface PublicJwk {
+  kty: "RSA";
+  alg: "RS384";
+  use: "sig";
+  kid: string;
+  n: string;
+  e: string;
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/**
+ * Convert an RSA public key (PEM) → JWK form suitable for upload at
+ * open.epic.com. The exported PEM is SPKI; we strip the ASN.1 envelope
+ * and pull out the modulus (`n`) and exponent (`e`).
+ */
+function rsaPublicPemToJwk(spkiPem: string, kid: string): PublicJwk {
+  const der = pemToDer(spkiPem);
+  // Parse the SPKI structure to extract the RSA public key. RFC 5280
+  // §4.1.2.7 SubjectPublicKeyInfo: SEQUENCE { algorithm, subjectPublicKey BIT STRING }
+  // For RSA, the BIT STRING wraps RSAPublicKey: SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+  // We walk the DER manually rather than pulling in an ASN.1 lib — the
+  // structure is small and stable.
+  const rsaKey = extractRsaPublicKey(der);
+  return {
+    kty: "RSA",
+    alg: "RS384",
+    use: "sig",
+    kid,
+    n: base64UrlEncode(rsaKey.modulus),
+    e: base64UrlEncode(rsaKey.exponent),
+  };
+}
+
+function pemToDer(pem: string): Buffer {
+  const body = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  return Buffer.from(body, "base64");
+}
+
+/**
+ * Walk an SPKI-encoded RSA public key and pull out modulus + exponent.
+ * The structure is:
+ *   SEQUENCE {                             // outer SPKI
+ *     SEQUENCE { OID, NULL }               // algorithm identifier
+ *     BIT STRING {
+ *       SEQUENCE {                         // RSAPublicKey
+ *         INTEGER modulus
+ *         INTEGER exponent
+ *       }
+ *     }
+ *   }
+ */
+function extractRsaPublicKey(spki: Buffer): {
+  modulus: Buffer;
+  exponent: Buffer;
+} {
+  let cursor = 0;
+  // outer SEQUENCE
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected SEQUENCE");
+  cursor += readLength(spki, cursor).bytes;
+  // algorithm identifier SEQUENCE — skip
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected algorithm SEQUENCE");
+  const algLen = readLength(spki, cursor);
+  cursor += algLen.bytes + algLen.value;
+  // BIT STRING
+  if (spki[cursor++] !== 0x03) throw new Error("SPKI: expected BIT STRING");
+  const bitLen = readLength(spki, cursor);
+  cursor += bitLen.bytes;
+  if (spki[cursor++] !== 0x00)
+    throw new Error("SPKI: expected 0 unused bits in BIT STRING");
+  // inner SEQUENCE RSAPublicKey
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected RSAPublicKey SEQUENCE");
+  cursor += readLength(spki, cursor).bytes;
+  // INTEGER modulus
+  if (spki[cursor++] !== 0x02) throw new Error("SPKI: expected INTEGER modulus");
+  const modLen = readLength(spki, cursor);
+  cursor += modLen.bytes;
+  let modulus = spki.subarray(cursor, cursor + modLen.value);
+  // RSA moduli have a leading 0x00 sign byte; strip it so the JWK `n`
+  // is the unsigned big-endian magnitude per RFC 7518 §6.3.1.
+  if (modulus[0] === 0x00) modulus = modulus.subarray(1);
+  cursor += modLen.value;
+  // INTEGER exponent
+  if (spki[cursor++] !== 0x02) throw new Error("SPKI: expected INTEGER exponent");
+  const expLen = readLength(spki, cursor);
+  cursor += expLen.bytes;
+  const exponent = spki.subarray(cursor, cursor + expLen.value);
+  return { modulus, exponent };
+}
+
+function readLength(
+  buf: Buffer,
+  offset: number,
+): { value: number; bytes: number } {
+  const first = buf[offset];
+  if (first === undefined) throw new Error("DER: truncated length");
+  if (first < 0x80) return { value: first, bytes: 1 };
+  const numBytes = first & 0x7f;
+  let value = 0;
+  for (let i = 1; i <= numBytes; i++) {
+    const b = buf[offset + i];
+    if (b === undefined) throw new Error("DER: truncated length");
+    value = (value << 8) | b;
+  }
+  return { value, bytes: numBytes + 1 };
+}
+
+export interface GenerateOptions {
+  /** Path the private key PEM is written to. */
+  privateKeyPath: string;
+  /**
+   * Override the kid. Defaults to a fresh UUID — fine for first-time
+   * setup. Rotations should pass the prior kid so server-side caches
+   * don't have to refetch the JWKS.
+   */
+  kid?: string;
+  /**
+   * Override the keypair generator (test injection). Defaults to the
+   * Node crypto generator.
+   */
+  generator?: () => { privatePem: string; publicPem: string };
+}
+
+/**
+ * Generate an RS384 keypair, persist the private key, and return the
+ * public JWK + kid for upload to open.epic.com.
+ */
+export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
+  const kid = options.kid ?? randomUUIDv5Stable();
+  const generated =
+    options.generator?.() ??
+    (() => {
+      const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+      });
+      return {
+        privatePem: privateKey
+          .export({ type: "pkcs8", format: "pem" })
+          .toString(),
+        publicPem: publicKey
+          .export({ type: "spki", format: "pem" })
+          .toString(),
+      };
+    })();
+
+  mkdirSync(dirname(options.privateKeyPath), { recursive: true });
+  writeFileSync(options.privateKeyPath, generated.privatePem, "utf8");
+  // Tighten permissions so the private key isn't world-readable. The
+  // openssl-generated default leaves 0644 on macOS — easy to leak via
+  // a misconfigured backup.
+  chmodSync(options.privateKeyPath, 0o600);
+
+  const publicJwk = rsaPublicPemToJwk(generated.publicPem, kid);
+  return {
+    privateKeyPath: options.privateKeyPath,
+    publicJwk,
+    kid,
+    publicKeyPem: generated.publicPem,
+  };
+}
+
+/**
+ * Stable kid generator — uses crypto.randomUUID under the hood. Kept
+ * factorable so tests can stub kid generation.
+ */
+function randomUUIDv5Stable(): string {
+  return randomUUID();
+}
+
+/**
+ * Convenience: sha-256 fingerprint of a public PEM, useful for printing
+ * a short identifier alongside the kid for human verification at upload
+ * time ("is this the same key I just generated?").
+ */
+export function publicKeyFingerprint(spkiPem: string): string {
+  const der = pemToDer(spkiPem);
+  return createHash("sha256").update(der).digest("hex").slice(0, 16);
+}

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -117,14 +117,18 @@ export class EpicTokenClient {
 
     if (!response.ok) {
       const text = await response.text();
-      // Epic returns structured OAuth2 errors as JSON; preserve them in
-      // the log for debugging but throw a clean message upstream — the
-      // body may contain the assertion (echoed back), so the caller
-      // should not surface it to end users.
+      // Epic returns OAuth 2.0 error payloads as JSON with `error` /
+      // `error_description` fields. Parse those out and log ONLY the
+      // structured fields — never the raw body, which may echo back the
+      // client_assertion JWT (a credential that, if leaked to log
+      // collectors, can be replayed against Epic for the assertion's
+      // lifetime).
+      const errorFields = parseOAuthError(text);
       log.warn("Epic token request failed", {
         status: response.status,
         statusText: response.statusText,
-        bodyPrefix: text.slice(0, 200),
+        oauth_error: errorFields.error,
+        oauth_error_description: errorFields.error_description,
       });
       throw new Error(
         `Epic token endpoint returned ${response.status} ${response.statusText}`,
@@ -148,5 +152,29 @@ export class EpicTokenClient {
    */
   invalidate(): void {
     this.cached = null;
+  }
+}
+
+/**
+ * Best-effort parser for OAuth 2.0 error responses (RFC 6749 §5.2).
+ * Returns the structured `error` + `error_description` fields when the
+ * body is JSON; falls back to undefined when it isn't (so the caller
+ * doesn't accidentally log opaque token endpoint output).
+ */
+function parseOAuthError(body: string): {
+  error?: string;
+  error_description?: string;
+} {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    return {
+      error: typeof parsed.error === "string" ? parsed.error : undefined,
+      error_description:
+        typeof parsed.error_description === "string"
+          ? parsed.error_description
+          : undefined,
+    };
+  } catch {
+    return {};
   }
 }

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -1,0 +1,152 @@
+/**
+ * Epic SMART Backend Services token client (#389).
+ *
+ * Exchanges a client_assertion JWT for an OAuth 2.0 access token at
+ * Epic's token endpoint, caching the result until shortly before expiry.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/backend-services.html
+ *
+ * Request shape (form-encoded):
+ *   grant_type=client_credentials
+ *   client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+ *   client_assertion=<RS384-signed JWT>
+ *   scope=<space-separated SMART scopes>
+ *
+ * Response: { access_token, expires_in, token_type, scope }
+ */
+import { createLogger } from "@carebridge/logger";
+import { buildClientAssertion } from "./jwt-assertion.js";
+import type { EpicConfig } from "./config.js";
+
+const log = createLogger("epic-token-client");
+
+/**
+ * Default SMART Backend Services scopes (Epic-supported subset).
+ * Callers can override by passing `scopes` to {@link getAccessToken}.
+ */
+export const DEFAULT_SYSTEM_SCOPES = [
+  "system/Patient.read",
+  "system/Observation.read",
+  "system/Condition.read",
+  "system/MedicationRequest.read",
+  "system/AllergyIntolerance.read",
+  "system/Encounter.read",
+];
+
+/**
+ * Refresh-buffer window (seconds). When the cached token's remaining
+ * lifetime drops below this, the next call requests a fresh one. 60s
+ * is comfortably longer than the worst-case network RTT and Epic's
+ * documented token-issue latency.
+ */
+const REFRESH_BUFFER_SEC = 60;
+
+export interface TokenResponse {
+  /** Bearer access token to send as Authorization: Bearer <token>. */
+  access_token: string;
+  /** Seconds until expiry from issue time. Epic typically returns 3600. */
+  expires_in: number;
+  /** Always "Bearer" for SMART Backend Services. */
+  token_type: string;
+  /** Granted scopes (space-separated); may be a subset of what was requested. */
+  scope: string;
+}
+
+interface CachedToken {
+  response: TokenResponse;
+  /** Absolute wall-clock time the token expires (ms). */
+  expiresAtMs: number;
+}
+
+/**
+ * Stateful token client. Holds the cached token and the config.
+ * One instance per Epic tenant; multi-tenant deployments instantiate
+ * separately per (clientId, tokenUrl) pair.
+ */
+export class EpicTokenClient {
+  private cached: CachedToken | null = null;
+
+  constructor(
+    private readonly config: EpicConfig,
+    /** Override for tests; defaults to global fetch. */
+    private readonly fetchImpl: typeof fetch = fetch,
+    /** Override for tests; defaults to Date.now. */
+    private readonly nowMs: () => number = () => Date.now(),
+  ) {}
+
+  /**
+   * Return a usable access token. Uses the cached value when it has
+   * more than REFRESH_BUFFER_SEC of lifetime left; otherwise requests
+   * a fresh one. Thread-safe in Node's single-threaded event loop —
+   * concurrent callers within a tick share the same in-flight request
+   * via the cache being populated on resolution.
+   */
+  async getAccessToken(scopes: string[] = DEFAULT_SYSTEM_SCOPES): Promise<string> {
+    if (this.cached) {
+      const remainingMs = this.cached.expiresAtMs - this.nowMs();
+      if (remainingMs > REFRESH_BUFFER_SEC * 1000) {
+        return this.cached.response.access_token;
+      }
+    }
+
+    const issuedAtMs = this.nowMs();
+    const assertion = buildClientAssertion({
+      clientId: this.config.clientId,
+      tokenUrl: this.config.tokenUrl,
+      kid: this.config.jwtKid,
+      privateKeyPem: this.config.privateKeyPem,
+      now: () => Math.floor(issuedAtMs / 1000),
+    });
+
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: assertion,
+      scope: scopes.join(" "),
+    });
+
+    const response = await this.fetchImpl(this.config.tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      // Epic returns structured OAuth2 errors as JSON; preserve them in
+      // the log for debugging but throw a clean message upstream — the
+      // body may contain the assertion (echoed back), so the caller
+      // should not surface it to end users.
+      log.warn("Epic token request failed", {
+        status: response.status,
+        statusText: response.statusText,
+        bodyPrefix: text.slice(0, 200),
+      });
+      throw new Error(
+        `Epic token endpoint returned ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const parsed = (await response.json()) as TokenResponse;
+    this.cached = {
+      response: parsed,
+      expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
+    };
+
+    return parsed.access_token;
+  }
+
+  /**
+   * Drop the cached token. Forces the next {@link getAccessToken} call
+   * to request a fresh one. Useful when the FHIR client receives a 401
+   * (token revoked / org rotated keys) and wants to retry once with a
+   * fresh assertion before failing.
+   */
+  invalidate(): void {
+    this.cached = null;
+  }
+}

--- a/services/epic-connector/tsconfig.json
+++ b/services/epic-connector/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/services/epic-connector/vitest.config.ts
+++ b/services/epic-connector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

New \`@carebridge/epic-connector\` workspace package implementing the SMART App Launch Backend Services flow for system-to-system Epic access (#389). Foundational layer — #390 (FHIR client), #391 (sync worker), #392 (App Launch), and #393 (outbound flag push) all build on this.

## Components

- **RS384 JWT client-assertion builder** (\`jwt-assertion.ts\`). Uses Node's \`createSign('RSA-SHA384')\` directly to keep the algorithm choice explicit at the call site — Epic rejects RS256, the default of most JWT libraries.
- **Token client with expiry-aware caching** (\`token-client.ts\`). Refreshes 60s before expiry, invalidatable on 401, exposes the OAuth scopes needed for \`system/*\` reads.
- **SMART configuration discovery** (\`capability.ts\`). Fetches and parses \`/.well-known/smart-configuration\` so the token endpoint can be resolved at startup.
- **Config loader with strict env validation** (\`config.ts\`). Defaults to the \`fhir.epic.com\` sandbox; overridable via \`EPIC_TOKEN_URL\` / \`EPIC_FHIR_BASE_URL\`. Private key from \`EPIC_PRIVATE_KEY_PATH\` (preferred) or \`EPIC_PRIVATE_KEY_PEM\`.
- **RS384 keypair generator + JWK conversion** (\`keygen.ts\`). Walks SPKI DER to extract modulus/exponent, emits base64url JWK with \`alg: RS384, use: sig, kid\`. Private key written with mode \`0600\`.
- **CLI wrapper** \`carebridge-epic-keygen\` wired as \`pnpm epic:keygen\`. One-shot setup: produces private key, JWK to paste at open.epic.com, and \`.env.local\` snippet.

## Setup (what you do after merging)

\`\`\`bash
pnpm --filter @carebridge/epic-connector epic:keygen
# 1. Paste the printed JWK at open.epic.com → App Settings → Public Keys
# 2. Add the .env.local snippet (EPIC_CLIENT_ID, EPIC_PRIVATE_KEY_PATH, EPIC_JWT_KID)
# 3. Token client now works against fhir.epic.com sandbox out of the box
\`\`\`

## Test plan

- [ ] CI green
- [ ] \`pnpm typecheck && pnpm turbo lint\` pass — verified
- [ ] epic-connector: 43 tests pass (all offline — no Epic calls)

43 tests across 5 files:
- JWT assertion: 10 tests including a negative algorithm-strict test (signature must NOT verify under RS256)
- Token client: 8 tests with mocked fetch covering cache hit, refresh-buffer expiry, invalidate, non-2xx errors, custom scope override
- SMART config discovery: 5 tests covering happy path + missing-endpoint rejection
- Keygen: 10 tests including JWK round-trip (signed payload verifies under reconstructed public key from JWK), file-mode 0600, intermediate directory creation
- Config loader: 10 tests covering sandbox defaults, production overrides, PATH-vs-PEM priority, malformed-key rejection

End-to-end test against fhir.epic.com is intentionally not in CI — it requires real Epic credentials and runs locally once the user has registered their public JWK.

## Out of scope (tracked separately)

- Epic FHIR client + per-resource read operations → #390
- BullMQ sync worker + clinical-event emission → #391
- SMART App Launch (user-facing) → #392
- Outbound flag push (\`system/Flag.write\`) → #393

Closes #389