### PR TITLE
feat(epic): BullMQ sync worker, persistence, AI-oversight integration (#391)

### DIFF
--- a/packages/db-schema/drizzle/0048_epic_sync_state.sql
+++ b/packages/db-schema/drizzle/0048_epic_sync_state.sql
@@ -1,0 +1,30 @@
+-- #391: per-patient, per-resource-type Epic sync bookkeeping.
+--
+-- The Epic sync worker (services/epic-connector/src/workers/sync-worker.ts)
+-- pulls FHIR resources from Epic on a schedule. To support incremental
+-- pulls (Epic search-param `_lastUpdated=gt<ts>`) and to surface sync
+-- health in the clinician portal, we track the last successful sync
+-- timestamp, the FHIR `_lastUpdated` watermark, and the most recent
+-- error per (patient_id, resource_type) tuple.
+--
+-- One row per (patient, resource_type). `last_fhir_lastupdated` is the
+-- watermark used in the next incremental request (NOT the wall-clock
+-- time the sync ran — that's `last_synced_at`).
+CREATE TABLE IF NOT EXISTS "epic_sync_state" (
+  "patient_id" text NOT NULL REFERENCES "patients"("id"),
+  "resource_type" text NOT NULL,
+  "last_synced_at" text,
+  "last_fhir_lastupdated" text,
+  "status" text NOT NULL DEFAULT 'pending',
+  "resources_synced_count" integer NOT NULL DEFAULT 0,
+  "error_count" integer NOT NULL DEFAULT 0,
+  "last_error_message" text,
+  "last_error_at" text,
+  PRIMARY KEY ("patient_id", "resource_type")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_epic_sync_state_status"
+  ON "epic_sync_state" ("status");
+
+CREATE INDEX IF NOT EXISTS "idx_epic_sync_state_last_synced"
+  ON "epic_sync_state" ("last_synced_at");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1747929840000,
       "tag": "0047_medications_concentration",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1747929900000,
+      "tag": "0048_epic_sync_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/epic-sync.ts
+++ b/packages/db-schema/src/schema/epic-sync.ts
@@ -1,0 +1,45 @@
+import { pgTable, text, integer, primaryKey, index } from "drizzle-orm/pg-core";
+import { patients } from "./patients.js";
+
+/**
+ * Per-patient, per-resource-type Epic sync bookkeeping (#391).
+ *
+ * The Epic sync worker reads/writes one row per (patient_id, resource_type)
+ * tuple to drive incremental pulls (`_lastUpdated=gt<watermark>`) and to
+ * surface sync health in the clinician portal.
+ *
+ * Columns:
+ *   - last_synced_at        — wall-clock time the sync job last RAN
+ *   - last_fhir_lastupdated — FHIR `_lastUpdated` watermark to feed the
+ *                             NEXT incremental request. NOT the same as
+ *                             `last_synced_at` — Epic resources may be
+ *                             back-dated days after `last_synced_at`.
+ *   - status                — pending | running | ok | failed
+ *   - resources_synced_count — cumulative successful imports
+ *   - error_count           — cumulative failures
+ */
+export const epicSyncState = pgTable(
+  "epic_sync_state",
+  {
+    patient_id: text("patient_id")
+      .notNull()
+      .references(() => patients.id),
+    resource_type: text("resource_type").notNull(),
+    last_synced_at: text("last_synced_at"),
+    last_fhir_lastupdated: text("last_fhir_lastupdated"),
+    status: text("status").notNull().default("pending"),
+    resources_synced_count: integer("resources_synced_count")
+      .notNull()
+      .default(0),
+    error_count: integer("error_count").notNull().default(0),
+    last_error_message: text("last_error_message"),
+    last_error_at: text("last_error_at"),
+  },
+  (table) => [
+    primaryKey({ columns: [table.patient_id, table.resource_type] }),
+    index("idx_epic_sync_state_status").on(table.status),
+    index("idx_epic_sync_state_last_synced").on(table.last_synced_at),
+  ],
+);
+
+export type EpicSyncStatus = "pending" | "running" | "ok" | "failed";

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -13,3 +13,4 @@ export * from "./emergency-access.js";
 export * from "./fhir.js";
 export * from "./family-access.js";
 export * from "./allergy-overrides.js";
+export * from "./epic-sync.js";

--- a/packages/test-utils/src/mock-db.ts
+++ b/packages/test-utils/src/mock-db.ts
@@ -134,6 +134,8 @@ function createChainProxy(
     "groupBy",
     "having",
     "offset",
+    "onConflictDoUpdate",
+    "onConflictDoNothing",
   ] as const;
 
   for (const name of chainNames) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/epic-connector':
+        specifier: workspace:*
+        version: link:../epic-connector
       '@carebridge/fhir-gateway':
         specifier: workspace:*
         version: link:../fhir-gateway
@@ -630,12 +633,33 @@ importers:
 
   services/epic-connector:
     dependencies:
+      '@carebridge/db-schema':
+        specifier: workspace:*
+        version: link:../../packages/db-schema
       '@carebridge/fhir-gateway':
         specifier: workspace:*
         version: link:../fhir-gateway
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger
+      '@carebridge/outbox':
+        specifier: workspace:*
+        version: link:../../packages/outbox
+      '@carebridge/redis-config':
+        specifier: workspace:*
+        version: link:../../packages/redis-config
+      '@carebridge/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+      '@trpc/server':
+        specifier: ^11.0.0
+        version: 11.16.0(typescript@5.9.3)
+      bullmq:
+        specifier: ^5.30.0
+        version: 5.74.1
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/react@19.2.14)(postgres@3.4.9)(react@19.2.5)
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -19,6 +19,7 @@
     "@carebridge/clinical-data": "workspace:*",
     "@carebridge/clinical-notes": "workspace:*",
     "@carebridge/ai-oversight": "workspace:*",
+    "@carebridge/epic-connector": "workspace:*",
     "@carebridge/notifications": "workspace:*",
     "@carebridge/logger": "workspace:*",
     "@carebridge/scheduling": "workspace:*",

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -11,6 +11,7 @@ import { fhirRbacRouter } from "./routers/fhir.js";
 import { notificationsRbacRouter } from "./routers/notifications.js";
 import { familyAccessRbacRouter } from "./routers/family-access.js";
 import { careTeamRbacRouter } from "./routers/care-team.js";
+import { epicSyncRbacRouter } from "./routers/epic-sync.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -32,6 +33,7 @@ export const appRouter = router({
   fhir: fhirRbacRouter,
   familyAccess: familyAccessRbacRouter,
   careTeam: careTeamRbacRouter,
+  epicSync: epicSyncRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/routers/epic-sync.ts
+++ b/services/api-gateway/src/routers/epic-sync.ts
@@ -1,0 +1,158 @@
+/**
+ * RBAC-enforced Epic-sync router (#391).
+ *
+ * Layered on top of the raw `epicSyncRouter` exported from
+ * @carebridge/epic-connector. All procedures require authentication;
+ * `triggerSync` is admin-only (manually re-pulling someone else's patient
+ * data is a privileged operation, even with no PHI leak risk).
+ * `getSyncStatus` and `listSyncErrors` honour the same care-team RBAC
+ * the ai-oversight router uses.
+ */
+import { initTRPC, TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+  SUPPORTED_RESOURCE_TYPES,
+} from "@carebridge/epic-connector";
+import type { Context } from "../context.js";
+import { assertCareTeamAccess } from "../middleware/rbac.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+const isAdmin = isAuthenticated.unstable_pipe(({ ctx, next }) => {
+  if (ctx.user.role !== "admin") {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Only admins may trigger Epic sync jobs",
+    });
+  }
+  return next({ ctx });
+});
+const adminProcedure = t.procedure.use(isAdmin);
+
+async function enforcePatientAccess(
+  user: NonNullable<Context["user"]>,
+  patientId: string,
+  clientIp?: string | null,
+): Promise<void> {
+  if (user.role === "admin") return;
+  if (user.role === "patient") {
+    if (user.id !== patientId) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "Access denied: patients may only access their own sync status",
+      });
+    }
+    return;
+  }
+  const hasAccess = await assertCareTeamAccess(user.id, patientId, clientIp);
+  if (!hasAccess) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Access denied: no active care-team assignment for this patient",
+    });
+  }
+}
+
+const syncResourceTypeSchema = z.enum(
+  SUPPORTED_RESOURCE_TYPES as [string, ...string[]],
+);
+
+export const epicSyncRbacRouter = t.router({
+  /**
+   * Admin-only mutation that enqueues a sync job for a patient.
+   */
+  triggerSync: adminProcedure
+    .input(
+      z.discriminatedUnion("mode", [
+        z.object({
+          mode: z.literal("full"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("incremental"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("single"),
+          patient_id: z.string().uuid(),
+          resource_type: syncResourceTypeSchema,
+          epic_patient_fhir_id: z.string().optional(),
+          watermark: z.string().nullish(),
+        }),
+      ]),
+    )
+    .mutation(async ({ input }) => {
+      if (input.mode === "full") {
+        await enqueueFullSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return { enqueued: "full-sync" as const, patient_id: input.patient_id };
+      }
+      if (input.mode === "incremental") {
+        await enqueueIncrementalSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return {
+          enqueued: "incremental-sync" as const,
+          patient_id: input.patient_id,
+        };
+      }
+      await enqueueSingleResourceSync({
+        patient_id: input.patient_id,
+        resource_type:
+          input.resource_type as (typeof SUPPORTED_RESOURCE_TYPES)[number],
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        watermark: input.watermark,
+      });
+      return {
+        enqueued: "single-resource-sync" as const,
+        patient_id: input.patient_id,
+        resource_type: input.resource_type,
+      };
+    }),
+
+  /**
+   * Read sync status rows for a patient. Care-team RBAC is enforced.
+   */
+  getSyncStatus: protectedProcedure
+    .input(z.object({ patient_id: z.string().uuid() }))
+    .query(async ({ input, ctx }) => {
+      await enforcePatientAccess(
+        ctx.user,
+        input.patient_id,
+        ctx.clientIp ?? null,
+      );
+      return getAllSyncStatesForPatient(input.patient_id);
+    }),
+
+  /**
+   * Admin-only list of recent sync failures across patients.
+   */
+  listSyncErrors: adminProcedure
+    .input(z.object({ limit: z.number().min(1).max(500).optional() }))
+    .query(async ({ input }) => {
+      return listRecentFailures(input.limit);
+    }),
+});

--- a/services/epic-connector/package.json
+++ b/services/epic-connector/package.json
@@ -17,8 +17,15 @@
     "epic:keygen": "tsx src/bin/keygen.ts"
   },
   "dependencies": {
+    "@carebridge/db-schema": "workspace:*",
     "@carebridge/fhir-gateway": "workspace:*",
     "@carebridge/logger": "workspace:*",
+    "@carebridge/outbox": "workspace:*",
+    "@carebridge/redis-config": "workspace:*",
+    "@carebridge/shared-types": "workspace:*",
+    "@trpc/server": "^11.0.0",
+    "bullmq": "^5.30.0",
+    "drizzle-orm": "^0.38.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the sync-job orchestrators (#391).
+ *
+ * Verifies the full/incremental/single dispatch wiring without touching
+ * Redis, Postgres, or Epic. Persistence + sync-state-repo are mocked so
+ * each test can assert exactly which calls the orchestrator made.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ClinicalEvent } from "@carebridge/shared-types";
+
+// ── Mock persistence ─────────────────────────────────────────────
+const persistPatient = vi.fn();
+const persistObservation = vi.fn();
+const persistCondition = vi.fn();
+const persistMedicationRequest = vi.fn();
+const persistAllergy = vi.fn();
+
+vi.mock("../sync/persistence.js", () => ({
+  persistPatient,
+  persistObservation,
+  persistCondition,
+  persistMedicationRequest,
+  persistAllergy,
+  persistMedicationStatement: vi.fn(),
+}));
+
+// ── Mock sync-state-repo ─────────────────────────────────────────
+const markRunning = vi.fn().mockResolvedValue(undefined);
+const markOk = vi.fn().mockResolvedValue(undefined);
+const markFailed = vi.fn().mockResolvedValue(undefined);
+const getSyncState = vi.fn().mockResolvedValue(null);
+
+vi.mock("../sync/sync-state-repo.js", () => ({
+  markRunning,
+  markOk,
+  markFailed,
+  getSyncState,
+  getAllSyncStatesForPatient: vi.fn(),
+  listRecentFailures: vi.fn(),
+}));
+
+// ── Import after mocks ──────────────────────────────────────────
+const {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  SUPPORTED_RESOURCE_TYPES,
+} = await import("../sync/sync-jobs.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+const EPIC_PATIENT_FHIR_ID = "epic-patient-1";
+
+function makeFakeClient(resourcesByType: Record<string, unknown[]>) {
+  return {
+    readPatient: vi.fn().mockResolvedValue(
+      resourcesByType.Patient?.[0] ?? {
+        resourceType: "Patient",
+        id: EPIC_PATIENT_FHIR_ID,
+      },
+    ),
+    searchAll: vi.fn().mockImplementation((resourceType: string) => {
+      const list = resourcesByType[resourceType] ?? [];
+      return (async function* () {
+        for (const r of list) yield r;
+      })();
+    }),
+  } as unknown as Parameters<typeof runFullSync>[1]["client"];
+}
+
+describe("Epic sync-jobs (#391)", () => {
+  let emit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emit = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("runSingleResourceSync fetches, persists, and emits a clinical-event with source_system=epic", async () => {
+    persistObservation.mockResolvedValueOnce({
+      internalId: "internal-vital-1",
+      kind: "vital",
+      inserted: true,
+    });
+    const client = makeFakeClient({
+      Observation: [
+        { resourceType: "Observation", id: "obs-1", meta: { lastUpdated: "2026-05-20T10:00:00Z" } },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markRunning).toHaveBeenCalledWith(PATIENT_ID, "Observation");
+    expect(persistObservation).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledOnce();
+
+    const event = emit.mock.calls[0]![0] as ClinicalEvent;
+    expect(event.type).toBe("vital.created");
+    expect(event.patient_id).toBe(PATIENT_ID);
+    expect(event.data.source_system).toBe("epic");
+    expect(event.data.epic_fhir_id).toBe("obs-1");
+    expect(event.data.operation).toBe("created");
+
+    expect(markOk).toHaveBeenCalledOnce();
+    expect(markOk.mock.calls[0]![0]).toMatchObject({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      highWatermark: "2026-05-20T10:00:00Z",
+      importedCount: 1,
+    });
+
+    expect(result).toMatchObject({
+      patient_id: PATIENT_ID,
+      resource_type: "Observation",
+      imported: 1,
+      updated: 0,
+      conflicts: 0,
+      errors: [],
+    });
+  });
+
+  it("emits vital.updated (not vital.created) when persist reports inserted=false", async () => {
+    persistObservation.mockResolvedValueOnce({
+      internalId: "internal-vital-1",
+      kind: "vital",
+      inserted: false,
+    });
+    const client = makeFakeClient({
+      Observation: [{ resourceType: "Observation", id: "obs-1" }],
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    const event = emit.mock.calls[0]![0] as ClinicalEvent;
+    expect(event.type).toBe("vital.updated");
+    expect(event.data.operation).toBe("updated");
+  });
+
+  it("does NOT emit when persist returns a conflict", async () => {
+    persistMedicationRequest.mockResolvedValueOnce({
+      internalId: "internal-med-1",
+      kind: "medication",
+      inserted: false,
+      conflict: "source_system_conflict",
+    });
+    const client = makeFakeClient({
+      MedicationRequest: [
+        { resourceType: "MedicationRequest", id: "med-1" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(emit).not.toHaveBeenCalled();
+    expect(result.conflicts).toBe(1);
+    expect(result.imported).toBe(0);
+  });
+
+  it("skips unmapped resources without crashing the loop", async () => {
+    persistObservation
+      .mockResolvedValueOnce({
+        internalId: null,
+        kind: "unmapped",
+        inserted: false,
+      })
+      .mockResolvedValueOnce({
+        internalId: "internal-vital-2",
+        kind: "vital",
+        inserted: true,
+      });
+    const client = makeFakeClient({
+      Observation: [
+        { resourceType: "Observation", id: "obs-unmappable" },
+        { resourceType: "Observation", id: "obs-good" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(persistObservation).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenCalledOnce();
+    expect(result.imported).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("captures per-resource failures without aborting the resource-type batch", async () => {
+    persistCondition
+      .mockRejectedValueOnce(new Error("write blew up"))
+      .mockResolvedValueOnce({
+        internalId: "diag-2",
+        kind: "diagnosis",
+        inserted: true,
+      });
+    const client = makeFakeClient({
+      Condition: [
+        { resourceType: "Condition", id: "cond-1" },
+        { resourceType: "Condition", id: "cond-2" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(1);
+    expect(result.errors).toEqual(["write blew up"]);
+    // Failure of one resource still results in `markOk` for the batch —
+    // the per-resource errors are surfaced via the SyncResult, not by
+    // marking the whole resource_type as failed.
+    expect(markOk).toHaveBeenCalled();
+  });
+
+  it("marks the resource_type FAILED when the fetch itself throws", async () => {
+    const client = makeFakeClient({});
+    (client.searchAll as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("network down");
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markFailed).toHaveBeenCalledWith({
+      patientId: PATIENT_ID,
+      resourceType: "Condition",
+      errorMessage: "network down",
+    });
+    expect(result.errors).toContain("network down");
+  });
+
+  it("Patient resource fetch uses readPatient(epicPatientFhirId), not searchAll", async () => {
+    persistPatient.mockResolvedValueOnce({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({
+      Patient: [{ resourceType: "Patient", id: EPIC_PATIENT_FHIR_ID }],
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Patient",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(client.readPatient).toHaveBeenCalledWith(EPIC_PATIENT_FHIR_ID);
+    expect(client.searchAll).not.toHaveBeenCalled();
+  });
+
+  it("incremental sync passes the stored watermark as _lastUpdated=gt<value>", async () => {
+    getSyncState.mockImplementation(async (_p, rt) =>
+      rt === "Observation"
+        ? {
+            patient_id: PATIENT_ID,
+            resource_type: "Observation",
+            last_fhir_lastupdated: "2026-05-01T00:00:00Z",
+            last_synced_at: "2026-05-01T00:00:00Z",
+            status: "ok",
+            resources_synced_count: 5,
+            error_count: 0,
+            last_error_message: null,
+            last_error_at: null,
+          }
+        : null,
+    );
+    persistPatient.mockResolvedValue({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({});
+
+    await runIncrementalSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+      },
+      { client, emit },
+    );
+
+    const observationCall = (client.searchAll as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === "Observation",
+    );
+    expect(observationCall).toBeDefined();
+    expect(observationCall![1]._lastUpdated).toBe("gt2026-05-01T00:00:00Z");
+  });
+
+  it("full sync iterates every supported resource type", async () => {
+    persistPatient.mockResolvedValue({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({});
+    await runFullSync(
+      { patientId: PATIENT_ID, epicPatientFhirId: EPIC_PATIENT_FHIR_ID },
+      { client, emit },
+    );
+    // Patient = readPatient; the rest = searchAll
+    const searchedTypes = (client.searchAll as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0],
+    );
+    for (const rt of SUPPORTED_RESOURCE_TYPES) {
+      if (rt === "Patient") continue;
+      expect(searchedTypes).toContain(rt);
+    }
+  });
+});

--- a/services/epic-connector/src/__tests__/sync-state-repo.test.ts
+++ b/services/epic-connector/src/__tests__/sync-state-repo.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the epic_sync_state CRUD helpers (#391).
+ *
+ * Uses the shared mock-db builder so the chain assertions stay decoupled
+ * from any drizzle method-order quirks. No real Postgres involved.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  epicSyncState: {
+    patient_id: "patient_id",
+    resource_type: "resource_type",
+    status: "status",
+    last_error_at: "last_error_at",
+  },
+}));
+
+const {
+  getSyncState,
+  getAllSyncStatesForPatient,
+  markRunning,
+  markOk,
+  markFailed,
+  listRecentFailures,
+} = await import("../sync/sync-state-repo.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+describe("epic_sync_state repo (#391)", () => {
+  it("getSyncState returns the first row or null", async () => {
+    db.willSelect([
+      {
+        patient_id: PATIENT_ID,
+        resource_type: "Observation",
+        status: "ok",
+        last_synced_at: "2026-05-20T00:00:00Z",
+        last_fhir_lastupdated: "2026-05-19T23:00:00Z",
+        resources_synced_count: 5,
+        error_count: 0,
+        last_error_message: null,
+        last_error_at: null,
+      },
+    ]);
+    const row = await getSyncState(PATIENT_ID, "Observation");
+    expect(row?.status).toBe("ok");
+    expect(row?.last_fhir_lastupdated).toBe("2026-05-19T23:00:00Z");
+  });
+
+  it("getSyncState returns null when no row exists", async () => {
+    db.willSelect([]);
+    const row = await getSyncState(PATIENT_ID, "Observation");
+    expect(row).toBeNull();
+  });
+
+  it("getAllSyncStatesForPatient returns every row for the patient", async () => {
+    db.willSelect([
+      { patient_id: PATIENT_ID, resource_type: "Observation", status: "ok" },
+      { patient_id: PATIENT_ID, resource_type: "Condition", status: "failed" },
+    ]);
+    const rows = await getAllSyncStatesForPatient(PATIENT_ID);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("markRunning upserts a row with status=running", async () => {
+    db.willInsert();
+    await markRunning(PATIENT_ID, "Observation");
+    expect(db.insert).toHaveBeenCalledOnce();
+    const call = db.insert.calls[0]!;
+    expect(call.chain).toContain("values");
+    expect(call.chain).toContain("onConflictDoUpdate");
+    const values = call.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.status).toBe("running");
+  });
+
+  it("markOk records the high watermark and increments the success counter", async () => {
+    db.willInsert();
+    await markOk({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      highWatermark: "2026-05-20T12:00:00Z",
+      importedCount: 7,
+    });
+    expect(db.insert).toHaveBeenCalledOnce();
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.status).toBe("ok");
+    expect(values.last_fhir_lastupdated).toBe("2026-05-20T12:00:00Z");
+    expect(values.resources_synced_count).toBe(7);
+  });
+
+  it("markFailed truncates very long error messages to 1KiB", async () => {
+    db.willInsert();
+    const oversized = "x".repeat(2048);
+    await markFailed({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      errorMessage: oversized,
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect((values.last_error_message as string).length).toBe(1024);
+    expect(values.status).toBe("failed");
+    expect(values.error_count).toBe(1);
+  });
+
+  it("listRecentFailures filters status=failed and orders by last_error_at desc", async () => {
+    db.willSelect([
+      { patient_id: PATIENT_ID, resource_type: "Observation", status: "failed" },
+    ]);
+    const rows = await listRecentFailures(10);
+    expect(rows).toHaveLength(1);
+    const call = db.select.calls[0]!;
+    expect(call.chain).toContain("where");
+    expect(call.chain).toContain("orderBy");
+    expect(call.chain).toContain("limit");
+  });
+});

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -7,8 +7,10 @@
  *
  * #390 adds the typed FHIR R4 client + Epic→CareBridge converters.
  *
- * Follow-ups will add the sync worker (#391), App Launch (#392), and
- * outbound flag push (#393).
+ * #391 adds the BullMQ sync worker, persistence layer, clinical-event
+ * emission, and tRPC surface for sync orchestration / status.
+ *
+ * Follow-ups will add App Launch (#392) and outbound flag push (#393).
  */
 export { loadEpicConfig, type EpicConfig } from "./config.js";
 export {
@@ -61,3 +63,42 @@ export {
   type EpicLabResultRow,
   type EpicObservationConversion,
 } from "./converters.js";
+export {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  SUPPORTED_RESOURCE_TYPES,
+  type SyncResourceType,
+  type SyncResult,
+  type SyncJobDeps,
+  type EmitFn,
+} from "./sync/sync-jobs.js";
+export {
+  getSyncState,
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+  markRunning,
+  markOk,
+  markFailed,
+  type EpicSyncStateRow,
+  type EpicSyncStatusValue,
+} from "./sync/sync-state-repo.js";
+export {
+  persistPatient,
+  persistMedicationRequest,
+  persistMedicationStatement,
+  persistObservation,
+  persistCondition,
+  persistAllergy,
+  type PersistResult,
+} from "./sync/persistence.js";
+export {
+  startEpicSyncWorker,
+  getEpicSyncQueue,
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+  EPIC_SYNC_QUEUE_NAME,
+  type EpicSyncJobData,
+} from "./workers/sync-worker.js";
+export { epicSyncRouter, type EpicSyncRouter } from "./router.js";

--- a/services/epic-connector/src/router.ts
+++ b/services/epic-connector/src/router.ts
@@ -1,0 +1,121 @@
+/**
+ * Epic-sync tRPC router (#391).
+ *
+ * Surface for the clinician portal's Epic sync dashboard and for
+ * admin-driven manual sync triggers. Wired into the api-gateway via
+ * services/api-gateway/src/routers/epic-sync.ts which adds RBAC.
+ *
+ * This module exports the raw router; auth/RBAC is layered in the
+ * gateway, mirroring how ai-oversight, clinical-data and patient-records
+ * structure their wrappers.
+ *
+ * Procedures:
+ *   - epicSync.triggerSync       — enqueue a sync job (admin)
+ *   - epicSync.getSyncStatus     — read all (patient, resource_type)
+ *                                  rows for a patient
+ *   - epicSync.listSyncErrors    — paginate the most recent failed
+ *                                  sync rows across patients
+ */
+import { initTRPC } from "@trpc/server";
+import { z } from "zod";
+import {
+  enqueueFullSync,
+  enqueueIncrementalSync,
+  enqueueSingleResourceSync,
+} from "./workers/sync-worker.js";
+import {
+  getAllSyncStatesForPatient,
+  listRecentFailures,
+} from "./sync/sync-state-repo.js";
+import { SUPPORTED_RESOURCE_TYPES } from "./sync/sync-jobs.js";
+
+const t = initTRPC.create();
+
+const syncResourceTypeSchema = z.enum(
+  SUPPORTED_RESOURCE_TYPES as [string, ...string[]],
+);
+
+export const epicSyncRouter = t.router({
+  /**
+   * Enqueue a sync job. Three flavours:
+   *   full         — pull every resource type, no watermark
+   *   incremental  — pull every resource type, using stored watermarks
+   *   single       — pull one resource type, optional watermark
+   */
+  triggerSync: t.procedure
+    .input(
+      z.discriminatedUnion("mode", [
+        z.object({
+          mode: z.literal("full"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("incremental"),
+          patient_id: z.string().uuid(),
+          epic_patient_fhir_id: z.string().optional(),
+        }),
+        z.object({
+          mode: z.literal("single"),
+          patient_id: z.string().uuid(),
+          resource_type: syncResourceTypeSchema,
+          epic_patient_fhir_id: z.string().optional(),
+          watermark: z.string().nullish(),
+        }),
+      ]),
+    )
+    .mutation(async ({ input }) => {
+      if (input.mode === "full") {
+        await enqueueFullSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return { enqueued: "full-sync", patient_id: input.patient_id };
+      }
+      if (input.mode === "incremental") {
+        await enqueueIncrementalSync({
+          patient_id: input.patient_id,
+          epic_patient_fhir_id: input.epic_patient_fhir_id,
+        });
+        return {
+          enqueued: "incremental-sync",
+          patient_id: input.patient_id,
+        };
+      }
+      await enqueueSingleResourceSync({
+        patient_id: input.patient_id,
+        // safe: the zod enum schema is built from SUPPORTED_RESOURCE_TYPES
+        resource_type:
+          input.resource_type as (typeof SUPPORTED_RESOURCE_TYPES)[number],
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        watermark: input.watermark,
+      });
+      return {
+        enqueued: "single-resource-sync",
+        patient_id: input.patient_id,
+        resource_type: input.resource_type,
+      };
+    }),
+
+  /**
+   * Read every (resource_type) sync row for a patient. The clinician
+   * portal renders this as the per-patient Epic-sync health card.
+   */
+  getSyncStatus: t.procedure
+    .input(z.object({ patient_id: z.string().uuid() }))
+    .query(async ({ input }) => {
+      return getAllSyncStatesForPatient(input.patient_id);
+    }),
+
+  /**
+   * List the most recent N failed syncs across all patients — powers
+   * the admin "things needing attention" dashboard.
+   */
+  listSyncErrors: t.procedure
+    .input(z.object({ limit: z.number().min(1).max(500).optional() }))
+    .query(async ({ input }) => {
+      return listRecentFailures(input.limit);
+    }),
+});
+
+export type EpicSyncRouter = typeof epicSyncRouter;

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -1,0 +1,638 @@
+/**
+ * Persistence layer for Epic-synced FHIR resources (#391).
+ *
+ * Each persistResource* function:
+ *  1. Looks up the existing CareBridge row for the (Epic resource_type, resource_id)
+ *     tuple via the `fhir_resources` mapping table.
+ *  2. UPSERTs the target row (insert when no mapping exists; update when
+ *     it does).
+ *  3. UPSERTs the `fhir_resources` mapping row so the next sync pull can
+ *     find the same internal row.
+ *  4. Records a conflict to `audit_log` if the existing target row has
+ *     `source_system != "epic"` — Epic does not get to overwrite
+ *     CareBridge-originated data; we keep CareBridge's row and log the
+ *     attempted overwrite for manual review.
+ *
+ * Idempotent by design: re-running the same FHIR resource is a no-op
+ * after the first call other than refreshing `updated_at`. This lets
+ * the BullMQ job runner retry freely on transient errors.
+ */
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import {
+  getDb,
+  patients,
+  medications,
+  vitals,
+  labPanels,
+  labResults,
+  diagnoses,
+  allergies,
+  fhirResources,
+  auditLog,
+} from "@carebridge/db-schema";
+import {
+  epicPatientToRow,
+  epicMedicationRequestToRow,
+  epicMedicationStatementToRow,
+  epicObservationToRow,
+  epicConditionToRow,
+  epicAllergyToRow,
+  EPIC_SOURCE_SYSTEM_TAG,
+} from "../converters.js";
+import type { FhirResource } from "../fhir-types.js";
+
+const EPIC_SYNC_AUDIT_USER = "system:epic-sync";
+
+export interface PersistResult {
+  /** Internal CareBridge row id, or null when the resource was unmappable. */
+  internalId: string | null;
+  /** Discriminator for downstream event emission. */
+  kind:
+    | "patient"
+    | "medication"
+    | "vital"
+    | "lab"
+    | "diagnosis"
+    | "allergy"
+    | "unmapped";
+  /** True when the call inserted a new row; false when it updated. */
+  inserted: boolean;
+  /** Set when the call rejected an Epic update due to source_system mismatch. */
+  conflict?: string;
+}
+
+interface MappingLookup {
+  internalId: string | null;
+  /** When set, an existing target row owns this resource with non-Epic source. */
+  existingSourceSystem?: string | null;
+}
+
+async function findMapping(
+  resourceType: string,
+  fhirId: string,
+): Promise<MappingLookup> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(fhirResources)
+    .where(
+      and(
+        eq(fhirResources.resource_type, resourceType),
+        eq(fhirResources.resource_id, fhirId),
+      ),
+    )
+    .limit(1);
+  const existing = rows[0];
+  if (!existing) return { internalId: null };
+  return {
+    internalId: existing.internal_record_id ?? null,
+    existingSourceSystem: existing.source_system,
+  };
+}
+
+async function upsertMapping(args: {
+  resourceType: string;
+  fhirId: string;
+  internalId: string;
+  patientId: string | null;
+  resource: unknown;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  // fhir_resources.id is a free-form PK in the existing schema; we
+  // synthesise a deterministic id from (resource_type, fhir_id) so a
+  // re-emit upserts the same mapping row rather than appending.
+  const mappingId = `epic:${args.resourceType}:${args.fhirId}`;
+  await db
+    .insert(fhirResources)
+    .values({
+      id: mappingId,
+      resource_type: args.resourceType,
+      resource_id: args.fhirId,
+      patient_id: args.patientId,
+      resource: args.resource as object,
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      internal_record_id: args.internalId,
+      imported_at: now,
+    })
+    .onConflictDoUpdate({
+      target: fhirResources.id,
+      set: {
+        resource: args.resource as object,
+        internal_record_id: args.internalId,
+        imported_at: now,
+      },
+    });
+}
+
+async function logSourceConflict(args: {
+  resourceType: string;
+  fhirId: string;
+  internalId: string;
+  patientId: string | null;
+  existingSourceSystem: string | null | undefined;
+}): Promise<void> {
+  const db = getDb();
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: EPIC_SYNC_AUDIT_USER,
+    action: "update",
+    resource_type: args.resourceType,
+    resource_id: args.internalId,
+    patient_id: args.patientId,
+    success: false,
+    details: JSON.stringify({
+      reason: "source_system_conflict",
+      attempted_source: EPIC_SOURCE_SYSTEM_TAG,
+      existing_source: args.existingSourceSystem ?? null,
+      epic_fhir_id: args.fhirId,
+      resolution: "keep_carebridge_value",
+    }),
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Per-row write helpers: each calls findMapping → INSERT or UPDATE on
+ * the target table → upsertMapping. The conflict check (source_system
+ * != "epic") refuses to overwrite CareBridge-originated rows.
+ */
+
+export async function persistPatient(
+  resource: FhirResource,
+): Promise<PersistResult> {
+  const row = epicPatientToRow(resource);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const mapping = await findMapping("Patient", fhirId);
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  if (mapping.internalId) {
+    // Patient already imported — update only Epic-owned rows.
+    // Patient identity is treated as Epic-owned when first imported
+    // from Epic, so the conflict check is a belt-and-braces guard.
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "Patient",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId: mapping.internalId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "patient",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(patients)
+      .set({
+        name: row.name,
+        date_of_birth: row.date_of_birth,
+        biological_sex: row.biological_sex,
+        mrn: row.mrn ?? undefined,
+        updated_at: now,
+      })
+      .where(eq(patients.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Patient",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId: mapping.internalId,
+      resource,
+    });
+    return { internalId: mapping.internalId, kind: "patient", inserted: false };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(patients).values({
+    id,
+    mrn: row.mrn ?? undefined,
+    name: row.name,
+    date_of_birth: row.date_of_birth,
+    biological_sex: row.biological_sex,
+    created_at: now,
+    updated_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Patient",
+    fhirId,
+    internalId: id,
+    patientId: id,
+    resource,
+  });
+  return { internalId: id, kind: "patient", inserted: true };
+}
+
+export async function persistMedicationRequest(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const row = epicMedicationRequestToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+  return persistMedicationRow(row, resource, patientId, "MedicationRequest");
+}
+
+export async function persistMedicationStatement(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const row = epicMedicationStatementToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+  return persistMedicationRow(row, resource, patientId, "MedicationStatement");
+}
+
+async function persistMedicationRow(
+  row: NonNullable<ReturnType<typeof epicMedicationRequestToRow>>,
+  resource: FhirResource,
+  patientId: string,
+  resourceType: "MedicationRequest" | "MedicationStatement",
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const mapping = await findMapping(resourceType, fhirId);
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType,
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "medication",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(medications)
+      .set({
+        name: row.name,
+        dose_amount: row.dose_amount,
+        dose_unit: row.dose_unit,
+        route: row.route,
+        frequency: row.frequency,
+        status: row.status,
+        rxnorm_code: row.rxnorm_code,
+        max_doses_per_day: row.max_doses_per_day,
+        updated_at: now,
+      })
+      .where(eq(medications.id, mapping.internalId));
+    await upsertMapping({
+      resourceType,
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "medication",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(medications).values({
+    id,
+    patient_id: patientId,
+    name: row.name,
+    dose_amount: row.dose_amount,
+    dose_unit: row.dose_unit,
+    route: row.route,
+    frequency: row.frequency,
+    status: row.status,
+    rxnorm_code: row.rxnorm_code,
+    max_doses_per_day: row.max_doses_per_day,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
+    created_at: now,
+    updated_at: now,
+  });
+  await upsertMapping({
+    resourceType,
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "medication", inserted: true };
+}
+
+export async function persistObservation(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const conversion = epicObservationToRow(resource, patientId);
+  if (conversion.kind === "unmapped") {
+    return { internalId: null, kind: "unmapped", inserted: false };
+  }
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("Observation", fhirId);
+
+  if (conversion.kind === "vital") {
+    if (mapping.internalId) {
+      if (
+        mapping.existingSourceSystem &&
+        mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+      ) {
+        await logSourceConflict({
+          resourceType: "Observation",
+          fhirId,
+          internalId: mapping.internalId,
+          patientId,
+          existingSourceSystem: mapping.existingSourceSystem,
+        });
+        return {
+          internalId: mapping.internalId,
+          kind: "vital",
+          inserted: false,
+          conflict: "source_system_conflict",
+        };
+      }
+      await db
+        .update(vitals)
+        .set({
+          type: conversion.row.type,
+          loinc_code: conversion.row.loinc_code,
+          value_primary: conversion.row.value_primary,
+          value_secondary: conversion.row.value_secondary,
+          unit: conversion.row.unit,
+          recorded_at: conversion.row.recorded_at,
+        })
+        .where(eq(vitals.id, mapping.internalId));
+      await upsertMapping({
+        resourceType: "Observation",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        resource,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "vital",
+        inserted: false,
+      };
+    }
+    const id = crypto.randomUUID();
+    await db.insert(vitals).values({
+      id,
+      patient_id: patientId,
+      type: conversion.row.type,
+      loinc_code: conversion.row.loinc_code,
+      value_primary: conversion.row.value_primary,
+      value_secondary: conversion.row.value_secondary,
+      unit: conversion.row.unit,
+      recorded_at: conversion.row.recorded_at,
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      created_at: now,
+    });
+    await upsertMapping({
+      resourceType: "Observation",
+      fhirId,
+      internalId: id,
+      patientId,
+      resource,
+    });
+    return { internalId: id, kind: "vital", inserted: true };
+  }
+
+  // Lab result — single-result panel synthesised for the Epic
+  // resource. Multi-test panels arriving from Epic come in as a
+  // DiagnosticReport (deferred to #391-followup) and are not handled
+  // here yet.
+  if (mapping.internalId) {
+    // Existing lab_results rows are leaves — conflict logic on the panel
+    // level is out of scope for the first cut. Refresh the value in place.
+    await db
+      .update(labResults)
+      .set({
+        test_name: conversion.row.test_name,
+        test_code: conversion.row.test_code,
+        value: conversion.row.value,
+        unit: conversion.row.unit,
+        reference_low: conversion.row.reference_low,
+        reference_high: conversion.row.reference_high,
+        flag: conversion.row.flag,
+      })
+      .where(eq(labResults.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Observation",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return { internalId: mapping.internalId, kind: "lab", inserted: false };
+  }
+
+  const panelId = crypto.randomUUID();
+  await db.insert(labPanels).values({
+    id: panelId,
+    patient_id: patientId,
+    panel_name: conversion.row.test_name,
+    collected_at: conversion.row.recorded_at,
+    reported_at: conversion.row.recorded_at,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
+    created_at: now,
+  });
+  const resultId = crypto.randomUUID();
+  await db.insert(labResults).values({
+    id: resultId,
+    panel_id: panelId,
+    test_name: conversion.row.test_name,
+    test_code: conversion.row.test_code,
+    value: conversion.row.value,
+    unit: conversion.row.unit,
+    reference_low: conversion.row.reference_low,
+    reference_high: conversion.row.reference_high,
+    flag: conversion.row.flag,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Observation",
+    fhirId,
+    internalId: resultId,
+    patientId,
+    resource,
+  });
+  return { internalId: resultId, kind: "lab", inserted: true };
+}
+
+export async function persistCondition(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const row = epicConditionToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("Condition", fhirId);
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "Condition",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "diagnosis",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(diagnoses)
+      .set({
+        description: row.description,
+        icd10_code: row.icd10_code,
+        snomed_code: row.snomed_code,
+        status: row.status,
+        onset_date: row.onset_date,
+        resolved_date: row.resolved_date,
+      })
+      .where(eq(diagnoses.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "Condition",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "diagnosis",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(diagnoses).values({
+    id,
+    patient_id: patientId,
+    description: row.description,
+    icd10_code: row.icd10_code,
+    snomed_code: row.snomed_code,
+    status: row.status,
+    onset_date: row.onset_date,
+    resolved_date: row.resolved_date,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "Condition",
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "diagnosis", inserted: true };
+}
+
+export async function persistAllergy(
+  resource: FhirResource,
+  patientId: string,
+): Promise<PersistResult> {
+  const fhirId = resource.id;
+  if (!fhirId) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const row = epicAllergyToRow(resource, patientId);
+  if (!row) return { internalId: null, kind: "unmapped", inserted: false };
+
+  const db = getDb();
+  const now = new Date().toISOString();
+  const mapping = await findMapping("AllergyIntolerance", fhirId);
+
+  if (mapping.internalId) {
+    if (
+      mapping.existingSourceSystem &&
+      mapping.existingSourceSystem !== EPIC_SOURCE_SYSTEM_TAG
+    ) {
+      await logSourceConflict({
+        resourceType: "AllergyIntolerance",
+        fhirId,
+        internalId: mapping.internalId,
+        patientId,
+        existingSourceSystem: mapping.existingSourceSystem,
+      });
+      return {
+        internalId: mapping.internalId,
+        kind: "allergy",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
+    await db
+      .update(allergies)
+      .set({
+        allergen: row.allergen,
+        severity: row.severity,
+        reaction: row.reaction,
+      })
+      .where(eq(allergies.id, mapping.internalId));
+    await upsertMapping({
+      resourceType: "AllergyIntolerance",
+      fhirId,
+      internalId: mapping.internalId,
+      patientId,
+      resource,
+    });
+    return {
+      internalId: mapping.internalId,
+      kind: "allergy",
+      inserted: false,
+    };
+  }
+
+  const id = crypto.randomUUID();
+  await db.insert(allergies).values({
+    id,
+    patient_id: patientId,
+    allergen: row.allergen,
+    severity: row.severity,
+    reaction: row.reaction,
+    created_at: now,
+  });
+  await upsertMapping({
+    resourceType: "AllergyIntolerance",
+    fhirId,
+    internalId: id,
+    patientId,
+    resource,
+  });
+  return { internalId: id, kind: "allergy", inserted: true };
+}

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -1,0 +1,340 @@
+/**
+ * Epic sync job runners (#391).
+ *
+ * Pure orchestration functions — they take their dependencies
+ * (FHIR client, persistence helpers, emit) as arguments so the BullMQ
+ * worker can wire production dependencies while tests can inject mocks
+ * without touching Redis or Postgres.
+ *
+ * Job types:
+ *  - full-sync           — pull every resource type for a patient with
+ *                          no `_lastUpdated` watermark. Used for first
+ *                          import and "refresh everything" admin ops.
+ *  - incremental-sync    — pull resources updated since the watermark
+ *                          stored on `epic_sync_state`. Used for
+ *                          background-scheduled syncs.
+ *  - single-resource-sync — refresh one resource type for one patient.
+ *                          Used by the tRPC trigger endpoint and by
+ *                          the medication reconciliation flow.
+ *
+ * After each pull, every imported row emits a ClinicalEvent on the
+ * `clinical-events` BullMQ queue with `source_system: "epic"` in the
+ * event metadata. The existing ai-oversight review worker picks them
+ * up unchanged — the AI safety rules fire on Epic-sourced data the
+ * same way they fire on internally-recorded data.
+ */
+import crypto from "node:crypto";
+import { createLogger } from "@carebridge/logger";
+import type {
+  ClinicalEvent,
+  ClinicalEventType,
+} from "@carebridge/shared-types";
+import { EpicFhirClient, type EpicResourceType } from "../fhir-client.js";
+import { EPIC_SOURCE_SYSTEM_TAG } from "../converters.js";
+import {
+  persistAllergy,
+  persistCondition,
+  persistMedicationRequest,
+  persistObservation,
+  persistPatient,
+  type PersistResult,
+} from "./persistence.js";
+import {
+  getSyncState,
+  markFailed,
+  markOk,
+  markRunning,
+} from "./sync-state-repo.js";
+import type { FhirResource } from "../fhir-types.js";
+
+const log = createLogger("epic-sync-jobs");
+
+export type SyncResourceType = Exclude<EpicResourceType, "Encounter">;
+
+/**
+ * Resource types this PR ships sync support for. Encounter persistence
+ * is deferred to a follow-up — there's no inbound encounter mapper in
+ * fhir-gateway yet, and the `encounters` table writes need their own
+ * idempotency story (Epic CSN ↔ internal id).
+ */
+export const SUPPORTED_RESOURCE_TYPES: SyncResourceType[] = [
+  "Patient",
+  "Observation",
+  "Condition",
+  "MedicationRequest",
+  "AllergyIntolerance",
+];
+
+export type EmitFn = (event: ClinicalEvent) => Promise<void>;
+
+export interface SyncJobDeps {
+  client: EpicFhirClient;
+  emit: EmitFn;
+}
+
+export interface SyncResult {
+  patient_id: string;
+  resource_type: SyncResourceType;
+  imported: number;
+  updated: number;
+  conflicts: number;
+  errors: string[];
+}
+
+/**
+ * Full-sync: pull every supported resource type for the given patient
+ * with no incremental watermark. Used for first import.
+ */
+export async function runFullSync(
+  args: { patientId: string; epicPatientFhirId?: string },
+  deps: SyncJobDeps,
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const resourceType of SUPPORTED_RESOURCE_TYPES) {
+    results.push(
+      await syncResourceType(
+        {
+          patientId: args.patientId,
+          epicPatientFhirId: args.epicPatientFhirId,
+          resourceType,
+          watermark: null,
+        },
+        deps,
+      ),
+    );
+  }
+  return results;
+}
+
+/**
+ * Incremental sync: pull resources updated since the watermark stored
+ * on `epic_sync_state` for each (patient, resource_type) tuple.
+ */
+export async function runIncrementalSync(
+  args: { patientId: string; epicPatientFhirId?: string },
+  deps: SyncJobDeps,
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const resourceType of SUPPORTED_RESOURCE_TYPES) {
+    const state = await getSyncState(args.patientId, resourceType);
+    results.push(
+      await syncResourceType(
+        {
+          patientId: args.patientId,
+          epicPatientFhirId: args.epicPatientFhirId,
+          resourceType,
+          watermark: state?.last_fhir_lastupdated ?? null,
+        },
+        deps,
+      ),
+    );
+  }
+  return results;
+}
+
+/**
+ * Refresh a single resource type for a single patient.
+ */
+export async function runSingleResourceSync(
+  args: {
+    patientId: string;
+    epicPatientFhirId?: string;
+    resourceType: SyncResourceType;
+    /** When set, use as the `_lastUpdated=gt<watermark>` filter. */
+    watermark?: string | null;
+  },
+  deps: SyncJobDeps,
+): Promise<SyncResult> {
+  return syncResourceType(
+    {
+      patientId: args.patientId,
+      epicPatientFhirId: args.epicPatientFhirId,
+      resourceType: args.resourceType,
+      watermark: args.watermark ?? null,
+    },
+    deps,
+  );
+}
+
+interface SyncOneArgs {
+  patientId: string;
+  epicPatientFhirId?: string;
+  resourceType: SyncResourceType;
+  watermark: string | null;
+}
+
+async function syncResourceType(
+  args: SyncOneArgs,
+  deps: SyncJobDeps,
+): Promise<SyncResult> {
+  await markRunning(args.patientId, args.resourceType);
+
+  const result: SyncResult = {
+    patient_id: args.patientId,
+    resource_type: args.resourceType,
+    imported: 0,
+    updated: 0,
+    conflicts: 0,
+    errors: [],
+  };
+  let highWatermark: string | null = args.watermark;
+
+  try {
+    const resources = await fetchResources(args, deps.client);
+
+    for (const resource of resources) {
+      try {
+        const persisted = await persistOne(
+          resource,
+          args.resourceType,
+          args.patientId,
+        );
+        if (persisted.kind === "unmapped") continue;
+
+        if (persisted.conflict) {
+          result.conflicts++;
+        } else if (persisted.inserted) {
+          result.imported++;
+        } else {
+          result.updated++;
+        }
+
+        if (!persisted.conflict && persisted.internalId) {
+          await deps.emit(
+            buildClinicalEvent({
+              persisted,
+              patientId: args.patientId,
+              resource,
+            }),
+          );
+        }
+
+        const lastUpdated = (
+          resource.meta as { lastUpdated?: string } | undefined
+        )?.lastUpdated;
+        if (lastUpdated && (!highWatermark || lastUpdated > highWatermark)) {
+          highWatermark = lastUpdated;
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : String(err);
+        log.error("Epic sync — per-resource failure", {
+          patientId: args.patientId,
+          resourceType: args.resourceType,
+          fhirId: resource.id,
+          error: message,
+        });
+        result.errors.push(message);
+      }
+    }
+
+    await markOk({
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      highWatermark,
+      importedCount: result.imported,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("Epic sync — resource-type failure", {
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      error: message,
+    });
+    await markFailed({
+      patientId: args.patientId,
+      resourceType: args.resourceType,
+      errorMessage: message,
+    });
+    result.errors.push(message);
+  }
+
+  return result;
+}
+
+async function fetchResources(
+  args: SyncOneArgs,
+  client: EpicFhirClient,
+): Promise<FhirResource[]> {
+  if (args.resourceType === "Patient") {
+    if (!args.epicPatientFhirId) return [];
+    return [await client.readPatient(args.epicPatientFhirId)];
+  }
+
+  const lastUpdated = args.watermark ? `gt${args.watermark}` : undefined;
+  const params: Record<string, string | undefined> = {
+    patient: args.epicPatientFhirId ?? args.patientId,
+    _lastUpdated: lastUpdated,
+  };
+
+  const resources: FhirResource[] = [];
+  for await (const r of client.searchAll(args.resourceType, params)) {
+    resources.push(r);
+  }
+  return resources;
+}
+
+async function persistOne(
+  resource: FhirResource,
+  resourceType: SyncResourceType,
+  patientId: string,
+): Promise<PersistResult> {
+  switch (resourceType) {
+    case "Patient":
+      return persistPatient(resource);
+    case "Observation":
+      return persistObservation(resource, patientId);
+    case "Condition":
+      return persistCondition(resource, patientId);
+    case "MedicationRequest":
+      return persistMedicationRequest(resource, patientId);
+    case "AllergyIntolerance":
+      return persistAllergy(resource, patientId);
+  }
+}
+
+function buildClinicalEvent(args: {
+  persisted: PersistResult;
+  patientId: string;
+  resource: FhirResource;
+}): ClinicalEvent {
+  const type = eventTypeFor(args.persisted);
+  return {
+    id: crypto.randomUUID(),
+    type,
+    patient_id: args.patientId,
+    timestamp: new Date().toISOString(),
+    data: {
+      source_system: EPIC_SOURCE_SYSTEM_TAG,
+      epic_fhir_id: args.resource.id,
+      epic_resource_type: args.resource.resourceType,
+      internal_record_id: args.persisted.internalId,
+      operation: args.persisted.inserted ? "created" : "updated",
+    },
+  };
+}
+
+function eventTypeFor(persisted: PersistResult): ClinicalEventType {
+  switch (persisted.kind) {
+    case "patient":
+      return "patient.observation";
+    case "vital":
+      return persisted.inserted ? "vital.created" : "vital.updated";
+    case "lab":
+      return "lab.resulted";
+    case "medication":
+      return persisted.inserted
+        ? "medication.created"
+        : "medication.updated";
+    case "diagnosis":
+      return persisted.inserted ? "diagnosis.added" : "diagnosis.updated";
+    case "allergy":
+      return persisted.inserted ? "allergy.added" : "allergy.updated";
+    case "unmapped":
+      // Should never happen — buildClinicalEvent is gated by
+      // persisted.kind !== "unmapped" at the callsite. Fall through to
+      // a generic "fhir.imported" so the event still surfaces in
+      // audit trails if a future bug breaks the gate.
+      return "fhir.imported";
+  }
+}

--- a/services/epic-connector/src/sync/sync-state-repo.ts
+++ b/services/epic-connector/src/sync/sync-state-repo.ts
@@ -1,0 +1,165 @@
+/**
+ * Per-patient, per-resource-type sync state CRUD (#391).
+ *
+ * Backed by the `epic_sync_state` table introduced in migration 0048.
+ * The Epic sync worker reads the watermark before each incremental
+ * pull and writes back the new watermark plus the success/error counts
+ * after each pull completes.
+ *
+ * Status state machine:
+ *   pending → running → ok        (happy path)
+ *   pending → running → failed    (transient error, eligible for retry)
+ *
+ * `last_fhir_lastupdated` is the value to feed into the NEXT
+ * incremental request as `_lastUpdated=gt<value>`. It tracks the
+ * highest `meta.lastUpdated` observed across the previous pull's
+ * resources — NOT the wall-clock time the pull happened (those drift
+ * apart when Epic back-dates resources).
+ */
+import { and, eq, desc, sql } from "drizzle-orm";
+import { getDb, epicSyncState } from "@carebridge/db-schema";
+import type { EpicResourceType } from "../fhir-client.js";
+
+export type EpicSyncStatusValue = "pending" | "running" | "ok" | "failed";
+
+export interface EpicSyncStateRow {
+  patient_id: string;
+  resource_type: EpicResourceType;
+  last_synced_at: string | null;
+  last_fhir_lastupdated: string | null;
+  status: EpicSyncStatusValue;
+  resources_synced_count: number;
+  error_count: number;
+  last_error_message: string | null;
+  last_error_at: string | null;
+}
+
+export async function getSyncState(
+  patientId: string,
+  resourceType: EpicResourceType,
+): Promise<EpicSyncStateRow | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicSyncState)
+    .where(
+      and(
+        eq(epicSyncState.patient_id, patientId),
+        eq(epicSyncState.resource_type, resourceType),
+      ),
+    )
+    .limit(1);
+  return (rows[0] as EpicSyncStateRow | undefined) ?? null;
+}
+
+export async function getAllSyncStatesForPatient(
+  patientId: string,
+): Promise<EpicSyncStateRow[]> {
+  const db = getDb();
+  return (await db
+    .select()
+    .from(epicSyncState)
+    .where(eq(epicSyncState.patient_id, patientId))) as EpicSyncStateRow[];
+}
+
+export async function markRunning(
+  patientId: string,
+  resourceType: EpicResourceType,
+): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: patientId,
+      resource_type: resourceType,
+      status: "running",
+      last_synced_at: now,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: { status: "running", last_synced_at: now },
+    });
+}
+
+export async function markOk(args: {
+  patientId: string;
+  resourceType: EpicResourceType;
+  /** Highest `meta.lastUpdated` seen in this pull — watermark for next pull. */
+  highWatermark: string | null;
+  /** Number of resources successfully imported on this pull. */
+  importedCount: number;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: args.patientId,
+      resource_type: args.resourceType,
+      status: "ok",
+      last_synced_at: now,
+      last_fhir_lastupdated: args.highWatermark,
+      resources_synced_count: args.importedCount,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: {
+        status: "ok",
+        last_synced_at: now,
+        last_fhir_lastupdated: args.highWatermark ?? sql`epic_sync_state.last_fhir_lastupdated`,
+        resources_synced_count: sql`epic_sync_state.resources_synced_count + ${args.importedCount}`,
+      },
+    });
+}
+
+export async function markFailed(args: {
+  patientId: string;
+  resourceType: EpicResourceType;
+  errorMessage: string;
+}): Promise<void> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  // Truncate error messages so a runaway stack trace doesn't bloat the
+  // status column to gigabytes. 1KiB is plenty for triage; full stack
+  // traces live in the worker logs / DLQ.
+  const truncated = args.errorMessage.slice(0, 1024);
+  await db
+    .insert(epicSyncState)
+    .values({
+      patient_id: args.patientId,
+      resource_type: args.resourceType,
+      status: "failed",
+      last_synced_at: now,
+      last_error_message: truncated,
+      last_error_at: now,
+      error_count: 1,
+    })
+    .onConflictDoUpdate({
+      target: [epicSyncState.patient_id, epicSyncState.resource_type],
+      set: {
+        status: "failed",
+        last_synced_at: now,
+        last_error_message: truncated,
+        last_error_at: now,
+        error_count: sql`epic_sync_state.error_count + 1`,
+      },
+    });
+}
+
+/**
+ * List the N most recent failed sync rows across all patients —
+ * powers the tRPC `listSyncErrors` query that the clinician portal's
+ * Epic-sync dashboard renders.
+ */
+export async function listRecentFailures(
+  limit = 50,
+): Promise<EpicSyncStateRow[]> {
+  const db = getDb();
+  return (await db
+    .select()
+    .from(epicSyncState)
+    .where(eq(epicSyncState.status, "failed"))
+    .orderBy(desc(epicSyncState.last_error_at))
+    .limit(limit)) as EpicSyncStateRow[];
+}

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -1,0 +1,225 @@
+/**
+ * BullMQ worker that processes Epic sync jobs (#391).
+ *
+ * Listens on the "epic-sync" queue. Each job is one of:
+ *   - { type: "full-sync",        patient_id, epic_patient_fhir_id? }
+ *   - { type: "incremental-sync", patient_id, epic_patient_fhir_id? }
+ *   - { type: "single-resource-sync", patient_id, epic_patient_fhir_id?,
+ *       resource_type, watermark? }
+ *
+ * Production wiring expects `loadEpicConfig()` to succeed at startup —
+ * if Epic credentials aren't configured, the host service should NOT
+ * call `startEpicSyncWorker()`. Local dev environments without Epic
+ * registration silently skip starting the worker so unrelated services
+ * keep booting.
+ */
+import { Worker, Queue, type Job } from "bullmq";
+import { createLogger } from "@carebridge/logger";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import { emitClinicalEvent } from "@carebridge/outbox";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import { loadEpicConfig } from "../config.js";
+import {
+  runFullSync,
+  runIncrementalSync,
+  runSingleResourceSync,
+  type SyncResourceType,
+} from "../sync/sync-jobs.js";
+
+const log = createLogger("epic-sync-worker");
+
+export const EPIC_SYNC_QUEUE_NAME = "epic-sync";
+
+export type EpicSyncJobData =
+  | {
+      type: "full-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+    }
+  | {
+      type: "incremental-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+    }
+  | {
+      type: "single-resource-sync";
+      patient_id: string;
+      epic_patient_fhir_id?: string;
+      resource_type: SyncResourceType;
+      watermark?: string | null;
+    };
+
+let queueSingleton: Queue<EpicSyncJobData> | null = null;
+
+/**
+ * Lazily-instantiated Epic-sync queue. Defer construction until first
+ * use so importing this module from a host that ultimately decides NOT
+ * to start the worker (e.g. local dev without Epic creds) doesn't
+ * open an idle Redis connection.
+ */
+export function getEpicSyncQueue(): Queue<EpicSyncJobData> {
+  if (!queueSingleton) {
+    queueSingleton = new Queue(EPIC_SYNC_QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+    });
+  }
+  return queueSingleton;
+}
+
+export async function enqueueFullSync(args: {
+  patient_id: string;
+  epic_patient_fhir_id?: string;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "full-sync",
+    { type: "full-sync", ...args },
+    { jobId: `full-sync:${args.patient_id}` },
+  );
+}
+
+export async function enqueueIncrementalSync(args: {
+  patient_id: string;
+  epic_patient_fhir_id?: string;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "incremental-sync",
+    { type: "incremental-sync", ...args },
+    {
+      // Coalesce overlapping incremental requests for the same patient.
+      // BullMQ's jobId dedupe makes back-to-back triggers cheap.
+      jobId: `incremental-sync:${args.patient_id}`,
+    },
+  );
+}
+
+export async function enqueueSingleResourceSync(args: {
+  patient_id: string;
+  resource_type: SyncResourceType;
+  epic_patient_fhir_id?: string;
+  watermark?: string | null;
+}): Promise<void> {
+  await getEpicSyncQueue().add(
+    "single-resource-sync",
+    { type: "single-resource-sync", ...args },
+    {
+      jobId: `single:${args.resource_type}:${args.patient_id}`,
+    },
+  );
+}
+
+/**
+ * Start the Epic-sync BullMQ worker. Pulls Epic credentials from env
+ * via `loadEpicConfig()` and wires the FHIR client + outbox emit into
+ * the job runners. Returns the Worker handle so the host can wire
+ * graceful-shutdown listeners.
+ *
+ * Returns null when Epic credentials are not configured — the host
+ * service should treat this as "Epic integration is disabled" rather
+ * than an error, so local dev keeps booting without registering with
+ * Epic.
+ */
+export function startEpicSyncWorker(): Worker<EpicSyncJobData> | null {
+  let config;
+  try {
+    config = loadEpicConfig();
+  } catch (err) {
+    log.info("Epic sync worker not started — credentials not configured", {
+      reason: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const tokens = new EpicTokenClient(config);
+  const client = new EpicFhirClient(config, tokens);
+
+  const worker = new Worker<EpicSyncJobData>(
+    EPIC_SYNC_QUEUE_NAME,
+    async (job: Job<EpicSyncJobData>) => {
+      const start = Date.now();
+      try {
+        if (job.data.type === "full-sync") {
+          const results = await runFullSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise(results);
+        }
+        if (job.data.type === "incremental-sync") {
+          const results = await runIncrementalSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise(results);
+        }
+        if (job.data.type === "single-resource-sync") {
+          const result = await runSingleResourceSync(
+            {
+              patientId: job.data.patient_id,
+              epicPatientFhirId: job.data.epic_patient_fhir_id,
+              resourceType: job.data.resource_type,
+              watermark: job.data.watermark ?? null,
+            },
+            { client, emit: emitClinicalEvent },
+          );
+          return summarise([result]);
+        }
+        // exhaustiveness guard
+        const exhaustive: never = job.data;
+        throw new Error(`Unknown job type: ${JSON.stringify(exhaustive)}`);
+      } finally {
+        const elapsed = Date.now() - start;
+        log.info("Epic sync job completed", {
+          jobId: job.id,
+          type: job.data.type,
+          elapsed_ms: elapsed,
+        });
+      }
+    },
+    { connection: getRedisConnection(), concurrency: 2 },
+  );
+
+  worker.on("failed", (job, err) => {
+    log.error("Epic sync job failed", {
+      jobId: job?.id,
+      error: err.message,
+    });
+  });
+
+  return worker;
+}
+
+function summarise(
+  results: Array<{
+    resource_type: string;
+    imported: number;
+    updated: number;
+    conflicts: number;
+    errors: string[];
+  }>,
+): {
+  imported: number;
+  updated: number;
+  conflicts: number;
+  errors: number;
+} {
+  return results.reduce(
+    (acc, r) => ({
+      imported: acc.imported + r.imported,
+      updated: acc.updated + r.updated,
+      conflicts: acc.conflicts + r.conflicts,
+      errors: acc.errors + r.errors.length,
+    }),
+    { imported: 0, updated: 0, conflicts: 0, errors: 0 },
+  );
+}


### PR DESCRIPTION
Replaces #1086 (auto-closed when feat/390 was deleted during the #1090 squash-merge).

## Summary

Implements #391. Capstone of the inbound Epic integration — Epic data flows in, AI oversight catches the cross-specialty gap Epic alone missed, and the resulting flag emits on the existing \`clinical-events\` queue.

Builds on #1084 (#389 auth) + #1090 (#390 FHIR client).

- **Migration 0048 (idx 52)**: \`epic_sync_state\` table — per-patient, per-resource-type sync bookkeeping with FHIR \`_lastUpdated\` watermark, status state machine, error counters.
- **BullMQ \`epic-sync\` queue**: full-sync / incremental-sync / single-resource-sync jobs. Lazy queue construction. \`startEpicSyncWorker()\` returns null when Epic isn't configured so local dev keeps booting.
- **Sync orchestration (DI-friendly)**: pure functions take \`{ client, emit }\` as args — tests run offline without Redis/Postgres.
- **Persistence + conflict resolution**: idempotent upserts keyed via \`fhir_resources\`; refuses to overwrite \`source_system != "epic"\` rows and logs each rejected overwrite to \`audit_log\`.
- **Clinical-event emission**: every imported row emits a \`ClinicalEvent\` with \`source_system: "epic"\` — the existing ai-oversight review-worker picks them up unchanged.
- **tRPC router**: \`epicSync.triggerSync\` (admin), \`epicSync.getSyncStatus\` (care-team RBAC), \`epicSync.listSyncErrors\` (admin).

## Test plan

- [x] 16 new unit tests pass (\`pnpm --filter @carebridge/epic-connector test\` — 83 total)
- [x] \`pnpm turbo typecheck lint\` clean across the monorepo

Original PR: #1086