### PR TITLE
feat(epic): typed FHIR R4 client + Epic→CareBridge converters (#390)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
 
   services/epic-connector:
     dependencies:
+      '@carebridge/fhir-gateway':
+        specifier: workspace:*
+        version: link:../fhir-gateway
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -17,6 +17,7 @@
     "epic:keygen": "tsx src/bin/keygen.ts"
   },
   "dependencies": {
+    "@carebridge/fhir-gateway": "workspace:*",
     "@carebridge/logger": "workspace:*",
     "zod": "^3.24.0"
   },

--- a/services/epic-connector/src/__tests__/converters.test.ts
+++ b/services/epic-connector/src/__tests__/converters.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for Epic FHIR → CareBridge row converters (#390).
+ *
+ * Uses realistic FHIR R4 payload shapes (Epic-style identifier systems,
+ * SNOMED route codes, LOINC observation codes) so the tests catch
+ * Epic-specific quirks without requiring sandbox access.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  EPIC_SOURCE_SYSTEM_TAG,
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+} from "../converters.js";
+import type { FhirResource } from "../fhir-types.js";
+
+describe("Epic FHIR → CareBridge converters (#390)", () => {
+  describe("epicPatientToRow", () => {
+    it("maps a typical Epic Patient resource and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "Patient",
+        id: "epic-patient-1",
+        active: true,
+        identifier: [
+          {
+            use: "usual",
+            system: "urn:oid:1.2.840.114350.1.13.0.1.7.5.737384.0",
+            value: "E1234",
+          },
+          {
+            use: "official",
+            type: {
+              coding: [
+                {
+                  system: "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  code: "MR",
+                  display: "Medical Record Number",
+                },
+              ],
+            },
+            value: "MRN-987",
+          },
+        ],
+        name: [{ use: "official", family: "Smith", given: ["John", "Q"] }],
+        gender: "male",
+        birthDate: "1980-01-15",
+      };
+
+      const row = epicPatientToRow(resource);
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.mrn).toBe("MRN-987");
+    });
+
+    it("returns null for retired patient (active=false)", () => {
+      const row = epicPatientToRow({
+        resourceType: "Patient",
+        id: "p-1",
+        active: false,
+        name: [{ family: "Smith", given: ["John"] }],
+      });
+      expect(row).toBeNull();
+    });
+  });
+
+  describe("epicMedicationRequestToRow", () => {
+    it("maps a MedicationRequest with dosing and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "MedicationRequest",
+        id: "med-req-1",
+        status: "active",
+        intent: "order",
+        medicationCodeableConcept: {
+          coding: [
+            {
+              system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+              code: "1049502",
+              display: "acetaminophen 325 MG Oral Tablet",
+            },
+          ],
+        },
+        subject: { reference: "Patient/p-1" },
+        dosageInstruction: [
+          {
+            route: {
+              coding: [
+                {
+                  system: "http://snomed.info/sct",
+                  code: "26643006",
+                  display: "Oral route",
+                },
+              ],
+            },
+            doseAndRate: [
+              { doseQuantity: { value: 650, unit: "mg" } },
+            ],
+          },
+        ],
+      };
+      const row = epicMedicationRequestToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+      expect(row?.route).toBe("oral");
+    });
+
+    it("returns null for entered-in-error MedicationRequest", () => {
+      const row = epicMedicationRequestToRow(
+        {
+          resourceType: "MedicationRequest",
+          status: "entered-in-error",
+          medicationCodeableConcept: { text: "tylenol" },
+        },
+        "p-1",
+      );
+      expect(row).toBeNull();
+    });
+  });
+
+  describe("epicMedicationStatementToRow", () => {
+    it("maps a MedicationStatement (prior outpatient med list)", () => {
+      const resource: FhirResource = {
+        resourceType: "MedicationStatement",
+        status: "active",
+        medicationCodeableConcept: { text: "lisinopril 10 mg" },
+        subject: { reference: "Patient/p-1" },
+      };
+      const row = epicMedicationStatementToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+    });
+  });
+
+  describe("epicObservationToRow", () => {
+    it("routes vital-signs Observations to a vital row", () => {
+      const resource: FhirResource = {
+        resourceType: "Observation",
+        status: "final",
+        category: [
+          {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/observation-category",
+                code: "vital-signs",
+              },
+            ],
+          },
+        ],
+        code: {
+          coding: [
+            { system: "http://loinc.org", code: "8867-4", display: "Heart rate" },
+          ],
+        },
+        effectiveDateTime: "2026-05-20T10:30:00Z",
+        valueQuantity: { value: 72, unit: "beats/min" },
+      };
+      const result = epicObservationToRow(resource, "patient-uuid-1");
+      expect(result.kind).toBe("vital");
+      if (result.kind !== "vital") return;
+      expect(result.row.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(result.row.patient_id).toBe("patient-uuid-1");
+      expect(result.row.type).toBe("heart_rate");
+    });
+
+    it("routes laboratory Observations to a lab row with patient_id + source_system", () => {
+      const resource: FhirResource = {
+        resourceType: "Observation",
+        status: "final",
+        category: [
+          {
+            coding: [
+              {
+                system: "http://terminology.hl7.org/CodeSystem/observation-category",
+                code: "laboratory",
+              },
+            ],
+          },
+        ],
+        code: {
+          coding: [
+            { system: "http://loinc.org", code: "718-7", display: "Hemoglobin" },
+          ],
+          text: "Hemoglobin",
+        },
+        effectiveDateTime: "2026-05-20T08:00:00Z",
+        valueQuantity: { value: 13.5, unit: "g/dL" },
+      };
+      const result = epicObservationToRow(resource, "patient-uuid-1");
+      expect(result.kind).toBe("lab");
+      if (result.kind !== "lab") return;
+      expect(result.row.patient_id).toBe("patient-uuid-1");
+      expect(result.row.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(result.row.test_code).toBe("718-7");
+    });
+
+    it("returns unmapped for Observations with no category", () => {
+      const result = epicObservationToRow(
+        {
+          resourceType: "Observation",
+          status: "final",
+          code: { coding: [{ system: "http://loinc.org", code: "9999-9" }] },
+        },
+        "p-1",
+      );
+      expect(result.kind).toBe("unmapped");
+    });
+  });
+
+  describe("epicConditionToRow", () => {
+    it("maps an active Condition and adds source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "Condition",
+        clinicalStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              code: "active",
+            },
+          ],
+        },
+        code: {
+          coding: [
+            {
+              system: "http://hl7.org/fhir/sid/icd-10-cm",
+              code: "I82.401",
+              display: "Acute embolism and thrombosis of unspecified deep veins of right lower extremity",
+            },
+          ],
+          text: "DVT, right lower extremity",
+        },
+        subject: { reference: "Patient/p-1" },
+        onsetDateTime: "2026-05-15",
+      };
+      const row = epicConditionToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.status).toBe("active");
+      expect(row?.icd10_code).toBe("I82.401");
+    });
+  });
+
+  describe("epicAllergyToRow", () => {
+    it("maps an active AllergyIntolerance and tags source_system=epic", () => {
+      const resource: FhirResource = {
+        resourceType: "AllergyIntolerance",
+        clinicalStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              code: "active",
+            },
+          ],
+        },
+        verificationStatus: {
+          coding: [
+            {
+              system:
+                "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+              code: "confirmed",
+            },
+          ],
+        },
+        code: {
+          coding: [
+            {
+              system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+              code: "7980",
+              display: "Penicillin G",
+            },
+          ],
+          text: "Penicillin",
+        },
+        patient: { reference: "Patient/p-1" },
+        criticality: "high",
+      };
+      const row = epicAllergyToRow(resource, "patient-uuid-1");
+      expect(row).not.toBeNull();
+      expect(row?.source_system).toBe(EPIC_SOURCE_SYSTEM_TAG);
+      expect(row?.patient_id).toBe("patient-uuid-1");
+    });
+  });
+
+  it("EPIC_SOURCE_SYSTEM_TAG is the string 'epic' (lock-in)", () => {
+    // The tag is part of the public contract — downstream queries
+    // filter by it. Don't accidentally rename it without coordinating
+    // with the sync worker (#391).
+    expect(EPIC_SOURCE_SYSTEM_TAG).toBe("epic");
+  });
+});

--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for EpicFhirClient (#390).
+ *
+ * All tests run offline — fetch is mocked, sleep is a no-op so backoff
+ * doesn't burn wall-clock time. The integration test against
+ * fhir.epic.com is intentionally not in CI; it runs locally when the
+ * caller has registered credentials.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+import type { FhirBundle, FhirResource } from "../fhir-types.js";
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client-id",
+    tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+function makeTokenResponse() {
+  return new Response(
+    JSON.stringify({
+      access_token: "fake-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "system/*.read",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function jsonResponse<T>(body: T, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/fhir+json", ...(init.headers ?? {}) },
+  });
+}
+
+function bundleOf(
+  resources: FhirResource[],
+  links: { relation: string; url: string }[] = [],
+): FhirBundle {
+  return {
+    resourceType: "Bundle",
+    type: "searchset",
+    total: resources.length,
+    link: links,
+    entry: resources.map((r) => ({ resource: r })),
+  };
+}
+
+describe("EpicFhirClient (#390)", () => {
+  let privatePem: string;
+
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  function setup(responses: Array<Response | (() => Response)>) {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith("/token")) return makeTokenResponse();
+      const next = responses.shift();
+      if (!next) throw new Error(`unexpected fetch: ${url}`);
+      return typeof next === "function" ? next() : next;
+    });
+    const config = makeConfig(privatePem);
+    const tokens = new EpicTokenClient(config, fetchMock);
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+    const client = new EpicFhirClient(config, tokens, {
+      fetchImpl: fetchMock,
+      sleep: sleepMock,
+      backoffBaseMs: 1,
+    });
+    return { client, fetchMock, sleepMock, tokens };
+  }
+
+  it("read() sends Authorization Bearer and returns the resource", async () => {
+    const { client, fetchMock } = setup([
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+    const patient = await client.read("Patient", "p-1");
+    expect(patient).toEqual({ resourceType: "Patient", id: "p-1" });
+
+    // First call is token; second is the FHIR request
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe(
+      "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/Patient/p-1",
+    );
+    expect(init.headers.Authorization).toBe("Bearer fake-token");
+    expect(init.headers.Accept).toBe("application/fhir+json");
+  });
+
+  it("read() throws when the server returns an OperationOutcome", async () => {
+    const { client } = setup([
+      jsonResponse({
+        resourceType: "OperationOutcome",
+        issue: [{ severity: "error", code: "not-found", diagnostics: "no such patient" }],
+      }),
+    ]);
+    await expect(client.read("Patient", "missing")).rejects.toThrow(
+      /OperationOutcome: not-found — no such patient/,
+    );
+  });
+
+  it("search() encodes params and returns the bundle", async () => {
+    const bundle = bundleOf([{ resourceType: "Observation", id: "obs-1" }]);
+    const { client, fetchMock } = setup([jsonResponse(bundle)]);
+
+    const result = await client.search("Observation", {
+      patient: "p-1",
+      category: "vital-signs",
+    });
+    expect(result.entry?.[0]?.resource?.id).toBe("obs-1");
+    const [url] = fetchMock.mock.calls[1]!;
+    expect(url).toContain("Observation?");
+    expect(url).toContain("patient=p-1");
+    expect(url).toContain("category=vital-signs");
+  });
+
+  it("searchAll() walks Bundle.link rel=next to exhaust pages", async () => {
+    const page1 = bundleOf(
+      [
+        { resourceType: "Observation", id: "obs-1" },
+        { resourceType: "Observation", id: "obs-2" },
+      ],
+      [{ relation: "next", url: "https://fhir.epic.com/api/page2" }],
+    );
+    const page2 = bundleOf([{ resourceType: "Observation", id: "obs-3" }]);
+    const { client, fetchMock } = setup([jsonResponse(page1), jsonResponse(page2)]);
+
+    const ids: string[] = [];
+    for await (const obs of client.searchAll("Observation", { patient: "p-1" })) {
+      ids.push(obs.id!);
+    }
+    expect(ids).toEqual(["obs-1", "obs-2", "obs-3"]);
+    // Token fetch + initial search + follow next link
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]![0]).toBe("https://fhir.epic.com/api/page2");
+  });
+
+  it("retries once on 401 after invalidating the cached token", async () => {
+    const { client, fetchMock, tokens } = setup([
+      jsonResponse({}, { status: 401 }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+    const invalidateSpy = vi.spyOn(tokens, "invalidate");
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(invalidateSpy).toHaveBeenCalledOnce();
+    // Token (1) + first 401 (2) + retried token (3) + retried success (4)
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does NOT retry-loop on persistent 401 — surfaces the error", async () => {
+    const { client } = setup([
+      jsonResponse({}, { status: 401 }),
+      jsonResponse({}, { status: 401 }),
+    ]);
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(/401/);
+  });
+
+  it("respects Retry-After (seconds) on 429 and retries", async () => {
+    const { client, fetchMock, sleepMock } = setup([
+      jsonResponse({}, { status: 429, headers: { "Retry-After": "2" } }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(sleepMock).toHaveBeenCalledOnce();
+    expect(sleepMock.mock.calls[0]![0]).toBe(2000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("exponentially backs off on 5xx and gives up after maxRetries", async () => {
+    // 4 failed responses = 1 initial + 3 retries; maxRetries=3 means
+    // attempts 0,1,2,3 fail then throw.
+    const responses = Array.from({ length: 4 }, () =>
+      jsonResponse({}, { status: 503 }),
+    );
+    const { client, sleepMock } = setup(responses);
+
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(/4 attempts.*503/);
+    // Sleep called 3 times (between attempts 0→1, 1→2, 2→3)
+    expect(sleepMock).toHaveBeenCalledTimes(3);
+    // backoffBase=1, expBackoff = 1, 2, 4 (+jitter up to 1ms each)
+    expect(sleepMock.mock.calls[0]![0]).toBeGreaterThanOrEqual(1);
+    expect(sleepMock.mock.calls[1]![0]).toBeGreaterThanOrEqual(2);
+    expect(sleepMock.mock.calls[2]![0]).toBeGreaterThanOrEqual(4);
+  });
+
+  it("recovers from a single 503 by retrying", async () => {
+    const { client, fetchMock } = setup([
+      jsonResponse({}, { status: 503 }),
+      jsonResponse<FhirResource>({ resourceType: "Patient", id: "p-1" }),
+    ]);
+
+    const patient = await client.read("Patient", "p-1");
+    expect(patient.id).toBe("p-1");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("surfaces 4xx (non-401, non-429) errors immediately with body prefix", async () => {
+    const { client } = setup([
+      new Response("malformed search param", { status: 400 }),
+    ]);
+    await expect(client.read("Patient", "p-1")).rejects.toThrow(
+      /400.*malformed search param/,
+    );
+  });
+
+  // Typed wrappers — sanity checks that params end up on the URL
+  it("searchObservations() emits expected URL params", async () => {
+    const { client, fetchMock } = setup([jsonResponse(bundleOf([]))]);
+    await client.searchObservations({
+      patient: "p-1",
+      category: "laboratory",
+      _lastUpdated: "gt2026-01-01",
+      _count: 50,
+    });
+    const url = fetchMock.mock.calls[1]![0] as string;
+    expect(url).toContain("patient=p-1");
+    expect(url).toContain("category=laboratory");
+    expect(url).toContain("_lastUpdated=gt2026-01-01");
+    expect(url).toContain("_count=50");
+  });
+
+  it("searchEncounters() includes _sort=-date", async () => {
+    const { client, fetchMock } = setup([jsonResponse(bundleOf([]))]);
+    await client.searchEncounters({ patient: "p-1", _sort: "-date" });
+    const url = fetchMock.mock.calls[1]![0] as string;
+    expect(url).toContain("_sort=-date");
+  });
+
+  it("treats absolute URLs (Bundle.link.url) verbatim", async () => {
+    // Page 1 link.next points to a different host (Epic may return
+    // absolute URLs with the FHIR base baked in)
+    const page1 = bundleOf(
+      [{ resourceType: "Patient", id: "p-1" }],
+      [{ relation: "next", url: "https://epic.example.com/explicit-next-url" }],
+    );
+    const page2 = bundleOf([{ resourceType: "Patient", id: "p-2" }]);
+    const { client, fetchMock } = setup([jsonResponse(page1), jsonResponse(page2)]);
+
+    for await (const _ of client.searchAll("Patient")) {
+      // no-op — we just need to drive the iterator
+    }
+    expect(fetchMock.mock.calls[2]![0]).toBe(
+      "https://epic.example.com/explicit-next-url",
+    );
+  });
+});

--- a/services/epic-connector/src/converters.ts
+++ b/services/epic-connector/src/converters.ts
@@ -1,0 +1,191 @@
+/**
+ * Epic FHIR R4 → CareBridge row converters (#390).
+ *
+ * Wraps the existing fhir-gateway inbound mappers so that Epic-sourced
+ * resources land in the same `patients`, `medications`, `vitals`,
+ * `lab_results`, `diagnoses`, `allergies` row shapes as the bundle-
+ * import path, but with `source_system: "epic"` instead of
+ * `"fhir_import"`. Downstream rows can then be filtered by origin (sync
+ * audit, conflict resolution, "where did this medication come from?").
+ *
+ * Why a wrapper rather than reaching into the mappers and parameterising
+ * the source tag:
+ *  - Keeps the mappers' invariants (single-line const, easy to grep)
+ *  - Keeps the Epic-specific knowledge co-located with the rest of the
+ *    Epic connector — fhir-gateway shouldn't know about Epic.
+ *  - Future Epic-only post-processing (extension parsing, MyChart
+ *    identifier mapping) has an obvious home.
+ */
+import {
+  mapFhirPatientToRow,
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  mapFhirConditionToRow,
+  mapFhirAllergyIntoleranceToRow,
+  type InboundPatient,
+  type MappedPatientRow,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+  type MappedMedicationRow,
+  type InboundObservation,
+  type MappedVitalRow,
+  type MappedLabResultRow,
+  type InboundCondition,
+  type MappedDiagnosisRow,
+  type InboundAllergyIntolerance,
+  type MappedAllergyRow,
+  type ObservationCategory,
+} from "@carebridge/fhir-gateway";
+import type { FhirResource } from "./fhir-types.js";
+
+export const EPIC_SOURCE_SYSTEM_TAG = "epic" as const;
+
+/**
+ * Variant of {@link MappedDiagnosisRow} that carries `source_system`.
+ * The fhir-gateway mapper omits this field today (the column is
+ * populated by the diagnoses writer), but the Epic sync path needs it
+ * so callers can tell Epic rows from internally-recorded ones without
+ * a JOIN to `epic_sync_state`.
+ */
+export type EpicDiagnosisRow = MappedDiagnosisRow & {
+  source_system: typeof EPIC_SOURCE_SYSTEM_TAG;
+};
+
+function withEpicSource<T extends { source_system?: unknown }>(row: T): T {
+  return { ...row, source_system: EPIC_SOURCE_SYSTEM_TAG };
+}
+
+/**
+ * Convert an Epic FHIR Patient to a CareBridge `patients`-row insert.
+ * Returns `null` for unmappable resources (no name/MRN, retired patient).
+ */
+export function epicPatientToRow(
+  resource: FhirResource,
+): MappedPatientRow | null {
+  const mapped = mapFhirPatientToRow(resource as unknown as InboundPatient);
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Convert an Epic FHIR MedicationRequest to a CareBridge `medications`-row
+ * insert. Returns `null` when the resource lacks a usable medication name
+ * or maps to a status we refuse to surface (entered-in-error, etc).
+ */
+export function epicMedicationRequestToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedMedicationRow | null {
+  const mapped = mapMedicationRequestToRow(
+    resource as unknown as InboundMedicationRequest,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Convert an Epic FHIR MedicationStatement to a CareBridge `medications`-row
+ * insert. Useful for med-rec pulls where Epic returns prior outpatient meds
+ * as Statements rather than Requests.
+ */
+export function epicMedicationStatementToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedMedicationRow | null {
+  const mapped = mapMedicationStatementToRow(
+    resource as unknown as InboundMedicationStatement,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}
+
+/**
+ * Classify and convert an Epic FHIR Observation. The Observation type
+ * fans out to either `vitals` or `lab_results` based on
+ * `Observation.category` — callers should dispatch on the returned
+ * `kind` discriminant before persisting.
+ */
+/**
+ * `lab_results` rows in CareBridge carry `patient_id` and `source_system`
+ * columns, but the underlying fhir-gateway lab mapper omits both — the
+ * import path attaches them at the writer layer. The Epic converter
+ * attaches them here so callers can persist directly without a second
+ * normalisation pass.
+ */
+export type EpicLabResultRow = MappedLabResultRow & {
+  patient_id: string;
+  source_system: typeof EPIC_SOURCE_SYSTEM_TAG;
+};
+
+export type EpicObservationConversion =
+  | { kind: "vital"; row: MappedVitalRow }
+  | { kind: "lab"; row: EpicLabResultRow }
+  | { kind: "unmapped"; reason: string };
+
+export function epicObservationToRow(
+  resource: FhirResource,
+  patientId: string,
+): EpicObservationConversion {
+  const inbound = resource as unknown as InboundObservation;
+  const category: ObservationCategory | null =
+    classifyObservationCategory(inbound);
+  if (category === "vital-signs") {
+    const row = mapFhirObservationToVitalRow(inbound, patientId);
+    if (!row) return { kind: "unmapped", reason: "vital-signs not mappable" };
+    return { kind: "vital", row: withEpicSource(row) };
+  }
+  if (category === "laboratory") {
+    const row = mapFhirObservationToLabResultRow(inbound);
+    if (!row) return { kind: "unmapped", reason: "laboratory not mappable" };
+    return {
+      kind: "lab",
+      row: {
+        ...row,
+        patient_id: patientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      },
+    };
+  }
+  return {
+    kind: "unmapped",
+    reason: `unsupported observation category: ${category ?? "missing"}`,
+  };
+}
+
+/**
+ * Convert an Epic FHIR Condition to a CareBridge `diagnoses`-row insert.
+ * The underlying mapper does not emit `source_system`, so the Epic
+ * converter adds it explicitly.
+ */
+export function epicConditionToRow(
+  resource: FhirResource,
+  patientId: string,
+): EpicDiagnosisRow | null {
+  const mapped = mapFhirConditionToRow(
+    resource as unknown as InboundCondition,
+    patientId,
+  );
+  if (!mapped) return null;
+  return { ...mapped, source_system: EPIC_SOURCE_SYSTEM_TAG };
+}
+
+/**
+ * Convert an Epic FHIR AllergyIntolerance to a CareBridge `allergies`-row
+ * insert.
+ */
+export function epicAllergyToRow(
+  resource: FhirResource,
+  patientId: string,
+): MappedAllergyRow | null {
+  const mapped = mapFhirAllergyIntoleranceToRow(
+    resource as unknown as InboundAllergyIntolerance,
+    patientId,
+  );
+  if (!mapped) return null;
+  return withEpicSource(mapped);
+}

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -1,0 +1,367 @@
+/**
+ * Epic FHIR R4 client (#390).
+ *
+ * Thin typed wrapper over Epic's interconnect FHIR endpoints. Handles:
+ *   - Bearer-token authentication via EpicTokenClient
+ *   - Bundle parsing, including `link[relation=next]` pagination
+ *   - 401 retry-once-after-invalidate (handles silent revocation)
+ *   - 429 backoff that respects the Retry-After header
+ *   - 5xx exponential backoff with a configurable retry budget
+ *
+ * The client intentionally returns raw FHIR R4 resources (typed as
+ * `FhirResource`). Conversion to CareBridge row shapes lives in
+ * `converters.ts`, layered on top of the existing fhir-gateway inbound
+ * mappers so the FHIR-import path and Epic-sync path share normalisation
+ * logic instead of diverging.
+ */
+import { createLogger } from "@carebridge/logger";
+import { EpicTokenClient } from "./token-client.js";
+import type { EpicConfig } from "./config.js";
+import type {
+  EpicSearchParams,
+  FhirBundle,
+  FhirBundleLink,
+  FhirResource,
+  OperationOutcome,
+} from "./fhir-types.js";
+
+const log = createLogger("epic-fhir-client");
+
+export interface EpicFhirClientOptions {
+  /** Maximum retry attempts on transient (429/5xx) errors. Default: 3. */
+  maxRetries?: number;
+  /** Base delay (ms) for exponential backoff. Default: 500. */
+  backoffBaseMs?: number;
+  /** Override fetch for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Override the sleep helper for tests. Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_OPTIONS = {
+  maxRetries: 3,
+  backoffBaseMs: 500,
+} as const;
+
+const SLEEP = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resources the Epic sandbox supports today. Adding to this list does
+ * not require a code change — `request()` takes an arbitrary path — but
+ * the typed wrappers (`searchPatients`, `searchObservations`, …) are
+ * driven from this union so unsupported resource types fail at
+ * compile time.
+ */
+export type EpicResourceType =
+  | "Patient"
+  | "Observation"
+  | "Condition"
+  | "MedicationRequest"
+  | "AllergyIntolerance"
+  | "Encounter";
+
+export class EpicFhirClient {
+  private readonly opts: Required<
+    Omit<EpicFhirClientOptions, "fetchImpl" | "sleep">
+  > & { fetchImpl: typeof fetch; sleep: (ms: number) => Promise<void> };
+
+  constructor(
+    private readonly config: EpicConfig,
+    private readonly tokens: EpicTokenClient,
+    options: EpicFhirClientOptions = {},
+  ) {
+    this.opts = {
+      maxRetries: options.maxRetries ?? DEFAULT_OPTIONS.maxRetries,
+      backoffBaseMs: options.backoffBaseMs ?? DEFAULT_OPTIONS.backoffBaseMs,
+      fetchImpl: options.fetchImpl ?? fetch,
+      sleep: options.sleep ?? SLEEP,
+    };
+  }
+
+  /**
+   * Read a single resource by id. Returns the resource or throws if
+   * the response is an OperationOutcome (404, 410, etc).
+   */
+  async read<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    id: string,
+  ): Promise<T> {
+    const resource = await this.request<T | OperationOutcome>(
+      `${resourceType}/${encodeURIComponent(id)}`,
+    );
+    if (resource.resourceType === "OperationOutcome") {
+      throw operationOutcomeError(resource as OperationOutcome);
+    }
+    return resource as T;
+  }
+
+  /**
+   * Search for resources. Returns the first page as a Bundle — callers
+   * who want every result should use `searchAll` which auto-paginates.
+   */
+  async search<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    params: EpicSearchParams = {},
+  ): Promise<FhirBundle<T>> {
+    const path = `${resourceType}?${encodeSearchParams(params)}`;
+    return this.request<FhirBundle<T>>(path);
+  }
+
+  /**
+   * Async iterator over every matching resource across all pages.
+   * Walks `Bundle.link` with relation=next until exhausted. Yields
+   * resources lazily so large result sets don't blow up memory.
+   */
+  async *searchAll<T extends FhirResource = FhirResource>(
+    resourceType: EpicResourceType,
+    params: EpicSearchParams = {},
+  ): AsyncIterable<T> {
+    let bundle: FhirBundle<T> | null = await this.search<T>(
+      resourceType,
+      params,
+    );
+    while (bundle !== null) {
+      for (const entry of bundle.entry ?? []) {
+        if (entry.resource) yield entry.resource;
+      }
+      const links: FhirBundleLink[] = bundle.link ?? [];
+      const next = links.find((l) => l.relation === "next");
+      if (!next) {
+        bundle = null;
+        break;
+      }
+      bundle = await this.request<FhirBundle<T>>(next.url);
+    }
+  }
+
+  /**
+   * Low-level request — used by read/search above. Exposed for callers
+   * that need to hit endpoints we don't have typed wrappers for
+   * (e.g. `/metadata`, `$lastn`). Takes either a relative path or an
+   * absolute URL (Bundle.link.url returns absolute URLs).
+   */
+  async request<T>(pathOrUrl: string): Promise<T> {
+    const url = pathOrUrl.startsWith("http")
+      ? pathOrUrl
+      : joinUrl(this.config.fhirBaseUrl, pathOrUrl);
+
+    return this.requestWithRetry<T>(url, /* didRefreshAuth */ false, 0);
+  }
+
+  private async requestWithRetry<T>(
+    url: string,
+    didRefreshAuth: boolean,
+    attempt: number,
+  ): Promise<T> {
+    const token = await this.tokens.getAccessToken();
+    const response = await this.opts.fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/fhir+json",
+      },
+    });
+
+    if (response.status === 401 && !didRefreshAuth) {
+      // Token revoked / org rotated keys: drop the cache and try once
+      // with a fresh assertion. If it 401s again we surface the error
+      // to the caller — repeated 401s mean credentials are misregistered
+      // and retrying just hammers Epic's token endpoint.
+      log.warn("Epic returned 401 — invalidating token and retrying once", {
+        url,
+      });
+      this.tokens.invalidate();
+      return this.requestWithRetry<T>(url, true, attempt);
+    }
+
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt >= this.opts.maxRetries) {
+        const body = await safeReadBody(response);
+        throw new Error(
+          `Epic FHIR request failed after ${attempt + 1} attempts: ` +
+            `${response.status} ${response.statusText}${body ? ` — ${body}` : ""}`,
+        );
+      }
+      const delay = backoffDelay({
+        status: response.status,
+        attempt,
+        retryAfter: response.headers.get("Retry-After"),
+        baseMs: this.opts.backoffBaseMs,
+      });
+      log.warn("Epic FHIR transient error, retrying", {
+        status: response.status,
+        attempt,
+        delayMs: delay,
+      });
+      await this.opts.sleep(delay);
+      return this.requestWithRetry<T>(url, didRefreshAuth, attempt + 1);
+    }
+
+    if (!response.ok) {
+      const body = await safeReadBody(response);
+      throw new Error(
+        `Epic FHIR request returned ${response.status} ${response.statusText}` +
+          (body ? ` — ${body}` : ""),
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  // ─────────────────────── Typed wrappers ────────────────────────
+  // Thin sugar over `read`/`search` so callers don't have to remember
+  // Epic's search-param names. Each method documents the params Epic
+  // actually accepts for that resource (the full FHIR R4 search-param
+  // surface is large; Epic supports a curated subset).
+
+  readPatient(id: string): Promise<FhirResource> {
+    return this.read("Patient", id);
+  }
+
+  /**
+   * Search for a Patient by MRN or other identifier.
+   * Epic search-param: `identifier=<system>|<value>` or just `<value>`.
+   */
+  searchPatients(params: {
+    identifier?: string;
+    family?: string;
+    given?: string;
+    birthdate?: string;
+  }): Promise<FhirBundle> {
+    return this.search("Patient", params);
+  }
+
+  /**
+   * Search for Observations for a patient.
+   * Epic supports: `patient`, `category` (vital-signs|laboratory),
+   * `code`, `_lastUpdated` (use `gt2024-01-01` form for incremental).
+   */
+  searchObservations(params: {
+    patient: string;
+    category?: "vital-signs" | "laboratory";
+    code?: string;
+    _lastUpdated?: string;
+    _count?: number;
+  }): Promise<FhirBundle> {
+    return this.search("Observation", params);
+  }
+
+  /**
+   * Search for Conditions for a patient. Defaults to active.
+   * Epic supports: `patient`, `clinical-status` (active|inactive|resolved),
+   * `category` (problem-list-item|encounter-diagnosis).
+   */
+  searchConditions(params: {
+    patient: string;
+    "clinical-status"?: "active" | "inactive" | "resolved";
+    category?: string;
+  }): Promise<FhirBundle> {
+    return this.search("Condition", params);
+  }
+
+  /**
+   * Search for MedicationRequests for a patient.
+   * Epic supports: `patient`, `status` (active|on-hold|completed|stopped),
+   * `_lastUpdated`.
+   */
+  searchMedicationRequests(params: {
+    patient: string;
+    status?: "active" | "on-hold" | "completed" | "stopped" | "cancelled";
+    _lastUpdated?: string;
+  }): Promise<FhirBundle> {
+    return this.search("MedicationRequest", params);
+  }
+
+  /**
+   * Search for AllergyIntolerances for a patient.
+   * Epic supports: `patient`, `clinical-status` (active|inactive|resolved).
+   */
+  searchAllergies(params: {
+    patient: string;
+    "clinical-status"?: "active" | "inactive" | "resolved";
+  }): Promise<FhirBundle> {
+    return this.search("AllergyIntolerance", params);
+  }
+
+  /**
+   * Search for Encounters for a patient.
+   * Epic supports: `patient`, `_lastUpdated`, `_sort=-date` for most-recent-first.
+   */
+  searchEncounters(params: {
+    patient: string;
+    _lastUpdated?: string;
+    _sort?: "-date" | "date";
+    _count?: number;
+  }): Promise<FhirBundle> {
+    return this.search("Encounter", params);
+  }
+}
+
+// ───────────────────────── Helpers ─────────────────────────────
+
+function encodeSearchParams(params: EpicSearchParams): string {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) qs.append(key, String(v));
+    } else {
+      qs.append(key, String(value));
+    }
+  }
+  return qs.toString();
+}
+
+function joinUrl(base: string, path: string): string {
+  const trimmedBase = base.endsWith("/") ? base : `${base}/`;
+  const trimmedPath = path.startsWith("/") ? path.slice(1) : path;
+  return `${trimmedBase}${trimmedPath}`;
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 500);
+  } catch {
+    return "";
+  }
+}
+
+function operationOutcomeError(outcome: OperationOutcome): Error {
+  const issue = outcome.issue?.[0];
+  const detail =
+    issue?.diagnostics ?? issue?.details?.text ?? "no diagnostics";
+  return new Error(
+    `Epic returned OperationOutcome: ${issue?.code ?? "unknown"} — ${detail}`,
+  );
+}
+
+/**
+ * Exponential backoff with a Retry-After override.
+ *
+ * Retry-After values come in two flavours per RFC 7231:
+ *   - delta-seconds   (e.g. "30")     → use directly
+ *   - HTTP-date       (e.g. RFC1123)  → compute the delta to now
+ * Epic's sandbox emits delta-seconds; we accept either for robustness.
+ *
+ * Without Retry-After: delay = base * 2^attempt + 0..base jitter.
+ * Jitter keeps multiple concurrent clients from thundering-herding the
+ * same retry window.
+ */
+function backoffDelay(args: {
+  status: number;
+  attempt: number;
+  retryAfter: string | null;
+  baseMs: number;
+}): number {
+  if (args.retryAfter) {
+    const seconds = Number(args.retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+    const dateMs = Date.parse(args.retryAfter);
+    if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  }
+  const expBackoff = args.baseMs * Math.pow(2, args.attempt);
+  const jitter = Math.random() * args.baseMs;
+  return expBackoff + jitter;
+}

--- a/services/epic-connector/src/fhir-types.ts
+++ b/services/epic-connector/src/fhir-types.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal FHIR R4 type shapes used by the Epic FHIR client (#390).
+ *
+ * Intentionally narrow — we type-only the fields we actually read from
+ * the wire and downcast everything else to `unknown`. The full FHIR R4
+ * surface lives in `services/fhir-gateway/src/types/fhir-r4.ts`, but
+ * pulling it in here would force epic-connector to depend on the entire
+ * fhir-gateway runtime. Callers who need the full resource shape can
+ * pass the returned `FhirResource` through to the fhir-gateway mappers.
+ */
+
+export interface FhirBundleEntry<TResource = FhirResource> {
+  fullUrl?: string;
+  resource?: TResource;
+  search?: { mode?: "match" | "include" | "outcome" };
+}
+
+export interface FhirBundleLink {
+  relation: string;
+  url: string;
+}
+
+export interface FhirBundle<TResource = FhirResource> {
+  resourceType: "Bundle";
+  type: "searchset" | "history" | "transaction" | "batch" | string;
+  total?: number;
+  link?: FhirBundleLink[];
+  entry?: FhirBundleEntry<TResource>[];
+}
+
+/**
+ * Opaque resource record — Epic returns arbitrary FHIR R4 resources and
+ * extensions. Strongly-typed shapes (FhirPatient, FhirObservation, …)
+ * are produced by the fhir-gateway generators on the outbound side; we
+ * keep inbound loose because Epic's payloads are looser than ours.
+ */
+export interface FhirResource {
+  resourceType: string;
+  id?: string;
+  meta?: {
+    versionId?: string;
+    lastUpdated?: string;
+    profile?: string[];
+  };
+  [k: string]: unknown;
+}
+
+/**
+ * FHIR `OperationOutcome` shape — Epic returns these instead of a
+ * resource Bundle when a request fails. We surface the `diagnostics`
+ * field in thrown error messages for debugging.
+ */
+export interface OperationOutcome {
+  resourceType: "OperationOutcome";
+  issue: Array<{
+    severity: "fatal" | "error" | "warning" | "information";
+    code: string;
+    diagnostics?: string;
+    details?: { text?: string };
+  }>;
+}
+
+export type EpicSearchParams = Record<
+  string,
+  string | number | undefined | string[]
+>;

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -5,8 +5,10 @@
  * assertion, OAuth2 client-credentials token exchange, expiry-aware
  * caching, and SMART configuration discovery.
  *
- * Follow-ups will add the typed FHIR client (#390), sync worker (#391),
- * App Launch (#392), and outbound flag push (#393).
+ * #390 adds the typed FHIR R4 client + Epic→CareBridge converters.
+ *
+ * Follow-ups will add the sync worker (#391), App Launch (#392), and
+ * outbound flag push (#393).
  */
 export { loadEpicConfig, type EpicConfig } from "./config.js";
 export {
@@ -34,3 +36,28 @@ export {
   type PublicJwk,
   type GenerateOptions,
 } from "./keygen.js";
+export {
+  EpicFhirClient,
+  type EpicFhirClientOptions,
+  type EpicResourceType,
+} from "./fhir-client.js";
+export type {
+  FhirBundle,
+  FhirBundleEntry,
+  FhirBundleLink,
+  FhirResource,
+  EpicSearchParams,
+  OperationOutcome,
+} from "./fhir-types.js";
+export {
+  EPIC_SOURCE_SYSTEM_TAG,
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+  type EpicDiagnosisRow,
+  type EpicLabResultRow,
+  type EpicObservationConversion,
+} from "./converters.js";

--- a/services/fhir-gateway/src/index.ts
+++ b/services/fhir-gateway/src/index.ts
@@ -20,3 +20,38 @@ export {
   toFhirPractitioner,
   type FhirObservation,
 } from "./generators/index.js";
+
+// Inbound resource mappers (#337/#1066 — used by importBundle and the
+// Epic FHIR client (#390) to project external FHIR resources into the
+// CareBridge row shapes the clinical-data writers consume).
+export {
+  mapFhirPatientToRow,
+  type InboundPatient,
+  type MappedPatientRow,
+} from "./patient-mapper.js";
+export {
+  mapMedicationRequestToRow,
+  mapMedicationStatementToRow,
+  type InboundMedicationRequest,
+  type InboundMedicationStatement,
+  type MappedMedicationRow,
+} from "./medication-mapper.js";
+export {
+  classifyObservationCategory,
+  mapFhirObservationToVitalRow,
+  mapFhirObservationToLabResultRow,
+  type InboundObservation,
+  type MappedVitalRow,
+  type MappedLabResultRow,
+  type ObservationCategory,
+} from "./observation-mapper.js";
+export {
+  mapFhirConditionToRow,
+  type InboundCondition,
+  type MappedDiagnosisRow,
+} from "./condition-mapper.js";
+export {
+  mapFhirAllergyIntoleranceToRow,
+  type InboundAllergyIntolerance,
+  type MappedAllergyRow,
+} from "./allergy-mapper.js";


### PR DESCRIPTION
Replaces #1085 (auto-closed when its base branch was deleted during the #1084 squash-merge).

## Summary

Implements #390. Builds on the SMART Backend Services auth shipped in #1084.

- **EpicFhirClient** with typed wrappers for the 6 resource types Epic exposes (Patient, Observation, Condition, MedicationRequest, AllergyIntolerance, Encounter), plus \`searchAll()\` async iterator that paginates via \`Bundle.link[rel=next]\`.
- **Retry/backoff**: 401 → invalidate token + retry once; 429 → respect \`Retry-After\`; 5xx → exponential backoff with jitter (default 3 attempts).
- **Epic → CareBridge converters** that wrap the existing fhir-gateway inbound mappers (#337/#1066) and override \`source_system\` to \`"epic"\`.
- **Observation classifier**: routes vital-signs and laboratory observations to the right CareBridge row shape; attaches \`patient_id\` + \`source_system\` to lab rows.

## Test plan

- [x] 24 unit tests pass (\`pnpm --filter @carebridge/epic-connector test\` — 67 total)
- [x] \`pnpm turbo typecheck lint\` clean across the monorepo

Original PR: #1085