### PR TITLE
feat(epic): push CareBridge AI flags to Epic as FHIR Flag (#393)

### DIFF
--- a/packages/db-schema/drizzle/0050_clinical_flags_epic_push.sql
+++ b/packages/db-schema/drizzle/0050_clinical_flags_epic_push.sql
@@ -1,0 +1,24 @@
+-- #393: outbound FHIR Flag push tracking on clinical_flags.
+--
+-- When the epic-outbound-flags worker successfully POSTs a CareBridge
+-- clinical_flag to Epic as a FHIR Flag resource, it records the Epic
+-- resource id here so subsequent status changes (acknowledge / resolve
+-- / dismiss) can be propagated via PUT rather than re-creating the
+-- resource on Epic's side. NULL on rows that haven't been pushed (Epic
+-- disabled locally, push failed, or push not yet processed).
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_flag_id" text;
+
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_org_iss" text;
+
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_pushed_at" text;
+
+-- Most-recent push error, truncated to 1KiB by the writer. NULL when
+-- the row has never failed or the most-recent push succeeded.
+ALTER TABLE "clinical_flags"
+  ADD COLUMN IF NOT EXISTS "epic_push_error" text;
+
+CREATE INDEX IF NOT EXISTS "idx_clinical_flags_epic_flag_id"
+  ON "clinical_flags" ("epic_flag_id");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1747929960000,
       "tag": "0049_epic_user_connections",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1747930020000,
+      "tag": "0050_clinical_flags_epic_push",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/ai-flags.ts
+++ b/packages/db-schema/src/schema/ai-flags.ts
@@ -37,6 +37,19 @@ export const clinicalFlags = pgTable("clinical_flags", {
    * Null for LLM-path flags and historical rows pre-#1039.
    */
   metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+  /**
+   * Outbound Epic FHIR Flag id (#393). Populated once this flag has
+   * been successfully POSTed to Epic; NULL otherwise. Subsequent status
+   * changes (acknowledge / resolve / dismiss) PUT to this id rather
+   * than re-creating the resource on Epic.
+   */
+  epic_flag_id: text("epic_flag_id"),
+  /** Epic org `iss` the flag was pushed to. */
+  epic_org_iss: text("epic_org_iss"),
+  /** Wall-clock time of the last successful push. */
+  epic_pushed_at: text("epic_pushed_at"),
+  /** Most-recent push error (truncated to 1KiB). NULL on success. */
+  epic_push_error: text("epic_push_error"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_flags_patient").on(table.patient_id, table.status),
@@ -48,6 +61,7 @@ export const clinicalFlags = pgTable("clinical_flags", {
     table.escalation_count,
   ),
   index("idx_flags_trigger_event_ids").using("gin", sql`trigger_event_ids jsonb_path_ops`),
+  index("idx_clinical_flags_epic_flag_id").on(table.epic_flag_id),
   uniqueIndex("idx_flags_open_rule_dedup")
     .on(table.patient_id, table.rule_id)
     .where(sql`status = 'open' AND rule_id IS NOT NULL`),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       '@carebridge/db-schema':
         specifier: workspace:*
         version: link:../../packages/db-schema
+      '@carebridge/epic-connector':
+        specifier: workspace:*
+        version: link:../epic-connector
       '@carebridge/logger':
         specifier: workspace:*
         version: link:../../packages/logger
@@ -6077,8 +6080,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6097,7 +6100,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6108,22 +6111,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6134,7 +6137,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/services/ai-oversight/package.json
+++ b/services/ai-oversight/package.json
@@ -29,6 +29,7 @@
     "@carebridge/db-schema": "workspace:*",
     "@carebridge/medical-logic": "workspace:*",
     "@carebridge/ai-prompts": "workspace:*",
+    "@carebridge/epic-connector": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
     "bullmq": "^5.30.0",
     "drizzle-orm": "^0.38.0",

--- a/services/ai-oversight/src/services/flag-service.ts
+++ b/services/ai-oversight/src/services/flag-service.ts
@@ -16,6 +16,10 @@ import {
   recordFlagResolved,
 } from "./shadow-metrics.js";
 import { emitNotificationEvent } from "@carebridge/notifications";
+import {
+  enqueueEpicFlagPushCreate,
+  enqueueEpicFlagPushUpdate,
+} from "@carebridge/epic-connector";
 
 // 24 hours in milliseconds — window for LLM flag deduplication
 const LLM_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -185,6 +189,11 @@ export async function createFlag(
     created_at: now,
   });
 
+  // Push to Epic as a FHIR Flag resource (#393). The enqueue is a
+  // no-op when EPIC_CLIENT_ID isn't configured, so this is safe to
+  // call unconditionally — local dev without Epic creds just skips it.
+  await enqueueEpicFlagPushCreate(id);
+
   return record as ClinicalFlag;
 }
 
@@ -206,6 +215,8 @@ export async function acknowledgeFlag(
       acknowledged_at: now,
     })
     .where(eq(clinicalFlags.id, flagId));
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**
@@ -234,6 +245,8 @@ export async function resolveFlag(
     rule_id: rows[0]?.rule_id ?? undefined,
     source: rows[0]?.source as ClinicalFlag["source"] | undefined,
   });
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**
@@ -262,6 +275,8 @@ export async function dismissFlag(
     rule_id: rows[0]?.rule_id ?? undefined,
     source: rows[0]?.source as ClinicalFlag["source"] | undefined,
   });
+
+  await enqueueEpicFlagPushUpdate(flagId);
 }
 
 /**

--- a/services/epic-connector/src/__tests__/fhir-client-write.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client-write.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the EpicFhirClient write methods (#393).
+ *
+ * Verifies the POST/PUT request shape, retry behavior, and
+ * OperationOutcome error handling.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import type { EpicConfig } from "../config.js";
+
+function tokenResponse() {
+  return new Response(
+    JSON.stringify({
+      access_token: "tok",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "system/*.write",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function jsonFhir(body: unknown, init: ResponseInit = { status: 201 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/fhir+json", ...(init.headers ?? {}) },
+  });
+}
+
+function makeConfig(privatePem: string): EpicConfig {
+  return {
+    clientId: "test-client",
+    tokenUrl: "https://fhir.epic.com/oauth2/token",
+    fhirBaseUrl: "https://fhir.epic.com/api/FHIR/R4/",
+    privateKeyPem: privatePem,
+    jwtKid: "test-kid",
+  };
+}
+
+describe("EpicFhirClient.createResource / updateResource (#393)", () => {
+  let privatePem: string;
+  beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    privatePem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  });
+
+  function setup(responses: Response[]) {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.endsWith("/token")) return tokenResponse();
+      const next = responses.shift();
+      if (!next) throw new Error(`unexpected fetch: ${url}`);
+      return next;
+    });
+    const config = makeConfig(privatePem);
+    const tokens = new EpicTokenClient(config, fetchMock);
+    const client = new EpicFhirClient(config, tokens, {
+      fetchImpl: fetchMock,
+      sleep: vi.fn().mockResolvedValue(undefined),
+      backoffBaseMs: 1,
+    });
+    return { client, fetchMock };
+  }
+
+  it("createResource POSTs FHIR JSON to the base URL + resource type", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-1" }, { status: 201 }),
+    ]);
+
+    const result = await client.createResource("Flag", {
+      resourceType: "Flag",
+      status: "active",
+      code: { text: "demo" },
+    });
+
+    expect(result).toMatchObject({ resourceType: "Flag", id: "epic-flag-1" });
+
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe("https://fhir.epic.com/api/FHIR/R4/Flag");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/fhir+json");
+    expect(init.headers.Authorization).toBe("Bearer tok");
+    expect(JSON.parse(init.body)).toMatchObject({ resourceType: "Flag" });
+  });
+
+  it("updateResource PUTs to /{type}/{id}", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-1" }),
+    ]);
+
+    await client.updateResource("Flag", "epic-flag-1", {
+      resourceType: "Flag",
+      id: "epic-flag-1",
+      status: "inactive",
+      code: { text: "demo" },
+    });
+
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(url).toBe("https://fhir.epic.com/api/FHIR/R4/Flag/epic-flag-1");
+    expect(init.method).toBe("PUT");
+  });
+
+  it("throws on OperationOutcome response (write rejected by Epic)", async () => {
+    const { client } = setup([
+      jsonFhir(
+        {
+          resourceType: "OperationOutcome",
+          issue: [
+            { severity: "error", code: "invariant", diagnostics: "missing subject" },
+          ],
+        },
+        { status: 422 },
+      ),
+    ]);
+
+    await expect(
+      client.createResource("Flag", {
+        resourceType: "Flag",
+        status: "active",
+        code: { text: "x" },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("retries on 503 then succeeds (same backoff path as reads)", async () => {
+    const { client, fetchMock } = setup([
+      jsonFhir({}, { status: 503 }),
+      jsonFhir({ resourceType: "Flag", id: "epic-flag-2" }, { status: 201 }),
+    ]);
+
+    const result = await client.createResource("Flag", {
+      resourceType: "Flag",
+      status: "active",
+      code: { text: "x" },
+    });
+
+    expect(result).toMatchObject({ id: "epic-flag-2" });
+    // Token + 503 + retry = 3 fetches
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/services/epic-connector/src/__tests__/flag-generator.test.ts
+++ b/services/epic-connector/src/__tests__/flag-generator.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the CareBridge ClinicalFlag → FHIR Flag generator (#393).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildFhirFlag,
+  flagSeverityCoding,
+  mapFlagStatusToFhir,
+  CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+  FHIR_FLAG_CATEGORY_SYSTEM,
+  RATIONALE_EXTENSION_URL,
+  SUGGESTED_ACTION_EXTENSION_URL,
+  RULE_ID_EXTENSION_URL,
+} from "../outbound/flag-generator.js";
+
+const baseFlag = {
+  summary: "Cross-specialty stroke risk: VTE + new neurologic symptoms",
+  rationale: "Patient with active VTE prescribed anticoagulant; reports headache",
+  suggested_action: "Order STAT non-contrast CT head",
+  severity: "critical" as const,
+  category: "cross-specialty" as const,
+  status: "open" as const,
+  rule_id: "ONCO-VTE-NEURO-001",
+  created_at: "2026-05-22T10:00:00Z",
+  resolved_at: undefined,
+  dismissed_at: undefined,
+};
+
+describe("buildFhirFlag (#393)", () => {
+  it("produces a FHIR R4 Flag with all required spec fields", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "epic-patient-1",
+    });
+
+    expect(flag.resourceType).toBe("Flag");
+    expect(flag.status).toBe("active");
+    expect(flag.code.text).toBe(baseFlag.summary);
+    expect(flag.subject.reference).toBe("Patient/epic-patient-1");
+    expect(flag.category[0]?.coding[0]?.system).toBe(FHIR_FLAG_CATEGORY_SYSTEM);
+    expect(flag.category[0]?.coding[0]?.code).toBe("clinical");
+  });
+
+  it("encodes severity in the code.coding entry", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const sev = flag.code.coding[0]!;
+    expect(sev.system).toBe(CAREBRIDGE_FLAG_SEVERITY_SYSTEM);
+    expect(sev.code).toBe("critical");
+    expect(sev.display).toMatch(/Critical/);
+  });
+
+  it("carries the category as a secondary coding for richer Epic display", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const codings = flag.category[0]?.coding ?? [];
+    const cb = codings.find((c) =>
+      c.system?.startsWith("https://carebridge.dev"),
+    );
+    expect(cb?.code).toBe("cross-specialty");
+  });
+
+  it("emits rationale + suggested_action + rule_id as FHIR extensions", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+    });
+    const ext = flag.extension ?? [];
+    expect(ext.find((e) => e.url === RATIONALE_EXTENSION_URL)?.valueString).toBe(
+      baseFlag.rationale,
+    );
+    expect(
+      ext.find((e) => e.url === SUGGESTED_ACTION_EXTENSION_URL)?.valueString,
+    ).toBe(baseFlag.suggested_action);
+    expect(ext.find((e) => e.url === RULE_ID_EXTENSION_URL)?.valueString).toBe(
+      baseFlag.rule_id,
+    );
+  });
+
+  it("omits rule_id extension when the flag is LLM-only (no rule_id)", () => {
+    const flag = buildFhirFlag({
+      flag: { ...baseFlag, rule_id: undefined },
+      epicPatientFhirId: "p-1",
+    });
+    const ext = flag.extension ?? [];
+    expect(ext.find((e) => e.url === RULE_ID_EXTENSION_URL)).toBeUndefined();
+  });
+
+  it("sets period.end on resolved flags", () => {
+    const flag = buildFhirFlag({
+      flag: {
+        ...baseFlag,
+        status: "resolved",
+        resolved_at: "2026-05-22T18:00:00Z",
+      },
+      epicPatientFhirId: "p-1",
+    });
+    expect(flag.status).toBe("inactive");
+    expect(flag.period?.start).toBe(baseFlag.created_at);
+    expect(flag.period?.end).toBe("2026-05-22T18:00:00Z");
+  });
+
+  it("sets period.end on dismissed flags", () => {
+    const flag = buildFhirFlag({
+      flag: {
+        ...baseFlag,
+        status: "dismissed",
+        dismissed_at: "2026-05-22T18:30:00Z",
+      },
+      epicPatientFhirId: "p-1",
+    });
+    expect(flag.status).toBe("inactive");
+    expect(flag.period?.end).toBe("2026-05-22T18:30:00Z");
+  });
+
+  it("propagates the epicFlagId onto the output for PUT payloads", () => {
+    const flag = buildFhirFlag({
+      flag: baseFlag,
+      epicPatientFhirId: "p-1",
+      epicFlagId: "epic-flag-abc",
+    });
+    expect(flag.id).toBe("epic-flag-abc");
+  });
+
+  it("acknowledged + escalated map to active (still surfaces in Epic banner)", () => {
+    expect(mapFlagStatusToFhir("open")).toBe("active");
+    expect(mapFlagStatusToFhir("acknowledged")).toBe("active");
+    expect(mapFlagStatusToFhir("escalated")).toBe("active");
+    expect(mapFlagStatusToFhir("resolved")).toBe("inactive");
+    expect(mapFlagStatusToFhir("dismissed")).toBe("inactive");
+  });
+
+  it("flagSeverityCoding includes a clinician-readable display per severity band", () => {
+    expect(flagSeverityCoding("critical").display).toMatch(/Critical/);
+    expect(flagSeverityCoding("warning").display).toMatch(/review/i);
+    expect(flagSeverityCoding("info").display).toBe("Informational");
+  });
+});

--- a/services/epic-connector/src/__tests__/flag-push.test.ts
+++ b/services/epic-connector/src/__tests__/flag-push.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the outbound flag-push orchestrator (#393).
+ *
+ * Mocks @carebridge/db-schema so no Postgres is required. Verifies:
+ *   - POST when epic_flag_id is unset (create path)
+ *   - PUT when epic_flag_id is already set (update path)
+ *   - skipped when patient has no Epic mapping
+ *   - audit_log row written on success AND on failure
+ *   - clinical_flags row updated with epic_flag_id + push timestamp
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  clinicalFlags: { id: "id" },
+  patients: {},
+  auditLog: {},
+  fhirResources: {
+    internal_record_id: "internal_record_id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+  },
+}));
+
+const { pushFlagToEpic, pushFlagStatusUpdate } = await import(
+  "../outbound/flag-push.js"
+);
+
+const FLAG = {
+  id: "flag-1",
+  patient_id: "patient-1",
+  summary: "summary text",
+  rationale: "rationale text",
+  suggested_action: "suggested action",
+  severity: "critical",
+  category: "cross-specialty",
+  status: "open",
+  rule_id: "ONCO-VTE-NEURO-001",
+  created_at: "2026-05-22T10:00:00Z",
+  resolved_at: null,
+  dismissed_at: null,
+  epic_flag_id: null,
+};
+
+function fakeClient() {
+  return {
+    createResource: vi
+      .fn()
+      .mockResolvedValue({ resourceType: "Flag", id: "epic-flag-99" }),
+    updateResource: vi
+      .fn()
+      .mockResolvedValue({ resourceType: "Flag", id: "epic-flag-99" }),
+  } as unknown as Parameters<typeof pushFlagToEpic>[1]["client"];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+describe("pushFlagToEpic (#393)", () => {
+  it("creates a Flag on Epic when epic_flag_id is unset, then records the id", async () => {
+    db.willSelect([FLAG]); // load flag
+    db.willSelect([{ resource_id: "epic-patient-1" }]); // patient mapping lookup
+    db.willUpdate(); // clinical_flags update
+    db.willInsert(); // audit_log insert
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+
+    expect(result).toMatchObject({
+      flag_id: "flag-1",
+      epic_flag_id: "epic-flag-99",
+      operation: "created",
+    });
+    expect(client.createResource).toHaveBeenCalledOnce();
+    const [resourceType, body] = (client.createResource as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(resourceType).toBe("Flag");
+    expect(body.resourceType).toBe("Flag");
+    expect(body.subject.reference).toBe("Patient/epic-patient-1");
+
+    // updated clinical_flags row, inserted audit_log
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(db.insert).toHaveBeenCalledOnce();
+    const auditValues = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(auditValues.action).toBe("epic_flag_push");
+    expect(auditValues.success).toBe(true);
+  });
+
+  it("updates an existing Flag on Epic (PUT) when epic_flag_id is already set", async () => {
+    db.willSelect([{ ...FLAG, epic_flag_id: "epic-flag-existing" }]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate();
+    db.willInsert();
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+
+    expect(result.operation).toBe("updated");
+    expect(client.createResource).not.toHaveBeenCalled();
+    expect(client.updateResource).toHaveBeenCalledOnce();
+    const [resourceType, id] = (client.updateResource as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(resourceType).toBe("Flag");
+    expect(id).toBe("epic-flag-existing");
+  });
+
+  it("returns skipped when the patient has no Epic mapping", async () => {
+    db.willSelect([FLAG]);
+    db.willSelect([]); // no mapping rows
+    const client = fakeClient();
+
+    const result = await pushFlagToEpic("flag-1", { client });
+    expect(result.operation).toBe("skipped");
+    expect(result.error).toBe("epic_patient_id_unknown");
+    expect(client.createResource).not.toHaveBeenCalled();
+  });
+
+  it("on Epic write failure, records the error on the flag row + audit_log", async () => {
+    db.willSelect([FLAG]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate(); // epic_push_error write
+    db.willInsert(); // failure audit
+    const client = fakeClient();
+    (client.createResource as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Epic write rejected (422)"),
+    );
+
+    const result = await pushFlagToEpic("flag-1", { client });
+    expect(result.operation).toBe("failed");
+    expect(result.error).toMatch(/Epic write rejected/);
+
+    const auditValues = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(auditValues.action).toBe("epic_flag_push");
+    expect(auditValues.success).toBe(false);
+    expect(auditValues.error_message).toMatch(/Epic write rejected/);
+  });
+
+  it("pushFlagStatusUpdate is a no-op when epic_flag_id is unset", async () => {
+    db.willSelect([{ epic_flag_id: null }]);
+    const client = fakeClient();
+    const result = await pushFlagStatusUpdate("flag-1", { client });
+    expect(result.operation).toBe("skipped");
+    expect(result.error).toBe("not_pushed_yet");
+    expect(client.createResource).not.toHaveBeenCalled();
+    expect(client.updateResource).not.toHaveBeenCalled();
+  });
+
+  it("pushFlagStatusUpdate delegates to pushFlagToEpic when epic_flag_id is set", async () => {
+    // 1st select inside pushFlagStatusUpdate
+    db.willSelect([{ epic_flag_id: "epic-flag-existing" }]);
+    // pushFlagToEpic then re-selects the full flag + mapping
+    db.willSelect([{ ...FLAG, epic_flag_id: "epic-flag-existing" }]);
+    db.willSelect([{ resource_id: "epic-patient-1" }]);
+    db.willUpdate();
+    db.willInsert();
+    const client = fakeClient();
+
+    const result = await pushFlagStatusUpdate("flag-1", { client });
+    expect(result.operation).toBe("updated");
+    expect(client.updateResource).toHaveBeenCalledOnce();
+  });
+});

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -146,21 +146,98 @@ export class EpicFhirClient {
       ? pathOrUrl
       : joinUrl(this.config.fhirBaseUrl, pathOrUrl);
 
-    return this.requestWithRetry<T>(url, /* didRefreshAuth */ false, 0);
+    return this.requestWithRetry<T>(
+      { url, method: "GET" },
+      /* didRefreshAuth */ false,
+      0,
+    );
+  }
+
+  /**
+   * POST a new FHIR resource to Epic. Used by the outbound flag-push
+   * worker (#393) and any other write surface. The returned resource
+   * is what Epic stored — typically the same payload echoed back with
+   * `id` and `meta.versionId` populated.
+   */
+  async createResource<TBody extends FhirResource, TResp = TBody>(
+    resourceType: EpicResourceType | "Flag",
+    body: TBody,
+  ): Promise<TResp> {
+    const url = joinUrl(this.config.fhirBaseUrl, resourceType);
+    const resp = await this.requestWithRetry<TResp | OperationOutcome>(
+      {
+        url,
+        method: "POST",
+        contentType: "application/fhir+json",
+        body: JSON.stringify(body),
+      },
+      false,
+      0,
+    );
+    if (
+      typeof resp === "object" &&
+      resp !== null &&
+      (resp as { resourceType?: string }).resourceType === "OperationOutcome"
+    ) {
+      throw operationOutcomeError(resp as OperationOutcome);
+    }
+    return resp as TResp;
+  }
+
+  /**
+   * PUT an existing FHIR resource on Epic (update by id). The resource
+   * body MUST carry `id` matching the URL path or Epic rejects.
+   */
+  async updateResource<TBody extends FhirResource, TResp = TBody>(
+    resourceType: EpicResourceType | "Flag",
+    id: string,
+    body: TBody,
+  ): Promise<TResp> {
+    const url = joinUrl(
+      this.config.fhirBaseUrl,
+      `${resourceType}/${encodeURIComponent(id)}`,
+    );
+    const resp = await this.requestWithRetry<TResp | OperationOutcome>(
+      {
+        url,
+        method: "PUT",
+        contentType: "application/fhir+json",
+        body: JSON.stringify(body),
+      },
+      false,
+      0,
+    );
+    if (
+      typeof resp === "object" &&
+      resp !== null &&
+      (resp as { resourceType?: string }).resourceType === "OperationOutcome"
+    ) {
+      throw operationOutcomeError(resp as OperationOutcome);
+    }
+    return resp as TResp;
   }
 
   private async requestWithRetry<T>(
-    url: string,
+    args: {
+      url: string;
+      method: "GET" | "POST" | "PUT" | "DELETE";
+      contentType?: string;
+      body?: string;
+    },
     didRefreshAuth: boolean,
     attempt: number,
   ): Promise<T> {
     const token = await this.tokens.getAccessToken();
-    const response = await this.opts.fetchImpl(url, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/fhir+json",
-      },
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/fhir+json",
+    };
+    if (args.contentType) headers["Content-Type"] = args.contentType;
+
+    const response = await this.opts.fetchImpl(args.url, {
+      method: args.method,
+      headers,
+      ...(args.body !== undefined ? { body: args.body } : {}),
     });
 
     if (response.status === 401 && !didRefreshAuth) {
@@ -169,10 +246,10 @@ export class EpicFhirClient {
       // to the caller — repeated 401s mean credentials are misregistered
       // and retrying just hammers Epic's token endpoint.
       log.warn("Epic returned 401 — invalidating token and retrying once", {
-        url,
+        url: args.url,
       });
       this.tokens.invalidate();
-      return this.requestWithRetry<T>(url, true, attempt);
+      return this.requestWithRetry<T>(args, true, attempt);
     }
 
     if (response.status === 429 || response.status >= 500) {
@@ -195,7 +272,7 @@ export class EpicFhirClient {
         delayMs: delay,
       });
       await this.opts.sleep(delay);
-      return this.requestWithRetry<T>(url, didRefreshAuth, attempt + 1);
+      return this.requestWithRetry<T>(args, didRefreshAuth, attempt + 1);
     }
 
     if (!response.ok) {
@@ -206,6 +283,8 @@ export class EpicFhirClient {
       );
     }
 
+    // 204 No Content (rare for FHIR but possible on PUT with Prefer: minimal)
+    if (response.status === 204) return undefined as T;
     return (await response.json()) as T;
   }
 

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -142,3 +142,29 @@ export {
   type EpicConnectionUpsert,
   type EpicConnectionRow,
 } from "./app-launch/connection-repo.js";
+export {
+  buildFhirFlag,
+  flagSeverityCoding,
+  mapFlagStatusToFhir,
+  CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+  FHIR_FLAG_CATEGORY_SYSTEM,
+  RATIONALE_EXTENSION_URL,
+  SUGGESTED_ACTION_EXTENSION_URL,
+  RULE_ID_EXTENSION_URL,
+  type FhirFlag,
+  type BuildFhirFlagArgs,
+} from "./outbound/flag-generator.js";
+export {
+  pushFlagToEpic,
+  pushFlagStatusUpdate,
+  type FlagPushDeps,
+  type FlagPushResult,
+} from "./outbound/flag-push.js";
+export {
+  startEpicOutboundFlagWorker,
+  enqueueEpicFlagPushCreate,
+  enqueueEpicFlagPushUpdate,
+  isEpicOutboundEnabled,
+  EPIC_OUTBOUND_FLAGS_QUEUE_NAME,
+  type EpicOutboundFlagJobData,
+} from "./workers/outbound-flag-worker.js";

--- a/services/epic-connector/src/outbound/flag-generator.ts
+++ b/services/epic-connector/src/outbound/flag-generator.ts
@@ -1,0 +1,213 @@
+/**
+ * CareBridge ClinicalFlag → FHIR R4 Flag generator (#393).
+ *
+ * FHIR R4 Flag spec: https://www.hl7.org/fhir/flag.html
+ *
+ * Mapping decisions:
+ *  - status:    open|acknowledged|escalated → "active"
+ *               resolved|dismissed         → "inactive"
+ *  - category:  always [{ system: "http://terminology.hl7.org/CodeSystem/flag-category", code: "clinical" }]
+ *  - code:      summary as the text + a CareBridge-internal severity coding
+ *               so Epic can render severity bands in its banner UI
+ *  - subject:   Patient/<epic-patient-fhir-id> when available, otherwise
+ *               internal `Patient/<carebridge-id>` (callers should pass
+ *               the Epic id for cross-system referential integrity)
+ *  - period.start: flag.created_at
+ *  - period.end:   set when the flag is inactive — picks the
+ *                  latest resolved_at / dismissed_at
+ *  - author:    Organization reference identifying CareBridge as the
+ *               flag's origin — Epic typically requires a sourced
+ *               author when the flag isn't authored by an Epic user
+ *  - extension: rationale and suggested_action surface as FHIR
+ *               extensions so they're visible alongside the flag
+ *               without polluting the standard code.text field
+ */
+import type {
+  ClinicalFlag,
+  FlagStatus,
+  FlagSeverity,
+} from "@carebridge/shared-types";
+
+export const CAREBRIDGE_FLAG_SEVERITY_SYSTEM =
+  "https://carebridge.dev/fhir/CodeSystem/flag-severity";
+
+export const CAREBRIDGE_FLAG_CATEGORY_SYSTEM =
+  "https://carebridge.dev/fhir/CodeSystem/flag-category";
+
+export const FHIR_FLAG_CATEGORY_SYSTEM =
+  "http://terminology.hl7.org/CodeSystem/flag-category";
+
+export const RATIONALE_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-rationale";
+
+export const SUGGESTED_ACTION_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-suggested-action";
+
+export const RULE_ID_EXTENSION_URL =
+  "https://carebridge.dev/fhir/StructureDefinition/flag-rule-id";
+
+export const CAREBRIDGE_ORGANIZATION_REFERENCE = "Organization/carebridge" as const;
+
+export interface FhirFlag {
+  resourceType: "Flag";
+  id?: string;
+  status: "active" | "inactive" | "entered-in-error";
+  category: Array<{
+    coding: Array<{ system: string; code: string; display?: string }>;
+  }>;
+  code: {
+    coding: Array<{ system: string; code: string; display?: string }>;
+    text: string;
+  };
+  subject: { reference: string };
+  period?: { start?: string; end?: string };
+  author?: { reference: string };
+  extension?: Array<{
+    url: string;
+    valueString?: string;
+  }>;
+  /** Passthrough for fields we don't model — keeps FhirFlag assignable to FhirResource. */
+  [k: string]: unknown;
+}
+
+export interface BuildFhirFlagArgs {
+  flag: Pick<
+    ClinicalFlag,
+    | "summary"
+    | "rationale"
+    | "suggested_action"
+    | "severity"
+    | "category"
+    | "status"
+    | "rule_id"
+    | "created_at"
+    | "resolved_at"
+    | "dismissed_at"
+  >;
+  /**
+   * FHIR Patient.id on Epic's side. Prefer the Epic id over the
+   * CareBridge UUID so the resource references resolve correctly when
+   * Epic's UI dereferences `subject.reference`.
+   */
+  epicPatientFhirId: string;
+  /**
+   * Optional existing Epic Flag id — set when generating a payload
+   * for a PUT (status update) so the output carries the right
+   * resource id.
+   */
+  epicFlagId?: string;
+}
+
+/**
+ * Map the internal CareBridge severity enum to a FHIR Flag.code coding.
+ * Display values are clinician-readable strings Epic surfaces in the
+ * Storyboard banner.
+ */
+export function flagSeverityCoding(severity: FlagSeverity): {
+  system: string;
+  code: FlagSeverity;
+  display: string;
+} {
+  switch (severity) {
+    case "critical":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "critical",
+        display: "Critical — immediate clinician attention required",
+      };
+    case "warning":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "warning",
+        display: "Warning — review recommended",
+      };
+    case "info":
+      return {
+        system: CAREBRIDGE_FLAG_SEVERITY_SYSTEM,
+        code: "info",
+        display: "Informational",
+      };
+  }
+}
+
+/**
+ * Map the internal FlagStatus to FHIR Flag.status. Resolved /
+ * dismissed flags are surfaced as `inactive` so they remain visible
+ * in Epic's history without raising the banner. `entered-in-error`
+ * is reserved for cases where CareBridge needs to retract a flag
+ * after-the-fact — not the same as `dismissed` (which means the
+ * clinician saw it and chose to ignore).
+ */
+export function mapFlagStatusToFhir(
+  status: FlagStatus,
+): "active" | "inactive" {
+  if (status === "resolved" || status === "dismissed") return "inactive";
+  return "active";
+}
+
+/**
+ * Determine the end of the active period. Returns null when the flag
+ * is still active.
+ */
+function periodEnd(
+  flag: BuildFhirFlagArgs["flag"],
+): string | null {
+  if (flag.status === "resolved") return flag.resolved_at ?? null;
+  if (flag.status === "dismissed") return flag.dismissed_at ?? null;
+  return null;
+}
+
+/**
+ * Build a FHIR R4 Flag resource ready to POST to Epic. The result
+ * passes FHIR R4 schema validation against the
+ * `http://hl7.org/fhir/StructureDefinition/Flag` profile (required
+ * fields: status, code, subject).
+ */
+export function buildFhirFlag(args: BuildFhirFlagArgs): FhirFlag {
+  const { flag } = args;
+  const severityCoding = flagSeverityCoding(flag.severity);
+  const status = mapFlagStatusToFhir(flag.status);
+  const end = periodEnd(flag);
+
+  const extension: FhirFlag["extension"] = [
+    { url: RATIONALE_EXTENSION_URL, valueString: flag.rationale },
+    { url: SUGGESTED_ACTION_EXTENSION_URL, valueString: flag.suggested_action },
+  ];
+  if (flag.rule_id) {
+    extension.push({ url: RULE_ID_EXTENSION_URL, valueString: flag.rule_id });
+  }
+
+  const out: FhirFlag = {
+    resourceType: "Flag",
+    status,
+    category: [
+      {
+        coding: [
+          { system: FHIR_FLAG_CATEGORY_SYSTEM, code: "clinical" },
+          {
+            system: CAREBRIDGE_FLAG_CATEGORY_SYSTEM,
+            code: flag.category,
+            display: flag.category,
+          },
+        ],
+      },
+    ],
+    code: {
+      coding: [severityCoding],
+      text: flag.summary,
+    },
+    subject: { reference: `Patient/${args.epicPatientFhirId}` },
+    period: {
+      start: flag.created_at,
+      ...(end ? { end } : {}),
+    },
+    author: { reference: CAREBRIDGE_ORGANIZATION_REFERENCE },
+    extension,
+  };
+
+  if (args.epicFlagId) {
+    out.id = args.epicFlagId;
+  }
+
+  return out;
+}

--- a/services/epic-connector/src/outbound/flag-push.ts
+++ b/services/epic-connector/src/outbound/flag-push.ts
@@ -1,0 +1,270 @@
+/**
+ * Outbound flag-push orchestrator (#393).
+ *
+ * Pushes CareBridge `clinical_flags` rows to Epic as FHIR Flag resources.
+ *
+ * Two entry points:
+ *   pushFlagToEpic(flagId, deps)         — creates the Flag on Epic
+ *                                          (or updates an existing one
+ *                                          if epic_flag_id is set)
+ *   pushFlagStatusUpdate(flagId, deps)   — updates the Flag's status
+ *                                          when the CareBridge flag is
+ *                                          acknowledged / resolved /
+ *                                          dismissed
+ *
+ * Both write to `audit_log` with action="epic_flag_push" and to the
+ * `clinical_flags` row's epic_* tracking columns so a re-run is
+ * idempotent: a flag already pushed updates in place instead of being
+ * created twice on Epic's side.
+ */
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { createLogger } from "@carebridge/logger";
+import {
+  getDb,
+  clinicalFlags,
+  auditLog,
+  fhirResources,
+} from "@carebridge/db-schema";
+import { EpicFhirClient } from "../fhir-client.js";
+import { buildFhirFlag, type FhirFlag } from "./flag-generator.js";
+import { EPIC_SOURCE_SYSTEM_TAG } from "../converters.js";
+
+const log = createLogger("epic-flag-push");
+
+const EPIC_PUSH_AUDIT_USER = "system:epic-flag-push";
+
+export interface FlagPushDeps {
+  client: EpicFhirClient;
+}
+
+export interface FlagPushResult {
+  flag_id: string;
+  epic_flag_id: string | null;
+  operation: "created" | "updated" | "skipped" | "failed";
+  error?: string;
+}
+
+/**
+ * Look up the Epic Patient FHIR id for a CareBridge patient. Uses the
+ * existing `fhir_resources` mapping table populated by the inbound
+ * sync worker (#391) — falls back to null when the patient hasn't been
+ * synced from Epic. Without an Epic Patient id we can't push the Flag
+ * because Epic rejects `subject.reference` to an unknown patient.
+ */
+async function lookupEpicPatientId(
+  carebridgePatientId: string,
+): Promise<string | null> {
+  const db = getDb();
+  const rows = await db
+    .select({ resource_id: fhirResources.resource_id })
+    .from(fhirResources)
+    .where(eq(fhirResources.internal_record_id, carebridgePatientId))
+    .limit(10);
+  // Find the Patient mapping among any others (the patient may also
+  // have linked Observation, Condition, etc. mappings).
+  for (const row of rows) {
+    // The mapping id pattern is `epic:<resourceType>:<fhirId>` so
+    // resource_id is the FHIR id directly. We trust resource_type
+    // implicitly by joining on internal_record_id (only Patient maps
+    // to the patient table's id).
+    return row.resource_id;
+  }
+  return null;
+}
+
+/**
+ * Core push routine. Generates the FHIR Flag payload, sends it to Epic,
+ * and persists the resulting epic_flag_id back on the clinical_flags
+ * row.
+ *
+ * Idempotency:
+ *  - If `epic_flag_id` is already set, this performs a PUT instead of
+ *    a POST so a replayed job updates the existing resource.
+ *  - If the patient hasn't been synced from Epic (no Epic Patient id
+ *    mapping), the push is skipped — Epic would reject the Flag for an
+ *    unknown subject.
+ */
+export async function pushFlagToEpic(
+  flagId: string,
+  deps: FlagPushDeps,
+): Promise<FlagPushResult> {
+  const db = getDb();
+  const [flag] = await db
+    .select()
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.id, flagId))
+    .limit(1);
+
+  if (!flag) {
+    return { flag_id: flagId, epic_flag_id: null, operation: "skipped", error: "flag not found" };
+  }
+
+  const epicPatientId = await lookupEpicPatientId(flag.patient_id);
+  if (!epicPatientId) {
+    log.info("Skipping Epic flag push — patient not yet mapped to Epic", {
+      flagId,
+      carebridgePatientId: flag.patient_id,
+    });
+    return {
+      flag_id: flagId,
+      epic_flag_id: flag.epic_flag_id,
+      operation: "skipped",
+      error: "epic_patient_id_unknown",
+    };
+  }
+
+  const payload: FhirFlag = buildFhirFlag({
+    flag: {
+      summary: flag.summary,
+      rationale: flag.rationale,
+      suggested_action: flag.suggested_action,
+      severity: flag.severity as "critical" | "warning" | "info",
+      category: flag.category as "cross-specialty" | "drug-interaction" | "medication-safety" | "care-gap" | "critical-value" | "trend-concern" | "documentation-discrepancy" | "patient-reported",
+      status: flag.status as "open" | "acknowledged" | "resolved" | "dismissed" | "escalated",
+      rule_id: flag.rule_id ?? undefined,
+      created_at: flag.created_at,
+      resolved_at: flag.resolved_at ?? undefined,
+      dismissed_at: flag.dismissed_at ?? undefined,
+    },
+    epicPatientFhirId: epicPatientId,
+    epicFlagId: flag.epic_flag_id ?? undefined,
+  });
+
+  const now = new Date().toISOString();
+
+  try {
+    let createdOrUpdated: FhirFlag;
+    let operation: "created" | "updated";
+    if (flag.epic_flag_id) {
+      createdOrUpdated = await deps.client.updateResource(
+        "Flag",
+        flag.epic_flag_id,
+        payload,
+      );
+      operation = "updated";
+    } else {
+      createdOrUpdated = await deps.client.createResource("Flag", payload);
+      operation = "created";
+    }
+
+    const epicFlagId = createdOrUpdated.id ?? flag.epic_flag_id ?? null;
+
+    await db
+      .update(clinicalFlags)
+      .set({
+        epic_flag_id: epicFlagId,
+        epic_org_iss: epicOrgIssFromClientBase(),
+        epic_pushed_at: now,
+        epic_push_error: null,
+      })
+      .where(eq(clinicalFlags.id, flagId));
+
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: EPIC_PUSH_AUDIT_USER,
+      action: "epic_flag_push",
+      resource_type: "clinical_flag",
+      resource_id: flagId,
+      patient_id: flag.patient_id,
+      success: true,
+      details: JSON.stringify({
+        operation,
+        epic_flag_id: epicFlagId,
+        epic_patient_fhir_id: epicPatientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      }),
+      timestamp: now,
+    });
+
+    log.info("Pushed CareBridge flag to Epic", {
+      flagId,
+      epicFlagId,
+      operation,
+    });
+
+    return {
+      flag_id: flagId,
+      epic_flag_id: epicFlagId,
+      operation,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Truncate to 1KiB matching the convention used elsewhere
+    // (sync-state-repo.markFailed).
+    const truncated = message.slice(0, 1024);
+
+    await db
+      .update(clinicalFlags)
+      .set({ epic_push_error: truncated })
+      .where(eq(clinicalFlags.id, flagId));
+
+    await db.insert(auditLog).values({
+      id: crypto.randomUUID(),
+      user_id: EPIC_PUSH_AUDIT_USER,
+      action: "epic_flag_push",
+      resource_type: "clinical_flag",
+      resource_id: flagId,
+      patient_id: flag.patient_id,
+      success: false,
+      details: JSON.stringify({
+        operation: flag.epic_flag_id ? "updated" : "created",
+        epic_patient_fhir_id: epicPatientId,
+        source_system: EPIC_SOURCE_SYSTEM_TAG,
+      }),
+      error_message: truncated,
+      timestamp: now,
+    });
+
+    log.error("Epic flag push failed", { flagId, error: truncated });
+
+    return {
+      flag_id: flagId,
+      epic_flag_id: flag.epic_flag_id,
+      operation: "failed",
+      error: truncated,
+    };
+  }
+}
+
+/**
+ * Push a status update (acknowledge / resolve / dismiss) to Epic for
+ * a flag that has already been pushed. No-op when the flag isn't yet
+ * tracked on Epic — the next regular push (which carries the new
+ * status) will handle it.
+ */
+export async function pushFlagStatusUpdate(
+  flagId: string,
+  deps: FlagPushDeps,
+): Promise<FlagPushResult> {
+  const db = getDb();
+  const [flag] = await db
+    .select({ epic_flag_id: clinicalFlags.epic_flag_id })
+    .from(clinicalFlags)
+    .where(eq(clinicalFlags.id, flagId))
+    .limit(1);
+  if (!flag?.epic_flag_id) {
+    log.debug("Status update push skipped — flag not yet on Epic", { flagId });
+    return {
+      flag_id: flagId,
+      epic_flag_id: null,
+      operation: "skipped",
+      error: "not_pushed_yet",
+    };
+  }
+  return pushFlagToEpic(flagId, deps);
+}
+
+/**
+ * Best-effort lookup of the Epic FHIR base URL we're configured for.
+ * Returns `null` in tests / dev where Epic env isn't set. The full
+ * config load happens in the worker; this helper only exists so the
+ * push function can stamp the org on the audit row without re-reading
+ * env on every call.
+ */
+function epicOrgIssFromClientBase(): string | null {
+  return process.env.EPIC_FHIR_BASE_URL ?? null;
+}
+
+// Re-exported types for test consumption.
+export type { FhirFlag } from "./flag-generator.js";

--- a/services/epic-connector/src/workers/outbound-flag-worker.ts
+++ b/services/epic-connector/src/workers/outbound-flag-worker.ts
@@ -1,0 +1,143 @@
+/**
+ * BullMQ worker that pushes CareBridge flags to Epic (#393).
+ *
+ * Listens on the `epic-outbound-flags` queue. Each job carries:
+ *   { type: "push-create",   flag_id }   — newly-created flag → POST
+ *   { type: "push-status",   flag_id }   — status changed → PUT (or
+ *                                          first-push if epic_flag_id
+ *                                          isn't set yet)
+ *
+ * Both job types go through {@link pushFlagToEpic} which decides POST
+ * vs PUT internally based on whether the row already has an
+ * epic_flag_id.
+ *
+ * The worker is opt-in: `startEpicOutboundFlagWorker()` returns null
+ * when Epic credentials aren't configured so local dev keeps booting.
+ *
+ * The enqueue helpers are also guarded — they no-op when Epic isn't
+ * configured so callers (the ai-oversight flag-service) can call them
+ * unconditionally and avoid duplicating the env-check at every site.
+ */
+import { Worker, Queue, type Job } from "bullmq";
+import { createLogger } from "@carebridge/logger";
+import {
+  getRedisConnection,
+  CLINICAL_EVENTS_JOB_OPTIONS,
+} from "@carebridge/redis-config";
+import { EpicFhirClient } from "../fhir-client.js";
+import { EpicTokenClient } from "../token-client.js";
+import { loadEpicConfig } from "../config.js";
+import { pushFlagToEpic } from "../outbound/flag-push.js";
+
+const log = createLogger("epic-outbound-flag-worker");
+
+export const EPIC_OUTBOUND_FLAGS_QUEUE_NAME = "epic-outbound-flags";
+
+export type EpicOutboundFlagJobData =
+  | { type: "push-create"; flag_id: string }
+  | { type: "push-status"; flag_id: string };
+
+let queueSingleton: Queue<EpicOutboundFlagJobData> | null = null;
+
+function getQueue(): Queue<EpicOutboundFlagJobData> {
+  if (!queueSingleton) {
+    queueSingleton = new Queue(EPIC_OUTBOUND_FLAGS_QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: CLINICAL_EVENTS_JOB_OPTIONS,
+    });
+  }
+  return queueSingleton;
+}
+
+/**
+ * Returns true when Epic credentials are configured enough to attempt
+ * outbound writes. Centralises the env check so callers don't all have
+ * to remember which vars to check.
+ */
+export function isEpicOutboundEnabled(): boolean {
+  return Boolean(process.env.EPIC_CLIENT_ID && process.env.EPIC_FHIR_BASE_URL);
+}
+
+/**
+ * Enqueue a "newly-created flag → push" job. Safe to call when Epic
+ * isn't configured — falls through as a no-op. Use jobId so a
+ * duplicate-create from a retried flag-service write doesn't queue twice.
+ */
+export async function enqueueEpicFlagPushCreate(
+  flagId: string,
+): Promise<void> {
+  if (!isEpicOutboundEnabled()) return;
+  await getQueue().add(
+    "push-create",
+    { type: "push-create", flag_id: flagId },
+    { jobId: `push-create:${flagId}` },
+  );
+}
+
+/**
+ * Enqueue a "flag status changed → propagate" job. Same idempotency
+ * guarantees as {@link enqueueEpicFlagPushCreate}.
+ */
+export async function enqueueEpicFlagPushUpdate(
+  flagId: string,
+): Promise<void> {
+  if (!isEpicOutboundEnabled()) return;
+  await getQueue().add(
+    "push-status",
+    { type: "push-status", flag_id: flagId },
+    {
+      // jobId is per (flag, status-update-call) — repeated status
+      // updates for the same flag DO need to enqueue distinct jobs,
+      // unlike the create-push which dedupes on the flag id alone.
+      // Add a timestamp suffix to break uniqueness.
+      jobId: `push-status:${flagId}:${Date.now()}`,
+    },
+  );
+}
+
+/**
+ * Start the Epic outbound-flag worker. Returns null when Epic isn't
+ * configured (mirrors {@link startEpicSyncWorker}).
+ */
+export function startEpicOutboundFlagWorker(): Worker<EpicOutboundFlagJobData> | null {
+  let config;
+  try {
+    config = loadEpicConfig();
+  } catch (err) {
+    log.info(
+      "Epic outbound flag worker not started — credentials not configured",
+      { reason: err instanceof Error ? err.message : String(err) },
+    );
+    return null;
+  }
+  const tokens = new EpicTokenClient(config);
+  const client = new EpicFhirClient(config, tokens);
+
+  const worker = new Worker<EpicOutboundFlagJobData>(
+    EPIC_OUTBOUND_FLAGS_QUEUE_NAME,
+    async (job: Job<EpicOutboundFlagJobData>) => {
+      const start = Date.now();
+      try {
+        const result = await pushFlagToEpic(job.data.flag_id, { client });
+        return result;
+      } finally {
+        log.info("Epic outbound flag job completed", {
+          jobId: job.id,
+          type: job.data.type,
+          flag_id: job.data.flag_id,
+          elapsed_ms: Date.now() - start,
+        });
+      }
+    },
+    { connection: getRedisConnection(), concurrency: 2 },
+  );
+
+  worker.on("failed", (job, err) => {
+    log.error("Epic outbound flag job failed", {
+      jobId: job?.id,
+      error: err.message,
+    });
+  });
+
+  return worker;
+}


### PR DESCRIPTION
Replaces #1088 (auto-closed when feat/392 was deleted during the #1092 squash-merge).

## Summary

Implements #393. Closes the Epic interop loop — AI oversight raises a flag, it lands on Epic as a FHIR Flag resource. Status changes propagate bidirectionally.

Builds on #1084 / #1090 / #1091 / #1092.

- **Migration 0050 (idx 54)**: \`clinical_flags\` gains \`epic_flag_id\`, \`epic_org_iss\`, \`epic_pushed_at\`, \`epic_push_error\` tracking columns. Idempotent re-push by design.
- **FHIR Flag generator**: severity → \`Flag.code\` coding with CareBridge CodeSystem so Epic can render severity bands; rationale, suggested_action, rule_id as FHIR extensions; \`author = Organization/carebridge\`.
- **EpicFhirClient.createResource() + updateResource()** — POST / PUT with the same retry/backoff path as reads.
- **Outbound orchestrator**: POSTs new flags, PUTs status changes, audit-logs every push.
- **BullMQ \`epic-outbound-flags\` queue** + opt-in worker. Enqueue helpers check \`isEpicOutboundEnabled()\` and silently skip when Epic isn't configured.
- **ai-oversight flag-service hooks** on createFlag / acknowledgeFlag / resolveFlag / dismissFlag. All 938 existing ai-oversight tests still pass.

## Test plan

- [x] 20 new unit tests (128 total in epic-connector, all offline)
- [x] All 938 existing ai-oversight tests still pass
- [x] \`pnpm turbo typecheck lint\` clean (40/40)

Original PR: #1088