### PR TITLE
feat(epic): push CareBridge AI flags to Epic as FHIR Flag (#393)

### DIFF
--- a/packages/db-schema/drizzle/0048_epic_sync_state.sql
+++ b/packages/db-schema/drizzle/0048_epic_sync_state.sql
@@ -1,0 +1,30 @@
+-- #391: per-patient, per-resource-type Epic sync bookkeeping.
+--
+-- The Epic sync worker (services/epic-connector/src/workers/sync-worker.ts)
+-- pulls FHIR resources from Epic on a schedule. To support incremental
+-- pulls (Epic search-param `_lastUpdated=gt<ts>`) and to surface sync
+-- health in the clinician portal, we track the last successful sync
+-- timestamp, the FHIR `_lastUpdated` watermark, and the most recent
+-- error per (patient_id, resource_type) tuple.
+--
+-- One row per (patient, resource_type). `last_fhir_lastupdated` is the
+-- watermark used in the next incremental request (NOT the wall-clock
+-- time the sync ran — that's `last_synced_at`).
+CREATE TABLE IF NOT EXISTS "epic_sync_state" (
+  "patient_id" text NOT NULL REFERENCES "patients"("id"),
+  "resource_type" text NOT NULL,
+  "last_synced_at" text,
+  "last_fhir_lastupdated" text,
+  "status" text NOT NULL DEFAULT 'pending',
+  "resources_synced_count" integer NOT NULL DEFAULT 0,
+  "error_count" integer NOT NULL DEFAULT 0,
+  "last_error_message" text,
+  "last_error_at" text,
+  PRIMARY KEY ("patient_id", "resource_type")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_epic_sync_state_status"
+  ON "epic_sync_state" ("status");
+
+CREATE INDEX IF NOT EXISTS "idx_epic_sync_state_last_synced"
+  ON "epic_sync_state" ("last_synced_at");

--- a/packages/db-schema/drizzle/0049_epic_user_connections.sql
+++ b/packages/db-schema/drizzle/0049_epic_user_connections.sql
@@ -1,0 +1,39 @@
+-- #392: per-user, per-Epic-org OAuth connection state.
+--
+-- Records the SMART on FHIR App Launch tokens a CareBridge user has
+-- authorised against a given Epic organisation. One row per
+-- (user_id, epic_org_iss) tuple — a clinician who covers shifts at
+-- two hospitals on separate Epic instances has two rows.
+--
+-- Tokens are encrypted at rest by the application layer (the
+-- application-level encryption hook used elsewhere for PHI columns).
+-- The columns are declared `text` here — encryption is transparent to
+-- the DB schema and applied via the same path as patient.mrn etc.
+--
+-- `id_token_subject` is the `sub` claim Epic returns on the id_token;
+-- combined with `epic_org_iss` it gives a stable identity for the
+-- Epic practitioner across sessions. `epic_practitioner_fhir_id` is
+-- the FHIR Practitioner.id Epic includes in the user-context launch
+-- response (also called `fhirUser` in the SMART spec).
+CREATE TABLE IF NOT EXISTS "epic_user_connections" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL REFERENCES "users"("id"),
+  "epic_org_iss" text NOT NULL,
+  "id_token_subject" text,
+  "epic_practitioner_fhir_id" text,
+  "epic_patient_fhir_id" text,
+  "access_token_enc" text NOT NULL,
+  "refresh_token_enc" text,
+  "expires_at" text NOT NULL,
+  "scopes" text NOT NULL,
+  "launch_encounter_fhir_id" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL,
+  CONSTRAINT "unique_user_epic_org" UNIQUE ("user_id", "epic_org_iss")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_epic_user_connections_user"
+  ON "epic_user_connections" ("user_id");
+
+CREATE INDEX IF NOT EXISTS "idx_epic_user_connections_practitioner"
+  ON "epic_user_connections" ("epic_practitioner_fhir_id");

--- a/packages/db-schema/drizzle/0050_clinical_flags_epic_push.sql
+++ b/packages/db-schema/drizzle/0050_clinical_flags_epic_push.sql
@@ -1,0 +1,24 @@
+-- #393: outbound FHIR Flag push tracking on clinical_flags.
+--
+-- When the epic-outbound-flags worker successfully POSTs a CareBridge
+-- clinical_flag to Epic as a FHIR Flag resource, it records the Epic
+-- resource id here so subsequent status changes (acknowledge / resolve
+-- / dismiss) can be propagated via PUT rather than re-creating the
+-- resource on Epic's side. NULL on rows that haven't been pushed (Epic
+-- disabled locally, push failed, or push not yet processed).
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_flag_id" text;
+
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_org_iss" text;
+
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_pushed_at" text;
+
+-- Most-recent push error, truncated to 1KiB by the writer. NULL when
+-- the row has never failed or the most-recent push succeeded.
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_push_error" text;
+
+CREATE INDEX IF NOT EXISTS "idx_clinical_flags_epic_flag_id"
+  ON "clinical_flags" ("epic_flag_id");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1747929900000,
       "tag": "0048_epic_sync_state",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1747929960000,
+      "tag": "0049_epic_user_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1747929840000,
       "tag": "0047_medications_concentration",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1747929900000,
+      "tag": "0048_epic_sync_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1747929960000,
       "tag": "0049_epic_user_connections",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1747930020000,
+      "tag": "0050_clinical_flags_epic_push",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -37,6 +37,19 @@ export const clinicalFlags = pgTable("clinical_flags", {
    * Null for LLM-path flags and historical rows pre-#1039.
    */
   metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+  /**
+   * Outbound Epic FHIR Flag id (#393). Populated once this flag has
+   * been successfully POSTed to Epic; NULL otherwise. Subsequent status
+   * changes (acknowledge / resolve / dismiss) PUT to this id rather
+   * than re-creating the resource on Epic.
+   */
+  epic_flag_id: text("epic_flag_id"),
+  /** Epic org `iss` the flag was pushed to. */
+  epic_org_iss: text("epic_org_iss"),
+  /** Wall-clock time of the last successful push. */
+  epic_pushed_at: text("epic_pushed_at"),
+  /** Most-recent push error (truncated to 1KiB). NULL on success. */
+  epic_push_error: text("epic_push_error"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_flags_patient").on(table.patient_id, table.status),
@@ -48,6 +61,7 @@ export const clinicalFlags = pgTable("clinical_flags", {
     table.escalation_count,
   ),
   index("idx_flags_trigger_event_ids").using("gin", sql`trigger_event_ids jsonb_path_ops`),
+  index("idx_clinical_flags_epic_flag_id").on(table.epic_flag_id),
   uniqueIndex("idx_flags_open_rule_dedup")
     .on(table.patient_id, table.rule_id)
     .where(sql`status = 'open' AND rule_id IS NOT NULL`),

--- a/packages/db-schema/src/schema/epic-sync.ts
+++ b/packages/db-schema/src/schema/epic-sync.ts
@@ -1,0 +1,45 @@
+import { pgTable, text, integer, primaryKey, index } from "drizzle-orm/pg-core";
+import { patients } from "./patients.js";
+
+/**
+ * Per-patient, per-resource-type Epic sync bookkeeping (#391).
+ *
+ * The Epic sync worker reads/writes one row per (patient_id, resource_type)
+ * tuple to drive incremental pulls (`_lastUpdated=gt<watermark>`) and to
+ * surface sync health in the clinician portal.
+ *
+ * Columns:
+ *   - last_synced_at        — wall-clock time the sync job last RAN
+ *   - last_fhir_lastupdated — FHIR `_lastUpdated` watermark to feed the
+ *                             NEXT incremental request. NOT the same as
+ *                             `last_synced_at` — Epic resources may be
+ *                             back-dated days after `last_synced_at`.
+ *   - status                — pending | running | ok | failed
+ *   - resources_synced_count — cumulative successful imports
+ *   - error_count           — cumulative failures
+ */
+export const epicSyncState = pgTable(
+  "epic_sync_state",
+  {
+    patient_id: text("patient_id")
+      .notNull()
+      .references(() => patients.id),
+    resource_type: text("resource_type").notNull(),
+    last_synced_at: text("last_synced_at"),
+    last_fhir_lastupdated: text("last_fhir_lastupdated"),
+    status: text("status").notNull().default("pending"),
+    resources_synced_count: integer("resources_synced_count")
+      .notNull()
+      .default(0),
+    error_count: integer("error_count").notNull().default(0),
+    last_error_message: text("last_error_message"),
+    last_error_at: text("last_error_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.patient_id, table.resource_type] }),
+    index("idx_epic_sync_state_status").on(table.status),
+    index("idx_epic_sync_state_last_synced").on(table.last_synced_at),
+  ],
+);
+
+export type EpicSyncStatus = "pending" | "running" | "ok" | "failed";

--- a/packages/db-schema/src/schema/epic-user-connections.ts
+++ b/packages/db-schema/src/schema/epic-user-connections.ts
@@ -1,0 +1,66 @@
+import { pgTable, text, unique, index } from "drizzle-orm/pg-core";
+import { users } from "./auth.js";
+import { encryptedText } from "../encryption.js";
+
+/**
+ * SMART on FHIR App Launch connection state (#392).
+ *
+ * One row per (CareBridge user, Epic organisation). Captures the
+ * OAuth tokens, scopes, and launch context returned by Epic when a
+ * clinician authorises CareBridge against their Epic identity.
+ *
+ * Token columns are encrypted at rest via the same encryption hook
+ * used for PHI columns (see {@link encryptedText}). Refresh tokens
+ * may be NULL if the granted scope set didn't include `offline_access`
+ * — short-lived sessions still get an access_token, but the user has
+ * to re-launch from Epic when it expires.
+ */
+export const epicUserConnections = pgTable(
+  "epic_user_connections",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    /**
+     * Epic's `iss` URL — the FHIR base URL for the org. Identifies
+     * which Epic instance the tokens are valid against.
+     */
+    epic_org_iss: text("epic_org_iss").notNull(),
+    /**
+     * `sub` claim from the id_token. Together with epic_org_iss this
+     * gives a stable identifier for the Epic identity across sessions.
+     */
+    id_token_subject: text("id_token_subject"),
+    /**
+     * FHIR Practitioner.id Epic returns in the `fhirUser` field. Used
+     * to attribute clinical actions back to the right Practitioner
+     * resource for outbound flag push (#393).
+     */
+    epic_practitioner_fhir_id: text("epic_practitioner_fhir_id"),
+    /**
+     * FHIR Patient.id Epic returns in the launch context (EHR launch
+     * only). NULL for standalone launches.
+     */
+    epic_patient_fhir_id: text("epic_patient_fhir_id"),
+    access_token_enc: encryptedText("access_token_enc").notNull(),
+    refresh_token_enc: encryptedText("refresh_token_enc"),
+    expires_at: text("expires_at").notNull(),
+    /** Space-separated SMART scopes Epic granted (may be a subset of requested). */
+    scopes: text("scopes").notNull(),
+    /**
+     * FHIR Encounter.id from EHR launch context, when Epic supplies one
+     * (typical for inpatient launches; outpatient launches often omit).
+     */
+    launch_encounter_fhir_id: text("launch_encounter_fhir_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => [
+    unique("unique_user_epic_org").on(table.user_id, table.epic_org_iss),
+    index("idx_epic_user_connections_user").on(table.user_id),
+    index("idx_epic_user_connections_practitioner").on(
+      table.epic_practitioner_fhir_id,
+    ),
+  ],
+);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from "./fhir.js";
 export * from "./family-access.js";
 export * from "./allergy-overrides.js";
 export * from "./epic-sync.js";
+export * from "./epic-user-connections.js";

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -13,3 +13,4 @@ export * from "./emergency-access.js";
 export * from "./fhir.js";
 export * from "./family-access.js";
 export * from "./allergy-overrides.js";
+export * from "./epic-sync.js";

--- a/packages/test-utils/src/mock-db.ts
+++ b/packages/test-utils/src/mock-db.ts
@@ -134,6 +134,8 @@ function createChainProxy(
     "groupBy",
     "having",
     "offset",
+    "onConflictDoUpdate",
+    "onConflictDoNothing",
   ] as const;
 
   for (const name of chainNames) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
 
   services/epic-connector:
     dependencies:
+      '@carebridge/fhir-gateway':
+        specifier: workspace:*
+        version: link:../fhir-gateway
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/epic-connector':
+        specifier: workspace:*
+        version: link:../epic-connector
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger
@@ -6077,8 +6080,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6097,7 +6100,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6108,22 +6111,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6134,7 +6137,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/epic-connector':
+        specifier: workspace:*
+        version: link:../epic-connector
       '@carebridge/fhir-gateway':
         specifier: workspace:*
         version: link:../fhir-gateway
@@ -630,12 +633,33 @@ importers:
 
   services/epic-connector:
     dependencies:
+      '@carebridge/db-schema':
+        specifier: workspace:*
+        version: link:../../packages/db-schema
       '@carebridge/fhir-gateway':
         specifier: workspace:*
         version: link:../fhir-gateway
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@carebridge/outbox':
+        specifier: workspace:*
+        version: link:../../packages/outbox
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
+      '@carebridge/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+      '@trpc/server':
+        specifier: ^11.0.0
+        version: 11.16.0(typescript@5.9.3)
+      bullmq:
+        specifier: ^5.30.0
+        version: 5.74.1
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.9)(react@19.2.5)
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,6 +628,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
 
+  services/epic-connector:
+    dependencies:
+      '@carebridge/logger':
+        specifier: workspace:*
+        version: link:../../packages/logger
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@carebridge/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/test-utils
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
+
   services/fhir-gateway:
     dependencies:
       '@carebridge/clinical-data':

--- a/services/ai-oversight/package.json
+++ b/services/ai-oversight/package.json
@@ -29,6 +29,7 @@
     "@carebridge/db-schema": "workspace:*",
     "@carebridge/medical-logic": "workspace:*",
     "@carebridge/ai-prompts": "workspace:*",
+    "@carebridge/epic-connector": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
     "bullmq": "^5.30.0",
     "drizzle-orm": "^0.38.0",

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -16,6 +16,10 @@ import {
   recordFlagResolved,
 } from "./shadow-metrics.js";
 import { emitNotificationEvent } from "@carebridge/notifications";
+import {
+  enqueueEpicFlagPushCreate,
+  enqueueEpicFlagPushUpdate,
+} from "@carebridge/epic-connector";
 
 // 24 hours in milliseconds — window for LLM flag deduplication
 const LLM_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -185,6 +189,11 @@ export async function createFlag(
     created_at: now,
   });
 
+  // Push to Epic as a FHIR Flag resource (#393). The enqueue is a
+  // no-op when EPIC_CLIENT_ID isn't configured, so this is safe to
+  // call unconditionally — local dev without Epic creds just skips it.
+  await enqueueEpicFlagPushCreate(id);
+
   return record as ClinicalFlag;
 }
 
@@ -206,6 +215,8 @@ export async function acknowledgeFlag(
       acknowledged_at: now,
     })
     .where(eq(clinicalFlags.id, flagId));
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**
@@ -234,6 +245,8 @@ export async function resolveFlag(
     rule_id: rows[0]?.rule_id ?? undefined,
     source: rows[0]?.source as ClinicalFlag["source"] | undefined,
   });
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**
@@ -262,6 +275,8 @@ export async function dismissFlag(
     rule_id: rows[0]?.rule_id ?? undefined,
     source: rows[0]?.source as ClinicalFlag["source"] | undefined,
   });
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -19,6 +19,7 @@
     "@carebridge/clinical-data": "workspace:*",
     "@carebridge/clinical-notes": "workspace:*",
     "@carebridge/ai-oversight": "workspace:*",
+    "@carebridge/epic-connector": "workspace:*",
     "@carebridge/notifications": "workspace:*",
     "@carebridge/logger": "workspace:*",
     "@carebridge/scheduling": "workspace:*",

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -11,6 +11,7 @@ import { fhirRbacRouter } from "./routers/fhir.js";
 import { notificationsRbacRouter } from "./routers/notifications.js";
 import { familyAccessRbacRouter } from "./routers/family-access.js";
 import { careTeamRbacRouter } from "./routers/care-team.js";
+import { epicSyncRbacRouter } from "./routers/epic-sync.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -32,6 +33,7 @@ export const appRouter = router({
   fhir: fhirRbacRouter,
   familyAccess: familyAccessRbacRouter,
   careTeam: careTeamRbacRouter,
+  epicSync: epicSyncRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -12,6 +12,7 @@ import { notificationsRbacRouter } from "./routers/notifications.js";
 import { familyAccessRbacRouter } from "./routers/family-access.js";
 import { careTeamRbacRouter } from "./routers/care-team.js";
 import { epicSyncRbacRouter } from "./routers/epic-sync.js";
+import { epicAuthRbacRouter } from "./routers/epic-auth.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -34,6 +35,7 @@ export const appRouter = router({
   familyAccess: familyAccessRbacRouter,
   careTeam: careTeamRbacRouter,
   epicSync: epicSyncRbacRouter,
+  epicAuth: epicAuthRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/routers/epic-auth.ts
+++ b/services/api-gateway/src/routers/epic-auth.ts
@@ -1,0 +1,98 @@
+/**
+ * tRPC surface for SMART App Launch state (#392).
+ *
+ * Powers the clinician portal Settings page ("Connect to Epic" card)
+ * and the launch-context banner shown when a clinician arrives via
+ * EHR Launch.
+ *
+ *   epicAuth.getMyConnections  — list every Epic org this user has linked
+ *   epicAuth.getLaunchContext  — patient + encounter context for the
+ *                                most-recently-launched connection (if
+ *                                still within the access-token's TTL)
+ *   epicAuth.disconnect        — delete the connection row for a given org
+ *
+ * No write of new connections via tRPC — those land via the OAuth
+ * callback (services/api-gateway/src/routes/epic-auth.ts) after a real
+ * browser round-trip to Epic.
+ */
+import { initTRPC, TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  getConnectionsForUser,
+  deleteConnection,
+} from "@carebridge/epic-connector";
+import type { Context } from "../context.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+export const epicAuthRbacRouter = t.router({
+  /**
+   * List every Epic-org connection for the authenticated user.
+   * Access/refresh tokens are intentionally NOT returned — clients
+   * never need them. We surface only the metadata (org URL, granted
+   * scopes, expiry, FHIR identity).
+   */
+  getMyConnections: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await getConnectionsForUser(ctx.user.id);
+    return rows.map((r) => ({
+      id: r.id,
+      epic_org_iss: r.epic_org_iss,
+      scopes: r.scopes,
+      expires_at: r.expires_at,
+      epic_practitioner_fhir_id: r.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: r.epic_patient_fhir_id,
+      launch_encounter_fhir_id: r.launch_encounter_fhir_id,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+    }));
+  }),
+
+  /**
+   * Return the most-recent connection plus its launch context, if
+   * still valid. Returns `null` when the user has no Epic connection
+   * or every connection's token has expired.
+   *
+   * The clinician portal uses this on page load to decide whether to
+   * pre-select the Epic-supplied patient/encounter.
+   */
+  getLaunchContext: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await getConnectionsForUser(ctx.user.id);
+    const valid = rows.filter(
+      (r) => Date.parse(r.expires_at) > Date.now(),
+    );
+    if (valid.length === 0) return null;
+    // Most-recently-updated (latest launch) wins.
+    valid.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const top = valid[0]!;
+    return {
+      epic_org_iss: top.epic_org_iss,
+      epic_practitioner_fhir_id: top.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: top.epic_patient_fhir_id,
+      launch_encounter_fhir_id: top.launch_encounter_fhir_id,
+      expires_at: top.expires_at,
+    };
+  }),
+
+  /**
+   * Delete a single Epic-org connection. Idempotent — returning
+   * { removed: false } when no row matched is treated as success.
+   */
+  disconnect: protectedProcedure
+    .input(z.object({ epic_org_iss: z.string().url() }))
+    .mutation(async ({ ctx, input }) => {
+      const removed = await deleteConnection(ctx.user.id, input.epic_org_iss);
+      return { removed };
+    }),
+});

--- a/services/api-gateway/src/routers/epic-sync.ts
+++ b/services/api-gateway/src/routers/epic-sync.ts
@@ -1,0 +1,158 @@
+/**
+ * RBAC-enforced Epic-sync router (#391).
+ *
+ * Layered on top of the raw `epicSyncRouter` exported from
+ * @carebridge/epic-connector. All procedures require authentication;
+ * `triggerSync` is admin-only (manually re-pulling someone else's patient
+ * data is a privileged operation, even with no PHI leak risk).
+ * `getSyncStatus` and `listSyncErrors` honour the same care-team RBAC
+ * the ai-oversight router uses.
+ */
+import { initTRPC, TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+  SUPPORTED_RESOURCE_TYPES,
+} from "@carebridge/epic-connector";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+const isAdmin = isAuthenticated.unstable_pipe(({ ctx, next }) => {
+  if (ctx.user.role !== "admin") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only admins may trigger Epic sync jobs",
+    });
+  }
+  return next({ ctx });
+});
+const adminProcedure = t.procedure.use(isAdmin);
+
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+  clientIp?: string | null,
+): Promise<void> {
+  if (user.role === "admin") return;
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "Access denied: patients may only access their own sync status",
+      });
+    }
+    return;
+  }
+  const hasAccess = await assertCareTeamAccess(user.id, patientId, clientIp);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+const syncResourceTypeSchema = z.enum(
+  SUPPORTED_RESOURCE_TYPES as [string, ...string[]],
+);
+
+export const epicSyncRbacRouter = t.router({
+  /**
+   * Admin-only mutation that enqueues a sync job for a patient.
+   */
+  triggerSync: adminProcedure
+    .input(
+      z.discriminatedUnion("mode", [
+        z.object({
+          mode: z.literal("full"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("incremental"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("single"),
+          patient_id: z.string().uuid(),
+          resource_type: syncResourceTypeSchema,
+          epic_patient_fhir_id: z.string().optional(),
+          watermark: z.string().nullish(),
+        }),
+      ]),
+    )
+    .mutation(async ({ input }) => {
+      if (input.mode === "full") {
+        await enqueueFullSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return { enqueued: "full-sync" as const, patient_id: input.patient_id };
+      }
+      if (input.mode === "incremental") {
+        await enqueueIncrementalSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return {
+          enqueued: "incremental-sync" as const,
+          patient_id: input.patient_id,
+        };
+      }
+      await enqueueSingleResourceSync({
+        patient_id: input.patient_id,
+        resource_type:
+          input.resource_type as (typeof SUPPORTED_RESOURCE_TYPES)[number],
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        watermark: input.watermark,
+      });
+      return {
+        enqueued: "single-resource-sync" as const,
+        patient_id: input.patient_id,
+        resource_type: input.resource_type,
+      };
+    }),
+
+  /**
+   * Read sync status rows for a patient. Care-team RBAC is enforced.
+   */
+  getSyncStatus: protectedProcedure
+    .input(z.object({ patient_id: z.string().uuid() }))
+    .query(async ({ input, ctx }) => {
+      await enforcePatientAccess(
+        ctx.user,
+        input.patient_id,
+        ctx.clientIp ?? null,
+      );
+      return getAllSyncStatesForPatient(input.patient_id);
+    }),
+
+  /**
+   * Admin-only list of recent sync failures across patients.
+   */
+  listSyncErrors: adminProcedure
+    .input(z.object({ limit: z.number().min(1).max(500).optional() }))
+    .query(async ({ input }) => {
+      return listRecentFailures(input.limit);
+    }),
+});

--- a/services/api-gateway/src/routes/epic-auth.ts
+++ b/services/api-gateway/src/routes/epic-auth.ts
@@ -1,0 +1,183 @@
+/**
+ * SMART on FHIR App Launch routes (#392).
+ *
+ * Two endpoints:
+ *  GET /auth/epic/authorize  — kicks off the OAuth flow. Two ways in:
+ *      EHR Launch (Epic-initiated):
+ *        Epic redirects the user's browser to
+ *        `<our-host>/auth/epic/authorize?iss=<epic-base>&launch=<token>`
+ *      Standalone Launch (us-initiated):
+ *        Clinician clicks "Connect to Epic" → we redirect their browser
+ *        to `/auth/epic/authorize?iss=<epic-base>` (no launch token).
+ *
+ *  GET /auth/epic/callback   — handles the redirect back from Epic.
+ *      Verifies state, exchanges the code for tokens, persists the
+ *      connection row, and bounces the browser to the post-launch
+ *      destination.
+ *
+ * Both endpoints require an authenticated CareBridge session. For EHR
+ * Launch, the clinician must already be signed into CareBridge in the
+ * same browser session that Epic's MyChart shell is hosted in
+ * (typical Epic deployment puts the browser in an iframe that shares
+ * cookies). Sessions are out of scope here — `request.user` is set by
+ * the auth middleware before our handler runs.
+ */
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type { Redis } from "ioredis";
+import {
+  beginLaunch,
+  completeLaunch,
+  RedisLaunchStateStore,
+  InMemoryLaunchStateStore,
+  type LaunchStateStore,
+  type RedisLike,
+} from "@carebridge/epic-connector";
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-auth-routes");
+
+interface EpicAuthRouteOptions {
+  redis?: Redis;
+  /**
+   * Override the launch-state store for tests. When omitted and `redis`
+   * is provided, uses RedisLaunchStateStore; otherwise an in-memory
+   * fallback (single-process dev only).
+   */
+  store?: LaunchStateStore;
+}
+
+interface AuthorizeQuery {
+  iss?: string;
+  launch?: string;
+  redirect?: string;
+}
+
+interface CallbackQuery {
+  code?: string;
+  state?: string;
+  error?: string;
+  error_description?: string;
+}
+
+export function registerEpicAuthRoutes(
+  server: FastifyInstance,
+  opts: EpicAuthRouteOptions = {},
+): void {
+  const clientId = process.env.EPIC_CLIENT_ID;
+  const redirectUri = process.env.EPIC_APP_LAUNCH_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    log.info(
+      "Epic App Launch routes not registered — EPIC_CLIENT_ID or EPIC_APP_LAUNCH_REDIRECT_URI not set",
+    );
+    return;
+  }
+
+  let store: LaunchStateStore;
+  if (opts.store) {
+    store = opts.store;
+  } else if (opts.redis) {
+    const redis = opts.redis;
+    const redisAdapter: RedisLike = {
+      set: (k, v, mode, ttl) =>
+        redis.set(k, v, mode, ttl) as Promise<unknown>,
+      get: (k) => redis.get(k),
+      del: (k) => redis.del(k),
+    };
+    store = new RedisLaunchStateStore(redisAdapter);
+  } else {
+    store = new InMemoryLaunchStateStore();
+  }
+
+  server.get<{ Querystring: AuthorizeQuery }>(
+    "/auth/epic/authorize",
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.code(401).send({ error: "authentication_required" });
+      }
+      const iss = request.query.iss;
+      if (!iss) {
+        return reply.code(400).send({
+          error: "missing_iss",
+          message: "Provide ?iss=<Epic FHIR base URL>",
+        });
+      }
+
+      try {
+        const { authorizeUrl } = await beginLaunch(
+          {
+            iss,
+            launch: request.query.launch,
+            userId: request.user.id,
+            redirectUri,
+            clientId,
+            postLaunchRedirect: request.query.redirect ?? "/",
+          },
+          store,
+        );
+        return reply.redirect(authorizeUrl);
+      } catch (err) {
+        log.error("Epic App Launch begin failed", {
+          userId: request.user.id,
+          iss,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.code(502).send({
+          error: "epic_discovery_failed",
+          message: err instanceof Error ? err.message : "unknown error",
+        });
+      }
+    },
+  );
+
+  server.get<{ Querystring: CallbackQuery }>(
+    "/auth/epic/callback",
+    async (request: FastifyRequest<{ Querystring: CallbackQuery }>, reply: FastifyReply) => {
+      // Epic returns ?error=… on user-denial / consent failure.
+      if (request.query.error) {
+        return reply.code(400).send({
+          error: request.query.error,
+          message: request.query.error_description ?? "Epic returned an OAuth error",
+        });
+      }
+
+      const state = request.query.state;
+      const code = request.query.code;
+      if (!state || !code) {
+        return reply.code(400).send({
+          error: "missing_callback_params",
+          message: "Expected ?state and ?code in callback URL",
+        });
+      }
+
+      try {
+        const result = await completeLaunch(
+          { state, code, clientId, redirectUri },
+          store,
+        );
+        // EHR-launch context lives in the redirect URL as query params so
+        // the SPA can pick them up without another round-trip.
+        const target = new URL(result.postLaunchRedirect, "http://_dummy");
+        if (result.patientFhirId) {
+          target.searchParams.set("epic_patient", result.patientFhirId);
+        }
+        if (result.encounterFhirId) {
+          target.searchParams.set("epic_encounter", result.encounterFhirId);
+        }
+        const finalUrl =
+          target.origin === "http://_dummy"
+            ? target.pathname + target.search
+            : target.toString();
+        return reply.redirect(finalUrl);
+      } catch (err) {
+        log.error("Epic App Launch callback failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.code(400).send({
+          error: "epic_callback_failed",
+          message: err instanceof Error ? err.message : "unknown error",
+        });
+      }
+    },
+  );
+}

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -14,6 +14,7 @@ import { makePatientReadRateLimitHook } from "./middleware/patient-read-rate-lim
 import { makeFhirExportRateLimitHook } from "./middleware/fhir-export-rate-limit.js";
 import { registerNotificationSSE } from "./routes/notifications-sse.js";
 import { registerFhirRestRoutes } from "./routes/fhir-rest.js";
+import { registerEpicAuthRoutes } from "./routes/epic-auth.js";
 import { handleAuthMe } from "./handlers/auth-me.js";
 import { redactUrlIds } from "@carebridge/phi-sanitizer";
 import { startBackgroundWorkers } from "./workers.js";
@@ -235,6 +236,13 @@ async function main() {
   // alongside the internal /trpc/* surface for EHR / HIE / third-party
   // FHIR clients (Epic, HIEs, SMART apps). Read-only on first ship.
   registerFhirRestRoutes(server);
+
+  // --- Epic SMART App Launch (#392) ---
+  // GET /auth/epic/authorize + /auth/epic/callback. The route module
+  // checks EPIC_CLIENT_ID + EPIC_APP_LAUNCH_REDIRECT_URI at startup —
+  // if either is unset, registration is a no-op so local dev without
+  // Epic credentials keeps booting unchanged.
+  registerEpicAuthRoutes(server);
 
   // --- Health check ---
   server.get("/health", async () => {

--- a/services/epic-connector/README.md
+++ b/services/epic-connector/README.md
@@ -1,0 +1,59 @@
+# @carebridge/epic-connector
+
+Epic SMART on FHIR integration for CareBridge.
+
+Issue #389 ships the authentication layer — RS384 client-assertion JWT,
+OAuth 2.0 client-credentials token exchange, expiry-aware caching, and
+SMART configuration discovery. Follow-ups will add the typed FHIR
+client (#390), sync worker (#391), App Launch (#392), and outbound
+flag push (#393).
+
+## First-time setup
+
+```bash
+# 1. Generate an RS384 keypair and grab the public JWK
+pnpm --filter @carebridge/epic-connector epic:keygen
+
+# Output includes:
+#   - private key path  (default: ~/.carebridge/epic-private.pem, 0600)
+#   - kid               (UUID to embed in JWT assertions)
+#   - public JWK        (paste at open.epic.com → App Settings → Public Keys)
+#   - .env.local snippet
+
+# 2. Register the public JWK at open.epic.com.
+#    App Settings → Public Keys → "Add" → paste the JWK output.
+
+# 3. Add to .env.local (already gitignored):
+#    EPIC_CLIENT_ID=<your Non-Production Client ID>
+#    EPIC_PRIVATE_KEY_PATH=~/.carebridge/epic-private.pem
+#    EPIC_JWT_KID=<the kid from step 1>
+
+# Defaults to fhir.epic.com sandbox. Override EPIC_TOKEN_URL and
+# EPIC_FHIR_BASE_URL for production.
+```
+
+## Use
+
+```ts
+import { loadEpicConfig, EpicTokenClient } from "@carebridge/epic-connector";
+
+const config = loadEpicConfig();
+const client = new EpicTokenClient(config);
+
+const token = await client.getAccessToken();
+// → use as Authorization: Bearer ${token} on FHIR requests
+```
+
+The token client caches the response and refreshes 60s before expiry.
+Call `client.invalidate()` after a 401 to force a fresh assertion.
+
+## Test
+
+```bash
+pnpm --filter @carebridge/epic-connector test
+```
+
+Tests are offline: JWT signatures verify against an ephemeral keypair,
+token exchange uses a mocked fetch, JWK conversion round-trips through
+Node's crypto. The end-to-end sandbox test is intentionally not in CI
+— it requires real Epic credentials and runs locally when present.

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@carebridge/epic-connector",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
+  "bin": {
+    "carebridge-epic-keygen": "dist/bin/keygen.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "epic:keygen": "tsx src/bin/keygen.ts"
+  },
+  "dependencies": {
+    "@carebridge/logger": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@carebridge/test-utils": "workspace:*",
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -17,8 +17,15 @@
     "epic:keygen": "tsx src/bin/keygen.ts"
   },
   "dependencies": {
+    "@carebridge/db-schema": "workspace:*",
     "@carebridge/fhir-gateway": "workspace:*",
     "@carebridge/logger": "workspace:*",
+    "@carebridge/outbox": "workspace:*",
+    "@carebridge/redis-config": "workspace:*",
+    "@carebridge/shared-types": "workspace:*",
+    "@trpc/server": "^11.0.0",
+    "bullmq": "^5.30.0",
+    "drizzle-orm": "^0.38.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -17,6 +17,7 @@
     "epic:keygen": "tsx src/bin/keygen.ts"
   },
   "dependencies": {
+    "@carebridge/fhir-gateway": "workspace:*",
     "@carebridge/logger": "workspace:*",
     "zod": "^3.24.0"
   },

--- a/services/epic-connector/src/__tests__/authorize.test.ts
+++ b/services/epic-connector/src/__tests__/authorize.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Authorize-URL builder tests (#392).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+} from "../app-launch/authorize.js";
+
+const baseArgs = {
+  authorizeUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize",
+  clientId: "carebridge-client",
+  redirectUri: "https://app.carebridge.test/auth/epic/callback",
+  scopes: [...DEFAULT_APP_LAUNCH_SCOPES],
+  state: "opaque-state-1234",
+  aud: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+  codeChallenge: "challenge-abcdef",
+};
+
+describe("buildAuthorizeUrl (#392)", () => {
+  it("includes every required SMART App Launch param", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("carebridge-client");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://app.carebridge.test/auth/epic/callback",
+    );
+    expect(url.searchParams.get("state")).toBe("opaque-state-1234");
+    expect(url.searchParams.get("aud")).toBe(baseArgs.aud);
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-abcdef");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("space-joins the scope list per OAuth 2 standard", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.get("scope")).toBe(
+      "launch openid fhirUser offline_access patient/*.read user/Practitioner.read",
+    );
+  });
+
+  it("omits `launch` param when launch token is absent (Standalone Launch)", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.has("launch")).toBe(false);
+  });
+
+  it("includes `launch` param when token is provided (EHR Launch)", () => {
+    const url = new URL(
+      buildAuthorizeUrl({ ...baseArgs, launch: "ehr-launch-token-xyz" }),
+    );
+    expect(url.searchParams.get("launch")).toBe("ehr-launch-token-xyz");
+  });
+
+  it("targets the authorize endpoint passed in (not a hardcoded URL)", () => {
+    const customAuthorize = "https://fhir.example-hospital.org/oauth/auth";
+    const url = new URL(
+      buildAuthorizeUrl({ ...baseArgs, authorizeUrl: customAuthorize }),
+    );
+    expect(url.origin + url.pathname).toBe(customAuthorize);
+  });
+});

--- a/services/epic-connector/src/__tests__/capability.test.ts
+++ b/services/epic-connector/src/__tests__/capability.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for SMART configuration discovery (#389).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchSmartConfiguration,
+  smartConfigurationUrl,
+} from "../capability.js";
+
+describe("smartConfigurationUrl (#389)", () => {
+  it("appends /.well-known/smart-configuration to a base URL", () => {
+    expect(
+      smartConfigurationUrl("https://fhir.example.com/api/FHIR/R4/"),
+    ).toBe("https://fhir.example.com/api/FHIR/R4/.well-known/smart-configuration");
+  });
+
+  it("normalises trailing slashes", () => {
+    expect(
+      smartConfigurationUrl("https://fhir.example.com/api/FHIR/R4////"),
+    ).toBe("https://fhir.example.com/api/FHIR/R4/.well-known/smart-configuration");
+  });
+});
+
+describe("fetchSmartConfiguration (#389)", () => {
+  it("returns the parsed JSON on 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token_endpoint: "https://fhir.example.com/oauth2/token",
+          grant_types_supported: ["client_credentials"],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const cfg = await fetchSmartConfiguration(
+      "https://fhir.example.com/api/FHIR/R4/",
+      fetchMock,
+    );
+    expect(cfg.token_endpoint).toBe("https://fhir.example.com/oauth2/token");
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+    await expect(
+      fetchSmartConfiguration(
+        "https://fhir.example.com/api/FHIR/R4/",
+        fetchMock,
+      ),
+    ).rejects.toThrow(/SMART configuration discovery failed: 404/);
+  });
+
+  it("throws when token_endpoint is missing from the response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ grant_types_supported: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(
+      fetchSmartConfiguration(
+        "https://fhir.example.com/api/FHIR/R4/",
+        fetchMock,
+      ),
+    ).rejects.toThrow(/missing token_endpoint/);
+  });
+});

--- a/services/epic-connector/src/__tests__/config.test.ts
+++ b/services/epic-connector/src/__tests__/config.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for Epic config loading (#389).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  loadEpicConfig,
+  EPIC_SANDBOX_TOKEN_URL,
+  EPIC_SANDBOX_FHIR_BASE_URL,
+} from "../config.js";
+
+let tmpDir: string;
+let pemPath: string;
+let privatePem: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "carebridge-epic-config-"));
+  pemPath = join(tmpDir, "epic-private.pem");
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  writeFileSync(pemPath, privatePem, "utf8");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadEpicConfig (#389)", () => {
+  it("loads from a complete env with explicit file path", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.clientId).toBe("abc-123");
+    expect(cfg.jwtKid).toBe("kid-001");
+    expect(cfg.privateKeyPem).toBe(privatePem);
+  });
+
+  it("defaults to sandbox URLs when EPIC_TOKEN_URL / EPIC_FHIR_BASE_URL absent", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.tokenUrl).toBe(EPIC_SANDBOX_TOKEN_URL);
+    expect(cfg.fhirBaseUrl).toBe(EPIC_SANDBOX_FHIR_BASE_URL);
+  });
+
+  it("honours explicit EPIC_TOKEN_URL override (e.g. production)", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+      EPIC_TOKEN_URL: "https://prod.example.com/oauth2/token",
+      EPIC_FHIR_BASE_URL: "https://prod.example.com/api/FHIR/R4/",
+    });
+    expect(cfg.tokenUrl).toBe("https://prod.example.com/oauth2/token");
+    expect(cfg.fhirBaseUrl).toBe("https://prod.example.com/api/FHIR/R4/");
+  });
+
+  it("throws when EPIC_CLIENT_ID is missing", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_PRIVATE_KEY_PATH: pemPath,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow();
+  });
+
+  it("throws when EPIC_JWT_KID is missing", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: pemPath,
+      }),
+    ).toThrow();
+  });
+
+  it("throws when neither PATH nor PEM is set", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/EPIC_PRIVATE_KEY_PATH or EPIC_PRIVATE_KEY_PEM/);
+  });
+
+  it("throws when PATH points at a non-existent file", () => {
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: join(tmpDir, "does-not-exist.pem"),
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/Failed to read EPIC_PRIVATE_KEY_PATH/);
+  });
+
+  it("accepts inline PEM when PATH is absent", () => {
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PEM: privatePem,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(privatePem);
+  });
+
+  it("prefers PATH over PEM when both are set", () => {
+    const altPem =
+      "-----BEGIN PRIVATE KEY-----\nfake-different-key\n-----END PRIVATE KEY-----";
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_PRIVATE_KEY_PEM: altPem,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(privatePem); // came from PATH, not PEM
+  });
+
+  it("rejects a key that isn't a PEM-encoded RSA private key", () => {
+    const bogus = join(tmpDir, "not-a-key.pem");
+    writeFileSync(bogus, "this is not a key", "utf8");
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: bogus,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/private key must be a PEM/);
+  });
+});

--- a/services/epic-connector/src/__tests__/converters.test.ts
+++ b/services/epic-connector/src/__tests__/converters.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for Epic FHIR → CareBridge row converters (#390).
+ *
+ * Uses realistic FHIR R4 payload shapes (Epic-style identifier systems,
+ * SNOMED route codes, LOINC observation codes) so the tests catch
+ * Epic-specific quirks without requiring sandbox access.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EPIC_SOURCE_SYSTEM_TAG,
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+} from "../converters.js";
+import type { FhirResource } from "../fhir-types.js";
+
+describe("Epic FHIR → CareBridge converters (#390)", () => {
+  describe("epicPatientToRow", () => {
+    it("maps a typical Epic Patient resource and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "Patient",
+        id: "epic-patient-1",
+        active: true,
+        identifier: [
+          {
+            use: "usual",
+            system: "urn:oid:1.2.840.114350.1.13.0.1.7.5.737384.0",
+            value: "E1234",
+          },
+          {
+            use: "official",
+            type: {
+              coding: [
+                {
+                  system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  code: "MR",
+                  display: "Medical Record Number",
+                },
+              ],
+            },
+            value: "MRN-987",
+          },
+        ],
+        name: [{ use: "official", family: "Smith", given: ["John", "Q"] }],
+        gender: "male",
+        birthDate: "1980-01-15",
+      };
+
+      const row = epicPatientToRow(resource);
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.mrn).toBe("MRN-987");
+    });
+
+    it("returns null for retired patient (active=false)", () => {
+      const row = epicPatientToRow({
+        resourceType: "Patient",
+        id: "p-1",
+        active: false,
+        name: [{ family: "Smith", given: ["John"] }],
+      });
+      expect(row).toBeNull();
+    });
+  });
+
+  describe("epicMedicationRequestToRow", () => {
+    it("maps a MedicationRequest with dosing and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "MedicationRequest",
+        id: "med-req-1",
+        status: "active",
+        intent: "order",
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+              code: "1049502",
+              display: "acetaminophen 325 MG Oral Tablet",
+            },
+          ],
+        },
+        subject: { reference: "Patient/p-1" },
+        dosageInstruction: [
+          {
+            route: {
+              coding: [
+                {
+                  system: "http://snomed.info/sct",
+                  code: "26643006",
+                  display: "Oral route",
+                },
+              ],
+            },
+            doseAndRate: [
+              { doseQuantity: { value: 650, unit: "mg" } },
+            ],
+          },
+        ],
+      };
+      const row = epicMedicationRequestToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+      expect(row?.route).toBe("oral");
+    });
+
+    it("returns null for entered-in-error MedicationRequest", () => {
+      const row = epicMedicationRequestToRow(
+        {
+          resourceType: "MedicationRequest",
+          status: "entered-in-error",
+          medicationCodeableConcept: { text: "tylenol" },
+        },
+        "p-1",
+      );
+      expect(row).toBeNull();
+    });
+  });
+
+  describe("epicMedicationStatementToRow", () => {
+    it("maps a MedicationStatement (prior outpatient med list)", () => {
+      const resource: FhirResource = {
+        resourceType: "MedicationStatement",
+        status: "active",
+        medicationCodeableConcept: { text: "lisinopril 10 mg" },
+        subject: { reference: "Patient/p-1" },
+      };
+      const row = epicMedicationStatementToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+    });
+  });
+
+  describe("epicObservationToRow", () => {
+    it("routes vital-signs Observations to a vital row", () => {
+      const resource: FhirResource = {
+        resourceType: "Observation",
+        status: "final",
+        category: [
+          {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/observation-category",
+                code: "vital-signs",
+              },
+            ],
+          },
+        ],
+        code: {
+          coding: [
+            { system: "http://loinc.org", code: "8867-4", display: "Heart rate" },
+          ],
+        },
+        effectiveDateTime: "2026-05-20T10:30:00Z",
+        valueQuantity: { value: 72, unit: "beats/min" },
+      };
+      const result = epicObservationToRow(resource, "patient-uuid-1");
+      expect(result.kind).toBe("vital");
+      if (result.kind !== "vital") return;
+      expect(result.row.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(result.row.patient_id).toBe("patient-uuid-1");
+      expect(result.row.type).toBe("heart_rate");
+    });
+
+    it("routes laboratory Observations to a lab row with patient_id + source_system", () => {
+      const resource: FhirResource = {
+        resourceType: "Observation",
+        status: "final",
+        category: [
+          {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/observation-category",
+                code: "laboratory",
+              },
+            ],
+          },
+        ],
+        code: {
+          coding: [
+            { system: "http://loinc.org", code: "718-7", display: "Hemoglobin" },
+          ],
+          text: "Hemoglobin",
+        },
+        effectiveDateTime: "2026-05-20T08:00:00Z",
+        valueQuantity: { value: 13.5, unit: "g/dL" },
+      };
+      const result = epicObservationToRow(resource, "patient-uuid-1");
+      expect(result.kind).toBe("lab");
+      if (result.kind !== "lab") return;
+      expect(result.row.patient_id).toBe("patient-uuid-1");
+      expect(result.row.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(result.row.test_code).toBe("718-7");
+    });
+
+    it("returns unmapped for Observations with no category", () => {
+      const result = epicObservationToRow(
+        {
+          resourceType: "Observation",
+          status: "final",
+          code: { coding: [{ system: "http://loinc.org", code: "9999-9" }] },
+        },
+        "p-1",
+      );
+      expect(result.kind).toBe("unmapped");
+    });
+  });
+
+  describe("epicConditionToRow", () => {
+    it("maps an active Condition and adds source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "Condition",
+        clinicalStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              code: "active",
+            },
+          ],
+        },
+        code: {
+          coding: [
+            {
+              system: "http://hl7.org/fhir/sid/icd-10-cm",
+              code: "I82.401",
+              display: "Acute embolism and thrombosis of unspecified deep veins of right lower extremity",
+            },
+          ],
+          text: "DVT, right lower extremity",
+        },
+        subject: { reference: "Patient/p-1" },
+        onsetDateTime: "2026-05-15",
+      };
+      const row = epicConditionToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.status).toBe("active");
+      expect(row?.icd10_code).toBe("I82.401");
+    });
+  });
+
+  describe("epicAllergyToRow", () => {
+    it("maps an active AllergyIntolerance and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "AllergyIntolerance",
+        clinicalStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              code: "active",
+            },
+          ],
+        },
+        verificationStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              code: "confirmed",
+            },
+          ],
+        },
+        code: {
+          coding: [
+            {
+              system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+              code: "7980",
+              display: "Penicillin G",
+            },
+          ],
+          text: "Penicillin",
+        },
+        patient: { reference: "Patient/p-1" },
+        criticality: "high",
+      };
+      const row = epicAllergyToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+    });
+  });
+
+  it("EPIC_SOURCE_SYSTEM_TAG is the string 'epic' (lock-in)", () => {
+    // The tag is part of the public contract — downstream queries
+    // filter by it. Don't accidentally rename it without coordinating
+    // with the sync worker (#391).
+    expect(EPIC_SOURCE_SYSTEM_TAG).toBe("epic");
+  });
+});

--- a/services/epic-connector/src/__tests__/fhir-client-write.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client-write.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the EpicFhirClient write methods (#393).
+ *
+ * Verifies the POST/PUT request shape, retry behavior, and
+ * OperationOutcome error handling.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+
+function tokenResponse() {
+  return new Response(
+    JSON.stringify({
+      access_token: "tok",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "system/*.write",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function jsonFhir(body: unknown, init: ResponseInit = { status: 201 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/fhir+json", ...(init.headers ?? {}) },
+  });
+}
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client",
+    tokenUrl: "https://fhir.epic.com/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+describe("EpicFhirClient.createResource / updateResource (#393)", () => {
+  let privatePem: string;
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  function setup(responses: Response[]) {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith("/token")) return tokenResponse();
+      const next = responses.shift();
+      if (!next) throw new Error(`unexpected fetch: ${url}`);
+      return next;
+    });
+    const config = makeConfig(privatePem);
+    const tokens = new EpicTokenClient(config, fetchMock);
+    const client = new EpicFhirClient(config, tokens, {
+      fetchImpl: fetchMock,
+      sleep: vi.fn().mockResolvedValue(undefined),
+      backoffBaseMs: 1,
+    });
+    return { client, fetchMock };
+  }
+
+  it("createResource POSTs FHIR JSON to the base URL + resource type", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-1" }, { status: 201 }),
+    ]);
+
+    const result = await client.createResource("Flag", {
+      resourceType: "Flag",
+      status: "active",
+      code: { text: "demo" },
+    });
+
+    expect(result).toMatchObject({ resourceType: "Flag", id: "epic-flag-1" });
+
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe("https://fhir.epic.com/api/FHIR/R4/Flag");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/fhir+json");
+    expect(init.headers.Authorization).toBe("Bearer tok");
+    expect(JSON.parse(init.body)).toMatchObject({ resourceType: "Flag" });
+  });
+
+  it("updateResource PUTs to /{type}/{id}", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-1" }),
+    ]);
+
+    await client.updateResource("Flag", "epic-flag-1", {
+      resourceType: "Flag",
+      id: "epic-flag-1",
+      status: "inactive",
+      code: { text: "demo" },
+    });
+
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe("https://fhir.epic.com/api/FHIR/R4/Flag/epic-flag-1");
+    expect(init.method).toBe("PUT");
+  });
+
+  it("throws on OperationOutcome response (write rejected by Epic)", async () => {
+    const { client } = setup([
+      jsonFhir(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            { severity: "error", code: "invariant", diagnostics: "missing subject" },
+          ],
+        },
+        { status: 422 },
+      ),
+    ]);
+
+    await expect(
+      client.createResource("Flag", {
+        resourceType: "Flag",
+        status: "active",
+        code: { text: "x" },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("retries on 503 then succeeds (same backoff path as reads)", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({}, { status: 503 }),
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-2" }, { status: 201 }),
+    ]);
+
+    const result = await client.createResource("Flag", {
+      resourceType: "Flag",
+      status: "active",
+      code: { text: "x" },
+    });
+
+    expect(result).toMatchObject({ id: "epic-flag-2" });
+    // Token + 503 + retry = 3 fetches
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for EpicFhirClient (#390).
+ *
+ * All tests run offline — fetch is mocked, sleep is a no-op so backoff
+ * doesn't burn wall-clock time. The integration test against
+ * fhir.epic.com is intentionally not in CI; it runs locally when the
+ * caller has registered credentials.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+import type { FhirBundle, FhirResource } from "../fhir-types.js";
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client-id",
+    tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+function makeTokenResponse() {
+  return new Response(
+    JSON.stringify({
+      access_token: "fake-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "system/*.read",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function jsonResponse<T>(body: T, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/fhir+json", ...(init.headers ?? {}) },
+  });
+}
+
+function bundleOf(
+  resources: FhirResource[],
+  links: { relation: string; url: string }[] = [],
+): FhirBundle {
+  return {
+    resourceType: "Bundle",
+    type: "searchset",
+    total: resources.length,
+    link: links,
+    entry: resources.map((r) => ({ resource: r })),
+  };
+}
+
+describe("EpicFhirClient (#390)", () => {
+  let privatePem: string;
+
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  function setup(responses: Array<Response | (() => Response)>) {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith("/token")) return makeTokenResponse();
+      const next = responses.shift();
+      if (!next) throw new Error(`unexpected fetch: ${url}`);
+      return typeof next === "function" ? next() : next;
+    });
+    const config = makeConfig(privatePem);
+    const tokens = new EpicTokenClient(config, fetchMock);
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    const client = new EpicFhirClient(config, tokens, {
+      fetchImpl: fetchMock,
+      sleep: sleepMock,
+      backoffBaseMs: 1,
+    });
+    return { client, fetchMock, sleepMock, tokens };
+  }
+
+  it("read() sends Authorization Bearer and returns the resource", async () => {
+    const { client, fetchMock } = setup([
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+    const patient = await client.read("Patient", "p-1");
+    expect(patient).toEqual({ resourceType: "Patient", id: "p-1" });
+
+    // First call is token; second is the FHIR request
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient/p-1",
+    );
+    expect(init.headers.Authorization).toBe("Bearer fake-token");
+    expect(init.headers.Accept).toBe("application/fhir+json");
+  });
+
+  it("read() throws when the server returns an OperationOutcome", async () => {
+    const { client } = setup([
+      jsonResponse({
+        resourceType: "OperationOutcome",
+        issue: [{ severity: "error", code: "not-found", diagnostics: "no such patient" }],
+      }),
+    ]);
+    await expect(client.read("Patient", "missing")).rejects.toThrow(
+      /OperationOutcome: not-found — no such patient/,
+    );
+  });
+
+  it("search() encodes params and returns the bundle", async () => {
+    const bundle = bundleOf([{ resourceType: "Observation", id: "obs-1" }]);
+    const { client, fetchMock } = setup([jsonResponse(bundle)]);
+
+    const result = await client.search("Observation", {
+      patient: "p-1",
+      category: "vital-signs",
+    });
+    expect(result.entry?.[0]?.resource?.id).toBe("obs-1");
+    const [url] = fetchMock.mock.calls[1]!;
+    expect(url).toContain("Observation?");
+    expect(url).toContain("patient=p-1");
+    expect(url).toContain("category=vital-signs");
+  });
+
+  it("searchAll() walks Bundle.link rel=next to exhaust pages", async () => {
+    const page1 = bundleOf(
+      [
+        { resourceType: "Observation", id: "obs-1" },
+        { resourceType: "Observation", id: "obs-2" },
+      ],
+      [{ relation: "next", url: "https://fhir.epic.com/api/page2" }],
+    );
+    const page2 = bundleOf([{ resourceType: "Observation", id: "obs-3" }]);
+    const { client, fetchMock } = setup([jsonResponse(page1), jsonResponse(page2)]);
+
+    const ids: string[] = [];
+    for await (const obs of client.searchAll("Observation", { patient: "p-1" })) {
+      ids.push(obs.id!);
+    }
+    expect(ids).toEqual(["obs-1", "obs-2", "obs-3"]);
+    // Token fetch + initial search + follow next link
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]![0]).toBe("https://fhir.epic.com/api/page2");
+  });
+
+  it("retries once on 401 after invalidating the cached token", async () => {
+    const { client, fetchMock, tokens } = setup([
+      jsonResponse({}, { status: 401 }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+    const invalidateSpy = vi.spyOn(tokens, "invalidate");
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(invalidateSpy).toHaveBeenCalledOnce();
+    // Token (1) + first 401 (2) + retried token (3) + retried success (4)
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does NOT retry-loop on persistent 401 — surfaces the error", async () => {
+    const { client } = setup([
+      jsonResponse({}, { status: 401 }),
+      jsonResponse({}, { status: 401 }),
+    ]);
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(/401/);
+  });
+
+  it("respects Retry-After (seconds) on 429 and retries", async () => {
+    const { client, fetchMock, sleepMock } = setup([
+      jsonResponse({}, { status: 429, headers: { "Retry-After": "2" } }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(sleepMock).toHaveBeenCalledOnce();
+    expect(sleepMock.mock.calls[0]![0]).toBe(2000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("exponentially backs off on 5xx and gives up after maxRetries", async () => {
+    // 4 failed responses = 1 initial + 3 retries; maxRetries=3 means
+    // attempts 0,1,2,3 fail then throw.
+    const responses = Array.from({ length: 4 }, () =>
+      jsonResponse({}, { status: 503 }),
+    );
+    const { client, sleepMock } = setup(responses);
+
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(/4 attempts.*503/);
+    // Sleep called 3 times (between attempts 0→1, 1→2, 2→3)
+    expect(sleepMock).toHaveBeenCalledTimes(3);
+    // backoffBase=1, expBackoff = 1, 2, 4 (+jitter up to 1ms each)
+    expect(sleepMock.mock.calls[0]![0]).toBeGreaterThanOrEqual(1);
+    expect(sleepMock.mock.calls[1]![0]).toBeGreaterThanOrEqual(2);
+    expect(sleepMock.mock.calls[2]![0]).toBeGreaterThanOrEqual(4);
+  });
+
+  it("recovers from a single 503 by retrying", async () => {
+    const { client, fetchMock } = setup([
+      jsonResponse({}, { status: 503 }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("surfaces 4xx (non-401, non-429) errors immediately with body prefix", async () => {
+    const { client } = setup([
+      new Response("malformed search param", { status: 400 }),
+    ]);
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(
+      /400.*malformed search param/,
+    );
+  });
+
+  // Typed wrappers — sanity checks that params end up on the URL
+  it("searchObservations() emits expected URL params", async () => {
+    const { client, fetchMock } = setup([jsonResponse(bundleOf([]))]);
+    await client.searchObservations({
+      patient: "p-1",
+      category: "laboratory",
+      _lastUpdated: "gt2026-01-01",
+      _count: 50,
+    });
+    const url = fetchMock.mock.calls[1]![0] as string;
+    expect(url).toContain("patient=p-1");
+    expect(url).toContain("category=laboratory");
+    expect(url).toContain("_lastUpdated=gt2026-01-01");
+    expect(url).toContain("_count=50");
+  });
+
+  it("searchEncounters() includes _sort=-date", async () => {
+    const { client, fetchMock } = setup([jsonResponse(bundleOf([]))]);
+    await client.searchEncounters({ patient: "p-1", _sort: "-date" });
+    const url = fetchMock.mock.calls[1]![0] as string;
+    expect(url).toContain("_sort=-date");
+  });
+
+  it("treats absolute URLs (Bundle.link.url) verbatim", async () => {
+    // Page 1 link.next points to a different host (Epic may return
+    // absolute URLs with the FHIR base baked in)
+    const page1 = bundleOf(
+      [{ resourceType: "Patient", id: "p-1" }],
+      [{ relation: "next", url: "https://epic.example.com/explicit-next-url" }],
+    );
+    const page2 = bundleOf([{ resourceType: "Patient", id: "p-2" }]);
+    const { client, fetchMock } = setup([jsonResponse(page1), jsonResponse(page2)]);
+
+    for await (const _ of client.searchAll("Patient")) {
+      // no-op — we just need to drive the iterator
+    }
+    expect(fetchMock.mock.calls[2]![0]).toBe(
+      "https://epic.example.com/explicit-next-url",
+    );
+  });
+});

--- a/services/epic-connector/src/__tests__/flag-generator.test.ts
+++ b/services/epic-connector/src/__tests__/flag-generator.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the CareBridge ClinicalFlag → FHIR Flag generator (#393).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildFhirFlag,
+  flagSeverityCoding,
+  mapFlagStatusToFhir,
+  CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+  FHIR_FLAG_CATEGORY_SYSTEM,
+  RATIONALE_EXTENSION_URL,
+  SUGGESTED_ACTION_EXTENSION_URL,
+  RULE_ID_EXTENSION_URL,
+} from "../outbound/flag-generator.js";
+
+const baseFlag = {
+  summary: "Cross-specialty stroke risk: VTE + new neurologic symptoms",
+  rationale: "Patient with active VTE prescribed anticoagulant; reports headache",
+  suggested_action: "Order STAT non-contrast CT head",
+  severity: "critical" as const,
+  category: "cross-specialty" as const,
+  status: "open" as const,
+  rule_id: "ONCO-VTE-NEURO-001",
+  created_at: "2026-05-22T10:00:00Z",
+  resolved_at: undefined,
+  dismissed_at: undefined,
+};
+
+describe("buildFhirFlag (#393)", () => {
+  it("produces a FHIR R4 Flag with all required spec fields", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "epic-patient-1",
+    });
+
+    expect(flag.resourceType).toBe("Flag");
+    expect(flag.status).toBe("active");
+    expect(flag.code.text).toBe(baseFlag.summary);
+    expect(flag.subject.reference).toBe("Patient/epic-patient-1");
+    expect(flag.category[0]?.coding[0]?.system).toBe(FHIR_FLAG_CATEGORY_SYSTEM);
+    expect(flag.category[0]?.coding[0]?.code).toBe("clinical");
+  });
+
+  it("encodes severity in the code.coding entry", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const sev = flag.code.coding[0]!;
+    expect(sev.system).toBe(CAREBRIDGE_FLAG_SEVERITY_SYSTEM);
+    expect(sev.code).toBe("critical");
+    expect(sev.display).toMatch(/Critical/);
+  });
+
+  it("carries the category as a secondary coding for richer Epic display", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const codings = flag.category[0]?.coding ?? [];
+    const cb = codings.find((c) =>
+      c.system?.startsWith("https://carebridge.dev"),
+    );
+    expect(cb?.code).toBe("cross-specialty");
+  });
+
+  it("emits rationale + suggested_action + rule_id as FHIR extensions", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const ext = flag.extension ?? [];
+    expect(ext.find((e) => e.url === RATIONALE_EXTENSION_URL)?.valueString).toBe(
+      baseFlag.rationale,
+    );
+    expect(
+      ext.find((e) => e.url === SUGGESTED_ACTION_EXTENSION_URL)?.valueString,
+    ).toBe(baseFlag.suggested_action);
+    expect(ext.find((e) => e.url === RULE_ID_EXTENSION_URL)?.valueString).toBe(
+      baseFlag.rule_id,
+    );
+  });
+
+  it("omits rule_id extension when the flag is LLM-only (no rule_id)", () => {
+    const flag = buildFhirFlag({
+      flag: { ...baseFlag, rule_id: undefined },
+      epicPatientFhirId: "p-1",
+    });
+    const ext = flag.extension ?? [];
+    expect(ext.find((e) => e.url === RULE_ID_EXTENSION_URL)).toBeUndefined();
+  });
+
+  it("sets period.end on resolved flags", () => {
+    const flag = buildFhirFlag({
+      flag: {
+        ...baseFlag,
+        status: "resolved",
+        resolved_at: "2026-05-22T18:00:00Z",
+      },
+      epicPatientFhirId: "p-1",
+    });
+    expect(flag.status).toBe("inactive");
+    expect(flag.period?.start).toBe(baseFlag.created_at);
+    expect(flag.period?.end).toBe("2026-05-22T18:00:00Z");
+  });
+
+  it("sets period.end on dismissed flags", () => {
+    const flag = buildFhirFlag({
+      flag: {
+        ...baseFlag,
+        status: "dismissed",
+        dismissed_at: "2026-05-22T18:30:00Z",
+      },
+      epicPatientFhirId: "p-1",
+    });
+    expect(flag.status).toBe("inactive");
+    expect(flag.period?.end).toBe("2026-05-22T18:30:00Z");
+  });
+
+  it("propagates the epicFlagId onto the output for PUT payloads", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+      epicFlagId: "epic-flag-abc",
+    });
+    expect(flag.id).toBe("epic-flag-abc");
+  });
+
+  it("acknowledged + escalated map to active (still surfaces in Epic banner)", () => {
+    expect(mapFlagStatusToFhir("open")).toBe("active");
+    expect(mapFlagStatusToFhir("acknowledged")).toBe("active");
+    expect(mapFlagStatusToFhir("escalated")).toBe("active");
+    expect(mapFlagStatusToFhir("resolved")).toBe("inactive");
+    expect(mapFlagStatusToFhir("dismissed")).toBe("inactive");
+  });
+
+  it("flagSeverityCoding includes a clinician-readable display per severity band", () => {
+    expect(flagSeverityCoding("critical").display).toMatch(/Critical/);
+    expect(flagSeverityCoding("warning").display).toMatch(/review/i);
+    expect(flagSeverityCoding("info").display).toBe("Informational");
+  });
+});

--- a/services/epic-connector/src/__tests__/flag-push.test.ts
+++ b/services/epic-connector/src/__tests__/flag-push.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the outbound flag-push orchestrator (#393).
+ *
+ * Mocks @carebridge/db-schema so no Postgres is required. Verifies:
+ *   - POST when epic_flag_id is unset (create path)
+ *   - PUT when epic_flag_id is already set (update path)
+ *   - skipped when patient has no Epic mapping
+ *   - audit_log row written on success AND on failure
+ *   - clinical_flags row updated with epic_flag_id + push timestamp
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  clinicalFlags: { id: "id" },
+  patients: {},
+  auditLog: {},
+  fhirResources: {
+    internal_record_id: "internal_record_id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+  },
+}));
+
+const { pushFlagToEpic, pushFlagStatusUpdate } = await import(
+  "../outbound/flag-push.js"
+);
+
+const FLAG = {
+  id: "flag-1",
+  patient_id: "patient-1",
+  summary: "summary text",
+  rationale: "rationale text",
+  suggested_action: "suggested action",
+  severity: "critical",
+  category: "cross-specialty",
+  status: "open",
+  rule_id: "ONCO-VTE-NEURO-001",
+  created_at: "2026-05-22T10:00:00Z",
+  resolved_at: null,
+  dismissed_at: null,
+  epic_flag_id: null,
+};
+
+function fakeClient() {
+  return {
+    createResource: vi
+      .fn()
+      .mockResolvedValue({ resourceType: "Flag", id: "epic-flag-99" }),
+    updateResource: vi
+      .fn()
+      .mockResolvedValue({ resourceType: "Flag", id: "epic-flag-99" }),
+  } as unknown as Parameters<typeof pushFlagToEpic>[1]["client"];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+describe("pushFlagToEpic (#393)", () => {
+  it("creates a Flag on Epic when epic_flag_id is unset, then records the id", async () => {
+    db.willSelect([FLAG]); // load flag
+    db.willSelect([{ resource_id: "epic-patient-1" }]); // patient mapping lookup
+    db.willUpdate(); // clinical_flags update
+    db.willInsert(); // audit_log insert
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+
+    expect(result).toMatchObject({
+      flag_id: "flag-1",
+      epic_flag_id: "epic-flag-99",
+      operation: "created",
+    });
+    expect(client.createResource).toHaveBeenCalledOnce();
+    const [resourceType, body] = (client.createResource as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(resourceType).toBe("Flag");
+    expect(body.resourceType).toBe("Flag");
+    expect(body.subject.reference).toBe("Patient/epic-patient-1");
+
+    // updated clinical_flags row, inserted audit_log
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
+    const auditValues = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(auditValues.action).toBe("epic_flag_push");
+    expect(auditValues.success).toBe(true);
+  });
+
+  it("updates an existing Flag on Epic (PUT) when epic_flag_id is already set", async () => {
+    db.willSelect([{ ...FLAG, epic_flag_id: "epic-flag-existing" }]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate();
+    db.willInsert();
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+
+    expect(result.operation).toBe("updated");
+    expect(client.createResource).not.toHaveBeenCalled();
+    expect(client.updateResource).toHaveBeenCalledOnce();
+    const [resourceType, id] = (client.updateResource as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(resourceType).toBe("Flag");
+    expect(id).toBe("epic-flag-existing");
+  });
+
+  it("returns skipped when the patient has no Epic mapping", async () => {
+    db.willSelect([FLAG]);
+    db.willSelect([]); // no mapping rows
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+    expect(result.operation).toBe("skipped");
+    expect(result.error).toBe("epic_patient_id_unknown");
+    expect(client.createResource).not.toHaveBeenCalled();
+  });
+
+  it("on Epic write failure, records the error on the flag row + audit_log", async () => {
+    db.willSelect([FLAG]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate(); // epic_push_error write
+    db.willInsert(); // failure audit
+    const client = fakeClient();
+    (client.createResource as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Epic write rejected (422)"),
+    );
+
+    const result = await pushFlagToEpic("flag-1", { client });
+    expect(result.operation).toBe("failed");
+    expect(result.error).toMatch(/Epic write rejected/);
+
+    const auditValues = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(auditValues.action).toBe("epic_flag_push");
+    expect(auditValues.success).toBe(false);
+    expect(auditValues.error_message).toMatch(/Epic write rejected/);
+  });
+
+  it("pushFlagStatusUpdate is a no-op when epic_flag_id is unset", async () => {
+    db.willSelect([{ epic_flag_id: null }]);
+    const client = fakeClient();
+    const result = await pushFlagStatusUpdate("flag-1", { client });
+    expect(result.operation).toBe("skipped");
+    expect(result.error).toBe("not_pushed_yet");
+    expect(client.createResource).not.toHaveBeenCalled();
+    expect(client.updateResource).not.toHaveBeenCalled();
+  });
+
+  it("pushFlagStatusUpdate delegates to pushFlagToEpic when epic_flag_id is set", async () => {
+    // 1st select inside pushFlagStatusUpdate
+    db.willSelect([{ epic_flag_id: "epic-flag-existing" }]);
+    // pushFlagToEpic then re-selects the full flag + mapping
+    db.willSelect([{ ...FLAG, epic_flag_id: "epic-flag-existing" }]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate();
+    db.willInsert();
+    const client = fakeClient();
+
+    const result = await pushFlagStatusUpdate("flag-1", { client });
+    expect(result.operation).toBe("updated");
+    expect(client.updateResource).toHaveBeenCalledOnce();
+  });
+});

--- a/services/epic-connector/src/__tests__/jwt-assertion.test.ts
+++ b/services/epic-connector/src/__tests__/jwt-assertion.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the RS384 JWT assertion builder (#389).
+ *
+ * These verify the JWT against a fixture keypair generated inside the
+ * test (no Epic call). The verification step uses Node's crypto with
+ * the matching public key to confirm the signature is RS384 and that
+ * the payload claims are spec-compliant.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  generateKeyPairSync,
+  createVerify,
+  KeyObject,
+  randomUUID,
+} from "node:crypto";
+import {
+  buildClientAssertion,
+  decodeAssertionForTest,
+} from "../jwt-assertion.js";
+
+describe("buildClientAssertion (#389)", () => {
+  let privateKeyPem: string;
+  let publicKey: KeyObject;
+
+  beforeAll(() => {
+    const { privateKey, publicKey: pub } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    publicKey = pub;
+  });
+
+  function makeArgs(overrides: Partial<Parameters<typeof buildClientAssertion>[0]> = {}) {
+    return {
+      clientId: "test-client-id-123",
+      tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+      kid: "test-kid-abc",
+      privateKeyPem,
+      ...overrides,
+    };
+  }
+
+  it("emits a compact JWS with three segments", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("uses RS384 algorithm and includes the kid in the header", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { header } = decodeAssertionForTest(jwt);
+    expect(header.alg).toBe("RS384");
+    expect(header.typ).toBe("JWT");
+    expect(header.kid).toBe("test-kid-abc");
+  });
+
+  it("sets iss and sub to the client_id per Backend Services spec", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.iss).toBe("test-client-id-123");
+    expect(payload.sub).toBe("test-client-id-123");
+  });
+
+  it("binds aud to the token endpoint URL", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.aud).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    );
+  });
+
+  it("sets exp to iat + 240s by default (under Epic's 5-minute ceiling)", () => {
+    const fixedNow = 1_700_000_000;
+    const jwt = buildClientAssertion(makeArgs({ now: () => fixedNow }));
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.iat).toBe(fixedNow);
+    expect(payload.exp).toBe(fixedNow + 240);
+  });
+
+  it("honours the expiresInSec override", () => {
+    const fixedNow = 1_700_000_000;
+    const jwt = buildClientAssertion(
+      makeArgs({ now: () => fixedNow, expiresInSec: 60 }),
+    );
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.exp).toBe(fixedNow + 60);
+  });
+
+  it("includes a unique jti claim", () => {
+    const a = decodeAssertionForTest(buildClientAssertion(makeArgs()));
+    const b = decodeAssertionForTest(buildClientAssertion(makeArgs()));
+    expect(a.payload.jti).toBeDefined();
+    expect(b.payload.jti).toBeDefined();
+    expect(a.payload.jti).not.toBe(b.payload.jti);
+  });
+
+  it("honours an injected jti", () => {
+    const jti = randomUUID();
+    const jwt = buildClientAssertion(makeArgs({ jti }));
+    const { payload } = decodeAssertionForTest(jwt);
+    expect(payload.jti).toBe(jti);
+  });
+
+  it("produces an RS384 signature verifiable with the matching public key", () => {
+    const jwt = buildClientAssertion(makeArgs());
+    const [header, payload, signature] = jwt.split(".") as [string, string, string];
+    const signingInput = `${header}.${payload}`;
+
+    const sigBuf = Buffer.from(
+      signature.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (signature.length % 4)) % 4),
+      "base64",
+    );
+
+    const verifier = createVerify("RSA-SHA384");
+    verifier.update(signingInput);
+    verifier.end();
+    const ok = verifier.verify(publicKey, sigBuf);
+    expect(ok).toBe(true);
+  });
+
+  it("the same signature does NOT verify under RS256 (algorithm-strict)", () => {
+    // Defends against accidental algorithm downgrade — Epic rejects RS256
+    // for Backend Services so we must produce RS384 specifically.
+    const jwt = buildClientAssertion(makeArgs());
+    const [header, payload, signature] = jwt.split(".") as [string, string, string];
+    const signingInput = `${header}.${payload}`;
+    const sigBuf = Buffer.from(
+      signature.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (signature.length % 4)) % 4),
+      "base64",
+    );
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(signingInput);
+    verifier.end();
+    expect(verifier.verify(publicKey, sigBuf)).toBe(false);
+  });
+});

--- a/services/epic-connector/src/__tests__/keygen.test.ts
+++ b/services/epic-connector/src/__tests__/keygen.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the RS384 keypair generator (#389).
+ *
+ * These exercise the JWK conversion against a known-good RSA keypair
+ * and verify the file-permissions / structure of the on-disk output.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  generateKeyPairSync,
+  createSign,
+  createVerify,
+  createPublicKey,
+} from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeypair, publicKeyFingerprint } from "../keygen.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "carebridge-epic-keygen-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("generateKeypair (#389)", () => {
+  it("writes the private key to the requested path", () => {
+    const out = join(tmpDir, "epic-private.pem");
+    const result = generateKeypair({ privateKeyPath: out });
+    expect(result.privateKeyPath).toBe(out);
+    const pem = readFileSync(out, "utf8");
+    expect(pem).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("sets the private key file mode to 0600 (owner-only)", () => {
+    const out = join(tmpDir, "epic-private.pem");
+    generateKeypair({ privateKeyPath: out });
+    const mode = statSync(out).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("creates intermediate directories", () => {
+    const out = join(tmpDir, "nested", "dir", "epic-private.pem");
+    generateKeypair({ privateKeyPath: out });
+    expect(readFileSync(out, "utf8")).toContain("BEGIN PRIVATE KEY");
+  });
+
+  it("returns a JWK with kty=RSA, alg=RS384, use=sig", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    expect(result.publicJwk.kty).toBe("RSA");
+    expect(result.publicJwk.alg).toBe("RS384");
+    expect(result.publicJwk.use).toBe("sig");
+  });
+
+  it("uses the provided kid", () => {
+    const kid = "my-rotation-2026-01";
+    const result = generateKeypair({
+      privateKeyPath: join(tmpDir, "k.pem"),
+      kid,
+    });
+    expect(result.publicJwk.kid).toBe(kid);
+    expect(result.kid).toBe(kid);
+  });
+
+  it("generates a JWK that verifies signatures made with the private key", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    const privatePem = readFileSync(result.privateKeyPath, "utf8");
+
+    // Sign arbitrary data with the generated private key, then verify
+    // with a public key reconstructed from the JWK. This is the
+    // round-trip Epic does server-side when it receives our assertion.
+    const signer = createSign("RSA-SHA384");
+    signer.update("test-payload");
+    signer.end();
+    const sig = signer.sign(privatePem);
+
+    const publicKey = createPublicKey({
+      key: { ...result.publicJwk } as Record<string, string>,
+      format: "jwk",
+    });
+    const verifier = createVerify("RSA-SHA384");
+    verifier.update("test-payload");
+    verifier.end();
+    expect(verifier.verify(publicKey, sig)).toBe(true);
+  });
+
+  it("emits base64url-encoded n and e (no padding, URL-safe alphabet)", () => {
+    const result = generateKeypair({ privateKeyPath: join(tmpDir, "k.pem") });
+    // base64url: A-Z, a-z, 0-9, -, _ — no =, +, /
+    expect(result.publicJwk.n).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(result.publicJwk.e).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("honours an injected generator (test injection)", () => {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    });
+    const privatePem = privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString();
+    const publicPem = publicKey
+      .export({ type: "spki", format: "pem" })
+      .toString();
+
+    const result = generateKeypair({
+      privateKeyPath: join(tmpDir, "k.pem"),
+      generator: () => ({ privatePem, publicPem }),
+    });
+
+    // Writing the injected private key should produce a JWK whose
+    // public key matches the injected public key.
+    const reconstructed = createPublicKey({
+      key: { ...result.publicJwk } as Record<string, string>,
+      format: "jwk",
+    });
+    const reconstructedPem = reconstructed
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    expect(reconstructedPem).toBe(publicPem);
+  });
+});
+
+describe("publicKeyFingerprint (#389)", () => {
+  it("returns a 16-char hex prefix of the SHA-256 DER fingerprint", () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const fp = publicKeyFingerprint(pem);
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is deterministic for the same key", () => {
+    const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    expect(publicKeyFingerprint(pem)).toBe(publicKeyFingerprint(pem));
+  });
+});

--- a/services/epic-connector/src/__tests__/launch-service.test.ts
+++ b/services/epic-connector/src/__tests__/launch-service.test.ts
@@ -1,0 +1,265 @@
+/**
+ * End-to-end (offline) tests for the App Launch orchestrator (#392).
+ *
+ * The orchestrator wires together discovery → PKCE → authorize URL →
+ * state store → token exchange → connection upsert. Each step is
+ * tested in isolation elsewhere; here we verify the glue.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock the connection-repo so we don't touch Postgres ──────────
+const upsertEpicConnection = vi.fn().mockResolvedValue("conn-1");
+vi.mock("../app-launch/connection-repo.js", () => ({
+  upsertEpicConnection,
+  getConnectionsForUser: vi.fn(),
+  getConnection: vi.fn(),
+  deleteConnection: vi.fn(),
+}));
+
+const { beginLaunch, completeLaunch } = await import(
+  "../app-launch/launch-service.js"
+);
+const { InMemoryLaunchStateStore } = await import(
+  "../app-launch/state-store.js"
+);
+
+function smartConfigResponse(extras: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      token_endpoint:
+        "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+      authorization_endpoint:
+        "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize",
+      grant_types_supported: ["authorization_code", "client_credentials"],
+      ...extras,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function tokenExchangeResponse(extras: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: "epic-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "patient/*.read openid fhirUser launch",
+      refresh_token: "epic-refresh-token",
+      patient: "epic-patient-1",
+      ...extras,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const ISS = "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+const REDIRECT_URI = "https://app.carebridge.test/auth/epic/callback";
+const CLIENT_ID = "carebridge-client";
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("beginLaunch → completeLaunch (#392)", () => {
+  it("EHR Launch happy path: state persists, authorize URL has launch param", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(smartConfigResponse());
+    const store = new InMemoryLaunchStateStore();
+
+    const { authorizeUrl, state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/patients/abc",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    expect(state.length).toBeGreaterThan(20);
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.get("launch")).toBe("ehr-launch-token");
+    expect(url.searchParams.get("state")).toBe(state);
+    expect(url.searchParams.get("aud")).toBe(ISS);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const persisted = await store.get(state);
+    expect(persisted?.userId).toBe(USER_ID);
+    expect(persisted?.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(persisted?.launchToken).toBe("ehr-launch-token");
+  });
+
+  it("Standalone Launch strips 'launch' scope so Epic doesn't reject it", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(smartConfigResponse());
+    const store = new InMemoryLaunchStateStore();
+
+    const { authorizeUrl } = await beginLaunch(
+      {
+        iss: ISS,
+        // no launch token — Standalone
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.has("launch")).toBe(false);
+    expect(url.searchParams.get("scope")).not.toContain(" launch ");
+    expect(url.searchParams.get("scope")).not.toMatch(/^launch /);
+  });
+
+  it("completeLaunch exchanges code, decodes practitioner from id_token, upserts the connection", async () => {
+    // Build an id_token with a Practitioner FHIR reference
+    const idPayload = Buffer.from(
+      JSON.stringify({
+        sub: "epic-user-1",
+        fhirUser:
+          "https://fhir.epic.com/api/FHIR/R4/Practitioner/practitioner-xyz",
+      }),
+    )
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const fakeIdToken = `header.${idPayload}.sig`;
+
+    // First fetch = SMART discovery (during beginLaunch);
+    // second fetch = token exchange (during completeLaunch)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(smartConfigResponse())
+      .mockResolvedValueOnce(
+        tokenExchangeResponse({ id_token: fakeIdToken }),
+      );
+
+    const store = new InMemoryLaunchStateStore();
+
+    const { state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/patients/from-epic",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    const result = await completeLaunch(
+      {
+        state,
+        code: "epic-auth-code",
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    expect(result.connectionId).toBe("conn-1");
+    expect(result.patientFhirId).toBe("epic-patient-1");
+    expect(result.practitionerFhirId).toBe("practitioner-xyz");
+    expect(result.postLaunchRedirect).toBe("/patients/from-epic");
+
+    expect(upsertEpicConnection).toHaveBeenCalledOnce();
+    const upsertArgs = upsertEpicConnection.mock.calls[0]![0];
+    expect(upsertArgs.user_id).toBe(USER_ID);
+    expect(upsertArgs.access_token).toBe("epic-access-token");
+    expect(upsertArgs.refresh_token).toBe("epic-refresh-token");
+    expect(upsertArgs.epic_practitioner_fhir_id).toBe("practitioner-xyz");
+    expect(upsertArgs.epic_patient_fhir_id).toBe("epic-patient-1");
+    expect(upsertArgs.id_token_subject).toBe("epic-user-1");
+  });
+
+  it("state is single-use — a replay attempt errors", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(smartConfigResponse())
+      .mockResolvedValueOnce(tokenExchangeResponse())
+      .mockResolvedValueOnce(tokenExchangeResponse());
+
+    const store = new InMemoryLaunchStateStore();
+    const { state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    await completeLaunch(
+      {
+        state,
+        code: "code-1",
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    // Replay with same state — should fail because state was consumed
+    await expect(
+      completeLaunch(
+        {
+          state,
+          code: "code-2",
+          clientId: CLIENT_ID,
+          redirectUri: REDIRECT_URI,
+          fetchImpl: fetchMock,
+        },
+        store,
+      ),
+    ).rejects.toThrow(/state expired or unknown/);
+  });
+
+  it("rejects unknown / expired state", async () => {
+    const store = new InMemoryLaunchStateStore();
+    await expect(
+      completeLaunch(
+        {
+          state: "never-issued",
+          code: "x",
+          clientId: CLIENT_ID,
+          redirectUri: REDIRECT_URI,
+        },
+        store,
+      ),
+    ).rejects.toThrow(/state expired or unknown/);
+  });
+
+  it("InMemoryLaunchStateStore expires entries past their TTL", async () => {
+    let now = 1_000_000_000_000;
+    const store = new InMemoryLaunchStateStore(() => now);
+    await store.set(
+      "abc",
+      {
+        codeVerifier: "v",
+        iss: ISS,
+        tokenUrl: "https://t",
+        authorizeUrl: "https://a",
+        userId: USER_ID,
+        postLaunchRedirect: "/",
+        createdAt: new Date(now).toISOString(),
+      },
+      10, // 10s TTL
+    );
+    expect(await store.get("abc")).not.toBeNull();
+    now += 11_000; // 11s later — past TTL
+    expect(await store.get("abc")).toBeNull();
+  });
+});

--- a/services/epic-connector/src/__tests__/pkce.test.ts
+++ b/services/epic-connector/src/__tests__/pkce.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PKCE helper tests (#392).
+ *
+ * Verifies the implementation against RFC 7636 §4.6:
+ *   verifier:  43-128 chars from [A-Z][a-z][0-9]-._~
+ *   challenge: BASE64URL(SHA256(verifier))
+ *   method:    "S256" (we don't support "plain")
+ */
+import { describe, it, expect } from "vitest";
+import { generatePkcePair, verifyChallenge } from "../app-launch/pkce.js";
+import { createHash } from "node:crypto";
+
+describe("PKCE (#392)", () => {
+  it("generates a 43-char verifier with only URL-safe characters", () => {
+    const { codeVerifier } = generatePkcePair();
+    expect(codeVerifier.length).toBe(43);
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives the challenge as base64url(SHA-256(verifier))", () => {
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    const expected = createHash("sha256")
+      .update(codeVerifier)
+      .digest("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it("always uses the S256 challenge method (Epic rejects 'plain')", () => {
+    const { codeChallengeMethod } = generatePkcePair();
+    expect(codeChallengeMethod).toBe("S256");
+  });
+
+  it("verifyChallenge returns true for a matching pair, false otherwise", () => {
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    expect(verifyChallenge(codeVerifier, codeChallenge)).toBe(true);
+    expect(verifyChallenge(codeVerifier, "tampered_challenge")).toBe(false);
+    expect(verifyChallenge("tampered_verifier", codeChallenge)).toBe(false);
+  });
+
+  it("produces distinct pairs on subsequent calls", () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+
+  it("accepts an injected RNG for deterministic test fixtures", () => {
+    const fakeRng = (size: number) => Buffer.alloc(size, 0x41); // 'A' bytes
+    const pair = generatePkcePair(fakeRng);
+    // 32 0x41 bytes base64-encode to "QUFB" repeated 10 times + "QUFBQQ"
+    // (the trailing "==" is stripped per base64url).
+    expect(pair.codeVerifier).toBe(
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE",
+    );
+    expect(pair.codeVerifier.length).toBe(43);
+    expect(verifyChallenge(pair.codeVerifier, pair.codeChallenge)).toBe(true);
+  });
+});

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the sync-job orchestrators (#391).
+ *
+ * Verifies the full/incremental/single dispatch wiring without touching
+ * Redis, Postgres, or Epic. Persistence + sync-state-repo are mocked so
+ * each test can assert exactly which calls the orchestrator made.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+// ── Mock persistence ─────────────────────────────────────────────
+const persistPatient = vi.fn();
+const persistObservation = vi.fn();
+const persistCondition = vi.fn();
+const persistMedicationRequest = vi.fn();
+const persistAllergy = vi.fn();
+
+vi.mock("../sync/persistence.js", () => ({
+  persistPatient,
+  persistObservation,
+  persistCondition,
+  persistMedicationRequest,
+  persistAllergy,
+  persistMedicationStatement: vi.fn(),
+}));
+
+// ── Mock sync-state-repo ─────────────────────────────────────────
+const markRunning = vi.fn().mockResolvedValue(undefined);
+const markOk = vi.fn().mockResolvedValue(undefined);
+const markFailed = vi.fn().mockResolvedValue(undefined);
+const getSyncState = vi.fn().mockResolvedValue(null);
+
+vi.mock("../sync/sync-state-repo.js", () => ({
+  markRunning,
+  markOk,
+  markFailed,
+  getSyncState,
+  getAllSyncStatesForPatient: vi.fn(),
+  listRecentFailures: vi.fn(),
+}));
+
+// ── Import after mocks ──────────────────────────────────────────
+const {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  SUPPORTED_RESOURCE_TYPES,
+} = await import("../sync/sync-jobs.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+const EPIC_PATIENT_FHIR_ID = "epic-patient-1";
+
+function makeFakeClient(resourcesByType: Record<string, unknown[]>) {
+  return {
+    readPatient: vi.fn().mockResolvedValue(
+      resourcesByType.Patient?.[0] ?? {
+        resourceType: "Patient",
+        id: EPIC_PATIENT_FHIR_ID,
+      },
+    ),
+    searchAll: vi.fn().mockImplementation((resourceType: string) => {
+      const list = resourcesByType[resourceType] ?? [];
+      return (async function* () {
+        for (const r of list) yield r;
+      })();
+    }),
+  } as unknown as Parameters<typeof runFullSync>[1]["client"];
+}
+
+describe("Epic sync-jobs (#391)", () => {
+  let emit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emit = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("runSingleResourceSync fetches, persists, and emits a clinical-event with source_system=epic", async () => {
+    persistObservation.mockResolvedValueOnce({
+      internalId: "internal-vital-1",
+      kind: "vital",
+      inserted: true,
+    });
+    const client = makeFakeClient({
+      Observation: [
+        { resourceType: "Observation", id: "obs-1", meta: { lastUpdated: "2026-05-20T10:00:00Z" } },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markRunning).toHaveBeenCalledWith(PATIENT_ID, "Observation");
+    expect(persistObservation).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledOnce();
+
+    const event = emit.mock.calls[0]![0] as ClinicalEvent;
+    expect(event.type).toBe("vital.created");
+    expect(event.patient_id).toBe(PATIENT_ID);
+    expect(event.data.source_system).toBe("epic");
+    expect(event.data.epic_fhir_id).toBe("obs-1");
+    expect(event.data.operation).toBe("created");
+
+    expect(markOk).toHaveBeenCalledOnce();
+    expect(markOk.mock.calls[0]![0]).toMatchObject({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      highWatermark: "2026-05-20T10:00:00Z",
+      importedCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      patient_id: PATIENT_ID,
+      resource_type: "Observation",
+      imported: 1,
+      updated: 0,
+      conflicts: 0,
+      errors: [],
+    });
+  });
+
+  it("emits vital.updated (not vital.created) when persist reports inserted=false", async () => {
+    persistObservation.mockResolvedValueOnce({
+      internalId: "internal-vital-1",
+      kind: "vital",
+      inserted: false,
+    });
+    const client = makeFakeClient({
+      Observation: [{ resourceType: "Observation", id: "obs-1" }],
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    const event = emit.mock.calls[0]![0] as ClinicalEvent;
+    expect(event.type).toBe("vital.updated");
+    expect(event.data.operation).toBe("updated");
+  });
+
+  it("does NOT emit when persist returns a conflict", async () => {
+    persistMedicationRequest.mockResolvedValueOnce({
+      internalId: "internal-med-1",
+      kind: "medication",
+      inserted: false,
+      conflict: "source_system_conflict",
+    });
+    const client = makeFakeClient({
+      MedicationRequest: [
+        { resourceType: "MedicationRequest", id: "med-1" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(emit).not.toHaveBeenCalled();
+    expect(result.conflicts).toBe(1);
+    expect(result.imported).toBe(0);
+  });
+
+  it("skips unmapped resources without crashing the loop", async () => {
+    persistObservation
+      .mockResolvedValueOnce({
+        internalId: null,
+        kind: "unmapped",
+        inserted: false,
+      })
+      .mockResolvedValueOnce({
+        internalId: "internal-vital-2",
+        kind: "vital",
+        inserted: true,
+      });
+    const client = makeFakeClient({
+      Observation: [
+        { resourceType: "Observation", id: "obs-unmappable" },
+        { resourceType: "Observation", id: "obs-good" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(persistObservation).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenCalledOnce();
+    expect(result.imported).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("captures per-resource failures without aborting the resource-type batch", async () => {
+    persistCondition
+      .mockRejectedValueOnce(new Error("write blew up"))
+      .mockResolvedValueOnce({
+        internalId: "diag-2",
+        kind: "diagnosis",
+        inserted: true,
+      });
+    const client = makeFakeClient({
+      Condition: [
+        { resourceType: "Condition", id: "cond-1" },
+        { resourceType: "Condition", id: "cond-2" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(1);
+    expect(result.errors).toEqual(["write blew up"]);
+    // Failure of one resource still results in `markOk` for the batch —
+    // the per-resource errors are surfaced via the SyncResult, not by
+    // marking the whole resource_type as failed.
+    expect(markOk).toHaveBeenCalled();
+  });
+
+  it("marks the resource_type FAILED when the fetch itself throws", async () => {
+    const client = makeFakeClient({});
+    (client.searchAll as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("network down");
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markFailed).toHaveBeenCalledWith({
+      patientId: PATIENT_ID,
+      resourceType: "Condition",
+      errorMessage: "network down",
+    });
+    expect(result.errors).toContain("network down");
+  });
+
+  it("Patient resource fetch uses readPatient(epicPatientFhirId), not searchAll", async () => {
+    persistPatient.mockResolvedValueOnce({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({
+      Patient: [{ resourceType: "Patient", id: EPIC_PATIENT_FHIR_ID }],
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Patient",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(client.readPatient).toHaveBeenCalledWith(EPIC_PATIENT_FHIR_ID);
+    expect(client.searchAll).not.toHaveBeenCalled();
+  });
+
+  it("incremental sync passes the stored watermark as _lastUpdated=gt<value>", async () => {
+    getSyncState.mockImplementation(async (_p, rt) =>
+      rt === "Observation"
+        ? {
+            patient_id: PATIENT_ID,
+            resource_type: "Observation",
+            last_fhir_lastupdated: "2026-05-01T00:00:00Z",
+            last_synced_at: "2026-05-01T00:00:00Z",
+            status: "ok",
+            resources_synced_count: 5,
+            error_count: 0,
+            last_error_message: null,
+            last_error_at: null,
+          }
+        : null,
+    );
+    persistPatient.mockResolvedValue({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({});
+
+    await runIncrementalSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+      },
+      { client, emit },
+    );
+
+    const observationCall = (client.searchAll as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === "Observation",
+    );
+    expect(observationCall).toBeDefined();
+    expect(observationCall![1]._lastUpdated).toBe("gt2026-05-01T00:00:00Z");
+  });
+
+  it("full sync iterates every supported resource type", async () => {
+    persistPatient.mockResolvedValue({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({});
+    await runFullSync(
+      { patientId: PATIENT_ID, epicPatientFhirId: EPIC_PATIENT_FHIR_ID },
+      { client, emit },
+    );
+    // Patient = readPatient; the rest = searchAll
+    const searchedTypes = (client.searchAll as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    for (const rt of SUPPORTED_RESOURCE_TYPES) {
+      if (rt === "Patient") continue;
+      expect(searchedTypes).toContain(rt);
+    }
+  });
+});

--- a/services/epic-connector/src/__tests__/sync-state-repo.test.ts
+++ b/services/epic-connector/src/__tests__/sync-state-repo.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the epic_sync_state CRUD helpers (#391).
+ *
+ * Uses the shared mock-db builder so the chain assertions stay decoupled
+ * from any drizzle method-order quirks. No real Postgres involved.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  epicSyncState: {
+    patient_id: "patient_id",
+    resource_type: "resource_type",
+    status: "status",
+    last_error_at: "last_error_at",
+  },
+}));
+
+const {
+  getSyncState,
+  getAllSyncStatesForPatient,
+  markRunning,
+  markOk,
+  markFailed,
+  listRecentFailures,
+} = await import("../sync/sync-state-repo.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+describe("epic_sync_state repo (#391)", () => {
+  it("getSyncState returns the first row or null", async () => {
+    db.willSelect([
+      {
+        patient_id: PATIENT_ID,
+        resource_type: "Observation",
+        status: "ok",
+        last_synced_at: "2026-05-20T00:00:00Z",
+        last_fhir_lastupdated: "2026-05-19T23:00:00Z",
+        resources_synced_count: 5,
+        error_count: 0,
+        last_error_message: null,
+        last_error_at: null,
+      },
+    ]);
+    const row = await getSyncState(PATIENT_ID, "Observation");
+    expect(row?.status).toBe("ok");
+    expect(row?.last_fhir_lastupdated).toBe("2026-05-19T23:00:00Z");
+  });
+
+  it("getSyncState returns null when no row exists", async () => {
+    db.willSelect([]);
+    const row = await getSyncState(PATIENT_ID, "Observation");
+    expect(row).toBeNull();
+  });
+
+  it("getAllSyncStatesForPatient returns every row for the patient", async () => {
+    db.willSelect([
+      { patient_id: PATIENT_ID, resource_type: "Observation", status: "ok" },
+      { patient_id: PATIENT_ID, resource_type: "Condition", status: "failed" },
+    ]);
+    const rows = await getAllSyncStatesForPatient(PATIENT_ID);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("markRunning upserts a row with status=running", async () => {
+    db.willInsert();
+    await markRunning(PATIENT_ID, "Observation");
+    expect(db.insert).toHaveBeenCalledOnce();
+    const call = db.insert.calls[0]!;
+    expect(call.chain).toContain("values");
+    expect(call.chain).toContain("onConflictDoUpdate");
+    const values = call.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.status).toBe("running");
+  });
+
+  it("markOk records the high watermark and increments the success counter", async () => {
+    db.willInsert();
+    await markOk({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      highWatermark: "2026-05-20T12:00:00Z",
+      importedCount: 7,
+    });
+    expect(db.insert).toHaveBeenCalledOnce();
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.status).toBe("ok");
+    expect(values.last_fhir_lastupdated).toBe("2026-05-20T12:00:00Z");
+    expect(values.resources_synced_count).toBe(7);
+  });
+
+  it("markFailed truncates very long error messages to 1KiB", async () => {
+    db.willInsert();
+    const oversized = "x".repeat(2048);
+    await markFailed({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      errorMessage: oversized,
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect((values.last_error_message as string).length).toBe(1024);
+    expect(values.status).toBe("failed");
+    expect(values.error_count).toBe(1);
+  });
+
+  it("listRecentFailures filters status=failed and orders by last_error_at desc", async () => {
+    db.willSelect([
+      { patient_id: PATIENT_ID, resource_type: "Observation", status: "failed" },
+    ]);
+    const rows = await listRecentFailures(10);
+    expect(rows).toHaveLength(1);
+    const call = db.select.calls[0]!;
+    expect(call.chain).toContain("where");
+    expect(call.chain).toContain("orderBy");
+    expect(call.chain).toContain("limit");
+  });
+});

--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for EpicTokenClient (#389).
+ *
+ * Mocks fetch so the tests run offline. Real-Epic integration is gated
+ * on EPIC_CLIENT_ID and runs locally when the user has credentials.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicTokenClient, DEFAULT_SYSTEM_SCOPES } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client-id-xyz",
+    tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+function tokenResponse(opts: { expires_in?: number; access_token?: string } = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: opts.access_token ?? "fake-access-token",
+      expires_in: opts.expires_in ?? 3600,
+      token_type: "Bearer",
+      scope: DEFAULT_SYSTEM_SCOPES.join(" "),
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("EpicTokenClient (#389)", () => {
+  let privatePem: string;
+
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  it("requests a token via client_credentials with a JWT assertion", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    );
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("client_assertion_type")).toBe(
+      "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    );
+    expect(body.get("client_assertion")).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(body.get("scope")).toBe(DEFAULT_SYSTEM_SCOPES.join(" "));
+  });
+
+  it("returns the parsed access_token from a 200 response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      tokenResponse({ access_token: "abc-123" }),
+    );
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+    const token = await client.getAccessToken();
+    expect(token).toBe("abc-123");
+  });
+
+  it("caches the token and serves subsequent calls without re-fetching", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+    await client.getAccessToken();
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("re-requests when the cached token has less than 60s of lifetime left", async () => {
+    let now = 1_700_000_000_000;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () => tokenResponse({ expires_in: 100 }));
+    const client = new EpicTokenClient(
+      makeConfig(privatePem),
+      fetchMock,
+      () => now,
+    );
+
+    await client.getAccessToken();
+    // Jump forward 50 seconds — still within the 60s refresh buffer
+    // window (100 - 50 = 50 remaining ≤ 60 → re-request).
+    now += 50_000;
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT re-request when cache still has > 60s of lifetime", async () => {
+    let now = 1_700_000_000_000;
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse({ expires_in: 3600 }));
+    const client = new EpicTokenClient(
+      makeConfig(privatePem),
+      fetchMock,
+      () => now,
+    );
+
+    await client.getAccessToken();
+    now += 600_000; // 10 min later — token still has ~50 min left
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("invalidate() forces a fresh token on next call", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken();
+    client.invalidate();
+    await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on non-2xx response without leaking the assertion body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("invalid_client_assertion_or_signature", { status: 400 }),
+    );
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await expect(client.getAccessToken()).rejects.toThrow(/Epic token endpoint returned 400/);
+  });
+
+  it("accepts custom scope override", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => tokenResponse());
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken(["system/Patient.read"]);
+
+    const body = new URLSearchParams(
+      fetchMock.mock.calls[0]![1].body as string,
+    );
+    expect(body.get("scope")).toBe("system/Patient.read");
+  });
+});

--- a/services/epic-connector/src/__tests__/token-exchange.test.ts
+++ b/services/epic-connector/src/__tests__/token-exchange.test.ts
@@ -1,0 +1,146 @@
+/**
+ * App Launch token-exchange tests (#392).
+ *
+ * Mocks fetch so we never call Epic. Verifies request shape, response
+ * parsing, error handling, and id_token decoding.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+} from "../app-launch/token-exchange.js";
+
+function tokenResponse(overrides: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: "epic-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "patient/*.read user/Practitioner.read openid fhirUser",
+      id_token: "header.eyJzdWIiOiJlcGljLXVzZXItMSJ9.sig",
+      refresh_token: "epic-refresh-token",
+      patient: "epic-patient-1",
+      encounter: "epic-encounter-1",
+      need_patient_banner: true,
+      smart_style_url: "https://fhir.epic.com/style.json",
+      ...overrides,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const baseArgs = {
+  tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+  code: "auth-code-1",
+  redirectUri: "https://app.carebridge.test/auth/epic/callback",
+  clientId: "carebridge-client",
+  codeVerifier: "v".repeat(43),
+};
+
+describe("exchangeAuthorizationCode (#392)", () => {
+  it("posts grant_type=authorization_code + code + code_verifier + redirect_uri", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    await exchangeAuthorizationCode({ ...baseArgs, fetchImpl: fetchMock });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(baseArgs.tokenUrl);
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("auth-code-1");
+    expect(body.get("redirect_uri")).toBe(baseArgs.redirectUri);
+    expect(body.get("client_id")).toBe("carebridge-client");
+    expect(body.get("code_verifier")).toBe("v".repeat(43));
+    // We're a public client (PKCE only) — no client_secret should leak.
+    expect(body.get("client_secret")).toBeNull();
+  });
+
+  it("parses all the SMART App Launch fields plus passthrough extras", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    const result = await exchangeAuthorizationCode({
+      ...baseArgs,
+      fetchImpl: fetchMock,
+    });
+
+    expect(result.access_token).toBe("epic-access-token");
+    expect(result.token_type).toBe("Bearer");
+    expect(result.expires_in).toBe(3600);
+    expect(result.scope).toContain("patient/*.read");
+    expect(result.id_token).toBeDefined();
+    expect(result.refresh_token).toBe("epic-refresh-token");
+    expect(result.patient).toBe("epic-patient-1");
+    expect(result.encounter).toBe("epic-encounter-1");
+    expect(result.extra.need_patient_banner).toBe(true);
+    expect(result.extra.smart_style_url).toBe("https://fhir.epic.com/style.json");
+  });
+
+  it("omits patient/encounter when Epic doesn't return them (Standalone Launch)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      tokenResponse({ patient: undefined, encounter: undefined }),
+    );
+    const result = await exchangeAuthorizationCode({
+      ...baseArgs,
+      fetchImpl: fetchMock,
+    });
+    expect(result.patient).toBeUndefined();
+    expect(result.encounter).toBeUndefined();
+  });
+
+  it("throws on non-2xx responses without surfacing the body to the caller", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("invalid_grant: code already used", { status: 400 }),
+    );
+    await expect(
+      exchangeAuthorizationCode({ ...baseArgs, fetchImpl: fetchMock }),
+    ).rejects.toThrow(/Epic token endpoint returned 400/);
+  });
+});
+
+describe("decodeIdTokenUnsafe", () => {
+  it("decodes the JWS payload without verifying the signature", () => {
+    // payload = { sub: "user-1", fhirUser: "Practitioner/abc-1" }
+    const payload = Buffer.from(
+      JSON.stringify({
+        sub: "user-1",
+        fhirUser: "https://fhir.epic.com/api/FHIR/R4/Practitioner/abc-1",
+      }),
+    )
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const jwt = `header.${payload}.sig`;
+    const decoded = decodeIdTokenUnsafe(jwt);
+    expect(decoded?.sub).toBe("user-1");
+    expect(decoded?.fhirUser).toContain("Practitioner/abc-1");
+  });
+
+  it("returns null on a malformed JWT", () => {
+    expect(decodeIdTokenUnsafe("not.a.jwt-payload")).toBeNull();
+    expect(decodeIdTokenUnsafe("only-one-segment")).toBeNull();
+  });
+});
+
+describe("extractPractitionerId", () => {
+  it("pulls the FHIR id out of a Practitioner reference URL", () => {
+    expect(
+      extractPractitionerId(
+        "https://fhir.epic.com/interconnect/api/FHIR/R4/Practitioner/abc-123",
+      ),
+    ).toBe("abc-123");
+  });
+
+  it("returns null when the fhirUser claim doesn't reference a Practitioner", () => {
+    expect(
+      extractPractitionerId(
+        "https://fhir.epic.com/api/FHIR/R4/Patient/p-1",
+      ),
+    ).toBeNull();
+    expect(extractPractitionerId(undefined)).toBeNull();
+    expect(extractPractitionerId("garbage")).toBeNull();
+  });
+});

--- a/services/epic-connector/src/app-launch/authorize.ts
+++ b/services/epic-connector/src/app-launch/authorize.ts
@@ -1,0 +1,78 @@
+/**
+ * Authorize-URL builder for SMART App Launch (#392).
+ *
+ * Constructs the URL we redirect the user's browser to when they begin
+ * either an EHR Launch (Epic clicks "open CareBridge" → we get a
+ * `launch` token + `iss`) or a Standalone Launch (clinician opens
+ * CareBridge first → we discover Epic's authorize URL via
+ * .well-known/smart-configuration).
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/app-launch.html
+ *
+ * Required params:
+ *   response_type=code
+ *   client_id=<our Epic-registered client id>
+ *   redirect_uri=<our callback URL — must EXACTLY match what's
+ *                 registered at open.epic.com>
+ *   scope=<requested SMART scopes>
+ *   state=<opaque CSRF token; we use the OAuth state to key our
+ *          server-side launch-state row>
+ *   aud=<iss FHIR base — protects against confused-deputy attacks
+ *        where a different EHR's authorize endpoint reuses our code>
+ *   code_challenge=<S256-hashed PKCE challenge>
+ *   code_challenge_method=S256
+ *
+ * EHR-launch additions:
+ *   launch=<the launch token Epic gave us in the bootstrap redirect>
+ */
+export interface AuthorizeUrlArgs {
+  authorizeUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  state: string;
+  /** FHIR base URL — also the OAuth `aud` claim. Required by SMART. */
+  aud: string;
+  codeChallenge: string;
+  /** Present on EHR Launch; omit for Standalone. */
+  launch?: string;
+}
+
+/**
+ * Default scope set we request for a user-context Epic launch.
+ *
+ * - launch                — required for EHR Launch (no-op on Standalone)
+ * - openid + fhirUser     — we need an id_token with the Practitioner FHIR id
+ * - offline_access        — request a refresh token so the session
+ *                           survives access-token expiry without
+ *                           re-launching from Epic
+ * - patient/*.read        — read-only access to the launch-context
+ *                           patient
+ * - user/Practitioner.read — read the practitioner identity behind
+ *                           the launch so we can match them to the
+ *                           CareBridge user.
+ */
+export const DEFAULT_APP_LAUNCH_SCOPES = [
+  "launch",
+  "openid",
+  "fhirUser",
+  "offline_access",
+  "patient/*.read",
+  "user/Practitioner.read",
+] as const;
+
+export function buildAuthorizeUrl(args: AuthorizeUrlArgs): string {
+  const url = new URL(args.authorizeUrl);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", args.clientId);
+  url.searchParams.set("redirect_uri", args.redirectUri);
+  url.searchParams.set("scope", args.scopes.join(" "));
+  url.searchParams.set("state", args.state);
+  url.searchParams.set("aud", args.aud);
+  url.searchParams.set("code_challenge", args.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  if (args.launch) {
+    url.searchParams.set("launch", args.launch);
+  }
+  return url.toString();
+}

--- a/services/epic-connector/src/app-launch/connection-repo.ts
+++ b/services/epic-connector/src/app-launch/connection-repo.ts
@@ -1,0 +1,156 @@
+/**
+ * CRUD for `epic_user_connections` rows (#392).
+ *
+ * Upserts on (user_id, epic_org_iss) so a re-launch by the same
+ * clinician at the same Epic org refreshes the tokens in place rather
+ * than appending. Access/refresh tokens are encrypted at rest via the
+ * same encryption hook used for PHI columns.
+ */
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb, epicUserConnections } from "@carebridge/db-schema";
+
+export interface EpicConnectionUpsert {
+  user_id: string;
+  epic_org_iss: string;
+  access_token: string;
+  refresh_token: string | null;
+  expires_at: string;
+  scopes: string;
+  id_token_subject: string | null;
+  epic_practitioner_fhir_id: string | null;
+  epic_patient_fhir_id: string | null;
+  launch_encounter_fhir_id: string | null;
+}
+
+export interface EpicConnectionRow {
+  id: string;
+  user_id: string;
+  epic_org_iss: string;
+  /** Decrypted access token. */
+  access_token: string;
+  /** Decrypted refresh token (or null). */
+  refresh_token: string | null;
+  expires_at: string;
+  scopes: string;
+  id_token_subject: string | null;
+  epic_practitioner_fhir_id: string | null;
+  epic_patient_fhir_id: string | null;
+  launch_encounter_fhir_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Upsert the connection row. Returns the row id. Tokens are written
+ * via the encryption hook attached to the schema columns.
+ */
+export async function upsertEpicConnection(
+  input: EpicConnectionUpsert,
+): Promise<string> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+
+  await db
+    .insert(epicUserConnections)
+    .values({
+      id,
+      user_id: input.user_id,
+      epic_org_iss: input.epic_org_iss,
+      access_token_enc: input.access_token,
+      refresh_token_enc: input.refresh_token,
+      expires_at: input.expires_at,
+      scopes: input.scopes,
+      id_token_subject: input.id_token_subject,
+      epic_practitioner_fhir_id: input.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: input.epic_patient_fhir_id,
+      launch_encounter_fhir_id: input.launch_encounter_fhir_id,
+      created_at: now,
+      updated_at: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        epicUserConnections.user_id,
+        epicUserConnections.epic_org_iss,
+      ],
+      set: {
+        access_token_enc: input.access_token,
+        refresh_token_enc: input.refresh_token,
+        expires_at: input.expires_at,
+        scopes: input.scopes,
+        id_token_subject: input.id_token_subject,
+        epic_practitioner_fhir_id: input.epic_practitioner_fhir_id,
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        launch_encounter_fhir_id: input.launch_encounter_fhir_id,
+        updated_at: now,
+      },
+    });
+
+  return id;
+}
+
+export async function getConnectionsForUser(
+  userId: string,
+): Promise<EpicConnectionRow[]> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicUserConnections)
+    .where(eq(epicUserConnections.user_id, userId));
+  return rows.map(mapRow);
+}
+
+export async function getConnection(
+  userId: string,
+  epicOrgIss: string,
+): Promise<EpicConnectionRow | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicUserConnections)
+    .where(
+      and(
+        eq(epicUserConnections.user_id, userId),
+        eq(epicUserConnections.epic_org_iss, epicOrgIss),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  return row ? mapRow(row) : null;
+}
+
+export async function deleteConnection(
+  userId: string,
+  epicOrgIss: string,
+): Promise<boolean> {
+  const db = getDb();
+  const result = await db
+    .delete(epicUserConnections)
+    .where(
+      and(
+        eq(epicUserConnections.user_id, userId),
+        eq(epicUserConnections.epic_org_iss, epicOrgIss),
+      ),
+    )
+    .returning({ id: epicUserConnections.id });
+  return result.length > 0;
+}
+
+function mapRow(row: typeof epicUserConnections.$inferSelect): EpicConnectionRow {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    epic_org_iss: row.epic_org_iss,
+    access_token: row.access_token_enc,
+    refresh_token: row.refresh_token_enc,
+    expires_at: row.expires_at,
+    scopes: row.scopes,
+    id_token_subject: row.id_token_subject,
+    epic_practitioner_fhir_id: row.epic_practitioner_fhir_id,
+    epic_patient_fhir_id: row.epic_patient_fhir_id,
+    launch_encounter_fhir_id: row.launch_encounter_fhir_id,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}

--- a/services/epic-connector/src/app-launch/launch-service.ts
+++ b/services/epic-connector/src/app-launch/launch-service.ts
@@ -1,0 +1,226 @@
+/**
+ * SMART App Launch orchestrator (#392).
+ *
+ * Ties together the PKCE helpers, authorize URL builder, token exchange,
+ * launch-state store, and connection repo so the Fastify route handlers
+ * stay thin. Both EHR Launch (Epic bootstraps with `iss` + `launch`)
+ * and Standalone Launch (we know the `iss` from settings) come through
+ * the same `beginLaunch` → `completeLaunch` pair.
+ */
+import { randomBytes } from "node:crypto";
+import { createLogger } from "@carebridge/logger";
+import {
+  fetchSmartConfiguration,
+  type SmartConfiguration,
+} from "../capability.js";
+import { generatePkcePair } from "./pkce.js";
+import {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+} from "./authorize.js";
+import {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+  type AppLaunchTokenResponse,
+} from "./token-exchange.js";
+import { upsertEpicConnection } from "./connection-repo.js";
+import type { LaunchStateStore, LaunchState } from "./state-store.js";
+
+const log = createLogger("epic-app-launch");
+
+const STATE_TTL_SECONDS = 600; // 10 minutes — the user has to finish OAuth in that window
+
+export interface BeginLaunchArgs {
+  /** Epic FHIR base URL — from EHR launch `iss` param OR from settings for Standalone. */
+  iss: string;
+  /** EHR-launch `launch` token. Omit for Standalone. */
+  launch?: string;
+  /** CareBridge user id we will associate the resulting connection with. */
+  userId: string;
+  /** Callback URL we register with Epic. */
+  redirectUri: string;
+  /** CareBridge client id registered at open.epic.com. */
+  clientId: string;
+  /** Where to send the browser after a successful launch. */
+  postLaunchRedirect: string;
+  /** Override scopes; defaults to the full SMART set. */
+  scopes?: readonly string[];
+  /** Override the discovery fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override random bytes (test-only — predictable state values). */
+  rng?: (size: number) => Buffer;
+}
+
+export interface BeginLaunchResult {
+  /** Browser redirects here. */
+  authorizeUrl: string;
+  /** The OAuth state value — also the lookup key in the launch-state store. */
+  state: string;
+}
+
+/**
+ * Step 1: build the authorize URL, persist the launch state under the
+ * generated `state`, and return both.
+ */
+export async function beginLaunch(
+  args: BeginLaunchArgs,
+  store: LaunchStateStore,
+): Promise<BeginLaunchResult> {
+  const smart = await fetchSmartConfiguration(args.iss, args.fetchImpl);
+  if (!smart.authorization_endpoint) {
+    throw new Error(
+      `SMART configuration at ${args.iss} is missing authorization_endpoint — ` +
+        "App Launch requires the OAuth authorize URL",
+    );
+  }
+  const authorizationEndpoint = smart.authorization_endpoint;
+
+  const pkce = generatePkcePair(args.rng);
+  const state = generateOAuthState(args.rng);
+
+  const scopes = (args.scopes ?? DEFAULT_APP_LAUNCH_SCOPES).slice();
+  // Standalone launches must NOT request `launch` — Epic rejects the
+  // authorize call if the scope is present without a launch token.
+  if (!args.launch) {
+    const idx = scopes.indexOf("launch");
+    if (idx >= 0) scopes.splice(idx, 1);
+  }
+
+  const authorizeUrl = buildAuthorizeUrl({
+    authorizeUrl: authorizationEndpoint,
+    clientId: args.clientId,
+    redirectUri: args.redirectUri,
+    scopes,
+    state,
+    aud: args.iss,
+    codeChallenge: pkce.codeChallenge,
+    launch: args.launch,
+  });
+
+  const launchState: LaunchState = {
+    codeVerifier: pkce.codeVerifier,
+    iss: args.iss,
+    tokenUrl: smart.token_endpoint,
+    authorizeUrl: authorizationEndpoint,
+    userId: args.userId,
+    postLaunchRedirect: args.postLaunchRedirect,
+    launchToken: args.launch,
+    createdAt: new Date().toISOString(),
+  };
+  await store.set(state, launchState, STATE_TTL_SECONDS);
+
+  log.info("Epic App Launch initiated", {
+    userId: args.userId,
+    iss: args.iss,
+    isEhrLaunch: Boolean(args.launch),
+  });
+
+  return { authorizeUrl, state };
+}
+
+export interface CompleteLaunchArgs {
+  /** OAuth state from the callback query string. */
+  state: string;
+  /** Authorization code from the callback query string. */
+  code: string;
+  /** CareBridge client id (must match the begin step). */
+  clientId: string;
+  /** Callback URL (must match the begin step — Epic verifies). */
+  redirectUri: string;
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface CompleteLaunchResult {
+  /** CareBridge connection row id we just upserted. */
+  connectionId: string;
+  /** Where the browser should land next. */
+  postLaunchRedirect: string;
+  /** FHIR Patient.id from launch context (EHR launch only). */
+  patientFhirId: string | null;
+  /** FHIR Encounter.id from launch context. */
+  encounterFhirId: string | null;
+  /** FHIR Practitioner.id derived from id_token.fhirUser, if present. */
+  practitionerFhirId: string | null;
+  /** Raw token response — useful for logging and debugging. */
+  tokens: AppLaunchTokenResponse;
+}
+
+/**
+ * Step 2: exchange the auth code for tokens, decode the id_token,
+ * upsert the `epic_user_connections` row, and return where to send the
+ * browser next. Throws on state mismatch / expired state / token-exchange
+ * failure so the route handler can render a coherent error page.
+ */
+export async function completeLaunch(
+  args: CompleteLaunchArgs,
+  store: LaunchStateStore,
+): Promise<CompleteLaunchResult> {
+  const launchState = await store.get(args.state);
+  if (!launchState) {
+    throw new Error("Epic App Launch state expired or unknown");
+  }
+  // Single-use — drop the state before we even attempt the token
+  // exchange so a leaked code can't be replayed.
+  await store.delete(args.state);
+
+  const tokens = await exchangeAuthorizationCode({
+    tokenUrl: launchState.tokenUrl,
+    code: args.code,
+    redirectUri: args.redirectUri,
+    clientId: args.clientId,
+    codeVerifier: launchState.codeVerifier,
+    fetchImpl: args.fetchImpl,
+  });
+
+  const decoded = tokens.id_token ? decodeIdTokenUnsafe(tokens.id_token) : null;
+  const practitionerFhirId = extractPractitionerId(decoded?.fhirUser);
+
+  const expiresAtMs = Date.now() + tokens.expires_in * 1000;
+
+  const connectionId = await upsertEpicConnection({
+    user_id: launchState.userId,
+    epic_org_iss: launchState.iss,
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token ?? null,
+    expires_at: new Date(expiresAtMs).toISOString(),
+    scopes: tokens.scope,
+    id_token_subject: decoded?.sub ?? null,
+    epic_practitioner_fhir_id: practitionerFhirId,
+    epic_patient_fhir_id: tokens.patient ?? null,
+    launch_encounter_fhir_id: tokens.encounter ?? null,
+  });
+
+  log.info("Epic App Launch completed", {
+    connectionId,
+    userId: launchState.userId,
+    iss: launchState.iss,
+    practitionerFhirId,
+    hasPatientContext: Boolean(tokens.patient),
+  });
+
+  return {
+    connectionId,
+    postLaunchRedirect: launchState.postLaunchRedirect,
+    patientFhirId: tokens.patient ?? null,
+    encounterFhirId: tokens.encounter ?? null,
+    practitionerFhirId,
+    tokens,
+  };
+}
+
+/**
+ * 32 bytes → 43 base64url chars — same shape as the PKCE verifier so
+ * Epic's permissive state validation accepts it without escaping
+ * surprises in the URL.
+ */
+function generateOAuthState(rng: (size: number) => Buffer = randomBytes): string {
+  return rng(32)
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export type { SmartConfiguration };

--- a/services/epic-connector/src/app-launch/pkce.ts
+++ b/services/epic-connector/src/app-launch/pkce.ts
@@ -1,0 +1,71 @@
+/**
+ * PKCE (RFC 7636) helpers for SMART on FHIR App Launch (#392).
+ *
+ * Epic's SMART App Launch flow requires PKCE — the implicit grant is
+ * disallowed and bare authorization-code without `code_challenge` is
+ * rejected by the authorise endpoint.
+ *
+ * We use the S256 challenge method (the only one Epic accepts in
+ * production). The `code_verifier` is a 43-128 char URL-safe random
+ * string; the `code_challenge` is BASE64URL(SHA256(verifier)).
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+export interface PkcePair {
+  /** 43-char base64url-encoded random secret. Send with token exchange. */
+  codeVerifier: string;
+  /** SHA-256(codeVerifier), base64url-encoded. Sent on the authorize URL. */
+  codeChallenge: string;
+  /** Always "S256" — Epic does not accept "plain". */
+  codeChallengeMethod: "S256";
+}
+
+/**
+ * Generate a fresh PKCE verifier/challenge pair. The verifier MUST be
+ * persisted server-side keyed by the OAuth `state` value so the
+ * callback can supply it during code exchange (the browser does not
+ * see the verifier — that's the point of PKCE).
+ */
+export function generatePkcePair(
+  rng: (size: number) => Buffer = randomBytes,
+): PkcePair {
+  // 32 bytes → 43 base64url characters. RFC 7636 §4.1 requires 43-128
+  // characters; 43 is the minimum that still gives 256 bits of entropy
+  // after the base64url encoding.
+  const verifier = base64UrlEncode(rng(32));
+  const challenge = base64UrlEncode(createHash("sha256").update(verifier).digest());
+  return {
+    codeVerifier: verifier,
+    codeChallenge: challenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+/**
+ * Verify that a challenge derives from a verifier — used in tests
+ * and in defensive checks at code-exchange time.
+ */
+export function verifyChallenge(verifier: string, challenge: string): boolean {
+  const expected = base64UrlEncode(
+    createHash("sha256").update(verifier).digest(),
+  );
+  return timingSafeEqual(expected, challenge);
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/** Length-aware constant-time string compare. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/services/epic-connector/src/app-launch/state-store.ts
+++ b/services/epic-connector/src/app-launch/state-store.ts
@@ -1,0 +1,131 @@
+/**
+ * Short-lived launch-state storage for SMART App Launch (#392).
+ *
+ * The OAuth `state` parameter we mint on the /authorize step indexes a
+ * server-side record holding:
+ *   - the PKCE `code_verifier` we'll need on code exchange
+ *   - the `iss` / token URL we discovered (so the callback doesn't have
+ *     to re-fetch .well-known/smart-configuration)
+ *   - the CareBridge user_id we associate the resulting tokens with
+ *   - which redirect URL to bounce the user to after success
+ *   - the launch-context token (`launch=…`) so we can correlate
+ *
+ * Backed by Redis with a short TTL — the OAuth state is single-use and
+ * worthless after the user finishes the authorize round-trip. We don't
+ * persist this to the main DB because:
+ *   - one row per launch attempt would fill the table quickly
+ *   - we don't want to GC abandoned authorize flows ourselves
+ *
+ * The interface is dependency-injected so tests can swap in an in-memory
+ * store and avoid Redis.
+ */
+export interface LaunchState {
+  /** PKCE verifier — never serialised to the client. */
+  codeVerifier: string;
+  /** Epic FHIR base URL (the `iss`). */
+  iss: string;
+  /** Resolved token endpoint URL. */
+  tokenUrl: string;
+  /** Authorize endpoint we redirected to (echoed for audit). */
+  authorizeUrl: string;
+  /** CareBridge user id this launch is for. */
+  userId: string;
+  /** Final redirect URL after success (e.g. /patients/<id>). */
+  postLaunchRedirect: string;
+  /** EHR-launch `launch` token, if this is an EHR launch. */
+  launchToken?: string;
+  /** Created-at wall-clock for debugging. */
+  createdAt: string;
+}
+
+export interface LaunchStateStore {
+  set(state: string, value: LaunchState, ttlSeconds: number): Promise<void>;
+  get(state: string): Promise<LaunchState | null>;
+  /** Remove (consume) — every state is single-use. */
+  delete(state: string): Promise<void>;
+}
+
+/**
+ * Pure in-memory implementation. Used in tests AND as a sane default
+ * for single-process dev runs where bringing up Redis is overkill.
+ * Production multi-pod deployments MUST swap for the Redis-backed
+ * implementation below.
+ */
+export class InMemoryLaunchStateStore implements LaunchStateStore {
+  private readonly store = new Map<
+    string,
+    { value: LaunchState; expiresAt: number }
+  >();
+
+  constructor(private readonly nowMs: () => number = () => Date.now()) {}
+
+  async set(
+    state: string,
+    value: LaunchState,
+    ttlSeconds: number,
+  ): Promise<void> {
+    this.store.set(state, {
+      value,
+      expiresAt: this.nowMs() + ttlSeconds * 1000,
+    });
+  }
+
+  async get(state: string): Promise<LaunchState | null> {
+    const entry = this.store.get(state);
+    if (!entry) return null;
+    if (entry.expiresAt < this.nowMs()) {
+      this.store.delete(state);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async delete(state: string): Promise<void> {
+    this.store.delete(state);
+  }
+}
+
+/**
+ * Redis-backed implementation. Pass an ioredis instance compatible
+ * with the `set EX` / `get` / `del` commands. Kept narrow to avoid
+ * pulling ioredis types into the package — host services already have
+ * a connection.
+ */
+export interface RedisLike {
+  set(key: string, value: string, mode: "EX", ttlSeconds: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  del(key: string): Promise<number>;
+}
+
+const KEY_PREFIX = "epic:applaunch:state:";
+
+export class RedisLaunchStateStore implements LaunchStateStore {
+  constructor(private readonly redis: RedisLike) {}
+
+  async set(
+    state: string,
+    value: LaunchState,
+    ttlSeconds: number,
+  ): Promise<void> {
+    await this.redis.set(
+      KEY_PREFIX + state,
+      JSON.stringify(value),
+      "EX",
+      ttlSeconds,
+    );
+  }
+
+  async get(state: string): Promise<LaunchState | null> {
+    const raw = await this.redis.get(KEY_PREFIX + state);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as LaunchState;
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(state: string): Promise<void> {
+    await this.redis.del(KEY_PREFIX + state);
+  }
+}

--- a/services/epic-connector/src/app-launch/token-exchange.ts
+++ b/services/epic-connector/src/app-launch/token-exchange.ts
@@ -1,0 +1,175 @@
+/**
+ * SMART App Launch authorization-code → token exchange (#392).
+ *
+ * Posts to Epic's token endpoint with the authorization code, redirect
+ * URI (must match what was sent on the authorize step), client_id, and
+ * PKCE code_verifier. Returns the parsed token response including
+ * id_token and the EHR-launch context fields (`patient`, `encounter`).
+ *
+ * No client_secret — Epic public-client App Launch is PKCE-only.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/app-launch.html#token-response
+ */
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-app-launch-token");
+
+export interface ExchangeArgs {
+  tokenUrl: string;
+  code: string;
+  redirectUri: string;
+  clientId: string;
+  codeVerifier: string;
+  /** Override for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Subset of the token response that callers consume. Epic emits
+ * additional fields (`refresh_token_expires_in`, `need_patient_banner`,
+ * etc.) — passthrough JSON in {@link extra} preserves them so we don't
+ * have to revisit this file every time Epic adds a field.
+ */
+export interface AppLaunchTokenResponse {
+  access_token: string;
+  token_type: string;
+  /** Seconds until expiry, from issue time. */
+  expires_in: number;
+  /** Granted scopes (space-separated; may be a subset of requested). */
+  scope: string;
+  /**
+   * OpenID Connect id_token. Decoded by the caller; we don't sign-verify
+   * here because Epic's JWKS rotation cadence is out of scope for the
+   * App-Launch unit. Signature verification is best-effort delegated to
+   * the OAuth-callback handler.
+   */
+  id_token?: string;
+  /** Refresh token (only when `offline_access` was granted). */
+  refresh_token?: string;
+  /** EHR-launch patient context (FHIR Patient.id). Absent for Standalone. */
+  patient?: string;
+  /** EHR-launch encounter context (FHIR Encounter.id). Often absent. */
+  encounter?: string;
+  /** Raw passthrough for fields we don't model. */
+  extra: Record<string, unknown>;
+}
+
+export async function exchangeAuthorizationCode(
+  args: ExchangeArgs,
+): Promise<AppLaunchTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    client_id: args.clientId,
+    code_verifier: args.codeVerifier,
+  });
+
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const response = await fetchImpl(args.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const text = await safeReadBody(response);
+    log.warn("Epic App Launch token exchange failed", {
+      status: response.status,
+      bodyPrefix: text.slice(0, 200),
+    });
+    throw new Error(
+      `Epic token endpoint returned ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+
+  // Type-narrow each field we expose. Unknown extras stay in `extra`
+  // for callers that need them (need_patient_banner, smart_style_url
+  // for embedded launch UI theming, etc).
+  const known = new Set([
+    "access_token",
+    "token_type",
+    "expires_in",
+    "scope",
+    "id_token",
+    "refresh_token",
+    "patient",
+    "encounter",
+  ]);
+  const extra: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(json)) {
+    if (!known.has(k)) extra[k] = v;
+  }
+
+  return {
+    access_token: String(json.access_token ?? ""),
+    token_type: String(json.token_type ?? "Bearer"),
+    expires_in: Number(json.expires_in ?? 0),
+    scope: String(json.scope ?? ""),
+    id_token: optString(json.id_token),
+    refresh_token: optString(json.refresh_token),
+    patient: optString(json.patient),
+    encounter: optString(json.encounter),
+    extra,
+  };
+}
+
+function optString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Decode the JWS payload of an id_token without verifying the signature.
+ * Use only when:
+ *   - The token was just returned over TLS by the issuer's token endpoint
+ *     (we trust the source, not the token in isolation)
+ *   - The caller logs the issuer mismatch / kid lookup separately
+ * For long-term acceptance of an id_token (e.g. as a session anchor),
+ * use a JWKS verifier instead.
+ */
+export function decodeIdTokenUnsafe(
+  idToken: string,
+): { sub?: string; fhirUser?: string; iss?: string; aud?: string } | null {
+  const parts = idToken.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payloadBase64 = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payloadBase64.padEnd(
+      payloadBase64.length + ((4 - (payloadBase64.length % 4)) % 4),
+      "=",
+    );
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    return JSON.parse(decoded) as {
+      sub?: string;
+      fhirUser?: string;
+      iss?: string;
+      aud?: string;
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the Practitioner FHIR id from the `fhirUser` claim.
+ * The claim's value is a URL like `https://fhir.epic.com/.../Practitioner/abc-123`.
+ * Returns just `abc-123`, or null if the claim doesn't reference a Practitioner.
+ */
+export function extractPractitionerId(fhirUser: string | undefined): string | null {
+  if (!fhirUser) return null;
+  const m = fhirUser.match(/\/Practitioner\/([^/?#]+)$/);
+  return m ? m[1]! : null;
+}

--- a/services/epic-connector/src/bin/keygen.ts
+++ b/services/epic-connector/src/bin/keygen.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * `carebridge-epic-keygen` — one-shot RS384 keypair setup (#389).
+ *
+ * Usage:
+ *   pnpm epic:keygen [--out <path>] [--kid <id>]
+ *
+ * Defaults:
+ *   --out  ~/.carebridge/epic-private.pem
+ *   --kid  fresh UUID v4
+ *
+ * On success, prints:
+ *  1. The path the private key was written to (chmod 0600).
+ *  2. The kid to set as EPIC_JWT_KID.
+ *  3. The public JWK to paste into open.epic.com → App Settings →
+ *     Public Keys.
+ *  4. The .env snippet to copy into your local .env.local.
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { generateKeypair, publicKeyFingerprint } from "../keygen.js";
+
+interface Args {
+  out: string;
+  kid?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    out: join(homedir(), ".carebridge", "epic-private.pem"),
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out" || arg === "-o") {
+      const next = argv[++i];
+      if (!next) throw new Error("--out requires a path argument");
+      args.out = next;
+    } else if (arg === "--kid") {
+      const next = argv[++i];
+      if (!next) throw new Error("--kid requires an id argument");
+      args.kid = next;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `Usage: carebridge-epic-keygen [--out <path>] [--kid <id>]\n\n` +
+      `Generates an RS384 keypair for Epic SMART Backend Services and\n` +
+      `prints the public JWK for upload at open.epic.com.\n\n` +
+      `Options:\n` +
+      `  --out, -o   Path to write the private key PEM (chmod 0600).\n` +
+      `              Default: ~/.carebridge/epic-private.pem\n` +
+      `  --kid       Key id to embed in the JWK. Default: fresh UUID.\n` +
+      `  --help, -h  Show this help.\n`,
+  );
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const result = generateKeypair({
+    privateKeyPath: args.out,
+    kid: args.kid,
+  });
+
+  const fingerprint = publicKeyFingerprint(result.publicKeyPem);
+
+  /* eslint-disable no-console */
+  console.log("\n=== Epic SMART Backend Services keypair generated ===\n");
+  console.log(`Private key:    ${result.privateKeyPath}  (chmod 0600)`);
+  console.log(`Key id (kid):   ${result.kid}`);
+  console.log(`Fingerprint:    sha256:${fingerprint}\n`);
+  console.log("Public JWK — paste this at open.epic.com → App Settings → Public Keys:\n");
+  console.log(JSON.stringify(result.publicJwk, null, 2));
+  console.log("\n.env.local snippet:\n");
+  console.log(`EPIC_CLIENT_ID=<paste your Non-Production Client ID here>`);
+  console.log(`EPIC_PRIVATE_KEY_PATH=${result.privateKeyPath}`);
+  console.log(`EPIC_JWT_KID=${result.kid}\n`);
+  console.log(
+    "Defaults to Epic's sandbox (fhir.epic.com). Override " +
+      "EPIC_TOKEN_URL and EPIC_FHIR_BASE_URL for production.",
+  );
+  /* eslint-enable no-console */
+}
+
+try {
+  main();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(
+    `epic-keygen failed: ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+}

--- a/services/epic-connector/src/capability.ts
+++ b/services/epic-connector/src/capability.ts
@@ -31,13 +31,14 @@ export interface SmartConfiguration {
 }
 
 /**
- * Build the well-known URL for the given FHIR base URL. The well-known
- * doc lives at the server root, NOT under the FHIR base, so we strip
- * any /FHIR/R4 suffix before appending.
+ * Build the well-known URL for the given FHIR base URL. Per SMART App
+ * Launch §Discovery, the conformance document MAY be served from the
+ * FHIR base or from the server root — Epic's interconnect deployments
+ * serve it from the FHIR base, so we keep the path intact and just
+ * append `.well-known/smart-configuration`. Hosts that require root-
+ * level discovery can pass the root URL directly.
  */
 export function smartConfigurationUrl(fhirBaseUrl: string): string {
-  // Strip a trailing FHIR-version path segment if present, then append
-  // .well-known/smart-configuration per the spec.
   const trimmed = fhirBaseUrl.replace(/\/+$/, "");
   return `${trimmed}/.well-known/smart-configuration`;
 }

--- a/services/epic-connector/src/capability.ts
+++ b/services/epic-connector/src/capability.ts
@@ -1,0 +1,81 @@
+/**
+ * SMART configuration discovery (#389).
+ *
+ * Per the SMART App Launch spec §Discovery, a FHIR server publishes a
+ * JSON document at `/.well-known/smart-configuration` describing its
+ * OAuth2 endpoints, supported scopes, and capabilities.
+ *
+ * Used at startup to resolve the token endpoint when it isn't pinned in
+ * config, and to confirm the server advertises `client-credentials`
+ * grant support before we attempt a backend-services token exchange.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#smart-configuration
+ */
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-capability");
+
+export interface SmartConfiguration {
+  /** OAuth2 token endpoint — what the assertion's `aud` claim binds to. */
+  token_endpoint: string;
+  /** OAuth2 authorisation endpoint (used by SMART App Launch, not Backend Services). */
+  authorization_endpoint?: string;
+  /** JWKS URI Epic uses to validate the assertion's signature. */
+  jwks_uri?: string;
+  /** Capabilities advertised by the server (e.g. "client-confidential-asymmetric"). */
+  capabilities?: string[];
+  /** Grant types supported (we require "client_credentials"). */
+  grant_types_supported?: string[];
+  /** Scopes supported (subset of what we request). */
+  scopes_supported?: string[];
+}
+
+/**
+ * Build the well-known URL for the given FHIR base URL. The well-known
+ * doc lives at the server root, NOT under the FHIR base, so we strip
+ * any /FHIR/R4 suffix before appending.
+ */
+export function smartConfigurationUrl(fhirBaseUrl: string): string {
+  // Strip a trailing FHIR-version path segment if present, then append
+  // .well-known/smart-configuration per the spec.
+  const trimmed = fhirBaseUrl.replace(/\/+$/, "");
+  return `${trimmed}/.well-known/smart-configuration`;
+}
+
+/**
+ * Fetch and parse the SMART configuration. Throws on network failure,
+ * non-2xx response, or malformed JSON. Callers should cache the result
+ * — these documents change rarely and a refetch per token request is
+ * wasted network.
+ */
+export async function fetchSmartConfiguration(
+  fhirBaseUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SmartConfiguration> {
+  const url = smartConfigurationUrl(fhirBaseUrl);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `SMART configuration discovery failed: ${response.status} ${response.statusText} at ${url}`,
+    );
+  }
+  const parsed = (await response.json()) as SmartConfiguration;
+  if (!parsed.token_endpoint) {
+    throw new Error(
+      `SMART configuration at ${url} is missing token_endpoint`,
+    );
+  }
+  if (
+    parsed.grant_types_supported &&
+    !parsed.grant_types_supported.includes("client_credentials")
+  ) {
+    log.warn(
+      "SMART configuration does not advertise client_credentials grant",
+      { url, grants: parsed.grant_types_supported },
+    );
+  }
+  return parsed;
+}

--- a/services/epic-connector/src/config.ts
+++ b/services/epic-connector/src/config.ts
@@ -12,10 +12,11 @@
  *                               sandbox default when absent).
  *   EPIC_FHIR_BASE_URL        — FHIR R4 base URL for read operations.
  *   EPIC_PRIVATE_KEY_PATH     — Filesystem path to the RS384 private-key
- *                               PEM. Mutually exclusive with PEM env.
- *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Takes precedence over
- *                               PATH only when PATH is absent — explicit
- *                               PATH preferred for ease of rotation.
+ *                               PEM. Takes precedence when set.
+ *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Used only when
+ *                               EPIC_PRIVATE_KEY_PATH is unset. Setting
+ *                               both is allowed but PATH wins — explicit
+ *                               PATH is preferred for ease of rotation.
  *   EPIC_JWT_KID              — Key id matching the JWK uploaded at
  *                               open.epic.com. Required so Epic can
  *                               select the right public key when the

--- a/services/epic-connector/src/config.ts
+++ b/services/epic-connector/src/config.ts
@@ -1,0 +1,88 @@
+/**
+ * Epic connector configuration (#389).
+ *
+ * Resolves Epic credentials from environment, validates required fields,
+ * and loads the RS384 private key used to sign JWT client assertions for
+ * the SMART Backend Services flow.
+ *
+ * Env vars:
+ *   EPIC_CLIENT_ID            — Non-Production / Production Client ID issued
+ *                               by open.epic.com after app registration.
+ *   EPIC_TOKEN_URL            — OAuth2 token endpoint (resolved from the
+ *                               sandbox default when absent).
+ *   EPIC_FHIR_BASE_URL        — FHIR R4 base URL for read operations.
+ *   EPIC_PRIVATE_KEY_PATH     — Filesystem path to the RS384 private-key
+ *                               PEM. Mutually exclusive with PEM env.
+ *   EPIC_PRIVATE_KEY_PEM      — Inline PEM string. Takes precedence over
+ *                               PATH only when PATH is absent — explicit
+ *                               PATH preferred for ease of rotation.
+ *   EPIC_JWT_KID              — Key id matching the JWK uploaded at
+ *                               open.epic.com. Required so Epic can
+ *                               select the right public key when the
+ *                               registered JWKS has more than one entry.
+ */
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+const SANDBOX_TOKEN_URL =
+  "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token";
+const SANDBOX_FHIR_BASE_URL =
+  "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+
+const configSchema = z.object({
+  clientId: z.string().min(1, "EPIC_CLIENT_ID is required"),
+  tokenUrl: z.string().url(),
+  fhirBaseUrl: z.string().url(),
+  privateKeyPem: z
+    .string()
+    .min(1)
+    .refine(
+      (pem) =>
+        pem.includes("BEGIN RSA PRIVATE KEY") ||
+        pem.includes("BEGIN PRIVATE KEY"),
+      "private key must be a PEM-encoded RSA key",
+    ),
+  jwtKid: z.string().min(1, "EPIC_JWT_KID is required"),
+});
+
+export type EpicConfig = z.infer<typeof configSchema>;
+
+function readPrivateKey(env: NodeJS.ProcessEnv): string {
+  const inlinePem = env.EPIC_PRIVATE_KEY_PEM;
+  const path = env.EPIC_PRIVATE_KEY_PATH;
+
+  if (path) {
+    try {
+      return readFileSync(path, "utf8");
+    } catch (err) {
+      throw new Error(
+        `Failed to read EPIC_PRIVATE_KEY_PATH "${path}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  if (inlinePem) return inlinePem;
+  throw new Error(
+    "Either EPIC_PRIVATE_KEY_PATH or EPIC_PRIVATE_KEY_PEM must be set",
+  );
+}
+
+/**
+ * Resolve the Epic connector configuration from process env. Throws on
+ * missing required values or a malformed private key — fail loudly at
+ * boot rather than at first token request.
+ */
+export function loadEpicConfig(env: NodeJS.ProcessEnv = process.env): EpicConfig {
+  const parsed = configSchema.parse({
+    clientId: env.EPIC_CLIENT_ID,
+    tokenUrl: env.EPIC_TOKEN_URL ?? SANDBOX_TOKEN_URL,
+    fhirBaseUrl: env.EPIC_FHIR_BASE_URL ?? SANDBOX_FHIR_BASE_URL,
+    privateKeyPem: readPrivateKey(env),
+    jwtKid: env.EPIC_JWT_KID,
+  });
+  return parsed;
+}
+
+export const EPIC_SANDBOX_TOKEN_URL = SANDBOX_TOKEN_URL;
+export const EPIC_SANDBOX_FHIR_BASE_URL = SANDBOX_FHIR_BASE_URL;

--- a/services/epic-connector/src/converters.ts
+++ b/services/epic-connector/src/converters.ts
@@ -1,0 +1,191 @@
+/**
+ * Epic FHIR R4 → CareBridge row converters (#390).
+ *
+ * Wraps the existing fhir-gateway inbound mappers so that Epic-sourced
+ * resources land in the same `patients`, `medications`, `vitals`,
+ * `lab_results`, `diagnoses`, `allergies` row shapes as the bundle-
+ * import path, but with `source_system: "epic"` instead of
+ * `"fhir_import"`. Downstream rows can then be filtered by origin (sync
+ * audit, conflict resolution, "where did this medication come from?").
+ *
+ * Why a wrapper rather than reaching into the mappers and parameterising
+ * the source tag:
+ *  - Keeps the mappers' invariants (single-line const, easy to grep)
+ *  - Keeps the Epic-specific knowledge co-located with the rest of the
+ *    Epic connector — fhir-gateway shouldn't know about Epic.
+ *  - Future Epic-only post-processing (extension parsing, MyChart
+ *    identifier mapping) has an obvious home.
+ */
+import {
+  mapFhirPatientToRow,
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  mapFhirConditionToRow,
+  mapFhirAllergyIntoleranceToRow,
+  type InboundPatient,
+  type MappedPatientRow,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+  type MappedMedicationRow,
+  type InboundObservation,
+  type MappedVitalRow,
+  type MappedLabResultRow,
+  type InboundCondition,
+  type MappedDiagnosisRow,
+  type InboundAllergyIntolerance,
+  type MappedAllergyRow,
+  type ObservationCategory,
+} from "@carebridge/fhir-gateway";
+import type { FhirResource } from "./fhir-types.js";
+
+export const EPIC_SOURCE_SYSTEM_TAG = "epic" as const;
+
+/**
+ * Variant of {@link MappedDiagnosisRow} that carries `source_system`.
+ * The fhir-gateway mapper omits this field today (the column is
+ * populated by the diagnoses writer), but the Epic sync path needs it
+ * so callers can tell Epic rows from internally-recorded ones without
+ * a JOIN to `epic_sync_state`.
+ */
+export type EpicDiagnosisRow = MappedDiagnosisRow & {
+  source_system: typeof EPIC_SOURCE_SYSTEM_TAG;
+};
+
+function withEpicSource<T extends { source_system?: unknown }>(row: T): T {
+  return { ...row, source_system: EPIC_SOURCE_SYSTEM_TAG };
+}
+
+/**
+ * Convert an Epic FHIR Patient to a CareBridge `patients`-row insert.
+ * Returns `null` for unmappable resources (no name/MRN, retired patient).
+ */
+export function epicPatientToRow(
+  resource: FhirResource,
+): MappedPatientRow | null {
+  const mapped = mapFhirPatientToRow(resource as unknown as InboundPatient);
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Convert an Epic FHIR MedicationRequest to a CareBridge `medications`-row
+ * insert. Returns `null` when the resource lacks a usable medication name
+ * or maps to a status we refuse to surface (entered-in-error, etc).
+ */
+export function epicMedicationRequestToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedMedicationRow | null {
+  const mapped = mapMedicationRequestToRow(
+    resource as unknown as InboundMedicationRequest,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Convert an Epic FHIR MedicationStatement to a CareBridge `medications`-row
+ * insert. Useful for med-rec pulls where Epic returns prior outpatient meds
+ * as Statements rather than Requests.
+ */
+export function epicMedicationStatementToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedMedicationRow | null {
+  const mapped = mapMedicationStatementToRow(
+    resource as unknown as InboundMedicationStatement,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Classify and convert an Epic FHIR Observation. The Observation type
+ * fans out to either `vitals` or `lab_results` based on
+ * `Observation.category` — callers should dispatch on the returned
+ * `kind` discriminant before persisting.
+ */
+/**
+ * `lab_results` rows in CareBridge carry `patient_id` and `source_system`
+ * columns, but the underlying fhir-gateway lab mapper omits both — the
+ * import path attaches them at the writer layer. The Epic converter
+ * attaches them here so callers can persist directly without a second
+ * normalisation pass.
+ */
+export type EpicLabResultRow = MappedLabResultRow & {
+  patient_id: string;
+  source_system: typeof EPIC_SOURCE_SYSTEM_TAG;
+};
+
+export type EpicObservationConversion =
+  | { kind: "vital"; row: MappedVitalRow }
+  | { kind: "lab"; row: EpicLabResultRow }
+  | { kind: "unmapped"; reason: string };
+
+export function epicObservationToRow(
+  resource: FhirResource,
+  patientId: string,
+): EpicObservationConversion {
+  const inbound = resource as unknown as InboundObservation;
+  const category: ObservationCategory | null =
+    classifyObservationCategory(inbound);
+  if (category === "vital-signs") {
+    const row = mapFhirObservationToVitalRow(inbound, patientId);
+    if (!row) return { kind: "unmapped", reason: "vital-signs not mappable" };
+    return { kind: "vital", row: withEpicSource(row) };
+  }
+  if (category === "laboratory") {
+    const row = mapFhirObservationToLabResultRow(inbound);
+    if (!row) return { kind: "unmapped", reason: "laboratory not mappable" };
+    return {
+      kind: "lab",
+      row: {
+        ...row,
+        patient_id: patientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      },
+    };
+  }
+  return {
+    kind: "unmapped",
+    reason: `unsupported observation category: ${category ?? "missing"}`,
+  };
+}
+
+/**
+ * Convert an Epic FHIR Condition to a CareBridge `diagnoses`-row insert.
+ * The underlying mapper does not emit `source_system`, so the Epic
+ * converter adds it explicitly.
+ */
+export function epicConditionToRow(
+  resource: FhirResource,
+  patientId: string,
+): EpicDiagnosisRow | null {
+  const mapped = mapFhirConditionToRow(
+    resource as unknown as InboundCondition,
+    patientId,
+  );
+  if (!mapped) return null;
+  return { ...mapped, source_system: EPIC_SOURCE_SYSTEM_TAG };
+}
+
+/**
+ * Convert an Epic FHIR AllergyIntolerance to a CareBridge `allergies`-row
+ * insert.
+ */
+export function epicAllergyToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedAllergyRow | null {
+  const mapped = mapFhirAllergyIntoleranceToRow(
+    resource as unknown as InboundAllergyIntolerance,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -1,0 +1,367 @@
+/**
+ * Epic FHIR R4 client (#390).
+ *
+ * Thin typed wrapper over Epic's interconnect FHIR endpoints. Handles:
+ *   - Bearer-token authentication via EpicTokenClient
+ *   - Bundle parsing, including `link[relation=next]` pagination
+ *   - 401 retry-once-after-invalidate (handles silent revocation)
+ *   - 429 backoff that respects the Retry-After header
+ *   - 5xx exponential backoff with a configurable retry budget
+ *
+ * The client intentionally returns raw FHIR R4 resources (typed as
+ * `FhirResource`). Conversion to CareBridge row shapes lives in
+ * `converters.ts`, layered on top of the existing fhir-gateway inbound
+ * mappers so the FHIR-import path and Epic-sync path share normalisation
+ * logic instead of diverging.
+ */
+import { createLogger } from "@carebridge/logger";
+import { EpicTokenClient } from "./token-client.js";
+import type { EpicConfig } from "./config.js";
+import type {
+  EpicSearchParams,
+  FhirBundle,
+  FhirBundleLink,
+  FhirResource,
+  OperationOutcome,
+} from "./fhir-types.js";
+
+const log = createLogger("epic-fhir-client");
+
+export interface EpicFhirClientOptions {
+  /** Maximum retry attempts on transient (429/5xx) errors. Default: 3. */
+  maxRetries?: number;
+  /** Base delay (ms) for exponential backoff. Default: 500. */
+  backoffBaseMs?: number;
+  /** Override fetch for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Override the sleep helper for tests. Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_OPTIONS = {
+  maxRetries: 3,
+  backoffBaseMs: 500,
+} as const;
+
+const SLEEP = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resources the Epic sandbox supports today. Adding to this list does
+ * not require a code change — `request()` takes an arbitrary path — but
+ * the typed wrappers (`searchPatients`, `searchObservations`, …) are
+ * driven from this union so unsupported resource types fail at
+ * compile time.
+ */
+export type EpicResourceType =
+  | "Patient"
+  | "Observation"
+  | "Condition"
+  | "MedicationRequest"
+  | "AllergyIntolerance"
+  | "Encounter";
+
+export class EpicFhirClient {
+  private readonly opts: Required<
+    Omit<EpicFhirClientOptions, "fetchImpl" | "sleep">
+  > & { fetchImpl: typeof fetch; sleep: (ms: number) => Promise<void> };
+
+  constructor(
+    private readonly config: EpicConfig,
+    private readonly tokens: EpicTokenClient,
+    options: EpicFhirClientOptions = {},
+  ) {
+    this.opts = {
+      maxRetries: options.maxRetries ?? DEFAULT_OPTIONS.maxRetries,
+      backoffBaseMs: options.backoffBaseMs ?? DEFAULT_OPTIONS.backoffBaseMs,
+      fetchImpl: options.fetchImpl ?? fetch,
+      sleep: options.sleep ?? SLEEP,
+    };
+  }
+
+  /**
+   * Read a single resource by id. Returns the resource or throws if
+   * the response is an OperationOutcome (404, 410, etc).
+   */
+  async read<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    id: string,
+  ): Promise<T> {
+    const resource = await this.request<T | OperationOutcome>(
+      `${resourceType}/${encodeURIComponent(id)}`,
+    );
+    if (resource.resourceType === "OperationOutcome") {
+      throw operationOutcomeError(resource as OperationOutcome);
+    }
+    return resource as T;
+  }
+
+  /**
+   * Search for resources. Returns the first page as a Bundle — callers
+   * who want every result should use `searchAll` which auto-paginates.
+   */
+  async search<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    params: EpicSearchParams = {},
+  ): Promise<FhirBundle<T>> {
+    const path = `${resourceType}?${encodeSearchParams(params)}`;
+    return this.request<FhirBundle<T>>(path);
+  }
+
+  /**
+   * Async iterator over every matching resource across all pages.
+   * Walks `Bundle.link` with relation=next until exhausted. Yields
+   * resources lazily so large result sets don't blow up memory.
+   */
+  async *searchAll<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    params: EpicSearchParams = {},
+  ): AsyncIterable<T> {
+    let bundle: FhirBundle<T> | null = await this.search<T>(
+      resourceType,
+      params,
+    );
+    while (bundle !== null) {
+      for (const entry of bundle.entry ?? []) {
+        if (entry.resource) yield entry.resource;
+      }
+      const links: FhirBundleLink[] = bundle.link ?? [];
+      const next = links.find((l) => l.relation === "next");
+      if (!next) {
+        bundle = null;
+        break;
+      }
+      bundle = await this.request<FhirBundle<T>>(next.url);
+    }
+  }
+
+  /**
+   * Low-level request — used by read/search above. Exposed for callers
+   * that need to hit endpoints we don't have typed wrappers for
+   * (e.g. `/metadata`, `$lastn`). Takes either a relative path or an
+   * absolute URL (Bundle.link.url returns absolute URLs).
+   */
+  async request<T>(pathOrUrl: string): Promise<T> {
+    const url = pathOrUrl.startsWith("http")
+      ? pathOrUrl
+      : joinUrl(this.config.fhirBaseUrl, pathOrUrl);
+
+    return this.requestWithRetry<T>(url, /* didRefreshAuth */ false, 0);
+  }
+
+  private async requestWithRetry<T>(
+    url: string,
+    didRefreshAuth: boolean,
+    attempt: number,
+  ): Promise<T> {
+    const token = await this.tokens.getAccessToken();
+    const response = await this.opts.fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/fhir+json",
+      },
+    });
+
+    if (response.status === 401 && !didRefreshAuth) {
+      // Token revoked / org rotated keys: drop the cache and try once
+      // with a fresh assertion. If it 401s again we surface the error
+      // to the caller — repeated 401s mean credentials are misregistered
+      // and retrying just hammers Epic's token endpoint.
+      log.warn("Epic returned 401 — invalidating token and retrying once", {
+        url,
+      });
+      this.tokens.invalidate();
+      return this.requestWithRetry<T>(url, true, attempt);
+    }
+
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt >= this.opts.maxRetries) {
+        const body = await safeReadBody(response);
+        throw new Error(
+          `Epic FHIR request failed after ${attempt + 1} attempts: ` +
+            `${response.status} ${response.statusText}${body ? ` — ${body}` : ""}`,
+        );
+      }
+      const delay = backoffDelay({
+        status: response.status,
+        attempt,
+        retryAfter: response.headers.get("Retry-After"),
+        baseMs: this.opts.backoffBaseMs,
+      });
+      log.warn("Epic FHIR transient error, retrying", {
+        status: response.status,
+        attempt,
+        delayMs: delay,
+      });
+      await this.opts.sleep(delay);
+      return this.requestWithRetry<T>(url, didRefreshAuth, attempt + 1);
+    }
+
+    if (!response.ok) {
+      const body = await safeReadBody(response);
+      throw new Error(
+        `Epic FHIR request returned ${response.status} ${response.statusText}` +
+          (body ? ` — ${body}` : ""),
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  // ─────────────────────── Typed wrappers ────────────────────────
+  // Thin sugar over `read`/`search` so callers don't have to remember
+  // Epic's search-param names. Each method documents the params Epic
+  // actually accepts for that resource (the full FHIR R4 search-param
+  // surface is large; Epic supports a curated subset).
+
+  readPatient(id: string): Promise<FhirResource> {
+    return this.read("Patient", id);
+  }
+
+  /**
+   * Search for a Patient by MRN or other identifier.
+   * Epic search-param: `identifier=<system>|<value>` or just `<value>`.
+   */
+  searchPatients(params: {
+    identifier?: string;
+    family?: string;
+    given?: string;
+    birthdate?: string;
+  }): Promise<FhirBundle> {
+    return this.search("Patient", params);
+  }
+
+  /**
+   * Search for Observations for a patient.
+   * Epic supports: `patient`, `category` (vital-signs|laboratory),
+   * `code`, `_lastUpdated` (use `gt2024-01-01` form for incremental).
+   */
+  searchObservations(params: {
+    patient: string;
+    category?: "vital-signs" | "laboratory";
+    code?: string;
+    _lastUpdated?: string;
+    _count?: number;
+  }): Promise<FhirBundle> {
+    return this.search("Observation", params);
+  }
+
+  /**
+   * Search for Conditions for a patient. Defaults to active.
+   * Epic supports: `patient`, `clinical-status` (active|inactive|resolved),
+   * `category` (problem-list-item|encounter-diagnosis).
+   */
+  searchConditions(params: {
+    patient: string;
+    "clinical-status"?: "active" | "inactive" | "resolved";
+    category?: string;
+  }): Promise<FhirBundle> {
+    return this.search("Condition", params);
+  }
+
+  /**
+   * Search for MedicationRequests for a patient.
+   * Epic supports: `patient`, `status` (active|on-hold|completed|stopped),
+   * `_lastUpdated`.
+   */
+  searchMedicationRequests(params: {
+    patient: string;
+    status?: "active" | "on-hold" | "completed" | "stopped" | "cancelled";
+    _lastUpdated?: string;
+  }): Promise<FhirBundle> {
+    return this.search("MedicationRequest", params);
+  }
+
+  /**
+   * Search for AllergyIntolerances for a patient.
+   * Epic supports: `patient`, `clinical-status` (active|inactive|resolved).
+   */
+  searchAllergies(params: {
+    patient: string;
+    "clinical-status"?: "active" | "inactive" | "resolved";
+  }): Promise<FhirBundle> {
+    return this.search("AllergyIntolerance", params);
+  }
+
+  /**
+   * Search for Encounters for a patient.
+   * Epic supports: `patient`, `_lastUpdated`, `_sort=-date` for most-recent-first.
+   */
+  searchEncounters(params: {
+    patient: string;
+    _lastUpdated?: string;
+    _sort?: "-date" | "date";
+    _count?: number;
+  }): Promise<FhirBundle> {
+    return this.search("Encounter", params);
+  }
+}
+
+// ───────────────────────── Helpers ─────────────────────────────
+
+function encodeSearchParams(params: EpicSearchParams): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) qs.append(key, String(v));
+    } else {
+      qs.append(key, String(value));
+    }
+  }
+  return qs.toString();
+}
+
+function joinUrl(base: string, path: string): string {
+  const trimmedBase = base.endsWith("/") ? base : `${base}/`;
+  const trimmedPath = path.startsWith("/") ? path.slice(1) : path;
+  return `${trimmedBase}${trimmedPath}`;
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 500);
+  } catch {
+    return "";
+  }
+}
+
+function operationOutcomeError(outcome: OperationOutcome): Error {
+  const issue = outcome.issue?.[0];
+  const detail =
+    issue?.diagnostics ?? issue?.details?.text ?? "no diagnostics";
+  return new Error(
+    `Epic returned OperationOutcome: ${issue?.code ?? "unknown"} — ${detail}`,
+  );
+}
+
+/**
+ * Exponential backoff with a Retry-After override.
+ *
+ * Retry-After values come in two flavours per RFC 7231:
+ *   - delta-seconds   (e.g. "30")     → use directly
+ *   - HTTP-date       (e.g. RFC1123)  → compute the delta to now
+ * Epic's sandbox emits delta-seconds; we accept either for robustness.
+ *
+ * Without Retry-After: delay = base * 2^attempt + 0..base jitter.
+ * Jitter keeps multiple concurrent clients from thundering-herding the
+ * same retry window.
+ */
+function backoffDelay(args: {
+  status: number;
+  attempt: number;
+  retryAfter: string | null;
+  baseMs: number;
+}): number {
+  if (args.retryAfter) {
+    const seconds = Number(args.retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+    const dateMs = Date.parse(args.retryAfter);
+    if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  }
+  const expBackoff = args.baseMs * Math.pow(2, args.attempt);
+  const jitter = Math.random() * args.baseMs;
+  return expBackoff + jitter;
+}

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -146,21 +146,98 @@ export class EpicFhirClient {
       ? pathOrUrl
       : joinUrl(this.config.fhirBaseUrl, pathOrUrl);
 
-    return this.requestWithRetry<T>(url, /* didRefreshAuth */ false, 0);
+    return this.requestWithRetry<T>(
+      { url, method: "GET" },
+      /* didRefreshAuth */ false,
+      0,
+    );
+  }
+
+  /**
+   * POST a new FHIR resource to Epic. Used by the outbound flag-push
+   * worker (#393) and any other write surface. The returned resource
+   * is what Epic stored — typically the same payload echoed back with
+   * `id` and `meta.versionId` populated.
+   */
+  async createResource<TBody extends FhirResource, TResp = TBody>(
+    resourceType: EpicResourceType | "Flag",
+    body: TBody,
+  ): Promise<TResp> {
+    const url = joinUrl(this.config.fhirBaseUrl, resourceType);
+    const resp = await this.requestWithRetry<TResp | OperationOutcome>(
+      {
+        url,
+        method: "POST",
+        contentType: "application/fhir+json",
+        body: JSON.stringify(body),
+      },
+      false,
+      0,
+    );
+    if (
+      typeof resp === "object" &&
+      resp !== null &&
+      (resp as { resourceType?: string }).resourceType === "OperationOutcome"
+    ) {
+      throw operationOutcomeError(resp as OperationOutcome);
+    }
+    return resp as TResp;
+  }
+
+  /**
+   * PUT an existing FHIR resource on Epic (update by id). The resource
+   * body MUST carry `id` matching the URL path or Epic rejects.
+   */
+  async updateResource<TBody extends FhirResource, TResp = TBody>(
+    resourceType: EpicResourceType | "Flag",
+    id: string,
+    body: TBody,
+  ): Promise<TResp> {
+    const url = joinUrl(
+      this.config.fhirBaseUrl,
+      `${resourceType}/${encodeURIComponent(id)}`,
+    );
+    const resp = await this.requestWithRetry<TResp | OperationOutcome>(
+      {
+        url,
+        method: "PUT",
+        contentType: "application/fhir+json",
+        body: JSON.stringify(body),
+      },
+      false,
+      0,
+    );
+    if (
+      typeof resp === "object" &&
+      resp !== null &&
+      (resp as { resourceType?: string }).resourceType === "OperationOutcome"
+    ) {
+      throw operationOutcomeError(resp as OperationOutcome);
+    }
+    return resp as TResp;
   }
 
   private async requestWithRetry<T>(
-    url: string,
+    args: {
+      url: string;
+      method: "GET" | "POST" | "PUT" | "DELETE";
+      contentType?: string;
+      body?: string;
+    },
     didRefreshAuth: boolean,
     attempt: number,
   ): Promise<T> {
     const token = await this.tokens.getAccessToken();
-    const response = await this.opts.fetchImpl(url, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/fhir+json",
-      },
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/fhir+json",
+    };
+    if (args.contentType) headers["Content-Type"] = args.contentType;
+
+    const response = await this.opts.fetchImpl(args.url, {
+      method: args.method,
+      headers,
+      ...(args.body !== undefined ? { body: args.body } : {}),
     });
 
     if (response.status === 401 && !didRefreshAuth) {
@@ -169,10 +246,10 @@ export class EpicFhirClient {
       // to the caller — repeated 401s mean credentials are misregistered
       // and retrying just hammers Epic's token endpoint.
       log.warn("Epic returned 401 — invalidating token and retrying once", {
-        url,
+        url: args.url,
       });
       this.tokens.invalidate();
-      return this.requestWithRetry<T>(url, true, attempt);
+      return this.requestWithRetry<T>(args, true, attempt);
     }
 
     if (response.status === 429 || response.status >= 500) {
@@ -195,7 +272,7 @@ export class EpicFhirClient {
         delayMs: delay,
       });
       await this.opts.sleep(delay);
-      return this.requestWithRetry<T>(url, didRefreshAuth, attempt + 1);
+      return this.requestWithRetry<T>(args, didRefreshAuth, attempt + 1);
     }
 
     if (!response.ok) {
@@ -206,6 +283,8 @@ export class EpicFhirClient {
       );
     }
 
+    // 204 No Content (rare for FHIR but possible on PUT with Prefer: minimal)
+    if (response.status === 204) return undefined as T;
     return (await response.json()) as T;
   }
 

--- a/services/epic-connector/src/fhir-types.ts
+++ b/services/epic-connector/src/fhir-types.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal FHIR R4 type shapes used by the Epic FHIR client (#390).
+ *
+ * Intentionally narrow — we type-only the fields we actually read from
+ * the wire and downcast everything else to `unknown`. The full FHIR R4
+ * surface lives in `services/fhir-gateway/src/types/fhir-r4.ts`, but
+ * pulling it in here would force epic-connector to depend on the entire
+ * fhir-gateway runtime. Callers who need the full resource shape can
+ * pass the returned `FhirResource` through to the fhir-gateway mappers.
+ */
+
+export interface FhirBundleEntry<TResource = FhirResource> {
+  fullUrl?: string;
+  resource?: TResource;
+  search?: { mode?: "match" | "include" | "outcome" };
+}
+
+export interface FhirBundleLink {
+  relation: string;
+  url: string;
+}
+
+export interface FhirBundle<TResource = FhirResource> {
+  resourceType: "Bundle";
+  type: "searchset" | "history" | "transaction" | "batch" | string;
+  total?: number;
+  link?: FhirBundleLink[];
+  entry?: FhirBundleEntry<TResource>[];
+}
+
+/**
+ * Opaque resource record — Epic returns arbitrary FHIR R4 resources and
+ * extensions. Strongly-typed shapes (FhirPatient, FhirObservation, …)
+ * are produced by the fhir-gateway generators on the outbound side; we
+ * keep inbound loose because Epic's payloads are looser than ours.
+ */
+export interface FhirResource {
+  resourceType: string;
+  id?: string;
+  meta?: {
+    versionId?: string;
+    lastUpdated?: string;
+    profile?: string[];
+  };
+  [k: string]: unknown;
+}
+
+/**
+ * FHIR `OperationOutcome` shape — Epic returns these instead of a
+ * resource Bundle when a request fails. We surface the `diagnostics`
+ * field in thrown error messages for debugging.
+ */
+export interface OperationOutcome {
+  resourceType: "OperationOutcome";
+  issue: Array<{
+    severity: "fatal" | "error" | "warning" | "information";
+    code: string;
+    diagnostics?: string;
+    details?: { text?: string };
+  }>;
+}
+
+export type EpicSearchParams = Record<
+  string,
+  string | number | undefined | string[]
+>;

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -5,8 +5,10 @@
  * assertion, OAuth2 client-credentials token exchange, expiry-aware
  * caching, and SMART configuration discovery.
  *
- * Follow-ups will add the typed FHIR client (#390), sync worker (#391),
- * App Launch (#392), and outbound flag push (#393).
+ * #390 adds the typed FHIR R4 client + Epic→CareBridge converters.
+ *
+ * Follow-ups will add the sync worker (#391), App Launch (#392), and
+ * outbound flag push (#393).
  */
 export { loadEpicConfig, type EpicConfig } from "./config.js";
 export {
@@ -34,3 +36,28 @@ export {
   type PublicJwk,
   type GenerateOptions,
 } from "./keygen.js";
+export {
+  EpicFhirClient,
+  type EpicFhirClientOptions,
+  type EpicResourceType,
+} from "./fhir-client.js";
+export type {
+  FhirBundle,
+  FhirBundleEntry,
+  FhirBundleLink,
+  FhirResource,
+  EpicSearchParams,
+  OperationOutcome,
+} from "./fhir-types.js";
+export {
+  EPIC_SOURCE_SYSTEM_TAG,
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+  type EpicDiagnosisRow,
+  type EpicLabResultRow,
+  type EpicObservationConversion,
+} from "./converters.js";

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -15,7 +15,6 @@ export {
 } from "./config.js";
 export {
   buildClientAssertion,
-  decodeAssertionForTest,
   type BuildAssertionArgs,
 } from "./jwt-assertion.js";
 export {

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -102,3 +102,43 @@ export {
   type EpicSyncJobData,
 } from "./workers/sync-worker.js";
 export { epicSyncRouter, type EpicSyncRouter } from "./router.js";
+export {
+  generatePkcePair,
+  verifyChallenge,
+  type PkcePair,
+} from "./app-launch/pkce.js";
+export {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+  type AuthorizeUrlArgs,
+} from "./app-launch/authorize.js";
+export {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+  type AppLaunchTokenResponse,
+  type ExchangeArgs,
+} from "./app-launch/token-exchange.js";
+export {
+  InMemoryLaunchStateStore,
+  RedisLaunchStateStore,
+  type LaunchStateStore,
+  type LaunchState,
+  type RedisLike,
+} from "./app-launch/state-store.js";
+export {
+  beginLaunch,
+  completeLaunch,
+  type BeginLaunchArgs,
+  type BeginLaunchResult,
+  type CompleteLaunchArgs,
+  type CompleteLaunchResult,
+} from "./app-launch/launch-service.js";
+export {
+  upsertEpicConnection,
+  getConnectionsForUser,
+  getConnection,
+  deleteConnection,
+  type EpicConnectionUpsert,
+  type EpicConnectionRow,
+} from "./app-launch/connection-repo.js";

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -142,3 +142,29 @@ export {
   type EpicConnectionUpsert,
   type EpicConnectionRow,
 } from "./app-launch/connection-repo.js";
+export {
+  buildFhirFlag,
+  flagSeverityCoding,
+  mapFlagStatusToFhir,
+  CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+  FHIR_FLAG_CATEGORY_SYSTEM,
+  RATIONALE_EXTENSION_URL,
+  SUGGESTED_ACTION_EXTENSION_URL,
+  RULE_ID_EXTENSION_URL,
+  type FhirFlag,
+  type BuildFhirFlagArgs,
+} from "./outbound/flag-generator.js";
+export {
+  pushFlagToEpic,
+  pushFlagStatusUpdate,
+  type FlagPushDeps,
+  type FlagPushResult,
+} from "./outbound/flag-push.js";
+export {
+  startEpicOutboundFlagWorker,
+  enqueueEpicFlagPushCreate,
+  enqueueEpicFlagPushUpdate,
+  isEpicOutboundEnabled,
+  EPIC_OUTBOUND_FLAGS_QUEUE_NAME,
+  type EpicOutboundFlagJobData,
+} from "./workers/outbound-flag-worker.js";

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -7,8 +7,10 @@
  *
  * #390 adds the typed FHIR R4 client + Epic→CareBridge converters.
  *
- * Follow-ups will add the sync worker (#391), App Launch (#392), and
- * outbound flag push (#393).
+ * #391 adds the BullMQ sync worker, persistence layer, clinical-event
+ * emission, and tRPC surface for sync orchestration / status.
+ *
+ * Follow-ups will add App Launch (#392) and outbound flag push (#393).
  */
 export { loadEpicConfig, type EpicConfig } from "./config.js";
 export {
@@ -61,3 +63,42 @@ export {
   type EpicLabResultRow,
   type EpicObservationConversion,
 } from "./converters.js";
+export {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  SUPPORTED_RESOURCE_TYPES,
+  type SyncResourceType,
+  type SyncResult,
+  type SyncJobDeps,
+  type EmitFn,
+} from "./sync/sync-jobs.js";
+export {
+  getSyncState,
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+  markRunning,
+  markOk,
+  markFailed,
+  type EpicSyncStateRow,
+  type EpicSyncStatusValue,
+} from "./sync/sync-state-repo.js";
+export {
+  persistPatient,
+  persistMedicationRequest,
+  persistMedicationStatement,
+  persistObservation,
+  persistCondition,
+  persistAllergy,
+  type PersistResult,
+} from "./sync/persistence.js";
+export {
+  startEpicSyncWorker,
+  getEpicSyncQueue,
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+  EPIC_SYNC_QUEUE_NAME,
+  type EpicSyncJobData,
+} from "./workers/sync-worker.js";
+export { epicSyncRouter, type EpicSyncRouter } from "./router.js";

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @carebridge/epic-connector — Epic SMART on FHIR integration.
+ *
+ * #389 ships SMART Backend Services authentication: RS384 JWT
+ * assertion, OAuth2 client-credentials token exchange, expiry-aware
+ * caching, and SMART configuration discovery.
+ *
+ * Follow-ups will add the typed FHIR client (#390), sync worker (#391),
+ * App Launch (#392), and outbound flag push (#393).
+ */
+export { loadEpicConfig, type EpicConfig } from "./config.js";
+export {
+  EPIC_SANDBOX_TOKEN_URL,
+  EPIC_SANDBOX_FHIR_BASE_URL,
+} from "./config.js";
+export {
+  buildClientAssertion,
+  decodeAssertionForTest,
+  type BuildAssertionArgs,
+} from "./jwt-assertion.js";
+export {
+  EpicTokenClient,
+  DEFAULT_SYSTEM_SCOPES,
+  type TokenResponse,
+} from "./token-client.js";
+export {
+  fetchSmartConfiguration,
+  smartConfigurationUrl,
+  type SmartConfiguration,
+} from "./capability.js";
+export {
+  generateKeypair,
+  publicKeyFingerprint,
+  type GeneratedKeyPair,
+  type PublicJwk,
+  type GenerateOptions,
+} from "./keygen.js";

--- a/services/epic-connector/src/jwt-assertion.ts
+++ b/services/epic-connector/src/jwt-assertion.ts
@@ -90,8 +90,10 @@ export function buildClientAssertion(args: BuildAssertionArgs): string {
 }
 
 /**
- * Decode the JWT header + payload without verification. Test helper —
- * production code never inspects its own signed JWTs; Epic does that.
+ * Decode the JWT header + payload without verification. Internal test
+ * helper — intentionally NOT re-exported from the package entrypoint.
+ * Production code never inspects its own signed JWTs; Epic does that.
+ * Import from `./jwt-assertion.js` directly within tests.
  */
 export function decodeAssertionForTest(jwt: string): {
   header: Record<string, unknown>;

--- a/services/epic-connector/src/jwt-assertion.ts
+++ b/services/epic-connector/src/jwt-assertion.ts
@@ -1,0 +1,114 @@
+/**
+ * RS384-signed JWT client assertion for SMART Backend Services (#389).
+ *
+ * Per the SMART App Launch spec §Backend Services, the client_assertion
+ * is a JWT signed with the client's registered private key. Epic requires
+ * RS384 (RSA + SHA-384) — NOT the default RS256 most JWT libraries use.
+ *
+ * Claims per the spec:
+ *   iss  — client_id
+ *   sub  — client_id (same value; system-to-system, no user subject)
+ *   aud  — token endpoint URL (the resource the assertion authorises)
+ *   exp  — issued-at + 5 min (Epic rejects anything longer)
+ *   jti  — unique id (Epic rejects re-use within the exp window)
+ *
+ * Uses Node's crypto rather than a JWT library to keep the dependency
+ * surface small and so the algorithm choice is explicit at the call site.
+ */
+import { createSign, randomUUID } from "node:crypto";
+
+export interface BuildAssertionArgs {
+  clientId: string;
+  /** Epic token endpoint URL — the `aud` claim. */
+  tokenUrl: string;
+  /** Key id matching the JWK uploaded at open.epic.com. */
+  kid: string;
+  /** RS384 private key in PEM format. */
+  privateKeyPem: string;
+  /**
+   * Lifetime of the assertion in seconds. Defaults to 4 minutes (240s)
+   * — well under Epic's 5-minute ceiling but long enough to tolerate
+   * modest clock skew between this host and Epic.
+   */
+  expiresInSec?: number;
+  /**
+   * Override `iat` / `exp` time source for tests. Defaults to Date.now().
+   */
+  now?: () => number;
+  /**
+   * Override `jti` for tests. Defaults to crypto.randomUUID().
+   */
+  jti?: string;
+}
+
+function base64UrlEncode(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input) : input;
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/**
+ * Build an RS384-signed JWT client assertion. Returns the compact JWS
+ * (header.payload.signature) ready to plug into the
+ * client_assertion form parameter of a token request.
+ */
+export function buildClientAssertion(args: BuildAssertionArgs): string {
+  const now = args.now?.() ?? Math.floor(Date.now() / 1000);
+  const expiresInSec = args.expiresInSec ?? 240;
+  const jti = args.jti ?? randomUUID();
+
+  const header = {
+    alg: "RS384",
+    typ: "JWT",
+    kid: args.kid,
+  };
+  const payload = {
+    iss: args.clientId,
+    sub: args.clientId,
+    aud: args.tokenUrl,
+    exp: now + expiresInSec,
+    iat: now,
+    jti,
+  };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  // RSA-SHA384 sign. Node's createSign("RSA-SHA384") is the explicit RS384
+  // path — important because most generic crypto.sign callers default to
+  // RS256 which Epic rejects.
+  const signer = createSign("RSA-SHA384");
+  signer.update(signingInput);
+  signer.end();
+  const signature = base64UrlEncode(signer.sign(args.privateKeyPem));
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Decode the JWT header + payload without verification. Test helper —
+ * production code never inspects its own signed JWTs; Epic does that.
+ */
+export function decodeAssertionForTest(jwt: string): {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  signature: string;
+} {
+  const [h, p, s] = jwt.split(".");
+  if (!h || !p || !s) throw new Error("malformed JWT");
+  const fromB64Url = (input: string): string =>
+    Buffer.from(
+      input.replace(/-/g, "+").replace(/_/g, "/") +
+        "=".repeat((4 - (input.length % 4)) % 4),
+      "base64",
+    ).toString("utf8");
+  return {
+    header: JSON.parse(fromB64Url(h)) as Record<string, unknown>,
+    payload: JSON.parse(fromB64Url(p)) as Record<string, unknown>,
+    signature: s,
+  };
+}

--- a/services/epic-connector/src/keygen.ts
+++ b/services/epic-connector/src/keygen.ts
@@ -154,8 +154,8 @@ export interface GenerateOptions {
   privateKeyPath: string;
   /**
    * Override the kid. Defaults to a fresh UUID — fine for first-time
-   * setup. Rotations should pass the prior kid so server-side caches
-   * don't have to refetch the JWKS.
+   * setup. Rotations typically generate a NEW kid so the previous JWKS
+   * entry can be retained alongside the new one until Epic re-fetches.
    */
   kid?: string;
   /**
@@ -170,7 +170,7 @@ export interface GenerateOptions {
  * public JWK + kid for upload to open.epic.com.
  */
 export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
-  const kid = options.kid ?? randomUUIDv5Stable();
+  const kid = options.kid ?? generateKid();
   const generated =
     options.generator?.() ??
     (() => {
@@ -188,10 +188,19 @@ export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
     })();
 
   mkdirSync(dirname(options.privateKeyPath), { recursive: true });
-  writeFileSync(options.privateKeyPath, generated.privatePem, "utf8");
-  // Tighten permissions so the private key isn't world-readable. The
-  // openssl-generated default leaves 0644 on macOS — easy to leak via
-  // a misconfigured backup.
+  // Create the file with 0600 from the start. `writeFileSync` accepts a
+  // `mode` option that's applied at open() time, closing the race window
+  // where a separate chmod after writeFileSync would leave the key
+  // world-readable for the few syscalls in between. The `flag: "w"`
+  // matches the default but is explicit for the security audit trail.
+  writeFileSync(options.privateKeyPath, generated.privatePem, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: "w",
+  });
+  // Belt-and-braces: chmod after the write in case an existing file
+  // was overwritten and the new mode wasn't applied (older Node
+  // versions did NOT update mode on overwrite of an existing file).
   chmodSync(options.privateKeyPath, 0o600);
 
   const publicJwk = rsaPublicPemToJwk(generated.publicPem, kid);
@@ -204,10 +213,12 @@ export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
 }
 
 /**
- * Stable kid generator — uses crypto.randomUUID under the hood. Kept
- * factorable so tests can stub kid generation.
+ * Default kid generator — emits a fresh UUID v4 from crypto.randomUUID
+ * per invocation. Factored out so tests can stub kid generation for
+ * deterministic fixtures. The name was previously misleading; this is
+ * NOT a UUID v5 (no namespacing) and is NOT stable across invocations.
  */
-function randomUUIDv5Stable(): string {
+function generateKid(): string {
   return randomUUID();
 }
 

--- a/services/epic-connector/src/keygen.ts
+++ b/services/epic-connector/src/keygen.ts
@@ -1,0 +1,222 @@
+/**
+ * RS384 keypair generator for Epic SMART Backend Services (#389).
+ *
+ * Generates an RSA 2048-bit keypair (Epic's minimum), writes the private
+ * key as PEM to disk, and converts the public key to JWK form ready for
+ * upload at open.epic.com → App Settings → Public Keys.
+ *
+ * Why a custom helper instead of `openssl genrsa` + manual JWK conversion:
+ *  - Single command sets correct file permissions (0600) on the private
+ *    key, hard to get wrong with `openssl` defaults.
+ *  - JWK output already includes the `alg: "RS384"` and `kid` fields
+ *    Epic expects, with the right base64url encoding (not base64).
+ *  - No openssl version differences (LibreSSL on macOS vs OpenSSL on
+ *    Linux produce subtly different PEM headers).
+ */
+import { generateKeyPairSync, createHash, randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface GeneratedKeyPair {
+  /** Filesystem path the private key PEM was written to. */
+  privateKeyPath: string;
+  /** Public key as a JWK ready to paste into open.epic.com. */
+  publicJwk: PublicJwk;
+  /** Key id — matches the `kid` claim in JWT assertions. */
+  kid: string;
+  /**
+   * Public key in SPKI PEM form. Exposed alongside the JWK so callers
+   * can pass it through helpers expecting PEM (e.g. fingerprint
+   * printing) without having to re-derive it from the on-disk private
+   * key.
+   */
+  publicKeyPem: string;
+}
+
+export interface PublicJwk {
+  kty: "RSA";
+  alg: "RS384";
+  use: "sig";
+  kid: string;
+  n: string;
+  e: string;
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/**
+ * Convert an RSA public key (PEM) → JWK form suitable for upload at
+ * open.epic.com. The exported PEM is SPKI; we strip the ASN.1 envelope
+ * and pull out the modulus (`n`) and exponent (`e`).
+ */
+function rsaPublicPemToJwk(spkiPem: string, kid: string): PublicJwk {
+  const der = pemToDer(spkiPem);
+  // Parse the SPKI structure to extract the RSA public key. RFC 5280
+  // §4.1.2.7 SubjectPublicKeyInfo: SEQUENCE { algorithm, subjectPublicKey BIT STRING }
+  // For RSA, the BIT STRING wraps RSAPublicKey: SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+  // We walk the DER manually rather than pulling in an ASN.1 lib — the
+  // structure is small and stable.
+  const rsaKey = extractRsaPublicKey(der);
+  return {
+    kty: "RSA",
+    alg: "RS384",
+    use: "sig",
+    kid,
+    n: base64UrlEncode(rsaKey.modulus),
+    e: base64UrlEncode(rsaKey.exponent),
+  };
+}
+
+function pemToDer(pem: string): Buffer {
+  const body = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  return Buffer.from(body, "base64");
+}
+
+/**
+ * Walk an SPKI-encoded RSA public key and pull out modulus + exponent.
+ * The structure is:
+ *   SEQUENCE {                             // outer SPKI
+ *     SEQUENCE { OID, NULL }               // algorithm identifier
+ *     BIT STRING {
+ *       SEQUENCE {                         // RSAPublicKey
+ *         INTEGER modulus
+ *         INTEGER exponent
+ *       }
+ *     }
+ *   }
+ */
+function extractRsaPublicKey(spki: Buffer): {
+  modulus: Buffer;
+  exponent: Buffer;
+} {
+  let cursor = 0;
+  // outer SEQUENCE
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected SEQUENCE");
+  cursor += readLength(spki, cursor).bytes;
+  // algorithm identifier SEQUENCE — skip
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected algorithm SEQUENCE");
+  const algLen = readLength(spki, cursor);
+  cursor += algLen.bytes + algLen.value;
+  // BIT STRING
+  if (spki[cursor++] !== 0x03) throw new Error("SPKI: expected BIT STRING");
+  const bitLen = readLength(spki, cursor);
+  cursor += bitLen.bytes;
+  if (spki[cursor++] !== 0x00)
+    throw new Error("SPKI: expected 0 unused bits in BIT STRING");
+  // inner SEQUENCE RSAPublicKey
+  if (spki[cursor++] !== 0x30) throw new Error("SPKI: expected RSAPublicKey SEQUENCE");
+  cursor += readLength(spki, cursor).bytes;
+  // INTEGER modulus
+  if (spki[cursor++] !== 0x02) throw new Error("SPKI: expected INTEGER modulus");
+  const modLen = readLength(spki, cursor);
+  cursor += modLen.bytes;
+  let modulus = spki.subarray(cursor, cursor + modLen.value);
+  // RSA moduli have a leading 0x00 sign byte; strip it so the JWK `n`
+  // is the unsigned big-endian magnitude per RFC 7518 §6.3.1.
+  if (modulus[0] === 0x00) modulus = modulus.subarray(1);
+  cursor += modLen.value;
+  // INTEGER exponent
+  if (spki[cursor++] !== 0x02) throw new Error("SPKI: expected INTEGER exponent");
+  const expLen = readLength(spki, cursor);
+  cursor += expLen.bytes;
+  const exponent = spki.subarray(cursor, cursor + expLen.value);
+  return { modulus, exponent };
+}
+
+function readLength(
+  buf: Buffer,
+  offset: number,
+): { value: number; bytes: number } {
+  const first = buf[offset];
+  if (first === undefined) throw new Error("DER: truncated length");
+  if (first < 0x80) return { value: first, bytes: 1 };
+  const numBytes = first & 0x7f;
+  let value = 0;
+  for (let i = 1; i <= numBytes; i++) {
+    const b = buf[offset + i];
+    if (b === undefined) throw new Error("DER: truncated length");
+    value = (value << 8) | b;
+  }
+  return { value, bytes: numBytes + 1 };
+}
+
+export interface GenerateOptions {
+  /** Path the private key PEM is written to. */
+  privateKeyPath: string;
+  /**
+   * Override the kid. Defaults to a fresh UUID — fine for first-time
+   * setup. Rotations should pass the prior kid so server-side caches
+   * don't have to refetch the JWKS.
+   */
+  kid?: string;
+  /**
+   * Override the keypair generator (test injection). Defaults to the
+   * Node crypto generator.
+   */
+  generator?: () => { privatePem: string; publicPem: string };
+}
+
+/**
+ * Generate an RS384 keypair, persist the private key, and return the
+ * public JWK + kid for upload to open.epic.com.
+ */
+export function generateKeypair(options: GenerateOptions): GeneratedKeyPair {
+  const kid = options.kid ?? randomUUIDv5Stable();
+  const generated =
+    options.generator?.() ??
+    (() => {
+      const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+      });
+      return {
+        privatePem: privateKey
+          .export({ type: "pkcs8", format: "pem" })
+          .toString(),
+        publicPem: publicKey
+          .export({ type: "spki", format: "pem" })
+          .toString(),
+      };
+    })();
+
+  mkdirSync(dirname(options.privateKeyPath), { recursive: true });
+  writeFileSync(options.privateKeyPath, generated.privatePem, "utf8");
+  // Tighten permissions so the private key isn't world-readable. The
+  // openssl-generated default leaves 0644 on macOS — easy to leak via
+  // a misconfigured backup.
+  chmodSync(options.privateKeyPath, 0o600);
+
+  const publicJwk = rsaPublicPemToJwk(generated.publicPem, kid);
+  return {
+    privateKeyPath: options.privateKeyPath,
+    publicJwk,
+    kid,
+    publicKeyPem: generated.publicPem,
+  };
+}
+
+/**
+ * Stable kid generator — uses crypto.randomUUID under the hood. Kept
+ * factorable so tests can stub kid generation.
+ */
+function randomUUIDv5Stable(): string {
+  return randomUUID();
+}
+
+/**
+ * Convenience: sha-256 fingerprint of a public PEM, useful for printing
+ * a short identifier alongside the kid for human verification at upload
+ * time ("is this the same key I just generated?").
+ */
+export function publicKeyFingerprint(spkiPem: string): string {
+  const der = pemToDer(spkiPem);
+  return createHash("sha256").update(der).digest("hex").slice(0, 16);
+}

--- a/services/epic-connector/src/outbound/flag-generator.ts
+++ b/services/epic-connector/src/outbound/flag-generator.ts
@@ -1,0 +1,213 @@
+/**
+ * CareBridge ClinicalFlag → FHIR R4 Flag generator (#393).
+ *
+ * FHIR R4 Flag spec: https://www.hl7.org/fhir/flag.html
+ *
+ * Mapping decisions:
+ *  - status:    open|acknowledged|escalated → "active"
+ *               resolved|dismissed         → "inactive"
+ *  - category:  always [{ system: "http://terminology.hl7.org/CodeSystem/flag-category", code: "clinical" }]
+ *  - code:      summary as the text + a CareBridge-internal severity coding
+ *               so Epic can render severity bands in its banner UI
+ *  - subject:   Patient/<epic-patient-fhir-id> when available, otherwise
+ *               internal `Patient/<carebridge-id>` (callers should pass
+ *               the Epic id for cross-system referential integrity)
+ *  - period.start: flag.created_at
+ *  - period.end:   set when the flag is inactive — picks the
+ *                  latest resolved_at / dismissed_at
+ *  - author:    Organization reference identifying CareBridge as the
+ *               flag's origin — Epic typically requires a sourced
+ *               author when the flag isn't authored by an Epic user
+ *  - extension: rationale and suggested_action surface as FHIR
+ *               extensions so they're visible alongside the flag
+ *               without polluting the standard code.text field
+ */
+import type {
+  ClinicalFlag,
+  FlagStatus,
+  FlagSeverity,
+} from "@carebridge/shared-types";
+
+export const CAREBRIDGE_FLAG_SEVERITY_SYSTEM =
+  "https://carebridge.dev/fhir/CodeSystem/flag-severity";
+
+export const CAREBRIDGE_FLAG_CATEGORY_SYSTEM =
+  "https://carebridge.dev/fhir/CodeSystem/flag-category";
+
+export const FHIR_FLAG_CATEGORY_SYSTEM =
+  "http://terminology.hl7.org/CodeSystem/flag-category";
+
+export const RATIONALE_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-rationale";
+
+export const SUGGESTED_ACTION_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-suggested-action";
+
+export const RULE_ID_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-rule-id";
+
+export const CAREBRIDGE_ORGANIZATION_REFERENCE = "Organization/carebridge" as const;
+
+export interface FhirFlag {
+  resourceType: "Flag";
+  id?: string;
+  status: "active" | "inactive" | "entered-in-error";
+  category: Array<{
+    coding: Array<{ system: string; code: string; display?: string }>;
+  }>;
+  code: {
+    coding: Array<{ system: string; code: string; display?: string }>;
+    text: string;
+  };
+  subject: { reference: string };
+  period?: { start?: string; end?: string };
+  author?: { reference: string };
+  extension?: Array<{
+    url: string;
+    valueString?: string;
+  }>;
+  /** Passthrough for fields we don't model — keeps FhirFlag assignable to FhirResource. */
+  [k: string]: unknown;
+}
+
+export interface BuildFhirFlagArgs {
+  flag: Pick<
+    ClinicalFlag,
+    | "summary"
+    | "rationale"
+    | "suggested_action"
+    | "severity"
+    | "category"
+    | "status"
+    | "rule_id"
+    | "created_at"
+    | "resolved_at"
+    | "dismissed_at"
+  >;
+  /**
+   * FHIR Patient.id on Epic's side. Prefer the Epic id over the
+   * CareBridge UUID so the resource references resolve correctly when
+   * Epic's UI dereferences `subject.reference`.
+   */
+  epicPatientFhirId: string;
+  /**
+   * Optional existing Epic Flag id — set when generating a payload
+   * for a PUT (status update) so the output carries the right
+   * resource id.
+   */
+  epicFlagId?: string;
+}
+
+/**
+ * Map the internal CareBridge severity enum to a FHIR Flag.code coding.
+ * Display values are clinician-readable strings Epic surfaces in the
+ * Storyboard banner.
+ */
+export function flagSeverityCoding(severity: FlagSeverity): {
+  system: string;
+  code: FlagSeverity;
+  display: string;
+} {
+  switch (severity) {
+    case "critical":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "critical",
+        display: "Critical — immediate clinician attention required",
+      };
+    case "warning":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "warning",
+        display: "Warning — review recommended",
+      };
+    case "info":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "info",
+        display: "Informational",
+      };
+  }
+}
+
+/**
+ * Map the internal FlagStatus to FHIR Flag.status. Resolved /
+ * dismissed flags are surfaced as `inactive` so they remain visible
+ * in Epic's history without raising the banner. `entered-in-error`
+ * is reserved for cases where CareBridge needs to retract a flag
+ * after-the-fact — not the same as `dismissed` (which means the
+ * clinician saw it and chose to ignore).
+ */
+export function mapFlagStatusToFhir(
+  status: FlagStatus,
+): "active" | "inactive" {
+  if (status === "resolved" || status === "dismissed") return "inactive";
+  return "active";
+}
+
+/**
+ * Determine the end of the active period. Returns null when the flag
+ * is still active.
+ */
+function periodEnd(
+  flag: BuildFhirFlagArgs["flag"],
+): string | null {
+  if (flag.status === "resolved") return flag.resolved_at ?? null;
+  if (flag.status === "dismissed") return flag.dismissed_at ?? null;
+  return null;
+}
+
+/**
+ * Build a FHIR R4 Flag resource ready to POST to Epic. The result
+ * passes FHIR R4 schema validation against the
+ * `http://hl7.org/fhir/StructureDefinition/Flag` profile (required
+ * fields: status, code, subject).
+ */
+export function buildFhirFlag(args: BuildFhirFlagArgs): FhirFlag {
+  const { flag } = args;
+  const severityCoding = flagSeverityCoding(flag.severity);
+  const status = mapFlagStatusToFhir(flag.status);
+  const end = periodEnd(flag);
+
+  const extension: FhirFlag["extension"] = [
+    { url: RATIONALE_EXTENSION_URL, valueString: flag.rationale },
+    { url: SUGGESTED_ACTION_EXTENSION_URL, valueString: flag.suggested_action },
+  ];
+  if (flag.rule_id) {
+    extension.push({ url: RULE_ID_EXTENSION_URL, valueString: flag.rule_id });
+  }
+
+  const out: FhirFlag = {
+    resourceType: "Flag",
+    status,
+    category: [
+      {
+        coding: [
+          { system: FHIR_FLAG_CATEGORY_SYSTEM, code: "clinical" },
+          {
+            system: CAREBRIDGE_FLAG_CATEGORY_SYSTEM,
+            code: flag.category,
+            display: flag.category,
+          },
+        ],
+      },
+    ],
+    code: {
+      coding: [severityCoding],
+      text: flag.summary,
+    },
+    subject: { reference: `Patient/${args.epicPatientFhirId}` },
+    period: {
+      start: flag.created_at,
+      ...(end ? { end } : {}),
+    },
+    author: { reference: CAREBRIDGE_ORGANIZATION_REFERENCE },
+    extension,
+  };
+
+  if (args.epicFlagId) {
+    out.id = args.epicFlagId;
+  }
+
+  return out;
+}

--- a/services/epic-connector/src/outbound/flag-push.ts
+++ b/services/epic-connector/src/outbound/flag-push.ts
@@ -1,0 +1,270 @@
+/**
+ * Outbound flag-push orchestrator (#393).
+ *
+ * Pushes CareBridge `clinical_flags` rows to Epic as FHIR Flag resources.
+ *
+ * Two entry points:
+ *   pushFlagToEpic(flagId, deps)         — creates the Flag on Epic
+ *                                          (or updates an existing one
+ *                                          if epic_flag_id is set)
+ *   pushFlagStatusUpdate(flagId, deps)   — updates the Flag's status
+ *                                          when the CareBridge flag is
+ *                                          acknowledged / resolved /
+ *                                          dismissed
+ *
+ * Both write to `audit_log` with action="epic_flag_push" and to the
+ * `clinical_flags` row's epic_* tracking columns so a re-run is
+ * idempotent: a flag already pushed updates in place instead of being
+ * created twice on Epic's side.
+ */
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { createLogger } from "@carebridge/logger";
+import {
+  getDb,
+  clinicalFlags,
+  auditLog,
+  fhirResources,
+} from "@carebridge/db-schema";
+import { EpicFhirClient } from "../fhir-client.js";
+import { buildFhirFlag, type FhirFlag } from "./flag-generator.js";
+import { EPIC_SOURCE_SYSTEM_TAG } from "../converters.js";
+
+const log = createLogger("epic-flag-push");
+
+const EPIC_PUSH_AUDIT_USER = "system:epic-flag-push";
+
+export interface FlagPushDeps {
+  client: EpicFhirClient;
+}
+
+export interface FlagPushResult {
+  flag_id: string;
+  epic_flag_id: string | null;
+  operation: "created" | "updated" | "skipped" | "failed";
+  error?: string;
+}
+
+/**
+ * Look up the Epic Patient FHIR id for a CareBridge patient. Uses the
+ * existing `fhir_resources` mapping table populated by the inbound
+ * sync worker (#391) — falls back to null when the patient hasn't been
+ * synced from Epic. Without an Epic Patient id we can't push the Flag
+ * because Epic rejects `subject.reference` to an unknown patient.
+ */
+async function lookupEpicPatientId(
+  carebridgePatientId: string,
+): Promise<string | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ resource_id: fhirResources.resource_id })
+    .from(fhirResources)
+    .where(eq(fhirResources.internal_record_id, carebridgePatientId))
+    .limit(10);
+  // Find the Patient mapping among any others (the patient may also
+  // have linked Observation, Condition, etc. mappings).
+  for (const row of rows) {
+    // The mapping id pattern is `epic:<resourceType>:<fhirId>` so
+    // resource_id is the FHIR id directly. We trust resource_type
+    // implicitly by joining on internal_record_id (only Patient maps
+    // to the patient table's id).
+    return row.resource_id;
+  }
+  return null;
+}
+
+/**
+ * Core push routine. Generates the FHIR Flag payload, sends it to Epic,
+ * and persists the resulting epic_flag_id back on the clinical_flags
+ * row.
+ *
+ * Idempotency:
+ *  - If `epic_flag_id` is already set, this performs a PUT instead of
+ *    a POST so a replayed job updates the existing resource.
+ *  - If the patient hasn't been synced from Epic (no Epic Patient id
+ *    mapping), the push is skipped — Epic would reject the Flag for an
+ *    unknown subject.
+ */
+export async function pushFlagToEpic(
+  flagId: string,
+  deps: FlagPushDeps,
+): Promise<FlagPushResult> {
+  const db = getDb();
+  const [flag] = await db
+    .select()
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.id, flagId))
+    .limit(1);
+
+  if (!flag) {
+    return { flag_id: flagId, epic_flag_id: null, operation: "skipped", error: "flag not found" };
+  }
+
+  const epicPatientId = await lookupEpicPatientId(flag.patient_id);
+  if (!epicPatientId) {
+    log.info("Skipping Epic flag push — patient not yet mapped to Epic", {
+      flagId,
+      carebridgePatientId: flag.patient_id,
+    });
+    return {
+      flag_id: flagId,
+      epic_flag_id: flag.epic_flag_id,
+      operation: "skipped",
+      error: "epic_patient_id_unknown",
+    };
+  }
+
+  const payload: FhirFlag = buildFhirFlag({
+    flag: {
+      summary: flag.summary,
+      rationale: flag.rationale,
+      suggested_action: flag.suggested_action,
+      severity: flag.severity as "critical" | "warning" | "info",
+      category: flag.category as "cross-specialty" | "drug-interaction" | "medication-safety" | "care-gap" | "critical-value" | "trend-concern" | "documentation-discrepancy" | "patient-reported",
+      status: flag.status as "open" | "acknowledged" | "resolved" | "dismissed" | "escalated",
+      rule_id: flag.rule_id ?? undefined,
+      created_at: flag.created_at,
+      resolved_at: flag.resolved_at ?? undefined,
+      dismissed_at: flag.dismissed_at ?? undefined,
+    },
+    epicPatientFhirId: epicPatientId,
+    epicFlagId: flag.epic_flag_id ?? undefined,
+  });
+
+  const now = new Date().toISOString();
+
+  try {
+    let createdOrUpdated: FhirFlag;
+    let operation: "created" | "updated";
+    if (flag.epic_flag_id) {
+      createdOrUpdated = await deps.client.updateResource(
+        "Flag",
+        flag.epic_flag_id,
+        payload,
+      );
+      operation = "updated";
+    } else {
+      createdOrUpdated = await deps.client.createResource("Flag", payload);
+      operation = "created";
+    }
+
+    const epicFlagId = createdOrUpdated.id ?? flag.epic_flag_id ?? null;
+
+    await db
+      .update(clinicalFlags)
+      .set({
+        epic_flag_id: epicFlagId,
+        epic_org_iss: epicOrgIssFromClientBase(),
+        epic_pushed_at: now,
+        epic_push_error: null,
+      })
+      .where(eq(clinicalFlags.id, flagId));
+
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: EPIC_PUSH_AUDIT_USER,
+      action: "epic_flag_push",
+      resource_type: "clinical_flag",
+      resource_id: flagId,
+      patient_id: flag.patient_id,
+      success: true,
+      details: JSON.stringify({
+        operation,
+        epic_flag_id: epicFlagId,
+        epic_patient_fhir_id: epicPatientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      }),
+      timestamp: now,
+    });
+
+    log.info("Pushed CareBridge flag to Epic", {
+      flagId,
+      epicFlagId,
+      operation,
+    });
+
+    return {
+      flag_id: flagId,
+      epic_flag_id: epicFlagId,
+      operation,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Truncate to 1KiB matching the convention used elsewhere
+    // (sync-state-repo.markFailed).
+    const truncated = message.slice(0, 1024);
+
+    await db
+      .update(clinicalFlags)
+      .set({ epic_push_error: truncated })
+      .where(eq(clinicalFlags.id, flagId));
+
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: EPIC_PUSH_AUDIT_USER,
+      action: "epic_flag_push",
+      resource_type: "clinical_flag",
+      resource_id: flagId,
+      patient_id: flag.patient_id,
+      success: false,
+      details: JSON.stringify({
+        operation: flag.epic_flag_id ? "updated" : "created",
+        epic_patient_fhir_id: epicPatientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      }),
+      error_message: truncated,
+      timestamp: now,
+    });
+
+    log.error("Epic flag push failed", { flagId, error: truncated });
+
+    return {
+      flag_id: flagId,
+      epic_flag_id: flag.epic_flag_id,
+      operation: "failed",
+      error: truncated,
+    };
+  }
+}
+
+/**
+ * Push a status update (acknowledge / resolve / dismiss) to Epic for
+ * a flag that has already been pushed. No-op when the flag isn't yet
+ * tracked on Epic — the next regular push (which carries the new
+ * status) will handle it.
+ */
+export async function pushFlagStatusUpdate(
+  flagId: string,
+  deps: FlagPushDeps,
+): Promise<FlagPushResult> {
+  const db = getDb();
+  const [flag] = await db
+    .select({ epic_flag_id: clinicalFlags.epic_flag_id })
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.id, flagId))
+    .limit(1);
+  if (!flag?.epic_flag_id) {
+    log.debug("Status update push skipped — flag not yet on Epic", { flagId });
+    return {
+      flag_id: flagId,
+      epic_flag_id: null,
+      operation: "skipped",
+      error: "not_pushed_yet",
+    };
+  }
+  return pushFlagToEpic(flagId, deps);
+}
+
+/**
+ * Best-effort lookup of the Epic FHIR base URL we're configured for.
+ * Returns `null` in tests / dev where Epic env isn't set. The full
+ * config load happens in the worker; this helper only exists so the
+ * push function can stamp the org on the audit row without re-reading
+ * env on every call.
+ */
+function epicOrgIssFromClientBase(): string | null {
+  return process.env.EPIC_FHIR_BASE_URL ?? null;
+}
+
+// Re-exported types for test consumption.
+export type { FhirFlag } from "./flag-generator.js";

--- a/services/epic-connector/src/router.ts
+++ b/services/epic-connector/src/router.ts
@@ -1,0 +1,121 @@
+/**
+ * Epic-sync tRPC router (#391).
+ *
+ * Surface for the clinician portal's Epic sync dashboard and for
+ * admin-driven manual sync triggers. Wired into the api-gateway via
+ * services/api-gateway/src/routers/epic-sync.ts which adds RBAC.
+ *
+ * This module exports the raw router; auth/RBAC is layered in the
+ * gateway, mirroring how ai-oversight, clinical-data and patient-records
+ * structure their wrappers.
+ *
+ * Procedures:
+ *   - epicSync.triggerSync       — enqueue a sync job (admin)
+ *   - epicSync.getSyncStatus     — read all (patient, resource_type)
+ *                                  rows for a patient
+ *   - epicSync.listSyncErrors    — paginate the most recent failed
+ *                                  sync rows across patients
+ */
+import { initTRPC } from "@trpc/server";
+import { z } from "zod";
+import {
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+} from "./workers/sync-worker.js";
+import {
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+} from "./sync/sync-state-repo.js";
+import { SUPPORTED_RESOURCE_TYPES } from "./sync/sync-jobs.js";
+
+const t = initTRPC.create();
+
+const syncResourceTypeSchema = z.enum(
+  SUPPORTED_RESOURCE_TYPES as [string, ...string[]],
+);
+
+export const epicSyncRouter = t.router({
+  /**
+   * Enqueue a sync job. Three flavours:
+   *   full         — pull every resource type, no watermark
+   *   incremental  — pull every resource type, using stored watermarks
+   *   single       — pull one resource type, optional watermark
+   */
+  triggerSync: t.procedure
+    .input(
+      z.discriminatedUnion("mode", [
+        z.object({
+          mode: z.literal("full"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("incremental"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("single"),
+          patient_id: z.string().uuid(),
+          resource_type: syncResourceTypeSchema,
+          epic_patient_fhir_id: z.string().optional(),
+          watermark: z.string().nullish(),
+        }),
+      ]),
+    )
+    .mutation(async ({ input }) => {
+      if (input.mode === "full") {
+        await enqueueFullSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return { enqueued: "full-sync", patient_id: input.patient_id };
+      }
+      if (input.mode === "incremental") {
+        await enqueueIncrementalSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return {
+          enqueued: "incremental-sync",
+          patient_id: input.patient_id,
+        };
+      }
+      await enqueueSingleResourceSync({
+        patient_id: input.patient_id,
+        // safe: the zod enum schema is built from SUPPORTED_RESOURCE_TYPES
+        resource_type:
+          input.resource_type as (typeof SUPPORTED_RESOURCE_TYPES)[number],
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        watermark: input.watermark,
+      });
+      return {
+        enqueued: "single-resource-sync",
+        patient_id: input.patient_id,
+        resource_type: input.resource_type,
+      };
+    }),
+
+  /**
+   * Read every (resource_type) sync row for a patient. The clinician
+   * portal renders this as the per-patient Epic-sync health card.
+   */
+  getSyncStatus: t.procedure
+    .input(z.object({ patient_id: z.string().uuid() }))
+    .query(async ({ input }) => {
+      return getAllSyncStatesForPatient(input.patient_id);
+    }),
+
+  /**
+   * List the most recent N failed syncs across all patients — powers
+   * the admin "things needing attention" dashboard.
+   */
+  listSyncErrors: t.procedure
+    .input(z.object({ limit: z.number().min(1).max(500).optional() }))
+    .query(async ({ input }) => {
+      return listRecentFailures(input.limit);
+    }),
+});
+
+export type EpicSyncRouter = typeof epicSyncRouter;

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -1,0 +1,638 @@
+/**
+ * Persistence layer for Epic-synced FHIR resources (#391).
+ *
+ * Each persistResource* function:
+ *  1. Looks up the existing CareBridge row for the (Epic resource_type, resource_id)
+ *     tuple via the `fhir_resources` mapping table.
+ *  2. UPSERTs the target row (insert when no mapping exists; update when
+ *     it does).
+ *  3. UPSERTs the `fhir_resources` mapping row so the next sync pull can
+ *     find the same internal row.
+ *  4. Records a conflict to `audit_log` if the existing target row has
+ *     `source_system != "epic"` — Epic does not get to overwrite
+ *     CareBridge-originated data; we keep CareBridge's row and log the
+ *     attempted overwrite for manual review.
+ *
+ * Idempotent by design: re-running the same FHIR resource is a no-op
+ * after the first call other than refreshing `updated_at`. This lets
+ * the BullMQ job runner retry freely on transient errors.
+ */
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import {
+  getDb,
+  patients,
+  medications,
+  vitals,
+  labPanels,
+  labResults,
+  diagnoses,
+  allergies,
+  fhirResources,
+  auditLog,
+} from "@carebridge/db-schema";
+import {
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+  EPIC_SOURCE_SYSTEM_TAG,
+} from "../converters.js";
+import type { FhirResource } from "../fhir-types.js";
+
+const EPIC_SYNC_AUDIT_USER = "system:epic-sync";
+
+export interface PersistResult {
+  /** Internal CareBridge row id, or null when the resource was unmappable. */
+  internalId: string | null;
+  /** Discriminator for downstream event emission. */
+  kind:
+    | "patient"
+    | "medication"
+    | "vital"
+    | "lab"
+    | "diagnosis"
+    | "allergy"
+    | "unmapped";
+  /** True when the call inserted a new row; false when it updated. */
+  inserted: boolean;
+  /** Set when the call rejected an Epic update due to source_system mismatch. */
+  conflict?: string;
+}
+
+interface MappingLookup {
+  internalId: string | null;
+  /** When set, an existing target row owns this resource with non-Epic source. */
+  existingSourceSystem?: string | null;
+}
+
+async function findMapping(
+  resourceType: string,
+  fhirId: string,
+): Promise<MappingLookup> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(fhirResources)
+    .where(
+      and(
+        eq(fhirResources.resource_type, resourceType),
+        eq(fhirResources.resource_id, fhirId),
+      ),
+    )
+    .limit(1);
+  const existing = rows[0];
+  if (!existing) return { internalId: null };
+  return {
+    internalId: existing.internal_record_id ?? null,
+    existingSourceSystem: existing.source_system,
+  };
+}
+
+async function upsertMapping(args: {
+  resourceType: string;
+  fhirId: string;
+  internalId: string;
+  patientId: string | null;
+  resource: unknown;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  // fhir_resources.id is a free-form PK in the existing schema; we
+  // synthesise a deterministic id from (resource_type, fhir_id) so a
+  // re-emit upserts the same mapping row rather than appending.
+  const mappingId = `epic:${args.resourceType}:${args.fhirId}`;
+  await db
+    .insert(fhirResources)
+    .values({
+      id: mappingId,
+      resource_type: args.resourceType,
+      resource_id: args.fhirId,
+      patient_id: args.patientId,
+      resource: args.resource as object,
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      internal_record_id: args.internalId,
+      imported_at: now,
+    })
+    .onConflictDoUpdate({
+      target: fhirResources.id,
+      set: {
+        resource: args.resource as object,
+        internal_record_id: args.internalId,
+        imported_at: now,
+      },
+    });
+}
+
+async function logSourceConflict(args: {
+  resourceType: string;
+  fhirId: string;
+  internalId: string;
+  patientId: string | null;
+  existingSourceSystem: string | null | undefined;
+}): Promise<void> {
+  const db = getDb();
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: EPIC_SYNC_AUDIT_USER,
+    action: "update",
+    resource_type: args.resourceType,
+    resource_id: args.internalId,
+    patient_id: args.patientId,
+    success: false,
+    details: JSON.stringify({
+      reason: "source_system_conflict",
+      attempted_source: EPIC_SOURCE_SYSTEM_TAG,
+      existing_source: args.existingSourceSystem ?? null,
+      epic_fhir_id: args.fhirId,
+      resolution: "keep_carebridge_value",
+    }),
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Per-row write helpers: each calls findMapping → INSERT or UPDATE on
+ * the target table → upsertMapping. The conflict check (source_system
+ * != "epic") refuses to overwrite CareBridge-originated rows.
+ */
+
+export async function persistPatient(
+  resource: FhirResource,
+): Promise<PersistResult> {
+  const row = epicPatientToRow(resource);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const mapping = await findMapping("Patient", fhirId);
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  if (mapping.internalId) {
+    // Patient already imported — update only Epic-owned rows.
+    // Patient identity is treated as Epic-owned when first imported
+    // from Epic, so the conflict check is a belt-and-braces guard.
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "Patient",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId: mapping.internalId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "patient",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(patients)
+      .set({
+        name: row.name,
+        date_of_birth: row.date_of_birth,
+        biological_sex: row.biological_sex,
+        mrn: row.mrn ?? undefined,
+        updated_at: now,
+      })
+      .where(eq(patients.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Patient",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId: mapping.internalId,
+      resource,
+    });
+    return { internalId: mapping.internalId, kind: "patient", inserted: false };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(patients).values({
+    id,
+    mrn: row.mrn ?? undefined,
+    name: row.name,
+    date_of_birth: row.date_of_birth,
+    biological_sex: row.biological_sex,
+    created_at: now,
+    updated_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Patient",
+    fhirId,
+    internalId: id,
+    patientId: id,
+    resource,
+  });
+  return { internalId: id, kind: "patient", inserted: true };
+}
+
+export async function persistMedicationRequest(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const row = epicMedicationRequestToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+  return persistMedicationRow(row, resource, patientId, "MedicationRequest");
+}
+
+export async function persistMedicationStatement(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const row = epicMedicationStatementToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+  return persistMedicationRow(row, resource, patientId, "MedicationStatement");
+}
+
+async function persistMedicationRow(
+  row: NonNullable<ReturnType<typeof epicMedicationRequestToRow>>,
+  resource: FhirResource,
+  patientId: string,
+  resourceType: "MedicationRequest" | "MedicationStatement",
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const mapping = await findMapping(resourceType, fhirId);
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType,
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "medication",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(medications)
+      .set({
+        name: row.name,
+        dose_amount: row.dose_amount,
+        dose_unit: row.dose_unit,
+        route: row.route,
+        frequency: row.frequency,
+        status: row.status,
+        rxnorm_code: row.rxnorm_code,
+        max_doses_per_day: row.max_doses_per_day,
+        updated_at: now,
+      })
+      .where(eq(medications.id, mapping.internalId));
+    await upsertMapping({
+      resourceType,
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "medication",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(medications).values({
+    id,
+    patient_id: patientId,
+    name: row.name,
+    dose_amount: row.dose_amount,
+    dose_unit: row.dose_unit,
+    route: row.route,
+    frequency: row.frequency,
+    status: row.status,
+    rxnorm_code: row.rxnorm_code,
+    max_doses_per_day: row.max_doses_per_day,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
+    created_at: now,
+    updated_at: now,
+  });
+  await upsertMapping({
+    resourceType,
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "medication", inserted: true };
+}
+
+export async function persistObservation(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const conversion = epicObservationToRow(resource, patientId);
+  if (conversion.kind === "unmapped") {
+    return { internalId: null, kind: "unmapped", inserted: false };
+  }
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("Observation", fhirId);
+
+  if (conversion.kind === "vital") {
+    if (mapping.internalId) {
+      if (
+        mapping.existingSourceSystem &&
+        mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+      ) {
+        await logSourceConflict({
+          resourceType: "Observation",
+          fhirId,
+          internalId: mapping.internalId,
+          patientId,
+          existingSourceSystem: mapping.existingSourceSystem,
+        });
+        return {
+          internalId: mapping.internalId,
+          kind: "vital",
+          inserted: false,
+          conflict: "source_system_conflict",
+        };
+      }
+      await db
+        .update(vitals)
+        .set({
+          type: conversion.row.type,
+          loinc_code: conversion.row.loinc_code,
+          value_primary: conversion.row.value_primary,
+          value_secondary: conversion.row.value_secondary,
+          unit: conversion.row.unit,
+          recorded_at: conversion.row.recorded_at,
+        })
+        .where(eq(vitals.id, mapping.internalId));
+      await upsertMapping({
+        resourceType: "Observation",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        resource,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "vital",
+        inserted: false,
+      };
+    }
+    const id = crypto.randomUUID();
+    await db.insert(vitals).values({
+      id,
+      patient_id: patientId,
+      type: conversion.row.type,
+      loinc_code: conversion.row.loinc_code,
+      value_primary: conversion.row.value_primary,
+      value_secondary: conversion.row.value_secondary,
+      unit: conversion.row.unit,
+      recorded_at: conversion.row.recorded_at,
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      created_at: now,
+    });
+    await upsertMapping({
+      resourceType: "Observation",
+      fhirId,
+      internalId: id,
+      patientId,
+      resource,
+    });
+    return { internalId: id, kind: "vital", inserted: true };
+  }
+
+  // Lab result — single-result panel synthesised for the Epic
+  // resource. Multi-test panels arriving from Epic come in as a
+  // DiagnosticReport (deferred to #391-followup) and are not handled
+  // here yet.
+  if (mapping.internalId) {
+    // Existing lab_results rows are leaves — conflict logic on the panel
+    // level is out of scope for the first cut. Refresh the value in place.
+    await db
+      .update(labResults)
+      .set({
+        test_name: conversion.row.test_name,
+        test_code: conversion.row.test_code,
+        value: conversion.row.value,
+        unit: conversion.row.unit,
+        reference_low: conversion.row.reference_low,
+        reference_high: conversion.row.reference_high,
+        flag: conversion.row.flag,
+      })
+      .where(eq(labResults.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Observation",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return { internalId: mapping.internalId, kind: "lab", inserted: false };
+  }
+
+  const panelId = crypto.randomUUID();
+  await db.insert(labPanels).values({
+    id: panelId,
+    patient_id: patientId,
+    panel_name: conversion.row.test_name,
+    collected_at: conversion.row.recorded_at,
+    reported_at: conversion.row.recorded_at,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
+    created_at: now,
+  });
+  const resultId = crypto.randomUUID();
+  await db.insert(labResults).values({
+    id: resultId,
+    panel_id: panelId,
+    test_name: conversion.row.test_name,
+    test_code: conversion.row.test_code,
+    value: conversion.row.value,
+    unit: conversion.row.unit,
+    reference_low: conversion.row.reference_low,
+    reference_high: conversion.row.reference_high,
+    flag: conversion.row.flag,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Observation",
+    fhirId,
+    internalId: resultId,
+    patientId,
+    resource,
+  });
+  return { internalId: resultId, kind: "lab", inserted: true };
+}
+
+export async function persistCondition(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const row = epicConditionToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("Condition", fhirId);
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "Condition",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "diagnosis",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(diagnoses)
+      .set({
+        description: row.description,
+        icd10_code: row.icd10_code,
+        snomed_code: row.snomed_code,
+        status: row.status,
+        onset_date: row.onset_date,
+        resolved_date: row.resolved_date,
+      })
+      .where(eq(diagnoses.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Condition",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "diagnosis",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(diagnoses).values({
+    id,
+    patient_id: patientId,
+    description: row.description,
+    icd10_code: row.icd10_code,
+    snomed_code: row.snomed_code,
+    status: row.status,
+    onset_date: row.onset_date,
+    resolved_date: row.resolved_date,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Condition",
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "diagnosis", inserted: true };
+}
+
+export async function persistAllergy(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const row = epicAllergyToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("AllergyIntolerance", fhirId);
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "AllergyIntolerance",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "allergy",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(allergies)
+      .set({
+        allergen: row.allergen,
+        severity: row.severity,
+        reaction: row.reaction,
+      })
+      .where(eq(allergies.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "AllergyIntolerance",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "allergy",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(allergies).values({
+    id,
+    patient_id: patientId,
+    allergen: row.allergen,
+    severity: row.severity,
+    reaction: row.reaction,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "AllergyIntolerance",
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "allergy", inserted: true };
+}

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -1,0 +1,340 @@
+/**
+ * Epic sync job runners (#391).
+ *
+ * Pure orchestration functions — they take their dependencies
+ * (FHIR client, persistence helpers, emit) as arguments so the BullMQ
+ * worker can wire production dependencies while tests can inject mocks
+ * without touching Redis or Postgres.
+ *
+ * Job types:
+ *  - full-sync           — pull every resource type for a patient with
+ *                          no `_lastUpdated` watermark. Used for first
+ *                          import and "refresh everything" admin ops.
+ *  - incremental-sync    — pull resources updated since the watermark
+ *                          stored on `epic_sync_state`. Used for
+ *                          background-scheduled syncs.
+ *  - single-resource-sync — refresh one resource type for one patient.
+ *                          Used by the tRPC trigger endpoint and by
+ *                          the medication reconciliation flow.
+ *
+ * After each pull, every imported row emits a ClinicalEvent on the
+ * `clinical-events` BullMQ queue with `source_system: "epic"` in the
+ * event metadata. The existing ai-oversight review worker picks them
+ * up unchanged — the AI safety rules fire on Epic-sourced data the
+ * same way they fire on internally-recorded data.
+ */
+import crypto from "node:crypto";
+import { createLogger } from "@carebridge/logger";
+import type {
+  ClinicalEvent,
+  ClinicalEventType,
+} from "@carebridge/shared-types";
+import { EpicFhirClient, type EpicResourceType } from "../fhir-client.js";
+import { EPIC_SOURCE_SYSTEM_TAG } from "../converters.js";
+import {
+  persistAllergy,
+  persistCondition,
+  persistMedicationRequest,
+  persistObservation,
+  persistPatient,
+  type PersistResult,
+} from "./persistence.js";
+import {
+  getSyncState,
+  markFailed,
+  markOk,
+  markRunning,
+} from "./sync-state-repo.js";
+import type { FhirResource } from "../fhir-types.js";
+
+const log = createLogger("epic-sync-jobs");
+
+export type SyncResourceType = Exclude<EpicResourceType, "Encounter">;
+
+/**
+ * Resource types this PR ships sync support for. Encounter persistence
+ * is deferred to a follow-up — there's no inbound encounter mapper in
+ * fhir-gateway yet, and the `encounters` table writes need their own
+ * idempotency story (Epic CSN ↔ internal id).
+ */
+export const SUPPORTED_RESOURCE_TYPES: SyncResourceType[] = [
+  "Patient",
+  "Observation",
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+];
+
+export type EmitFn = (event: ClinicalEvent) => Promise<void>;
+
+export interface SyncJobDeps {
+  client: EpicFhirClient;
+  emit: EmitFn;
+}
+
+export interface SyncResult {
+  patient_id: string;
+  resource_type: SyncResourceType;
+  imported: number;
+  updated: number;
+  conflicts: number;
+  errors: string[];
+}
+
+/**
+ * Full-sync: pull every supported resource type for the given patient
+ * with no incremental watermark. Used for first import.
+ */
+export async function runFullSync(
+  args: { patientId: string; epicPatientFhirId?: string },
+  deps: SyncJobDeps,
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const resourceType of SUPPORTED_RESOURCE_TYPES) {
+    results.push(
+      await syncResourceType(
+        {
+          patientId: args.patientId,
+          epicPatientFhirId: args.epicPatientFhirId,
+          resourceType,
+          watermark: null,
+        },
+        deps,
+      ),
+    );
+  }
+  return results;
+}
+
+/**
+ * Incremental sync: pull resources updated since the watermark stored
+ * on `epic_sync_state` for each (patient, resource_type) tuple.
+ */
+export async function runIncrementalSync(
+  args: { patientId: string; epicPatientFhirId?: string },
+  deps: SyncJobDeps,
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const resourceType of SUPPORTED_RESOURCE_TYPES) {
+    const state = await getSyncState(args.patientId, resourceType);
+    results.push(
+      await syncResourceType(
+        {
+          patientId: args.patientId,
+          epicPatientFhirId: args.epicPatientFhirId,
+          resourceType,
+          watermark: state?.last_fhir_lastupdated ?? null,
+        },
+        deps,
+      ),
+    );
+  }
+  return results;
+}
+
+/**
+ * Refresh a single resource type for a single patient.
+ */
+export async function runSingleResourceSync(
+  args: {
+    patientId: string;
+    epicPatientFhirId?: string;
+    resourceType: SyncResourceType;
+    /** When set, use as the `_lastUpdated=gt<watermark>` filter. */
+    watermark?: string | null;
+  },
+  deps: SyncJobDeps,
+): Promise<SyncResult> {
+  return syncResourceType(
+    {
+      patientId: args.patientId,
+      epicPatientFhirId: args.epicPatientFhirId,
+      resourceType: args.resourceType,
+      watermark: args.watermark ?? null,
+    },
+    deps,
+  );
+}
+
+interface SyncOneArgs {
+  patientId: string;
+  epicPatientFhirId?: string;
+  resourceType: SyncResourceType;
+  watermark: string | null;
+}
+
+async function syncResourceType(
+  args: SyncOneArgs,
+  deps: SyncJobDeps,
+): Promise<SyncResult> {
+  await markRunning(args.patientId, args.resourceType);
+
+  const result: SyncResult = {
+    patient_id: args.patientId,
+    resource_type: args.resourceType,
+    imported: 0,
+    updated: 0,
+    conflicts: 0,
+    errors: [],
+  };
+  let highWatermark: string | null = args.watermark;
+
+  try {
+    const resources = await fetchResources(args, deps.client);
+
+    for (const resource of resources) {
+      try {
+        const persisted = await persistOne(
+          resource,
+          args.resourceType,
+          args.patientId,
+        );
+        if (persisted.kind === "unmapped") continue;
+
+        if (persisted.conflict) {
+          result.conflicts++;
+        } else if (persisted.inserted) {
+          result.imported++;
+        } else {
+          result.updated++;
+        }
+
+        if (!persisted.conflict && persisted.internalId) {
+          await deps.emit(
+            buildClinicalEvent({
+              persisted,
+              patientId: args.patientId,
+              resource,
+            }),
+          );
+        }
+
+        const lastUpdated = (
+          resource.meta as { lastUpdated?: string } | undefined
+        )?.lastUpdated;
+        if (lastUpdated && (!highWatermark || lastUpdated > highWatermark)) {
+          highWatermark = lastUpdated;
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : String(err);
+        log.error("Epic sync — per-resource failure", {
+          patientId: args.patientId,
+          resourceType: args.resourceType,
+          fhirId: resource.id,
+          error: message,
+        });
+        result.errors.push(message);
+      }
+    }
+
+    await markOk({
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      highWatermark,
+      importedCount: result.imported,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("Epic sync — resource-type failure", {
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      error: message,
+    });
+    await markFailed({
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      errorMessage: message,
+    });
+    result.errors.push(message);
+  }
+
+  return result;
+}
+
+async function fetchResources(
+  args: SyncOneArgs,
+  client: EpicFhirClient,
+): Promise<FhirResource[]> {
+  if (args.resourceType === "Patient") {
+    if (!args.epicPatientFhirId) return [];
+    return [await client.readPatient(args.epicPatientFhirId)];
+  }
+
+  const lastUpdated = args.watermark ? `gt${args.watermark}` : undefined;
+  const params: Record<string, string | undefined> = {
+    patient: args.epicPatientFhirId ?? args.patientId,
+    _lastUpdated: lastUpdated,
+  };
+
+  const resources: FhirResource[] = [];
+  for await (const r of client.searchAll(args.resourceType, params)) {
+    resources.push(r);
+  }
+  return resources;
+}
+
+async function persistOne(
+  resource: FhirResource,
+  resourceType: SyncResourceType,
+  patientId: string,
+): Promise<PersistResult> {
+  switch (resourceType) {
+    case "Patient":
+      return persistPatient(resource);
+    case "Observation":
+      return persistObservation(resource, patientId);
+    case "Condition":
+      return persistCondition(resource, patientId);
+    case "MedicationRequest":
+      return persistMedicationRequest(resource, patientId);
+    case "AllergyIntolerance":
+      return persistAllergy(resource, patientId);
+  }
+}
+
+function buildClinicalEvent(args: {
+  persisted: PersistResult;
+  patientId: string;
+  resource: FhirResource;
+}): ClinicalEvent {
+  const type = eventTypeFor(args.persisted);
+  return {
+    id: crypto.randomUUID(),
+    type,
+    patient_id: args.patientId,
+    timestamp: new Date().toISOString(),
+    data: {
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      epic_fhir_id: args.resource.id,
+      epic_resource_type: args.resource.resourceType,
+      internal_record_id: args.persisted.internalId,
+      operation: args.persisted.inserted ? "created" : "updated",
+    },
+  };
+}
+
+function eventTypeFor(persisted: PersistResult): ClinicalEventType {
+  switch (persisted.kind) {
+    case "patient":
+      return "patient.observation";
+    case "vital":
+      return persisted.inserted ? "vital.created" : "vital.updated";
+    case "lab":
+      return "lab.resulted";
+    case "medication":
+      return persisted.inserted
+        ? "medication.created"
+        : "medication.updated";
+    case "diagnosis":
+      return persisted.inserted ? "diagnosis.added" : "diagnosis.updated";
+    case "allergy":
+      return persisted.inserted ? "allergy.added" : "allergy.updated";
+    case "unmapped":
+      // Should never happen — buildClinicalEvent is gated by
+      // persisted.kind !== "unmapped" at the callsite. Fall through to
+      // a generic "fhir.imported" so the event still surfaces in
+      // audit trails if a future bug breaks the gate.
+      return "fhir.imported";
+  }
+}

--- a/services/epic-connector/src/sync/sync-state-repo.ts
+++ b/services/epic-connector/src/sync/sync-state-repo.ts
@@ -1,0 +1,165 @@
+/**
+ * Per-patient, per-resource-type sync state CRUD (#391).
+ *
+ * Backed by the `epic_sync_state` table introduced in migration 0048.
+ * The Epic sync worker reads the watermark before each incremental
+ * pull and writes back the new watermark plus the success/error counts
+ * after each pull completes.
+ *
+ * Status state machine:
+ *   pending → running → ok        (happy path)
+ *   pending → running → failed    (transient error, eligible for retry)
+ *
+ * `last_fhir_lastupdated` is the value to feed into the NEXT
+ * incremental request as `_lastUpdated=gt<value>`. It tracks the
+ * highest `meta.lastUpdated` observed across the previous pull's
+ * resources — NOT the wall-clock time the pull happened (those drift
+ * apart when Epic back-dates resources).
+ */
+import { and, eq, desc, sql } from "drizzle-orm";
+import { getDb, epicSyncState } from "@carebridge/db-schema";
+import type { EpicResourceType } from "../fhir-client.js";
+
+export type EpicSyncStatusValue = "pending" | "running" | "ok" | "failed";
+
+export interface EpicSyncStateRow {
+  patient_id: string;
+  resource_type: EpicResourceType;
+  last_synced_at: string | null;
+  last_fhir_lastupdated: string | null;
+  status: EpicSyncStatusValue;
+  resources_synced_count: number;
+  error_count: number;
+  last_error_message: string | null;
+  last_error_at: string | null;
+}
+
+export async function getSyncState(
+  patientId: string,
+  resourceType: EpicResourceType,
+): Promise<EpicSyncStateRow | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicSyncState)
+    .where(
+      and(
+        eq(epicSyncState.patient_id, patientId),
+        eq(epicSyncState.resource_type, resourceType),
+      ),
+    )
+    .limit(1);
+  return (rows[0] as EpicSyncStateRow | undefined) ?? null;
+}
+
+export async function getAllSyncStatesForPatient(
+  patientId: string,
+): Promise<EpicSyncStateRow[]> {
+  const db = getDb();
+  return (await db
+    .select()
+    .from(epicSyncState)
+    .where(eq(epicSyncState.patient_id, patientId))) as EpicSyncStateRow[];
+}
+
+export async function markRunning(
+  patientId: string,
+  resourceType: EpicResourceType,
+): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: patientId,
+      resource_type: resourceType,
+      status: "running",
+      last_synced_at: now,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: { status: "running", last_synced_at: now },
+    });
+}
+
+export async function markOk(args: {
+  patientId: string;
+  resourceType: EpicResourceType;
+  /** Highest `meta.lastUpdated` seen in this pull — watermark for next pull. */
+  highWatermark: string | null;
+  /** Number of resources successfully imported on this pull. */
+  importedCount: number;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: args.patientId,
+      resource_type: args.resourceType,
+      status: "ok",
+      last_synced_at: now,
+      last_fhir_lastupdated: args.highWatermark,
+      resources_synced_count: args.importedCount,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: {
+        status: "ok",
+        last_synced_at: now,
+        last_fhir_lastupdated: args.highWatermark ?? sql`epic_sync_state.last_fhir_lastupdated`,
+        resources_synced_count: sql`epic_sync_state.resources_synced_count + ${args.importedCount}`,
+      },
+    });
+}
+
+export async function markFailed(args: {
+  patientId: string;
+  resourceType: EpicResourceType;
+  errorMessage: string;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  // Truncate error messages so a runaway stack trace doesn't bloat the
+  // status column to gigabytes. 1KiB is plenty for triage; full stack
+  // traces live in the worker logs / DLQ.
+  const truncated = args.errorMessage.slice(0, 1024);
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: args.patientId,
+      resource_type: args.resourceType,
+      status: "failed",
+      last_synced_at: now,
+      last_error_message: truncated,
+      last_error_at: now,
+      error_count: 1,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: {
+        status: "failed",
+        last_synced_at: now,
+        last_error_message: truncated,
+        last_error_at: now,
+        error_count: sql`epic_sync_state.error_count + 1`,
+      },
+    });
+}
+
+/**
+ * List the N most recent failed sync rows across all patients —
+ * powers the tRPC `listSyncErrors` query that the clinician portal's
+ * Epic-sync dashboard renders.
+ */
+export async function listRecentFailures(
+  limit = 50,
+): Promise<EpicSyncStateRow[]> {
+  const db = getDb();
+  return (await db
+    .select()
+    .from(epicSyncState)
+    .where(eq(epicSyncState.status, "failed"))
+    .orderBy(desc(epicSyncState.last_error_at))
+    .limit(limit)) as EpicSyncStateRow[];
+}

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -117,14 +117,18 @@ export class EpicTokenClient {
 
     if (!response.ok) {
       const text = await response.text();
-      // Epic returns structured OAuth2 errors as JSON; preserve them in
-      // the log for debugging but throw a clean message upstream — the
-      // body may contain the assertion (echoed back), so the caller
-      // should not surface it to end users.
+      // Epic returns OAuth 2.0 error payloads as JSON with `error` /
+      // `error_description` fields. Parse those out and log ONLY the
+      // structured fields — never the raw body, which may echo back the
+      // client_assertion JWT (a credential that, if leaked to log
+      // collectors, can be replayed against Epic for the assertion's
+      // lifetime).
+      const errorFields = parseOAuthError(text);
       log.warn("Epic token request failed", {
         status: response.status,
         statusText: response.statusText,
-        bodyPrefix: text.slice(0, 200),
+        oauth_error: errorFields.error,
+        oauth_error_description: errorFields.error_description,
       });
       throw new Error(
         `Epic token endpoint returned ${response.status} ${response.statusText}`,
@@ -148,5 +152,29 @@ export class EpicTokenClient {
    */
   invalidate(): void {
     this.cached = null;
+  }
+}
+
+/**
+ * Best-effort parser for OAuth 2.0 error responses (RFC 6749 §5.2).
+ * Returns the structured `error` + `error_description` fields when the
+ * body is JSON; falls back to undefined when it isn't (so the caller
+ * doesn't accidentally log opaque token endpoint output).
+ */
+function parseOAuthError(body: string): {
+  error?: string;
+  error_description?: string;
+} {
+  try {
+    const parsed = JSON.parse(body) as Record<string, unknown>;
+    return {
+      error: typeof parsed.error === "string" ? parsed.error : undefined,
+      error_description:
+        typeof parsed.error_description === "string"
+          ? parsed.error_description
+          : undefined,
+    };
+  } catch {
+    return {};
   }
 }

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -1,0 +1,152 @@
+/**
+ * Epic SMART Backend Services token client (#389).
+ *
+ * Exchanges a client_assertion JWT for an OAuth 2.0 access token at
+ * Epic's token endpoint, caching the result until shortly before expiry.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/backend-services.html
+ *
+ * Request shape (form-encoded):
+ *   grant_type=client_credentials
+ *   client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+ *   client_assertion=<RS384-signed JWT>
+ *   scope=<space-separated SMART scopes>
+ *
+ * Response: { access_token, expires_in, token_type, scope }
+ */
+import { createLogger } from "@carebridge/logger";
+import { buildClientAssertion } from "./jwt-assertion.js";
+import type { EpicConfig } from "./config.js";
+
+const log = createLogger("epic-token-client");
+
+/**
+ * Default SMART Backend Services scopes (Epic-supported subset).
+ * Callers can override by passing `scopes` to {@link getAccessToken}.
+ */
+export const DEFAULT_SYSTEM_SCOPES = [
+  "system/Patient.read",
+  "system/Observation.read",
+  "system/Condition.read",
+  "system/MedicationRequest.read",
+  "system/AllergyIntolerance.read",
+  "system/Encounter.read",
+];
+
+/**
+ * Refresh-buffer window (seconds). When the cached token's remaining
+ * lifetime drops below this, the next call requests a fresh one. 60s
+ * is comfortably longer than the worst-case network RTT and Epic's
+ * documented token-issue latency.
+ */
+const REFRESH_BUFFER_SEC = 60;
+
+export interface TokenResponse {
+  /** Bearer access token to send as Authorization: Bearer <token>. */
+  access_token: string;
+  /** Seconds until expiry from issue time. Epic typically returns 3600. */
+  expires_in: number;
+  /** Always "Bearer" for SMART Backend Services. */
+  token_type: string;
+  /** Granted scopes (space-separated); may be a subset of what was requested. */
+  scope: string;
+}
+
+interface CachedToken {
+  response: TokenResponse;
+  /** Absolute wall-clock time the token expires (ms). */
+  expiresAtMs: number;
+}
+
+/**
+ * Stateful token client. Holds the cached token and the config.
+ * One instance per Epic tenant; multi-tenant deployments instantiate
+ * separately per (clientId, tokenUrl) pair.
+ */
+export class EpicTokenClient {
+  private cached: CachedToken | null = null;
+
+  constructor(
+    private readonly config: EpicConfig,
+    /** Override for tests; defaults to global fetch. */
+    private readonly fetchImpl: typeof fetch = fetch,
+    /** Override for tests; defaults to Date.now. */
+    private readonly nowMs: () => number = () => Date.now(),
+  ) {}
+
+  /**
+   * Return a usable access token. Uses the cached value when it has
+   * more than REFRESH_BUFFER_SEC of lifetime left; otherwise requests
+   * a fresh one. Thread-safe in Node's single-threaded event loop —
+   * concurrent callers within a tick share the same in-flight request
+   * via the cache being populated on resolution.
+   */
+  async getAccessToken(scopes: string[] = DEFAULT_SYSTEM_SCOPES): Promise<string> {
+    if (this.cached) {
+      const remainingMs = this.cached.expiresAtMs - this.nowMs();
+      if (remainingMs > REFRESH_BUFFER_SEC * 1000) {
+        return this.cached.response.access_token;
+      }
+    }
+
+    const issuedAtMs = this.nowMs();
+    const assertion = buildClientAssertion({
+      clientId: this.config.clientId,
+      tokenUrl: this.config.tokenUrl,
+      kid: this.config.jwtKid,
+      privateKeyPem: this.config.privateKeyPem,
+      now: () => Math.floor(issuedAtMs / 1000),
+    });
+
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_assertion_type:
+        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: assertion,
+      scope: scopes.join(" "),
+    });
+
+    const response = await this.fetchImpl(this.config.tokenUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      // Epic returns structured OAuth2 errors as JSON; preserve them in
+      // the log for debugging but throw a clean message upstream — the
+      // body may contain the assertion (echoed back), so the caller
+      // should not surface it to end users.
+      log.warn("Epic token request failed", {
+        status: response.status,
+        statusText: response.statusText,
+        bodyPrefix: text.slice(0, 200),
+      });
+      throw new Error(
+        `Epic token endpoint returned ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const parsed = (await response.json()) as TokenResponse;
+    this.cached = {
+      response: parsed,
+      expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
+    };
+
+    return parsed.access_token;
+  }
+
+  /**
+   * Drop the cached token. Forces the next {@link getAccessToken} call
+   * to request a fresh one. Useful when the FHIR client receives a 401
+   * (token revoked / org rotated keys) and wants to retry once with a
+   * fresh assertion before failing.
+   */
+  invalidate(): void {
+    this.cached = null;
+  }
+}

--- a/services/epic-connector/src/workers/outbound-flag-worker.ts
+++ b/services/epic-connector/src/workers/outbound-flag-worker.ts
@@ -1,0 +1,143 @@
+/**
+ * BullMQ worker that pushes CareBridge flags to Epic (#393).
+ *
+ * Listens on the `epic-outbound-flags` queue. Each job carries:
+ *   { type: "push-create",   flag_id }   — newly-created flag → POST
+ *   { type: "push-status",   flag_id }   — status changed → PUT (or
+ *                                          first-push if epic_flag_id
+ *                                          isn't set yet)
+ *
+ * Both job types go through {@link pushFlagToEpic} which decides POST
+ * vs PUT internally based on whether the row already has an
+ * epic_flag_id.
+ *
+ * The worker is opt-in: `startEpicOutboundFlagWorker()` returns null
+ * when Epic credentials aren't configured so local dev keeps booting.
+ *
+ * The enqueue helpers are also guarded — they no-op when Epic isn't
+ * configured so callers (the ai-oversight flag-service) can call them
+ * unconditionally and avoid duplicating the env-check at every site.
+ */
+import { Worker, Queue, type Job } from "bullmq";
+import { createLogger } from "@carebridge/logger";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import { loadEpicConfig } from "../config.js";
+import { pushFlagToEpic } from "../outbound/flag-push.js";
+
+const log = createLogger("epic-outbound-flag-worker");
+
+export const EPIC_OUTBOUND_FLAGS_QUEUE_NAME = "epic-outbound-flags";
+
+export type EpicOutboundFlagJobData =
+  | { type: "push-create"; flag_id: string }
+  | { type: "push-status"; flag_id: string };
+
+let queueSingleton: Queue<EpicOutboundFlagJobData> | null = null;
+
+function getQueue(): Queue<EpicOutboundFlagJobData> {
+  if (!queueSingleton) {
+    queueSingleton = new Queue(EPIC_OUTBOUND_FLAGS_QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+    });
+  }
+  return queueSingleton;
+}
+
+/**
+ * Returns true when Epic credentials are configured enough to attempt
+ * outbound writes. Centralises the env check so callers don't all have
+ * to remember which vars to check.
+ */
+export function isEpicOutboundEnabled(): boolean {
+  return Boolean(process.env.EPIC_CLIENT_ID && process.env.EPIC_FHIR_BASE_URL);
+}
+
+/**
+ * Enqueue a "newly-created flag → push" job. Safe to call when Epic
+ * isn't configured — falls through as a no-op. Use jobId so a
+ * duplicate-create from a retried flag-service write doesn't queue twice.
+ */
+export async function enqueueEpicFlagPushCreate(
+  flagId: string,
+): Promise<void> {
+  if (!isEpicOutboundEnabled()) return;
+  await getQueue().add(
+    "push-create",
+    { type: "push-create", flag_id: flagId },
+    { jobId: `push-create:${flagId}` },
+  );
+}
+
+/**
+ * Enqueue a "flag status changed → propagate" job. Same idempotency
+ * guarantees as {@link enqueueEpicFlagPushCreate}.
+ */
+export async function enqueueEpicFlagPushUpdate(
+  flagId: string,
+): Promise<void> {
+  if (!isEpicOutboundEnabled()) return;
+  await getQueue().add(
+    "push-status",
+    { type: "push-status", flag_id: flagId },
+    {
+      // jobId is per (flag, status-update-call) — repeated status
+      // updates for the same flag DO need to enqueue distinct jobs,
+      // unlike the create-push which dedupes on the flag id alone.
+      // Add a timestamp suffix to break uniqueness.
+      jobId: `push-status:${flagId}:${Date.now()}`,
+    },
+  );
+}
+
+/**
+ * Start the Epic outbound-flag worker. Returns null when Epic isn't
+ * configured (mirrors {@link startEpicSyncWorker}).
+ */
+export function startEpicOutboundFlagWorker(): Worker<EpicOutboundFlagJobData> | null {
+  let config;
+  try {
+    config = loadEpicConfig();
+  } catch (err) {
+    log.info(
+      "Epic outbound flag worker not started — credentials not configured",
+      { reason: err instanceof Error ? err.message : String(err) },
+    );
+    return null;
+  }
+  const tokens = new EpicTokenClient(config);
+  const client = new EpicFhirClient(config, tokens);
+
+  const worker = new Worker<EpicOutboundFlagJobData>(
+    EPIC_OUTBOUND_FLAGS_QUEUE_NAME,
+    async (job: Job<EpicOutboundFlagJobData>) => {
+      const start = Date.now();
+      try {
+        const result = await pushFlagToEpic(job.data.flag_id, { client });
+        return result;
+      } finally {
+        log.info("Epic outbound flag job completed", {
+          jobId: job.id,
+          type: job.data.type,
+          flag_id: job.data.flag_id,
+          elapsed_ms: Date.now() - start,
+        });
+      }
+    },
+    { connection: getRedisConnection(), concurrency: 2 },
+  );
+
+  worker.on("failed", (job, err) => {
+    log.error("Epic outbound flag job failed", {
+      jobId: job?.id,
+      error: err.message,
+    });
+  });
+
+  return worker;
+}

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -1,0 +1,225 @@
+/**
+ * BullMQ worker that processes Epic sync jobs (#391).
+ *
+ * Listens on the "epic-sync" queue. Each job is one of:
+ *   - { type: "full-sync",        patient_id, epic_patient_fhir_id? }
+ *   - { type: "incremental-sync", patient_id, epic_patient_fhir_id? }
+ *   - { type: "single-resource-sync", patient_id, epic_patient_fhir_id?,
+ *       resource_type, watermark? }
+ *
+ * Production wiring expects `loadEpicConfig()` to succeed at startup —
+ * if Epic credentials aren't configured, the host service should NOT
+ * call `startEpicSyncWorker()`. Local dev environments without Epic
+ * registration silently skip starting the worker so unrelated services
+ * keep booting.
+ */
+import { Worker, Queue, type Job } from "bullmq";
+import { createLogger } from "@carebridge/logger";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import { emitClinicalEvent } from "@carebridge/outbox";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import { loadEpicConfig } from "../config.js";
+import {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  type SyncResourceType,
+} from "../sync/sync-jobs.js";
+
+const log = createLogger("epic-sync-worker");
+
+export const EPIC_SYNC_QUEUE_NAME = "epic-sync";
+
+export type EpicSyncJobData =
+  | {
+      type: "full-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+    }
+  | {
+      type: "incremental-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+    }
+  | {
+      type: "single-resource-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+      resource_type: SyncResourceType;
+      watermark?: string | null;
+    };
+
+let queueSingleton: Queue<EpicSyncJobData> | null = null;
+
+/**
+ * Lazily-instantiated Epic-sync queue. Defer construction until first
+ * use so importing this module from a host that ultimately decides NOT
+ * to start the worker (e.g. local dev without Epic creds) doesn't
+ * open an idle Redis connection.
+ */
+export function getEpicSyncQueue(): Queue<EpicSyncJobData> {
+  if (!queueSingleton) {
+    queueSingleton = new Queue(EPIC_SYNC_QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+    });
+  }
+  return queueSingleton;
+}
+
+export async function enqueueFullSync(args: {
+  patient_id: string;
+  epic_patient_fhir_id?: string;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "full-sync",
+    { type: "full-sync", ...args },
+    { jobId: `full-sync:${args.patient_id}` },
+  );
+}
+
+export async function enqueueIncrementalSync(args: {
+  patient_id: string;
+  epic_patient_fhir_id?: string;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "incremental-sync",
+    { type: "incremental-sync", ...args },
+    {
+      // Coalesce overlapping incremental requests for the same patient.
+      // BullMQ's jobId dedupe makes back-to-back triggers cheap.
+      jobId: `incremental-sync:${args.patient_id}`,
+    },
+  );
+}
+
+export async function enqueueSingleResourceSync(args: {
+  patient_id: string;
+  resource_type: SyncResourceType;
+  epic_patient_fhir_id?: string;
+  watermark?: string | null;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "single-resource-sync",
+    { type: "single-resource-sync", ...args },
+    {
+      jobId: `single:${args.resource_type}:${args.patient_id}`,
+    },
+  );
+}
+
+/**
+ * Start the Epic-sync BullMQ worker. Pulls Epic credentials from env
+ * via `loadEpicConfig()` and wires the FHIR client + outbox emit into
+ * the job runners. Returns the Worker handle so the host can wire
+ * graceful-shutdown listeners.
+ *
+ * Returns null when Epic credentials are not configured — the host
+ * service should treat this as "Epic integration is disabled" rather
+ * than an error, so local dev keeps booting without registering with
+ * Epic.
+ */
+export function startEpicSyncWorker(): Worker<EpicSyncJobData> | null {
+  let config;
+  try {
+    config = loadEpicConfig();
+  } catch (err) {
+    log.info("Epic sync worker not started — credentials not configured", {
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const tokens = new EpicTokenClient(config);
+  const client = new EpicFhirClient(config, tokens);
+
+  const worker = new Worker<EpicSyncJobData>(
+    EPIC_SYNC_QUEUE_NAME,
+    async (job: Job<EpicSyncJobData>) => {
+      const start = Date.now();
+      try {
+        if (job.data.type === "full-sync") {
+          const results = await runFullSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise(results);
+        }
+        if (job.data.type === "incremental-sync") {
+          const results = await runIncrementalSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise(results);
+        }
+        if (job.data.type === "single-resource-sync") {
+          const result = await runSingleResourceSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+              resourceType: job.data.resource_type,
+              watermark: job.data.watermark ?? null,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise([result]);
+        }
+        // exhaustiveness guard
+        const exhaustive: never = job.data;
+        throw new Error(`Unknown job type: ${JSON.stringify(exhaustive)}`);
+      } finally {
+        const elapsed = Date.now() - start;
+        log.info("Epic sync job completed", {
+          jobId: job.id,
+          type: job.data.type,
+          elapsed_ms: elapsed,
+        });
+      }
+    },
+    { connection: getRedisConnection(), concurrency: 2 },
+  );
+
+  worker.on("failed", (job, err) => {
+    log.error("Epic sync job failed", {
+      jobId: job?.id,
+      error: err.message,
+    });
+  });
+
+  return worker;
+}
+
+function summarise(
+  results: Array<{
+    resource_type: string;
+    imported: number;
+    updated: number;
+    conflicts: number;
+    errors: string[];
+  }>,
+): {
+  imported: number;
+  updated: number;
+  conflicts: number;
+  errors: number;
+} {
+  return results.reduce(
+    (acc, r) => ({
+      imported: acc.imported + r.imported,
+      updated: acc.updated + r.updated,
+      conflicts: acc.conflicts + r.conflicts,
+      errors: acc.errors + r.errors.length,
+    }),
+    { imported: 0, updated: 0, conflicts: 0, errors: 0 },
+  );
+}

--- a/services/epic-connector/tsconfig.json
+++ b/services/epic-connector/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/services/epic-connector/vitest.config.ts
+++ b/services/epic-connector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/services/fhir-gateway/src/index.ts
+++ b/services/fhir-gateway/src/index.ts
@@ -20,3 +20,38 @@ export {
   toFhirPractitioner,
   type FhirObservation,
 } from "./generators/index.js";
+
+// Inbound resource mappers (#337/#1066 — used by importBundle and the
+// Epic FHIR client (#390) to project external FHIR resources into the
+// CareBridge row shapes the clinical-data writers consume).
+export {
+  mapFhirPatientToRow,
+  type InboundPatient,
+  type MappedPatientRow,
+} from "./patient-mapper.js";
+export {
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+  type MappedMedicationRow,
+} from "./medication-mapper.js";
+export {
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  type InboundObservation,
+  type MappedVitalRow,
+  type MappedLabResultRow,
+  type ObservationCategory,
+} from "./observation-mapper.js";
+export {
+  mapFhirConditionToRow,
+  type InboundCondition,
+  type MappedDiagnosisRow,
+} from "./condition-mapper.js";
+export {
+  mapFhirAllergyIntoleranceToRow,
+  type InboundAllergyIntolerance,
+  type MappedAllergyRow,
+} from "./allergy-mapper.js";


### PR DESCRIPTION
## Summary

Implements #393 — closes the Epic interop loop. AI oversight raises a flag in CareBridge → it lands on Epic as a FHIR Flag resource. Status changes (acknowledge / resolve / dismiss) propagate to Epic via PUT.

This completes the Epic epic stack. Combined with #1086 (sync worker), Epic data flows in, AI catches the cross-specialty gap Epic alone missed, and the resulting flag is visible inside Epic's Storyboard banner.

Stacked on **#1087** (#392 App Launch). Depends on **#1084** / **#1085** / **#1086** / **#1087**.

## What's in

- **Migration 0050 (idx 54)**: \`clinical_flags\` gains \`epic_flag_id\`, \`epic_org_iss\`, \`epic_pushed_at\`, \`epic_push_error\` tracking columns. Idempotent re-push by design.
- **FHIR Flag generator**: severity → \`Flag.code\` coding (CareBridge CodeSystem so Epic can render severity bands); status → \`active\` / \`inactive\`; rationale, suggested_action, rule_id as FHIR extensions; author = \`Organization/carebridge\`.
- **EpicFhirClient.createResource()** + **updateResource()** — POST / PUT with the same retry/backoff / 401-invalidate path as the existing reads.
- **Outbound orchestrator** (\`pushFlagToEpic\` / \`pushFlagStatusUpdate\`): POSTs new flags, PUTs status changes, stamps the row, writes \`audit_log\` (action=\`epic_flag_push\`) on success AND failure.
- **BullMQ epic-outbound-flags queue** + opt-in worker. Enqueue helpers check \`isEpicOutboundEnabled()\` and silently skip when \`EPIC_CLIENT_ID\` isn't set — callers don't duplicate env checks.
- **ai-oversight flag-service hooks**: createFlag / acknowledgeFlag / resolveFlag / dismissFlag → enqueue the push. All 938 existing ai-oversight tests still pass.

## Scope deferred to follow-ups

- **Bidirectional polling** — when an Epic user acknowledges the Flag inside Epic, that doesn't (yet) sync back to CareBridge. Add \`Flag\` to \`SUPPORTED_RESOURCE_TYPES\` in #1086's sync worker.
- **system/Flag.write scope UX** — the scope is requested in DEFAULT_SYSTEM_SCOPES; admins configure it via open.epic.com today.
- **Bulk re-push of historical flags** — only new/changed flags push from now on. A backfill mutation would be a small admin tRPC follow-up.

## Test plan

- [x] 20 new unit tests pass (\`pnpm --filter @carebridge/epic-connector test\` — 128 total). FHIR Flag shape verified against the spec. POST vs PUT path covered. Skip-when-no-Epic-mapping verified. Failure path writes \`audit_log\` with \`success=false\` + the truncated error. \`pushFlagStatusUpdate\` is a no-op until first push completes.
- [x] All 938 existing ai-oversight tests still pass after the flag-service hook
- [x] \`pnpm turbo typecheck lint\` clean across the monorepo (40/40 tasks)
- [ ] Live sandbox: enqueue a flag and verify it lands in Epic Storyboard (manual, after merge)

## Depends on

- #1084 — SMART Backend Services auth (#389)
- #1085 — FHIR R4 client (#390)
- #1086 — Sync worker (#391)
- #1087 — App Launch (#392)

## Closes

- #393