### PR TITLE
feat(epic): SMART on FHIR App Launch — EHR + Standalone (#392)

### DIFF
--- a/packages/db-schema/drizzle/0049_epic_user_connections.sql
+++ b/packages/db-schema/drizzle/0049_epic_user_connections.sql
@@ -1,0 +1,39 @@
+-- #392: per-user, per-Epic-org OAuth connection state.
+--
+-- Records the SMART on FHIR App Launch tokens a CareBridge user has
+-- authorised against a given Epic organisation. One row per
+-- (user_id, epic_org_iss) tuple — a clinician who covers shifts at
+-- two hospitals on separate Epic instances has two rows.
+--
+-- Tokens are encrypted at rest by the application layer (the
+-- application-level encryption hook used elsewhere for PHI columns).
+-- The columns are declared `text` here — encryption is transparent to
+-- the DB schema and applied via the same path as patient.mrn etc.
+--
+-- `id_token_subject` is the `sub` claim Epic returns on the id_token;
+-- combined with `epic_org_iss` it gives a stable identity for the
+-- Epic practitioner across sessions. `epic_practitioner_fhir_id` is
+-- the FHIR Practitioner.id Epic includes in the user-context launch
+-- response (also called `fhirUser` in the SMART spec).
+CREATE TABLE IF NOT EXISTS "epic_user_connections" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" text NOT NULL REFERENCES "users"("id"),
+  "epic_org_iss" text NOT NULL,
+  "id_token_subject" text,
+  "epic_practitioner_fhir_id" text,
+  "epic_patient_fhir_id" text,
+  "access_token_enc" text NOT NULL,
+  "refresh_token_enc" text,
+  "expires_at" text NOT NULL,
+  "scopes" text NOT NULL,
+  "launch_encounter_fhir_id" text,
+  "created_at" text NOT NULL,
+  "updated_at" text NOT NULL,
+  CONSTRAINT "unique_user_epic_org" UNIQUE ("user_id", "epic_org_iss")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_epic_user_connections_user"
+  ON "epic_user_connections" ("user_id");
+
+CREATE INDEX IF NOT EXISTS "idx_epic_user_connections_practitioner"
+  ON "epic_user_connections" ("epic_practitioner_fhir_id");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1747929900000,
       "tag": "0048_epic_sync_state",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1747929960000,
+      "tag": "0049_epic_user_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/epic-user-connections.ts
+++ b/packages/db-schema/src/schema/epic-user-connections.ts
@@ -1,0 +1,66 @@
+import { pgTable, text, unique, index } from "drizzle-orm/pg-core";
+import { users } from "./auth.js";
+import { encryptedText } from "../encryption.js";
+
+/**
+ * SMART on FHIR App Launch connection state (#392).
+ *
+ * One row per (CareBridge user, Epic organisation). Captures the
+ * OAuth tokens, scopes, and launch context returned by Epic when a
+ * clinician authorises CareBridge against their Epic identity.
+ *
+ * Token columns are encrypted at rest via the same encryption hook
+ * used for PHI columns (see {@link encryptedText}). Refresh tokens
+ * may be NULL if the granted scope set didn't include `offline_access`
+ * — short-lived sessions still get an access_token, but the user has
+ * to re-launch from Epic when it expires.
+ */
+export const epicUserConnections = pgTable(
+  "epic_user_connections",
+  {
+    id: text("id").primaryKey(),
+    user_id: text("user_id")
+      .notNull()
+      .references(() => users.id),
+    /**
+     * Epic's `iss` URL — the FHIR base URL for the org. Identifies
+     * which Epic instance the tokens are valid against.
+     */
+    epic_org_iss: text("epic_org_iss").notNull(),
+    /**
+     * `sub` claim from the id_token. Together with epic_org_iss this
+     * gives a stable identifier for the Epic identity across sessions.
+     */
+    id_token_subject: text("id_token_subject"),
+    /**
+     * FHIR Practitioner.id Epic returns in the `fhirUser` field. Used
+     * to attribute clinical actions back to the right Practitioner
+     * resource for outbound flag push (#393).
+     */
+    epic_practitioner_fhir_id: text("epic_practitioner_fhir_id"),
+    /**
+     * FHIR Patient.id Epic returns in the launch context (EHR launch
+     * only). NULL for standalone launches.
+     */
+    epic_patient_fhir_id: text("epic_patient_fhir_id"),
+    access_token_enc: encryptedText("access_token_enc").notNull(),
+    refresh_token_enc: encryptedText("refresh_token_enc"),
+    expires_at: text("expires_at").notNull(),
+    /** Space-separated SMART scopes Epic granted (may be a subset of requested). */
+    scopes: text("scopes").notNull(),
+    /**
+     * FHIR Encounter.id from EHR launch context, when Epic supplies one
+     * (typical for inpatient launches; outpatient launches often omit).
+     */
+    launch_encounter_fhir_id: text("launch_encounter_fhir_id"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => [
+    unique("unique_user_epic_org").on(table.user_id, table.epic_org_iss),
+    index("idx_epic_user_connections_user").on(table.user_id),
+    index("idx_epic_user_connections_practitioner").on(
+      table.epic_practitioner_fhir_id,
+    ),
+  ],
+);

--- a/packages/db-schema/src/schema/index.ts
+++ b/packages/db-schema/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from "./fhir.js";
 export * from "./family-access.js";
 export * from "./allergy-overrides.js";
 export * from "./epic-sync.js";
+export * from "./epic-user-connections.js";

--- a/services/api-gateway/src/router.ts
+++ b/services/api-gateway/src/router.ts
@@ -12,6 +12,7 @@ import { notificationsRbacRouter } from "./routers/notifications.js";
 import { familyAccessRbacRouter } from "./routers/family-access.js";
 import { careTeamRbacRouter } from "./routers/care-team.js";
 import { epicSyncRbacRouter } from "./routers/epic-sync.js";
+import { epicAuthRbacRouter } from "./routers/epic-auth.js";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -34,6 +35,7 @@ export const appRouter = router({
   familyAccess: familyAccessRbacRouter,
   careTeam: careTeamRbacRouter,
   epicSync: epicSyncRbacRouter,
+  epicAuth: epicAuthRbacRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/services/api-gateway/src/routers/epic-auth.ts
+++ b/services/api-gateway/src/routers/epic-auth.ts
@@ -1,0 +1,98 @@
+/**
+ * tRPC surface for SMART App Launch state (#392).
+ *
+ * Powers the clinician portal Settings page ("Connect to Epic" card)
+ * and the launch-context banner shown when a clinician arrives via
+ * EHR Launch.
+ *
+ *   epicAuth.getMyConnections  — list every Epic org this user has linked
+ *   epicAuth.getLaunchContext  — patient + encounter context for the
+ *                                most-recently-launched connection (if
+ *                                still within the access-token's TTL)
+ *   epicAuth.disconnect        — delete the connection row for a given org
+ *
+ * No write of new connections via tRPC — those land via the OAuth
+ * callback (services/api-gateway/src/routes/epic-auth.ts) after a real
+ * browser round-trip to Epic.
+ */
+import { initTRPC, TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  getConnectionsForUser,
+  deleteConnection,
+} from "@carebridge/epic-connector";
+import type { Context } from "../context.js";
+
+const t = initTRPC.context<Context>().create();
+
+const isAuthenticated = t.middleware(({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Authentication required",
+    });
+  }
+  return next({ ctx: { ...ctx, user: ctx.user } });
+});
+
+const protectedProcedure = t.procedure.use(isAuthenticated);
+
+export const epicAuthRbacRouter = t.router({
+  /**
+   * List every Epic-org connection for the authenticated user.
+   * Access/refresh tokens are intentionally NOT returned — clients
+   * never need them. We surface only the metadata (org URL, granted
+   * scopes, expiry, FHIR identity).
+   */
+  getMyConnections: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await getConnectionsForUser(ctx.user.id);
+    return rows.map((r) => ({
+      id: r.id,
+      epic_org_iss: r.epic_org_iss,
+      scopes: r.scopes,
+      expires_at: r.expires_at,
+      epic_practitioner_fhir_id: r.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: r.epic_patient_fhir_id,
+      launch_encounter_fhir_id: r.launch_encounter_fhir_id,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+    }));
+  }),
+
+  /**
+   * Return the most-recent connection plus its launch context, if
+   * still valid. Returns `null` when the user has no Epic connection
+   * or every connection's token has expired.
+   *
+   * The clinician portal uses this on page load to decide whether to
+   * pre-select the Epic-supplied patient/encounter.
+   */
+  getLaunchContext: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await getConnectionsForUser(ctx.user.id);
+    const valid = rows.filter(
+      (r) => Date.parse(r.expires_at) > Date.now(),
+    );
+    if (valid.length === 0) return null;
+    // Most-recently-updated (latest launch) wins.
+    valid.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const top = valid[0]!;
+    return {
+      epic_org_iss: top.epic_org_iss,
+      epic_practitioner_fhir_id: top.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: top.epic_patient_fhir_id,
+      launch_encounter_fhir_id: top.launch_encounter_fhir_id,
+      expires_at: top.expires_at,
+    };
+  }),
+
+  /**
+   * Delete a single Epic-org connection. Idempotent — returning
+   * { removed: false } when no row matched is treated as success.
+   */
+  disconnect: protectedProcedure
+    .input(z.object({ epic_org_iss: z.string().url() }))
+    .mutation(async ({ ctx, input }) => {
+      const removed = await deleteConnection(ctx.user.id, input.epic_org_iss);
+      return { removed };
+    }),
+});

--- a/services/api-gateway/src/routes/epic-auth.ts
+++ b/services/api-gateway/src/routes/epic-auth.ts
@@ -1,0 +1,183 @@
+/**
+ * SMART on FHIR App Launch routes (#392).
+ *
+ * Two endpoints:
+ *  GET /auth/epic/authorize  — kicks off the OAuth flow. Two ways in:
+ *      EHR Launch (Epic-initiated):
+ *        Epic redirects the user's browser to
+ *        `<our-host>/auth/epic/authorize?iss=<epic-base>&launch=<token>`
+ *      Standalone Launch (us-initiated):
+ *        Clinician clicks "Connect to Epic" → we redirect their browser
+ *        to `/auth/epic/authorize?iss=<epic-base>` (no launch token).
+ *
+ *  GET /auth/epic/callback   — handles the redirect back from Epic.
+ *      Verifies state, exchanges the code for tokens, persists the
+ *      connection row, and bounces the browser to the post-launch
+ *      destination.
+ *
+ * Both endpoints require an authenticated CareBridge session. For EHR
+ * Launch, the clinician must already be signed into CareBridge in the
+ * same browser session that Epic's MyChart shell is hosted in
+ * (typical Epic deployment puts the browser in an iframe that shares
+ * cookies). Sessions are out of scope here — `request.user` is set by
+ * the auth middleware before our handler runs.
+ */
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type { Redis } from "ioredis";
+import {
+  beginLaunch,
+  completeLaunch,
+  RedisLaunchStateStore,
+  InMemoryLaunchStateStore,
+  type LaunchStateStore,
+  type RedisLike,
+} from "@carebridge/epic-connector";
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-auth-routes");
+
+interface EpicAuthRouteOptions {
+  redis?: Redis;
+  /**
+   * Override the launch-state store for tests. When omitted and `redis`
+   * is provided, uses RedisLaunchStateStore; otherwise an in-memory
+   * fallback (single-process dev only).
+   */
+  store?: LaunchStateStore;
+}
+
+interface AuthorizeQuery {
+  iss?: string;
+  launch?: string;
+  redirect?: string;
+}
+
+interface CallbackQuery {
+  code?: string;
+  state?: string;
+  error?: string;
+  error_description?: string;
+}
+
+export function registerEpicAuthRoutes(
+  server: FastifyInstance,
+  opts: EpicAuthRouteOptions = {},
+): void {
+  const clientId = process.env.EPIC_CLIENT_ID;
+  const redirectUri = process.env.EPIC_APP_LAUNCH_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    log.info(
+      "Epic App Launch routes not registered — EPIC_CLIENT_ID or EPIC_APP_LAUNCH_REDIRECT_URI not set",
+    );
+    return;
+  }
+
+  let store: LaunchStateStore;
+  if (opts.store) {
+    store = opts.store;
+  } else if (opts.redis) {
+    const redis = opts.redis;
+    const redisAdapter: RedisLike = {
+      set: (k, v, mode, ttl) =>
+        redis.set(k, v, mode, ttl) as Promise<unknown>,
+      get: (k) => redis.get(k),
+      del: (k) => redis.del(k),
+    };
+    store = new RedisLaunchStateStore(redisAdapter);
+  } else {
+    store = new InMemoryLaunchStateStore();
+  }
+
+  server.get<{ Querystring: AuthorizeQuery }>(
+    "/auth/epic/authorize",
+    async (request, reply) => {
+      if (!request.user) {
+        return reply.code(401).send({ error: "authentication_required" });
+      }
+      const iss = request.query.iss;
+      if (!iss) {
+        return reply.code(400).send({
+          error: "missing_iss",
+          message: "Provide ?iss=<Epic FHIR base URL>",
+        });
+      }
+
+      try {
+        const { authorizeUrl } = await beginLaunch(
+          {
+            iss,
+            launch: request.query.launch,
+            userId: request.user.id,
+            redirectUri,
+            clientId,
+            postLaunchRedirect: request.query.redirect ?? "/",
+          },
+          store,
+        );
+        return reply.redirect(authorizeUrl);
+      } catch (err) {
+        log.error("Epic App Launch begin failed", {
+          userId: request.user.id,
+          iss,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.code(502).send({
+          error: "epic_discovery_failed",
+          message: err instanceof Error ? err.message : "unknown error",
+        });
+      }
+    },
+  );
+
+  server.get<{ Querystring: CallbackQuery }>(
+    "/auth/epic/callback",
+    async (request: FastifyRequest<{ Querystring: CallbackQuery }>, reply: FastifyReply) => {
+      // Epic returns ?error=… on user-denial / consent failure.
+      if (request.query.error) {
+        return reply.code(400).send({
+          error: request.query.error,
+          message: request.query.error_description ?? "Epic returned an OAuth error",
+        });
+      }
+
+      const state = request.query.state;
+      const code = request.query.code;
+      if (!state || !code) {
+        return reply.code(400).send({
+          error: "missing_callback_params",
+          message: "Expected ?state and ?code in callback URL",
+        });
+      }
+
+      try {
+        const result = await completeLaunch(
+          { state, code, clientId, redirectUri },
+          store,
+        );
+        // EHR-launch context lives in the redirect URL as query params so
+        // the SPA can pick them up without another round-trip.
+        const target = new URL(result.postLaunchRedirect, "http://_dummy");
+        if (result.patientFhirId) {
+          target.searchParams.set("epic_patient", result.patientFhirId);
+        }
+        if (result.encounterFhirId) {
+          target.searchParams.set("epic_encounter", result.encounterFhirId);
+        }
+        const finalUrl =
+          target.origin === "http://_dummy"
+            ? target.pathname + target.search
+            : target.toString();
+        return reply.redirect(finalUrl);
+      } catch (err) {
+        log.error("Epic App Launch callback failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.code(400).send({
+          error: "epic_callback_failed",
+          message: err instanceof Error ? err.message : "unknown error",
+        });
+      }
+    },
+  );
+}

--- a/services/api-gateway/src/server.ts
+++ b/services/api-gateway/src/server.ts
@@ -14,6 +14,7 @@ import { makePatientReadRateLimitHook } from "./middleware/patient-read-rate-lim
 import { makeFhirExportRateLimitHook } from "./middleware/fhir-export-rate-limit.js";
 import { registerNotificationSSE } from "./routes/notifications-sse.js";
 import { registerFhirRestRoutes } from "./routes/fhir-rest.js";
+import { registerEpicAuthRoutes } from "./routes/epic-auth.js";
 import { handleAuthMe } from "./handlers/auth-me.js";
 import { redactUrlIds } from "@carebridge/phi-sanitizer";
 import { startBackgroundWorkers } from "./workers.js";
@@ -235,6 +236,13 @@ async function main() {
   // alongside the internal /trpc/* surface for EHR / HIE / third-party
   // FHIR clients (Epic, HIEs, SMART apps). Read-only on first ship.
   registerFhirRestRoutes(server);
+
+  // --- Epic SMART App Launch (#392) ---
+  // GET /auth/epic/authorize + /auth/epic/callback. The route module
+  // checks EPIC_CLIENT_ID + EPIC_APP_LAUNCH_REDIRECT_URI at startup —
+  // if either is unset, registration is a no-op so local dev without
+  // Epic credentials keeps booting unchanged.
+  registerEpicAuthRoutes(server);
 
   // --- Health check ---
   server.get("/health", async () => {

--- a/services/epic-connector/src/__tests__/authorize.test.ts
+++ b/services/epic-connector/src/__tests__/authorize.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Authorize-URL builder tests (#392).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+} from "../app-launch/authorize.js";
+
+const baseArgs = {
+  authorizeUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize",
+  clientId: "carebridge-client",
+  redirectUri: "https://app.carebridge.test/auth/epic/callback",
+  scopes: [...DEFAULT_APP_LAUNCH_SCOPES],
+  state: "opaque-state-1234",
+  aud: "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/",
+  codeChallenge: "challenge-abcdef",
+};
+
+describe("buildAuthorizeUrl (#392)", () => {
+  it("includes every required SMART App Launch param", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("carebridge-client");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://app.carebridge.test/auth/epic/callback",
+    );
+    expect(url.searchParams.get("state")).toBe("opaque-state-1234");
+    expect(url.searchParams.get("aud")).toBe(baseArgs.aud);
+    expect(url.searchParams.get("code_challenge")).toBe("challenge-abcdef");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("space-joins the scope list per OAuth 2 standard", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.get("scope")).toBe(
+      "launch openid fhirUser offline_access patient/*.read user/Practitioner.read",
+    );
+  });
+
+  it("omits `launch` param when launch token is absent (Standalone Launch)", () => {
+    const url = new URL(buildAuthorizeUrl(baseArgs));
+    expect(url.searchParams.has("launch")).toBe(false);
+  });
+
+  it("includes `launch` param when token is provided (EHR Launch)", () => {
+    const url = new URL(
+      buildAuthorizeUrl({ ...baseArgs, launch: "ehr-launch-token-xyz" }),
+    );
+    expect(url.searchParams.get("launch")).toBe("ehr-launch-token-xyz");
+  });
+
+  it("targets the authorize endpoint passed in (not a hardcoded URL)", () => {
+    const customAuthorize = "https://fhir.example-hospital.org/oauth/auth";
+    const url = new URL(
+      buildAuthorizeUrl({ ...baseArgs, authorizeUrl: customAuthorize }),
+    );
+    expect(url.origin + url.pathname).toBe(customAuthorize);
+  });
+});

--- a/services/epic-connector/src/__tests__/launch-service.test.ts
+++ b/services/epic-connector/src/__tests__/launch-service.test.ts
@@ -1,0 +1,265 @@
+/**
+ * End-to-end (offline) tests for the App Launch orchestrator (#392).
+ *
+ * The orchestrator wires together discovery → PKCE → authorize URL →
+ * state store → token exchange → connection upsert. Each step is
+ * tested in isolation elsewhere; here we verify the glue.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock the connection-repo so we don't touch Postgres ──────────
+const upsertEpicConnection = vi.fn().mockResolvedValue("conn-1");
+vi.mock("../app-launch/connection-repo.js", () => ({
+  upsertEpicConnection,
+  getConnectionsForUser: vi.fn(),
+  getConnection: vi.fn(),
+  deleteConnection: vi.fn(),
+}));
+
+const { beginLaunch, completeLaunch } = await import(
+  "../app-launch/launch-service.js"
+);
+const { InMemoryLaunchStateStore } = await import(
+  "../app-launch/state-store.js"
+);
+
+function smartConfigResponse(extras: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      token_endpoint:
+        "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+      authorization_endpoint:
+        "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize",
+      grant_types_supported: ["authorization_code", "client_credentials"],
+      ...extras,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function tokenExchangeResponse(extras: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: "epic-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "patient/*.read openid fhirUser launch",
+      refresh_token: "epic-refresh-token",
+      patient: "epic-patient-1",
+      ...extras,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const ISS = "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+const REDIRECT_URI = "https://app.carebridge.test/auth/epic/callback";
+const CLIENT_ID = "carebridge-client";
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("beginLaunch → completeLaunch (#392)", () => {
+  it("EHR Launch happy path: state persists, authorize URL has launch param", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(smartConfigResponse());
+    const store = new InMemoryLaunchStateStore();
+
+    const { authorizeUrl, state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/patients/abc",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    expect(state.length).toBeGreaterThan(20);
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.get("launch")).toBe("ehr-launch-token");
+    expect(url.searchParams.get("state")).toBe(state);
+    expect(url.searchParams.get("aud")).toBe(ISS);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const persisted = await store.get(state);
+    expect(persisted?.userId).toBe(USER_ID);
+    expect(persisted?.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(persisted?.launchToken).toBe("ehr-launch-token");
+  });
+
+  it("Standalone Launch strips 'launch' scope so Epic doesn't reject it", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(smartConfigResponse());
+    const store = new InMemoryLaunchStateStore();
+
+    const { authorizeUrl } = await beginLaunch(
+      {
+        iss: ISS,
+        // no launch token — Standalone
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    const url = new URL(authorizeUrl);
+    expect(url.searchParams.has("launch")).toBe(false);
+    expect(url.searchParams.get("scope")).not.toContain(" launch ");
+    expect(url.searchParams.get("scope")).not.toMatch(/^launch /);
+  });
+
+  it("completeLaunch exchanges code, decodes practitioner from id_token, upserts the connection", async () => {
+    // Build an id_token with a Practitioner FHIR reference
+    const idPayload = Buffer.from(
+      JSON.stringify({
+        sub: "epic-user-1",
+        fhirUser:
+          "https://fhir.epic.com/api/FHIR/R4/Practitioner/practitioner-xyz",
+      }),
+    )
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const fakeIdToken = `header.${idPayload}.sig`;
+
+    // First fetch = SMART discovery (during beginLaunch);
+    // second fetch = token exchange (during completeLaunch)
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(smartConfigResponse())
+      .mockResolvedValueOnce(
+        tokenExchangeResponse({ id_token: fakeIdToken }),
+      );
+
+    const store = new InMemoryLaunchStateStore();
+
+    const { state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/patients/from-epic",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    const result = await completeLaunch(
+      {
+        state,
+        code: "epic-auth-code",
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    expect(result.connectionId).toBe("conn-1");
+    expect(result.patientFhirId).toBe("epic-patient-1");
+    expect(result.practitionerFhirId).toBe("practitioner-xyz");
+    expect(result.postLaunchRedirect).toBe("/patients/from-epic");
+
+    expect(upsertEpicConnection).toHaveBeenCalledOnce();
+    const upsertArgs = upsertEpicConnection.mock.calls[0]![0];
+    expect(upsertArgs.user_id).toBe(USER_ID);
+    expect(upsertArgs.access_token).toBe("epic-access-token");
+    expect(upsertArgs.refresh_token).toBe("epic-refresh-token");
+    expect(upsertArgs.epic_practitioner_fhir_id).toBe("practitioner-xyz");
+    expect(upsertArgs.epic_patient_fhir_id).toBe("epic-patient-1");
+    expect(upsertArgs.id_token_subject).toBe("epic-user-1");
+  });
+
+  it("state is single-use — a replay attempt errors", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(smartConfigResponse())
+      .mockResolvedValueOnce(tokenExchangeResponse())
+      .mockResolvedValueOnce(tokenExchangeResponse());
+
+    const store = new InMemoryLaunchStateStore();
+    const { state } = await beginLaunch(
+      {
+        iss: ISS,
+        launch: "ehr-launch-token",
+        userId: USER_ID,
+        redirectUri: REDIRECT_URI,
+        clientId: CLIENT_ID,
+        postLaunchRedirect: "/",
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    await completeLaunch(
+      {
+        state,
+        code: "code-1",
+        clientId: CLIENT_ID,
+        redirectUri: REDIRECT_URI,
+        fetchImpl: fetchMock,
+      },
+      store,
+    );
+
+    // Replay with same state — should fail because state was consumed
+    await expect(
+      completeLaunch(
+        {
+          state,
+          code: "code-2",
+          clientId: CLIENT_ID,
+          redirectUri: REDIRECT_URI,
+          fetchImpl: fetchMock,
+        },
+        store,
+      ),
+    ).rejects.toThrow(/state expired or unknown/);
+  });
+
+  it("rejects unknown / expired state", async () => {
+    const store = new InMemoryLaunchStateStore();
+    await expect(
+      completeLaunch(
+        {
+          state: "never-issued",
+          code: "x",
+          clientId: CLIENT_ID,
+          redirectUri: REDIRECT_URI,
+        },
+        store,
+      ),
+    ).rejects.toThrow(/state expired or unknown/);
+  });
+
+  it("InMemoryLaunchStateStore expires entries past their TTL", async () => {
+    let now = 1_000_000_000_000;
+    const store = new InMemoryLaunchStateStore(() => now);
+    await store.set(
+      "abc",
+      {
+        codeVerifier: "v",
+        iss: ISS,
+        tokenUrl: "https://t",
+        authorizeUrl: "https://a",
+        userId: USER_ID,
+        postLaunchRedirect: "/",
+        createdAt: new Date(now).toISOString(),
+      },
+      10, // 10s TTL
+    );
+    expect(await store.get("abc")).not.toBeNull();
+    now += 11_000; // 11s later — past TTL
+    expect(await store.get("abc")).toBeNull();
+  });
+});

--- a/services/epic-connector/src/__tests__/pkce.test.ts
+++ b/services/epic-connector/src/__tests__/pkce.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PKCE helper tests (#392).
+ *
+ * Verifies the implementation against RFC 7636 §4.6:
+ *   verifier:  43-128 chars from [A-Z][a-z][0-9]-._~
+ *   challenge: BASE64URL(SHA256(verifier))
+ *   method:    "S256" (we don't support "plain")
+ */
+import { describe, it, expect } from "vitest";
+import { generatePkcePair, verifyChallenge } from "../app-launch/pkce.js";
+import { createHash } from "node:crypto";
+
+describe("PKCE (#392)", () => {
+  it("generates a 43-char verifier with only URL-safe characters", () => {
+    const { codeVerifier } = generatePkcePair();
+    expect(codeVerifier.length).toBe(43);
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives the challenge as base64url(SHA-256(verifier))", () => {
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    const expected = createHash("sha256")
+      .update(codeVerifier)
+      .digest("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it("always uses the S256 challenge method (Epic rejects 'plain')", () => {
+    const { codeChallengeMethod } = generatePkcePair();
+    expect(codeChallengeMethod).toBe("S256");
+  });
+
+  it("verifyChallenge returns true for a matching pair, false otherwise", () => {
+    const { codeVerifier, codeChallenge } = generatePkcePair();
+    expect(verifyChallenge(codeVerifier, codeChallenge)).toBe(true);
+    expect(verifyChallenge(codeVerifier, "tampered_challenge")).toBe(false);
+    expect(verifyChallenge("tampered_verifier", codeChallenge)).toBe(false);
+  });
+
+  it("produces distinct pairs on subsequent calls", () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+
+  it("accepts an injected RNG for deterministic test fixtures", () => {
+    const fakeRng = (size: number) => Buffer.alloc(size, 0x41); // 'A' bytes
+    const pair = generatePkcePair(fakeRng);
+    // 32 0x41 bytes base64-encode to "QUFB" repeated 10 times + "QUFBQQ"
+    // (the trailing "==" is stripped per base64url).
+    expect(pair.codeVerifier).toBe(
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE",
+    );
+    expect(pair.codeVerifier.length).toBe(43);
+    expect(verifyChallenge(pair.codeVerifier, pair.codeChallenge)).toBe(true);
+  });
+});

--- a/services/epic-connector/src/__tests__/token-exchange.test.ts
+++ b/services/epic-connector/src/__tests__/token-exchange.test.ts
@@ -1,0 +1,146 @@
+/**
+ * App Launch token-exchange tests (#392).
+ *
+ * Mocks fetch so we never call Epic. Verifies request shape, response
+ * parsing, error handling, and id_token decoding.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+} from "../app-launch/token-exchange.js";
+
+function tokenResponse(overrides: Record<string, unknown> = {}) {
+  return new Response(
+    JSON.stringify({
+      access_token: "epic-access-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "patient/*.read user/Practitioner.read openid fhirUser",
+      id_token: "header.eyJzdWIiOiJlcGljLXVzZXItMSJ9.sig",
+      refresh_token: "epic-refresh-token",
+      patient: "epic-patient-1",
+      encounter: "epic-encounter-1",
+      need_patient_banner: true,
+      smart_style_url: "https://fhir.epic.com/style.json",
+      ...overrides,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const baseArgs = {
+  tokenUrl: "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token",
+  code: "auth-code-1",
+  redirectUri: "https://app.carebridge.test/auth/epic/callback",
+  clientId: "carebridge-client",
+  codeVerifier: "v".repeat(43),
+};
+
+describe("exchangeAuthorizationCode (#392)", () => {
+  it("posts grant_type=authorization_code + code + code_verifier + redirect_uri", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    await exchangeAuthorizationCode({ ...baseArgs, fetchImpl: fetchMock });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(baseArgs.tokenUrl);
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("auth-code-1");
+    expect(body.get("redirect_uri")).toBe(baseArgs.redirectUri);
+    expect(body.get("client_id")).toBe("carebridge-client");
+    expect(body.get("code_verifier")).toBe("v".repeat(43));
+    // We're a public client (PKCE only) — no client_secret should leak.
+    expect(body.get("client_secret")).toBeNull();
+  });
+
+  it("parses all the SMART App Launch fields plus passthrough extras", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(tokenResponse());
+    const result = await exchangeAuthorizationCode({
+      ...baseArgs,
+      fetchImpl: fetchMock,
+    });
+
+    expect(result.access_token).toBe("epic-access-token");
+    expect(result.token_type).toBe("Bearer");
+    expect(result.expires_in).toBe(3600);
+    expect(result.scope).toContain("patient/*.read");
+    expect(result.id_token).toBeDefined();
+    expect(result.refresh_token).toBe("epic-refresh-token");
+    expect(result.patient).toBe("epic-patient-1");
+    expect(result.encounter).toBe("epic-encounter-1");
+    expect(result.extra.need_patient_banner).toBe(true);
+    expect(result.extra.smart_style_url).toBe("https://fhir.epic.com/style.json");
+  });
+
+  it("omits patient/encounter when Epic doesn't return them (Standalone Launch)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      tokenResponse({ patient: undefined, encounter: undefined }),
+    );
+    const result = await exchangeAuthorizationCode({
+      ...baseArgs,
+      fetchImpl: fetchMock,
+    });
+    expect(result.patient).toBeUndefined();
+    expect(result.encounter).toBeUndefined();
+  });
+
+  it("throws on non-2xx responses without surfacing the body to the caller", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("invalid_grant: code already used", { status: 400 }),
+    );
+    await expect(
+      exchangeAuthorizationCode({ ...baseArgs, fetchImpl: fetchMock }),
+    ).rejects.toThrow(/Epic token endpoint returned 400/);
+  });
+});
+
+describe("decodeIdTokenUnsafe", () => {
+  it("decodes the JWS payload without verifying the signature", () => {
+    // payload = { sub: "user-1", fhirUser: "Practitioner/abc-1" }
+    const payload = Buffer.from(
+      JSON.stringify({
+        sub: "user-1",
+        fhirUser: "https://fhir.epic.com/api/FHIR/R4/Practitioner/abc-1",
+      }),
+    )
+      .toString("base64")
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const jwt = `header.${payload}.sig`;
+    const decoded = decodeIdTokenUnsafe(jwt);
+    expect(decoded?.sub).toBe("user-1");
+    expect(decoded?.fhirUser).toContain("Practitioner/abc-1");
+  });
+
+  it("returns null on a malformed JWT", () => {
+    expect(decodeIdTokenUnsafe("not.a.jwt-payload")).toBeNull();
+    expect(decodeIdTokenUnsafe("only-one-segment")).toBeNull();
+  });
+});
+
+describe("extractPractitionerId", () => {
+  it("pulls the FHIR id out of a Practitioner reference URL", () => {
+    expect(
+      extractPractitionerId(
+        "https://fhir.epic.com/interconnect/api/FHIR/R4/Practitioner/abc-123",
+      ),
+    ).toBe("abc-123");
+  });
+
+  it("returns null when the fhirUser claim doesn't reference a Practitioner", () => {
+    expect(
+      extractPractitionerId(
+        "https://fhir.epic.com/api/FHIR/R4/Patient/p-1",
+      ),
+    ).toBeNull();
+    expect(extractPractitionerId(undefined)).toBeNull();
+    expect(extractPractitionerId("garbage")).toBeNull();
+  });
+});

--- a/services/epic-connector/src/app-launch/authorize.ts
+++ b/services/epic-connector/src/app-launch/authorize.ts
@@ -1,0 +1,78 @@
+/**
+ * Authorize-URL builder for SMART App Launch (#392).
+ *
+ * Constructs the URL we redirect the user's browser to when they begin
+ * either an EHR Launch (Epic clicks "open CareBridge" → we get a
+ * `launch` token + `iss`) or a Standalone Launch (clinician opens
+ * CareBridge first → we discover Epic's authorize URL via
+ * .well-known/smart-configuration).
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/app-launch.html
+ *
+ * Required params:
+ *   response_type=code
+ *   client_id=<our Epic-registered client id>
+ *   redirect_uri=<our callback URL — must EXACTLY match what's
+ *                 registered at open.epic.com>
+ *   scope=<requested SMART scopes>
+ *   state=<opaque CSRF token; we use the OAuth state to key our
+ *          server-side launch-state row>
+ *   aud=<iss FHIR base — protects against confused-deputy attacks
+ *        where a different EHR's authorize endpoint reuses our code>
+ *   code_challenge=<S256-hashed PKCE challenge>
+ *   code_challenge_method=S256
+ *
+ * EHR-launch additions:
+ *   launch=<the launch token Epic gave us in the bootstrap redirect>
+ */
+export interface AuthorizeUrlArgs {
+  authorizeUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  state: string;
+  /** FHIR base URL — also the OAuth `aud` claim. Required by SMART. */
+  aud: string;
+  codeChallenge: string;
+  /** Present on EHR Launch; omit for Standalone. */
+  launch?: string;
+}
+
+/**
+ * Default scope set we request for a user-context Epic launch.
+ *
+ * - launch                — required for EHR Launch (no-op on Standalone)
+ * - openid + fhirUser     — we need an id_token with the Practitioner FHIR id
+ * - offline_access        — request a refresh token so the session
+ *                           survives access-token expiry without
+ *                           re-launching from Epic
+ * - patient/*.read        — read-only access to the launch-context
+ *                           patient
+ * - user/Practitioner.read — read the practitioner identity behind
+ *                           the launch so we can match them to the
+ *                           CareBridge user.
+ */
+export const DEFAULT_APP_LAUNCH_SCOPES = [
+  "launch",
+  "openid",
+  "fhirUser",
+  "offline_access",
+  "patient/*.read",
+  "user/Practitioner.read",
+] as const;
+
+export function buildAuthorizeUrl(args: AuthorizeUrlArgs): string {
+  const url = new URL(args.authorizeUrl);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", args.clientId);
+  url.searchParams.set("redirect_uri", args.redirectUri);
+  url.searchParams.set("scope", args.scopes.join(" "));
+  url.searchParams.set("state", args.state);
+  url.searchParams.set("aud", args.aud);
+  url.searchParams.set("code_challenge", args.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  if (args.launch) {
+    url.searchParams.set("launch", args.launch);
+  }
+  return url.toString();
+}

--- a/services/epic-connector/src/app-launch/connection-repo.ts
+++ b/services/epic-connector/src/app-launch/connection-repo.ts
@@ -1,0 +1,156 @@
+/**
+ * CRUD for `epic_user_connections` rows (#392).
+ *
+ * Upserts on (user_id, epic_org_iss) so a re-launch by the same
+ * clinician at the same Epic org refreshes the tokens in place rather
+ * than appending. Access/refresh tokens are encrypted at rest via the
+ * same encryption hook used for PHI columns.
+ */
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { getDb, epicUserConnections } from "@carebridge/db-schema";
+
+export interface EpicConnectionUpsert {
+  user_id: string;
+  epic_org_iss: string;
+  access_token: string;
+  refresh_token: string | null;
+  expires_at: string;
+  scopes: string;
+  id_token_subject: string | null;
+  epic_practitioner_fhir_id: string | null;
+  epic_patient_fhir_id: string | null;
+  launch_encounter_fhir_id: string | null;
+}
+
+export interface EpicConnectionRow {
+  id: string;
+  user_id: string;
+  epic_org_iss: string;
+  /** Decrypted access token. */
+  access_token: string;
+  /** Decrypted refresh token (or null). */
+  refresh_token: string | null;
+  expires_at: string;
+  scopes: string;
+  id_token_subject: string | null;
+  epic_practitioner_fhir_id: string | null;
+  epic_patient_fhir_id: string | null;
+  launch_encounter_fhir_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Upsert the connection row. Returns the row id. Tokens are written
+ * via the encryption hook attached to the schema columns.
+ */
+export async function upsertEpicConnection(
+  input: EpicConnectionUpsert,
+): Promise<string> {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const id = crypto.randomUUID();
+
+  await db
+    .insert(epicUserConnections)
+    .values({
+      id,
+      user_id: input.user_id,
+      epic_org_iss: input.epic_org_iss,
+      access_token_enc: input.access_token,
+      refresh_token_enc: input.refresh_token,
+      expires_at: input.expires_at,
+      scopes: input.scopes,
+      id_token_subject: input.id_token_subject,
+      epic_practitioner_fhir_id: input.epic_practitioner_fhir_id,
+      epic_patient_fhir_id: input.epic_patient_fhir_id,
+      launch_encounter_fhir_id: input.launch_encounter_fhir_id,
+      created_at: now,
+      updated_at: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        epicUserConnections.user_id,
+        epicUserConnections.epic_org_iss,
+      ],
+      set: {
+        access_token_enc: input.access_token,
+        refresh_token_enc: input.refresh_token,
+        expires_at: input.expires_at,
+        scopes: input.scopes,
+        id_token_subject: input.id_token_subject,
+        epic_practitioner_fhir_id: input.epic_practitioner_fhir_id,
+        epic_patient_fhir_id: input.epic_patient_fhir_id,
+        launch_encounter_fhir_id: input.launch_encounter_fhir_id,
+        updated_at: now,
+      },
+    });
+
+  return id;
+}
+
+export async function getConnectionsForUser(
+  userId: string,
+): Promise<EpicConnectionRow[]> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicUserConnections)
+    .where(eq(epicUserConnections.user_id, userId));
+  return rows.map(mapRow);
+}
+
+export async function getConnection(
+  userId: string,
+  epicOrgIss: string,
+): Promise<EpicConnectionRow | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(epicUserConnections)
+    .where(
+      and(
+        eq(epicUserConnections.user_id, userId),
+        eq(epicUserConnections.epic_org_iss, epicOrgIss),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  return row ? mapRow(row) : null;
+}
+
+export async function deleteConnection(
+  userId: string,
+  epicOrgIss: string,
+): Promise<boolean> {
+  const db = getDb();
+  const result = await db
+    .delete(epicUserConnections)
+    .where(
+      and(
+        eq(epicUserConnections.user_id, userId),
+        eq(epicUserConnections.epic_org_iss, epicOrgIss),
+      ),
+    )
+    .returning({ id: epicUserConnections.id });
+  return result.length > 0;
+}
+
+function mapRow(row: typeof epicUserConnections.$inferSelect): EpicConnectionRow {
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    epic_org_iss: row.epic_org_iss,
+    access_token: row.access_token_enc,
+    refresh_token: row.refresh_token_enc,
+    expires_at: row.expires_at,
+    scopes: row.scopes,
+    id_token_subject: row.id_token_subject,
+    epic_practitioner_fhir_id: row.epic_practitioner_fhir_id,
+    epic_patient_fhir_id: row.epic_patient_fhir_id,
+    launch_encounter_fhir_id: row.launch_encounter_fhir_id,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}

--- a/services/epic-connector/src/app-launch/launch-service.ts
+++ b/services/epic-connector/src/app-launch/launch-service.ts
@@ -1,0 +1,226 @@
+/**
+ * SMART App Launch orchestrator (#392).
+ *
+ * Ties together the PKCE helpers, authorize URL builder, token exchange,
+ * launch-state store, and connection repo so the Fastify route handlers
+ * stay thin. Both EHR Launch (Epic bootstraps with `iss` + `launch`)
+ * and Standalone Launch (we know the `iss` from settings) come through
+ * the same `beginLaunch` → `completeLaunch` pair.
+ */
+import { randomBytes } from "node:crypto";
+import { createLogger } from "@carebridge/logger";
+import {
+  fetchSmartConfiguration,
+  type SmartConfiguration,
+} from "../capability.js";
+import { generatePkcePair } from "./pkce.js";
+import {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+} from "./authorize.js";
+import {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+  type AppLaunchTokenResponse,
+} from "./token-exchange.js";
+import { upsertEpicConnection } from "./connection-repo.js";
+import type { LaunchStateStore, LaunchState } from "./state-store.js";
+
+const log = createLogger("epic-app-launch");
+
+const STATE_TTL_SECONDS = 600; // 10 minutes — the user has to finish OAuth in that window
+
+export interface BeginLaunchArgs {
+  /** Epic FHIR base URL — from EHR launch `iss` param OR from settings for Standalone. */
+  iss: string;
+  /** EHR-launch `launch` token. Omit for Standalone. */
+  launch?: string;
+  /** CareBridge user id we will associate the resulting connection with. */
+  userId: string;
+  /** Callback URL we register with Epic. */
+  redirectUri: string;
+  /** CareBridge client id registered at open.epic.com. */
+  clientId: string;
+  /** Where to send the browser after a successful launch. */
+  postLaunchRedirect: string;
+  /** Override scopes; defaults to the full SMART set. */
+  scopes?: readonly string[];
+  /** Override the discovery fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override random bytes (test-only — predictable state values). */
+  rng?: (size: number) => Buffer;
+}
+
+export interface BeginLaunchResult {
+  /** Browser redirects here. */
+  authorizeUrl: string;
+  /** The OAuth state value — also the lookup key in the launch-state store. */
+  state: string;
+}
+
+/**
+ * Step 1: build the authorize URL, persist the launch state under the
+ * generated `state`, and return both.
+ */
+export async function beginLaunch(
+  args: BeginLaunchArgs,
+  store: LaunchStateStore,
+): Promise<BeginLaunchResult> {
+  const smart = await fetchSmartConfiguration(args.iss, args.fetchImpl);
+  if (!smart.authorization_endpoint) {
+    throw new Error(
+      `SMART configuration at ${args.iss} is missing authorization_endpoint — ` +
+        "App Launch requires the OAuth authorize URL",
+    );
+  }
+  const authorizationEndpoint = smart.authorization_endpoint;
+
+  const pkce = generatePkcePair(args.rng);
+  const state = generateOAuthState(args.rng);
+
+  const scopes = (args.scopes ?? DEFAULT_APP_LAUNCH_SCOPES).slice();
+  // Standalone launches must NOT request `launch` — Epic rejects the
+  // authorize call if the scope is present without a launch token.
+  if (!args.launch) {
+    const idx = scopes.indexOf("launch");
+    if (idx >= 0) scopes.splice(idx, 1);
+  }
+
+  const authorizeUrl = buildAuthorizeUrl({
+    authorizeUrl: authorizationEndpoint,
+    clientId: args.clientId,
+    redirectUri: args.redirectUri,
+    scopes,
+    state,
+    aud: args.iss,
+    codeChallenge: pkce.codeChallenge,
+    launch: args.launch,
+  });
+
+  const launchState: LaunchState = {
+    codeVerifier: pkce.codeVerifier,
+    iss: args.iss,
+    tokenUrl: smart.token_endpoint,
+    authorizeUrl: authorizationEndpoint,
+    userId: args.userId,
+    postLaunchRedirect: args.postLaunchRedirect,
+    launchToken: args.launch,
+    createdAt: new Date().toISOString(),
+  };
+  await store.set(state, launchState, STATE_TTL_SECONDS);
+
+  log.info("Epic App Launch initiated", {
+    userId: args.userId,
+    iss: args.iss,
+    isEhrLaunch: Boolean(args.launch),
+  });
+
+  return { authorizeUrl, state };
+}
+
+export interface CompleteLaunchArgs {
+  /** OAuth state from the callback query string. */
+  state: string;
+  /** Authorization code from the callback query string. */
+  code: string;
+  /** CareBridge client id (must match the begin step). */
+  clientId: string;
+  /** Callback URL (must match the begin step — Epic verifies). */
+  redirectUri: string;
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface CompleteLaunchResult {
+  /** CareBridge connection row id we just upserted. */
+  connectionId: string;
+  /** Where the browser should land next. */
+  postLaunchRedirect: string;
+  /** FHIR Patient.id from launch context (EHR launch only). */
+  patientFhirId: string | null;
+  /** FHIR Encounter.id from launch context. */
+  encounterFhirId: string | null;
+  /** FHIR Practitioner.id derived from id_token.fhirUser, if present. */
+  practitionerFhirId: string | null;
+  /** Raw token response — useful for logging and debugging. */
+  tokens: AppLaunchTokenResponse;
+}
+
+/**
+ * Step 2: exchange the auth code for tokens, decode the id_token,
+ * upsert the `epic_user_connections` row, and return where to send the
+ * browser next. Throws on state mismatch / expired state / token-exchange
+ * failure so the route handler can render a coherent error page.
+ */
+export async function completeLaunch(
+  args: CompleteLaunchArgs,
+  store: LaunchStateStore,
+): Promise<CompleteLaunchResult> {
+  const launchState = await store.get(args.state);
+  if (!launchState) {
+    throw new Error("Epic App Launch state expired or unknown");
+  }
+  // Single-use — drop the state before we even attempt the token
+  // exchange so a leaked code can't be replayed.
+  await store.delete(args.state);
+
+  const tokens = await exchangeAuthorizationCode({
+    tokenUrl: launchState.tokenUrl,
+    code: args.code,
+    redirectUri: args.redirectUri,
+    clientId: args.clientId,
+    codeVerifier: launchState.codeVerifier,
+    fetchImpl: args.fetchImpl,
+  });
+
+  const decoded = tokens.id_token ? decodeIdTokenUnsafe(tokens.id_token) : null;
+  const practitionerFhirId = extractPractitionerId(decoded?.fhirUser);
+
+  const expiresAtMs = Date.now() + tokens.expires_in * 1000;
+
+  const connectionId = await upsertEpicConnection({
+    user_id: launchState.userId,
+    epic_org_iss: launchState.iss,
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token ?? null,
+    expires_at: new Date(expiresAtMs).toISOString(),
+    scopes: tokens.scope,
+    id_token_subject: decoded?.sub ?? null,
+    epic_practitioner_fhir_id: practitionerFhirId,
+    epic_patient_fhir_id: tokens.patient ?? null,
+    launch_encounter_fhir_id: tokens.encounter ?? null,
+  });
+
+  log.info("Epic App Launch completed", {
+    connectionId,
+    userId: launchState.userId,
+    iss: launchState.iss,
+    practitionerFhirId,
+    hasPatientContext: Boolean(tokens.patient),
+  });
+
+  return {
+    connectionId,
+    postLaunchRedirect: launchState.postLaunchRedirect,
+    patientFhirId: tokens.patient ?? null,
+    encounterFhirId: tokens.encounter ?? null,
+    practitionerFhirId,
+    tokens,
+  };
+}
+
+/**
+ * 32 bytes → 43 base64url chars — same shape as the PKCE verifier so
+ * Epic's permissive state validation accepts it without escaping
+ * surprises in the URL.
+ */
+function generateOAuthState(rng: (size: number) => Buffer = randomBytes): string {
+  return rng(32)
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export type { SmartConfiguration };

--- a/services/epic-connector/src/app-launch/pkce.ts
+++ b/services/epic-connector/src/app-launch/pkce.ts
@@ -1,0 +1,71 @@
+/**
+ * PKCE (RFC 7636) helpers for SMART on FHIR App Launch (#392).
+ *
+ * Epic's SMART App Launch flow requires PKCE — the implicit grant is
+ * disallowed and bare authorization-code without `code_challenge` is
+ * rejected by the authorise endpoint.
+ *
+ * We use the S256 challenge method (the only one Epic accepts in
+ * production). The `code_verifier` is a 43-128 char URL-safe random
+ * string; the `code_challenge` is BASE64URL(SHA256(verifier)).
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+export interface PkcePair {
+  /** 43-char base64url-encoded random secret. Send with token exchange. */
+  codeVerifier: string;
+  /** SHA-256(codeVerifier), base64url-encoded. Sent on the authorize URL. */
+  codeChallenge: string;
+  /** Always "S256" — Epic does not accept "plain". */
+  codeChallengeMethod: "S256";
+}
+
+/**
+ * Generate a fresh PKCE verifier/challenge pair. The verifier MUST be
+ * persisted server-side keyed by the OAuth `state` value so the
+ * callback can supply it during code exchange (the browser does not
+ * see the verifier — that's the point of PKCE).
+ */
+export function generatePkcePair(
+  rng: (size: number) => Buffer = randomBytes,
+): PkcePair {
+  // 32 bytes → 43 base64url characters. RFC 7636 §4.1 requires 43-128
+  // characters; 43 is the minimum that still gives 256 bits of entropy
+  // after the base64url encoding.
+  const verifier = base64UrlEncode(rng(32));
+  const challenge = base64UrlEncode(createHash("sha256").update(verifier).digest());
+  return {
+    codeVerifier: verifier,
+    codeChallenge: challenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+/**
+ * Verify that a challenge derives from a verifier — used in tests
+ * and in defensive checks at code-exchange time.
+ */
+export function verifyChallenge(verifier: string, challenge: string): boolean {
+  const expected = base64UrlEncode(
+    createHash("sha256").update(verifier).digest(),
+  );
+  return timingSafeEqual(expected, challenge);
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+/** Length-aware constant-time string compare. */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/services/epic-connector/src/app-launch/state-store.ts
+++ b/services/epic-connector/src/app-launch/state-store.ts
@@ -1,0 +1,131 @@
+/**
+ * Short-lived launch-state storage for SMART App Launch (#392).
+ *
+ * The OAuth `state` parameter we mint on the /authorize step indexes a
+ * server-side record holding:
+ *   - the PKCE `code_verifier` we'll need on code exchange
+ *   - the `iss` / token URL we discovered (so the callback doesn't have
+ *     to re-fetch .well-known/smart-configuration)
+ *   - the CareBridge user_id we associate the resulting tokens with
+ *   - which redirect URL to bounce the user to after success
+ *   - the launch-context token (`launch=…`) so we can correlate
+ *
+ * Backed by Redis with a short TTL — the OAuth state is single-use and
+ * worthless after the user finishes the authorize round-trip. We don't
+ * persist this to the main DB because:
+ *   - one row per launch attempt would fill the table quickly
+ *   - we don't want to GC abandoned authorize flows ourselves
+ *
+ * The interface is dependency-injected so tests can swap in an in-memory
+ * store and avoid Redis.
+ */
+export interface LaunchState {
+  /** PKCE verifier — never serialised to the client. */
+  codeVerifier: string;
+  /** Epic FHIR base URL (the `iss`). */
+  iss: string;
+  /** Resolved token endpoint URL. */
+  tokenUrl: string;
+  /** Authorize endpoint we redirected to (echoed for audit). */
+  authorizeUrl: string;
+  /** CareBridge user id this launch is for. */
+  userId: string;
+  /** Final redirect URL after success (e.g. /patients/<id>). */
+  postLaunchRedirect: string;
+  /** EHR-launch `launch` token, if this is an EHR launch. */
+  launchToken?: string;
+  /** Created-at wall-clock for debugging. */
+  createdAt: string;
+}
+
+export interface LaunchStateStore {
+  set(state: string, value: LaunchState, ttlSeconds: number): Promise<void>;
+  get(state: string): Promise<LaunchState | null>;
+  /** Remove (consume) — every state is single-use. */
+  delete(state: string): Promise<void>;
+}
+
+/**
+ * Pure in-memory implementation. Used in tests AND as a sane default
+ * for single-process dev runs where bringing up Redis is overkill.
+ * Production multi-pod deployments MUST swap for the Redis-backed
+ * implementation below.
+ */
+export class InMemoryLaunchStateStore implements LaunchStateStore {
+  private readonly store = new Map<
+    string,
+    { value: LaunchState; expiresAt: number }
+  >();
+
+  constructor(private readonly nowMs: () => number = () => Date.now()) {}
+
+  async set(
+    state: string,
+    value: LaunchState,
+    ttlSeconds: number,
+  ): Promise<void> {
+    this.store.set(state, {
+      value,
+      expiresAt: this.nowMs() + ttlSeconds * 1000,
+    });
+  }
+
+  async get(state: string): Promise<LaunchState | null> {
+    const entry = this.store.get(state);
+    if (!entry) return null;
+    if (entry.expiresAt < this.nowMs()) {
+      this.store.delete(state);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async delete(state: string): Promise<void> {
+    this.store.delete(state);
+  }
+}
+
+/**
+ * Redis-backed implementation. Pass an ioredis instance compatible
+ * with the `set EX` / `get` / `del` commands. Kept narrow to avoid
+ * pulling ioredis types into the package — host services already have
+ * a connection.
+ */
+export interface RedisLike {
+  set(key: string, value: string, mode: "EX", ttlSeconds: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  del(key: string): Promise<number>;
+}
+
+const KEY_PREFIX = "epic:applaunch:state:";
+
+export class RedisLaunchStateStore implements LaunchStateStore {
+  constructor(private readonly redis: RedisLike) {}
+
+  async set(
+    state: string,
+    value: LaunchState,
+    ttlSeconds: number,
+  ): Promise<void> {
+    await this.redis.set(
+      KEY_PREFIX + state,
+      JSON.stringify(value),
+      "EX",
+      ttlSeconds,
+    );
+  }
+
+  async get(state: string): Promise<LaunchState | null> {
+    const raw = await this.redis.get(KEY_PREFIX + state);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as LaunchState;
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(state: string): Promise<void> {
+    await this.redis.del(KEY_PREFIX + state);
+  }
+}

--- a/services/epic-connector/src/app-launch/token-exchange.ts
+++ b/services/epic-connector/src/app-launch/token-exchange.ts
@@ -1,0 +1,175 @@
+/**
+ * SMART App Launch authorization-code → token exchange (#392).
+ *
+ * Posts to Epic's token endpoint with the authorization code, redirect
+ * URI (must match what was sent on the authorize step), client_id, and
+ * PKCE code_verifier. Returns the parsed token response including
+ * id_token and the EHR-launch context fields (`patient`, `encounter`).
+ *
+ * No client_secret — Epic public-client App Launch is PKCE-only.
+ *
+ * Spec: https://build.fhir.org/ig/HL7/smart-app-launch/app-launch.html#token-response
+ */
+import { createLogger } from "@carebridge/logger";
+
+const log = createLogger("epic-app-launch-token");
+
+export interface ExchangeArgs {
+  tokenUrl: string;
+  code: string;
+  redirectUri: string;
+  clientId: string;
+  codeVerifier: string;
+  /** Override for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Subset of the token response that callers consume. Epic emits
+ * additional fields (`refresh_token_expires_in`, `need_patient_banner`,
+ * etc.) — passthrough JSON in {@link extra} preserves them so we don't
+ * have to revisit this file every time Epic adds a field.
+ */
+export interface AppLaunchTokenResponse {
+  access_token: string;
+  token_type: string;
+  /** Seconds until expiry, from issue time. */
+  expires_in: number;
+  /** Granted scopes (space-separated; may be a subset of requested). */
+  scope: string;
+  /**
+   * OpenID Connect id_token. Decoded by the caller; we don't sign-verify
+   * here because Epic's JWKS rotation cadence is out of scope for the
+   * App-Launch unit. Signature verification is best-effort delegated to
+   * the OAuth-callback handler.
+   */
+  id_token?: string;
+  /** Refresh token (only when `offline_access` was granted). */
+  refresh_token?: string;
+  /** EHR-launch patient context (FHIR Patient.id). Absent for Standalone. */
+  patient?: string;
+  /** EHR-launch encounter context (FHIR Encounter.id). Often absent. */
+  encounter?: string;
+  /** Raw passthrough for fields we don't model. */
+  extra: Record<string, unknown>;
+}
+
+export async function exchangeAuthorizationCode(
+  args: ExchangeArgs,
+): Promise<AppLaunchTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: args.code,
+    redirect_uri: args.redirectUri,
+    client_id: args.clientId,
+    code_verifier: args.codeVerifier,
+  });
+
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const response = await fetchImpl(args.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const text = await safeReadBody(response);
+    log.warn("Epic App Launch token exchange failed", {
+      status: response.status,
+      bodyPrefix: text.slice(0, 200),
+    });
+    throw new Error(
+      `Epic token endpoint returned ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+
+  // Type-narrow each field we expose. Unknown extras stay in `extra`
+  // for callers that need them (need_patient_banner, smart_style_url
+  // for embedded launch UI theming, etc).
+  const known = new Set([
+    "access_token",
+    "token_type",
+    "expires_in",
+    "scope",
+    "id_token",
+    "refresh_token",
+    "patient",
+    "encounter",
+  ]);
+  const extra: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(json)) {
+    if (!known.has(k)) extra[k] = v;
+  }
+
+  return {
+    access_token: String(json.access_token ?? ""),
+    token_type: String(json.token_type ?? "Bearer"),
+    expires_in: Number(json.expires_in ?? 0),
+    scope: String(json.scope ?? ""),
+    id_token: optString(json.id_token),
+    refresh_token: optString(json.refresh_token),
+    patient: optString(json.patient),
+    encounter: optString(json.encounter),
+    extra,
+  };
+}
+
+function optString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Decode the JWS payload of an id_token without verifying the signature.
+ * Use only when:
+ *   - The token was just returned over TLS by the issuer's token endpoint
+ *     (we trust the source, not the token in isolation)
+ *   - The caller logs the issuer mismatch / kid lookup separately
+ * For long-term acceptance of an id_token (e.g. as a session anchor),
+ * use a JWKS verifier instead.
+ */
+export function decodeIdTokenUnsafe(
+  idToken: string,
+): { sub?: string; fhirUser?: string; iss?: string; aud?: string } | null {
+  const parts = idToken.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const payloadBase64 = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payloadBase64.padEnd(
+      payloadBase64.length + ((4 - (payloadBase64.length % 4)) % 4),
+      "=",
+    );
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    return JSON.parse(decoded) as {
+      sub?: string;
+      fhirUser?: string;
+      iss?: string;
+      aud?: string;
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the Practitioner FHIR id from the `fhirUser` claim.
+ * The claim's value is a URL like `https://fhir.epic.com/.../Practitioner/abc-123`.
+ * Returns just `abc-123`, or null if the claim doesn't reference a Practitioner.
+ */
+export function extractPractitionerId(fhirUser: string | undefined): string | null {
+  if (!fhirUser) return null;
+  const m = fhirUser.match(/\/Practitioner\/([^/?#]+)$/);
+  return m ? m[1]! : null;
+}

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -102,3 +102,43 @@ export {
   type EpicSyncJobData,
 } from "./workers/sync-worker.js";
 export { epicSyncRouter, type EpicSyncRouter } from "./router.js";
+export {
+  generatePkcePair,
+  verifyChallenge,
+  type PkcePair,
+} from "./app-launch/pkce.js";
+export {
+  buildAuthorizeUrl,
+  DEFAULT_APP_LAUNCH_SCOPES,
+  type AuthorizeUrlArgs,
+} from "./app-launch/authorize.js";
+export {
+  exchangeAuthorizationCode,
+  decodeIdTokenUnsafe,
+  extractPractitionerId,
+  type AppLaunchTokenResponse,
+  type ExchangeArgs,
+} from "./app-launch/token-exchange.js";
+export {
+  InMemoryLaunchStateStore,
+  RedisLaunchStateStore,
+  type LaunchStateStore,
+  type LaunchState,
+  type RedisLike,
+} from "./app-launch/state-store.js";
+export {
+  beginLaunch,
+  completeLaunch,
+  type BeginLaunchArgs,
+  type BeginLaunchResult,
+  type CompleteLaunchArgs,
+  type CompleteLaunchResult,
+} from "./app-launch/launch-service.js";
+export {
+  upsertEpicConnection,
+  getConnectionsForUser,
+  getConnection,
+  deleteConnection,
+  type EpicConnectionUpsert,
+  type EpicConnectionRow,
+} from "./app-launch/connection-repo.js";


### PR DESCRIPTION
Replaces #1087 (auto-closed when feat/391 was deleted during the #1091 squash-merge).

## Summary

Implements #392. User-facing complement to #389 system-to-system auth — a clinician can click "CareBridge" inside Epic MyChart (EHR Launch) **or** open CareBridge and authorize against Epic (Standalone Launch). Tokens persisted per (user, Epic org).

Builds on #1084 / #1090 / #1091.

- **Migration 0049 (idx 53)**: \`epic_user_connections\` — encrypted access/refresh tokens via the same hook used for PHI.
- **PKCE (RFC 7636 S256)**: 43-char base64url verifier, single-use OAuth state, code-replay attempts fail closed.
- **Authorize URL builder** with full SMART param set incl. \`aud\` (confused-deputy protection) and \`code_challenge_method=S256\`.
- **Token exchange**: PKCE-only public-client POST. No \`client_secret\` ever leaves the server.
- **id_token decoding** (unverified, only after TLS receipt from issuer) — extracts \`fhirUser\` Practitioner FHIR id.
- **Launch-state store**: \`InMemoryLaunchStateStore\` + \`RedisLaunchStateStore\`, 10-minute TTL.
- **Fastify routes**: \`GET /auth/epic/authorize\` + \`GET /auth/epic/callback\`. No-op registration when Epic env vars unset.
- **tRPC**: \`epicAuth.getMyConnections\`, \`getLaunchContext\`, \`disconnect\`. Tokens never leave the server.

## Test plan

- [x] 29 new unit tests (108 total in epic-connector, all offline)
- [x] \`pnpm turbo typecheck lint\` clean (40/40)

Original PR: #1087