### PR TITLE
fix(epic): per-category Observation fan-out + soft-skip unauthorized scopes

### DIFF
--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -353,4 +353,237 @@ describe("Epic sync-jobs (#391)", () => {
       expect(searchedTypes).toContain(rt);
     }
   });
+
+  // ── #1094: Epic-specific search-param requirements ─────────────
+  // Epic's R4 sandbox rejects blanket `?patient=X` queries for
+  // Observation (needs `category`) and MedicationRequest (needs
+  // `status`). The sync-job fetch layer fans out so each request
+  // Epic sees carries the params it whitelists.
+
+  it("Observation fetch fans out across vital-signs and laboratory categories", async () => {
+    const client = makeFakeClient({
+      Observation: [{ resourceType: "Observation", id: "obs-1" }],
+    });
+    persistObservation.mockResolvedValue({
+      internalId: "obs-internal",
+      kind: "vital",
+      inserted: true,
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    const observationCalls = (
+      client.searchAll as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((c) => c[0] === "Observation");
+    expect(observationCalls).toHaveLength(2);
+    const categories = observationCalls.map((c) => c[1].category).sort();
+    expect(categories).toEqual(["laboratory", "vital-signs"]);
+    // Both calls must still carry `patient` so Epic scopes results.
+    for (const call of observationCalls) {
+      expect(call[1].patient).toBe(EPIC_PATIENT_FHIR_ID);
+    }
+  });
+
+  it("Observation fetch dedups resources that appear in multiple category fan-out responses", async () => {
+    // Same Observation id under both categories — defensive guard
+    // against Epic returning the same row for vital-signs and laboratory.
+    const sharedObservation = { resourceType: "Observation", id: "obs-shared" };
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          yield sharedObservation;
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    persistObservation.mockResolvedValue({
+      internalId: "obs-internal",
+      kind: "vital",
+      inserted: true,
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // searchAll fires twice (fan-out), persistObservation should
+    // fire once because the duplicate is dropped before persistence.
+    expect(client.searchAll).toHaveBeenCalledTimes(2);
+    expect(persistObservation).toHaveBeenCalledTimes(1);
+    expect(result.imported).toBe(1);
+  });
+
+  it("MedicationRequest fetch defaults to status=active so Epic accepts the query", async () => {
+    const client = makeFakeClient({
+      MedicationRequest: [{ resourceType: "MedicationRequest", id: "med-1" }],
+    });
+    persistMedicationRequest.mockResolvedValue({
+      internalId: "med-internal",
+      kind: "medication",
+      inserted: true,
+    });
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    const medCall = (
+      client.searchAll as ReturnType<typeof vi.fn>
+    ).mock.calls.find((c) => c[0] === "MedicationRequest");
+    expect(medCall).toBeDefined();
+    expect(medCall![1].status).toBe("active");
+    expect(medCall![1].patient).toBe(EPIC_PATIENT_FHIR_ID);
+  });
+
+  it("Observation fan-out swallows 'not authorized sub-resource' on individual categories", async () => {
+    // Simulate Epic rejecting vital-signs (app doesn't carry that scope)
+    // but accepting laboratory. Sync should still succeed for labs.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation((_resourceType: string, params: Record<string, string>) => {
+        if (params.category === "vital-signs") {
+          return (async function* () {
+            throw new Error(
+              "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource. No search was performed.",
+            );
+          })();
+        }
+        return (async function* () {
+          yield { resourceType: "Observation", id: "lab-1" };
+        })();
+      }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    persistObservation.mockResolvedValue({
+      internalId: "obs-internal",
+      kind: "lab",
+      inserted: true,
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(client.searchAll).toHaveBeenCalledTimes(2);
+    expect(persistObservation).toHaveBeenCalledTimes(1);
+    expect(result.imported).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("Observation fan-out re-throws errors that are NOT auth-scope failures", async () => {
+    // Network error, 5xx, malformed response — must NOT be swallowed.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() => {
+        throw new Error("connect ECONNREFUSED 127.0.0.1:443");
+      }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // Fetch threw → resource_type marked failed in result.errors.
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("ECONNREFUSED");
+  });
+
+  it("MedicationRequest fan-out gracefully skips when scope isn't authorized", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw new Error(
+            "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+          );
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // Soft-skip means zero imports and zero errors — the
+    // resource_type ran successfully, it just had nothing to import.
+    expect(result.imported).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(persistMedicationRequest).not.toHaveBeenCalled();
+  });
+
+  it("Observation fan-out preserves the incremental watermark on every category call", async () => {
+    getSyncState.mockImplementation(async (_p, rt) =>
+      rt === "Observation"
+        ? {
+            patient_id: PATIENT_ID,
+            resource_type: "Observation",
+            last_fhir_lastupdated: "2026-04-01T00:00:00Z",
+            last_synced_at: "2026-04-01T00:00:00Z",
+            status: "ok",
+            resources_synced_count: 0,
+            error_count: 0,
+            last_error_message: null,
+            last_error_at: null,
+          }
+        : null,
+    );
+    persistPatient.mockResolvedValue({
+      internalId: PATIENT_ID,
+      kind: "patient",
+      inserted: false,
+    });
+    const client = makeFakeClient({});
+
+    await runIncrementalSync(
+      { patientId: PATIENT_ID, epicPatientFhirId: EPIC_PATIENT_FHIR_ID },
+      { client, emit },
+    );
+
+    const observationCalls = (
+      client.searchAll as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((c) => c[0] === "Observation");
+    expect(observationCalls).toHaveLength(2);
+    for (const call of observationCalls) {
+      expect(call[1]._lastUpdated).toBe("gt2026-04-01T00:00:00Z");
+    }
+  });
 });

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -521,6 +521,39 @@ describe("Epic sync-jobs (#391)", () => {
     expect(result.errors[0]).toContain("ECONNREFUSED");
   });
 
+  it("Observation fan-out does NOT swallow Epic 400s that lack 'authorized sub-resource' (genuine request-shape errors)", async () => {
+    // Epic returns "Combination of parameters is not valid" for both
+    // scope-rejection (with "authorized sub-resource") AND for genuine
+    // request-shape problems (missing required params, unsupported
+    // search modifiers). The soft-skip MUST only swallow the former —
+    // dropping data because of a real shape bug would be silent corruption.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw new Error(
+            "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid. Unsupported search modifier on `_lastUpdated`.",
+          );
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // Surfaces as a per-resource-type error, NOT a silent skip.
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("Combination of parameters is not valid");
+    expect(result.errors[0]).not.toContain("authorized sub-resource");
+  });
+
   it("MedicationRequest fan-out gracefully skips when scope isn't authorized", async () => {
     const client = {
       readPatient: vi.fn(),

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -284,13 +284,18 @@ const MEDICATION_REQUEST_DEFAULT_STATUS = "active";
  * for. Epic emits this as a 400 with a 59022 code; we match on the human
  * text since the error code is buried in an OperationOutcome JSON blob
  * which the FHIR client surfaces as the trailing string of the Error.
+ *
+ * Match on the specific "authorized sub-resource" phrase rather than the
+ * looser "Combination of parameters is not valid" prefix — the prefix
+ * also appears in Epic 400s for genuine request-shape problems (missing
+ * required params, unsupported search modifiers), which the soft-skip
+ * MUST NOT swallow or we'd silently drop data on a real bug. Structured
+ * detection via OperationOutcome.issue.details.coding[].code = "59022"
+ * is tracked as a follow-up — see issue #1096.
  */
 function isUnauthorizedSubResourceError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  return (
-    err.message.includes("Combination of parameters is not valid") ||
-    err.message.includes("authorized sub-resource")
-  );
+  return err.message.includes("authorized sub-resource");
 }
 
 async function collectSearchOrSkipUnauthorized(

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -252,6 +252,78 @@ async function syncResourceType(
   return result;
 }
 
+/**
+ * Epic's R4 endpoint rejects `Observation?patient=X` without a `category`
+ * or `code` filter (400 with "Must have either code or category"). We
+ * fan out across the two categories the persistence layer cares about
+ * — vital-signs lands in `vitals`, laboratory lands in `lab_results`
+ * via observation-mapper.ts. Other categories (social-history, exam,
+ * etc.) aren't mapped to internal tables today, so omitting them isn't
+ * a data loss.
+ *
+ * Individual categories may 400 with "not authorized for this sub-resource"
+ * if the registered app doesn't carry that category's scope — see
+ * {@link isUnauthorizedSubResourceError}. Such failures are swallowed
+ * per category so a sync registered with only one of the two categories
+ * still imports what it's authorized for.
+ */
+const OBSERVATION_CATEGORY_FANOUT = ["vital-signs", "laboratory"] as const;
+
+/**
+ * Epic's R4 endpoint rejects `MedicationRequest?patient=X` without a
+ * `status` filter ("Combination of parameters is not valid"). Default
+ * to `active` since stopped/cancelled meds aren't clinically actionable
+ * for the AI oversight pipeline. Callers needing the full history can
+ * pass an override via the worker dispatch in a future iteration.
+ */
+const MEDICATION_REQUEST_DEFAULT_STATUS = "active";
+
+/**
+ * Detect Epic's "not authorized for this sub-resource" 400 response so the
+ * fan-out can skip categories the registered app doesn't carry the scope
+ * for. Epic emits this as a 400 with a 59022 code; we match on the human
+ * text since the error code is buried in an OperationOutcome JSON blob
+ * which the FHIR client surfaces as the trailing string of the Error.
+ */
+function isUnauthorizedSubResourceError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return (
+    err.message.includes("Combination of parameters is not valid") ||
+    err.message.includes("authorized sub-resource")
+  );
+}
+
+async function collectSearchOrSkipUnauthorized(
+  client: EpicFhirClient,
+  resourceType: SyncResourceType,
+  params: Record<string, string | undefined>,
+): Promise<FhirResource[] | null> {
+  const out: FhirResource[] = [];
+  try {
+    for await (const r of client.searchAll(resourceType, params)) {
+      out.push(r);
+    }
+    return out;
+  } catch (err) {
+    if (isUnauthorizedSubResourceError(err)) {
+      log.warn(
+        "Epic sync — skipping unauthorized sub-resource (registered scopes don't cover this filter)",
+        {
+          resourceType,
+          params: Object.entries(params)
+            .filter(([k]) => k !== "patient")
+            .reduce<Record<string, string | undefined>>((acc, [k, v]) => {
+              acc[k] = v;
+              return acc;
+            }, {}),
+        },
+      );
+      return null;
+    }
+    throw err;
+  }
+}
+
 async function fetchResources(
   args: SyncOneArgs,
   client: EpicFhirClient,
@@ -261,14 +333,53 @@ async function fetchResources(
     return [await client.readPatient(args.epicPatientFhirId)];
   }
 
+  const patient = args.epicPatientFhirId ?? args.patientId;
   const lastUpdated = args.watermark ? `gt${args.watermark}` : undefined;
-  const params: Record<string, string | undefined> = {
-    patient: args.epicPatientFhirId ?? args.patientId,
+  const baseParams: Record<string, string | undefined> = {
+    patient,
     _lastUpdated: lastUpdated,
   };
 
+  // Observation: fan out per category so Epic accepts each request.
+  // Dedup by resource.id in the rare case the same observation shows
+  // up under multiple categories (defensive — should not happen for
+  // vital-signs vs laboratory).
+  if (args.resourceType === "Observation") {
+    const seen = new Set<string>();
+    const out: FhirResource[] = [];
+    for (const category of OBSERVATION_CATEGORY_FANOUT) {
+      const params = { ...baseParams, category };
+      const batch = await collectSearchOrSkipUnauthorized(
+        client,
+        args.resourceType,
+        params,
+      );
+      if (batch === null) continue;
+      for (const r of batch) {
+        if (r.id && seen.has(r.id)) continue;
+        if (r.id) seen.add(r.id);
+        out.push(r);
+      }
+    }
+    return out;
+  }
+
+  // MedicationRequest: Epic requires `status` for unfiltered patient
+  // queries. Some app registrations (Order Template Medication only,
+  // for example) won't accept any `?patient=X` query — fail soft so
+  // the rest of the sync still runs.
+  if (args.resourceType === "MedicationRequest") {
+    const params = { ...baseParams, status: MEDICATION_REQUEST_DEFAULT_STATUS };
+    const batch = await collectSearchOrSkipUnauthorized(
+      client,
+      args.resourceType,
+      params,
+    );
+    return batch ?? [];
+  }
+
   const resources: FhirResource[] = [];
-  for await (const r of client.searchAll(args.resourceType, params)) {
+  for await (const r of client.searchAll(args.resourceType, baseParams)) {
     resources.push(r);
   }
   return resources;


### PR DESCRIPTION
## Summary
- Observation sync now fans out across `category=vital-signs` and `category=laboratory` so Epic's R4 sandbox accepts each request (it 400s blanket `?patient=X` queries with "Must have either code or category").
- MedicationRequest sync defaults to `status=active` to satisfy Epic's "valid combination of parameters" check.
- Both paths softly skip per-search 400s that match Epic's "not authorized sub-resource" error so an app that only registered SOME of the relevant scopes still imports what it CAN access. Non-auth errors (network, 5xx) still bubble up.

Closes #1094.

## Why this matters
End-to-end test against `fhir.epic.com` with Camila Lopez yesterday hit two real Epic-specific search-param restrictions. Before this PR, 2 of 5 resource types failed catastrophically. After this PR all 5 resource types complete successfully and 3 real lab results land in `lab_results`:

```
Before:                            After:
⚠️  Observation       errors=1     ✅ Observation       imported=3
✅ Condition         updated=1     ✅ Condition         updated=1
⚠️  MedicationRequest errors=1     ✅ MedicationRequest  imported=0 (gracefully skipped)
✅ AllergyIntolerance updated=1    ✅ AllergyIntolerance updated=1
✅ Patient            updated=1    ✅ Patient            updated=1
```

The `vital-signs` and `MedicationRequest` skips are due to **scope registration choices** on the Epic app (the test registration only carries Labs + Order Template Medication, not Vitals + Orders). With a richer app registration the same code path imports more — this PR doesn't enable that, it just stops the soft cases from breaking the whole batch.

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 16/16 pass (7 new: fan-out call shape, dedup, soft-fail on auth errors, re-throw on non-auth errors, watermark preservation across fan-out, status-default for MedicationRequest)
- [x] `pnpm --filter @carebridge/epic-connector typecheck` — clean
- [x] Live full sync against fhir.epic.com sandbox (Camila Maria Lopez) — 5/5 resource types green, 3 labs in DB, 6 ClinicalEvents queued for AI oversight
- [x] No regression on Patient / Condition / AllergyIntolerance sync paths