### PR TITLE
fix(epic): structured OperationOutcome detection for Epic 400 scope-rejection

### DIFF
--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -8,10 +8,10 @@
  */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { EpicFhirClient } from "../fhir-client.js";
+import { EpicFhirClient, EpicFhirError } from "../fhir-client.js";
 import { EpicTokenClient } from "../token-client.js";
 import type { EpicConfig } from "../config.js";
-import type { FhirBundle, FhirResource } from "../fhir-types.js";
+import type { FhirBundle, FhirResource, OperationOutcome } from "../fhir-types.js";
 
 function makeConfig(privatePem: string): EpicConfig {
   return {
@@ -238,6 +238,103 @@ describe("EpicFhirClient (#390)", () => {
     await client.searchEncounters({ patient: "p-1", _sort: "-date" });
     const url = fetchMock.mock.calls[1]![0] as string;
     expect(url).toContain("_sort=-date");
+  });
+
+  // ── #1096 / #1099: structured error surface ───────────────────────
+  // requestWithRetry now throws EpicFhirError instead of plain Error
+  // so downstream code can check `err.hasIssueCode("59022")` rather
+  // than substring-matching the message.
+
+  it("throws EpicFhirError with parsed OperationOutcome on 4xx with FHIR body", async () => {
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "invalid",
+          details: {
+            text: "Combination of parameters is not valid for any authorized sub-resource. No search was performed.",
+            coding: [
+              {
+                system: "urn:oid:1.2.840.114350.1.13.0.1.7.2.657369",
+                code: "59022",
+                display:
+                  "Combination of parameters is not valid for any authorized sub-resource.",
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const { client } = setup([jsonResponse(oo, { status: 400 })]);
+    let thrown: unknown;
+    try {
+      await client.read("Patient", "p-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.status).toBe(400);
+    expect(err.operationOutcome).toBeDefined();
+    expect(err.hasIssueCode("59022")).toBe(true);
+    expect(err.hasIssueCode("59108")).toBe(false);
+    // Message still carries the body so existing log/error consumers
+    // that read `err.message` keep working.
+    expect(err.message).toContain("400");
+  });
+
+  it("throws EpicFhirError without operationOutcome when the 4xx body is not JSON", async () => {
+    // Epic edge proxies sometimes return HTML / plain text instead of
+    // a FHIR OperationOutcome — the typed error must still construct
+    // (body retained, operationOutcome undefined, hasIssueCode false).
+    const { client } = setup([
+      new Response("<html>502 Bad Gateway</html>", { status: 400 }),
+    ]);
+    let thrown: unknown;
+    try {
+      await client.read("Patient", "p-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.operationOutcome).toBeUndefined();
+    expect(err.body).toContain("502 Bad Gateway");
+    expect(err.hasIssueCode("59022")).toBe(false);
+  });
+
+  it("throws EpicFhirError with parsed OperationOutcome after exhausting 5xx retries", async () => {
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "exception",
+          details: {
+            text: "Internal server error",
+            coding: [{ code: "INTERNAL" }],
+          },
+        },
+      ],
+    };
+    const { client } = setup([
+      jsonResponse(oo, { status: 503 }),
+      jsonResponse(oo, { status: 503 }),
+      jsonResponse(oo, { status: 503 }),
+      jsonResponse(oo, { status: 503 }),
+    ]);
+    let thrown: unknown;
+    try {
+      await client.read("Patient", "p-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.status).toBe(503);
+    expect(err.operationOutcome).toBeDefined();
+    expect(err.hasIssueCode("INTERNAL")).toBe(true);
   });
 
   it("treats absolute URLs (Bundle.link.url) verbatim", async () => {

--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -284,6 +284,36 @@ describe("EpicFhirClient (#390)", () => {
     expect(err.message).toContain("400");
   });
 
+  it("EpicFhirError.hasIssueCode returns false (no throw) when OperationOutcome.issue is malformed", async () => {
+    // Epic edge proxies occasionally return OperationOutcome-shaped
+    // JSON with a partial / null `issue` field. The error-handling
+    // path must be defensive: hasIssueCode should return false, not
+    // crash on `outcome.issue` being non-iterable.
+    const malformed = {
+      resourceType: "OperationOutcome",
+      // issue intentionally not an array
+      issue: null,
+    };
+    const { client } = setup([
+      new Response(JSON.stringify(malformed), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try {
+      await client.read("Patient", "p-1");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.operationOutcome).toBeDefined();
+    // Must NOT throw on malformed shape — should just return false.
+    expect(() => err.hasIssueCode("59022")).not.toThrow();
+    expect(err.hasIssueCode("59022")).toBe(false);
+  });
+
   it("throws EpicFhirError without operationOutcome when the 4xx body is not JSON", async () => {
     // Epic edge proxies sometimes return HTML / plain text instead of
     // a FHIR OperationOutcome — the typed error must still construct

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -7,6 +7,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ClinicalEvent } from "@carebridge/shared-types";
+import { EpicFhirError } from "../fhir-client.js";
+import type { OperationOutcome } from "../fhir-types.js";
 
 // ── Mock persistence ─────────────────────────────────────────────
 const persistPatient = vi.fn();
@@ -619,4 +621,261 @@ describe("Epic sync-jobs (#391)", () => {
       expect(call[1]._lastUpdated).toBe("gt2026-04-01T00:00:00Z");
     }
   });
+
+  // ── #1096 / #1099: structured detection + error-shape coverage ──
+  // The fhir-client now throws EpicFhirError carrying the parsed
+  // OperationOutcome. isUnauthorizedSubResourceError prefers structured
+  // detection on `details.coding[].code === "59022"` over substring
+  // matching the human text. Tests below cover BOTH the structured
+  // path (new) and the substring fallback (legacy safety net).
+
+  function epicAuthScopeError(): EpicFhirError {
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "invalid",
+          details: {
+            text: "Combination of parameters is not valid for any authorized sub-resource. No search was performed.",
+            coding: [{ code: "59022" }],
+          },
+        },
+      ],
+    };
+    return new EpicFhirError(
+      "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+      400,
+      "Bad Request",
+      JSON.stringify(oo),
+      oo,
+    );
+  }
+
+  function epicMissingElementError(): EpicFhirError {
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "required",
+          details: {
+            text: "A required element is missing.",
+            coding: [{ code: "59108" }],
+          },
+        },
+      ],
+    };
+    return new EpicFhirError(
+      "Epic FHIR request returned 400 Bad Request — A required element is missing.",
+      400,
+      "Bad Request",
+      JSON.stringify(oo),
+      oo,
+    );
+  }
+
+  it("structured detection: EpicFhirError with code 59022 → soft-skipped", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw epicAuthScopeError();
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(0);
+    expect(result.errors).toHaveLength(0);
+    expect(persistMedicationRequest).not.toHaveBeenCalled();
+  });
+
+  it("structured detection: EpicFhirError with code 59108 (missing element) → NOT swallowed", async () => {
+    // 59108 means the request shape is bad (e.g. Observation without
+    // category) — that's a real bug in the caller, not a scope issue.
+    // Soft-skip MUST NOT swallow it or we'd silently lose data after
+    // a future fhir-client refactor breaks param construction.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw epicMissingElementError();
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("A required element is missing");
+  });
+
+  it("substring fallback: EpicFhirError without parsed OO but message says 'authorized sub-resource' → soft-skipped", async () => {
+    // Real-world fallback: Epic edge proxy returns the auth-scope
+    // error as a non-JSON body (HTML/plain text). The OperationOutcome
+    // parse fails, but the substring is still in the Error message.
+    const fallback = new EpicFhirError(
+      "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+      400,
+      "Bad Request",
+      "non-json body",
+      undefined,
+    );
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw fallback;
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // #1099 acceptance #1: lock-in for the operationOutcomeError() shape
+  it("substring fallback: 'Epic returned OperationOutcome:' shape with auth-scope text → soft-skipped", async () => {
+    // fhir-client's operationOutcomeError() helper produces this
+    // alternate shape: "Epic returned OperationOutcome: invalid — <text>".
+    // It's currently emitted from createResource/updateResource and
+    // from read() on an OperationOutcome response. The soft-skip must
+    // match this shape too so future code that catches this Error form
+    // gets the same skip behavior.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw new Error(
+            "Epic returned OperationOutcome: invalid — Combination of parameters is not valid for any authorized sub-resource. No search was performed.",
+          );
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // #1099 acceptance #2: dedup invariant with non-trivial overlap
+  it("Observation dedup correctly merges [A,B] + [B,C] → [A,B,C]", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation((_rt: string, params: Record<string, string>) => {
+        if (params.category === "vital-signs") {
+          return (async function* () {
+            yield { resourceType: "Observation", id: "A" };
+            yield { resourceType: "Observation", id: "B" };
+          })();
+        }
+        // laboratory
+        return (async function* () {
+          yield { resourceType: "Observation", id: "B" };
+          yield { resourceType: "Observation", id: "C" };
+        })();
+      }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    persistObservation.mockResolvedValue({
+      internalId: "internal",
+      kind: "vital",
+      inserted: true,
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // 3 unique observations persisted (A, B, C) — not 4.
+    expect(persistObservation).toHaveBeenCalledTimes(3);
+    const persistedIds = persistObservation.mock.calls
+      .map((c) => (c[0] as { id: string }).id)
+      .sort();
+    expect(persistedIds).toEqual(["A", "B", "C"]);
+    expect(result.imported).toBe(3);
+  });
+
+  // #1099 acceptance #3: synchronous-throw soft-skip case
+  it("soft-skip works when EpicFhirError is thrown SYNCHRONOUSLY from searchAll (not just from inside the generator)", async () => {
+    // Earlier soft-skip tests throw from inside the async generator
+    // body. Some fetch wrappers throw synchronously *before* returning
+    // the iterable — this test locks in that the wrapping catch in
+    // collectSearchOrSkipUnauthorized covers BOTH call paths.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() => {
+        throw epicAuthScopeError();
+      }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.imported).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // #1099 acceptance #4: documented placeholder for multi-status fan-out
+  it.skip(
+    "MedicationRequest fan-out supports multi-status override (active + on-hold + completed) — future",
+    async () => {
+      // When the worker dispatch grows a `medication_request_statuses?:
+      // string[]` override, this test should drive the fan-out across
+      // each status as a separate searchAll call. Today the default is
+      // hardcoded to "active" and there's no per-job override channel
+      // — see issue #1097 for the related sync_result signalling work.
+      expect(false).toBe(true);
+    },
+  );
 });

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -24,8 +24,71 @@ import type {
   FhirResource,
   OperationOutcome,
 } from "./fhir-types.js";
+import { operationOutcomeHasIssueCode } from "./fhir-types.js";
 
 const log = createLogger("epic-fhir-client");
+
+/**
+ * Typed error thrown by the Epic FHIR client on non-2xx responses.
+ *
+ * Carries the parsed OperationOutcome alongside the original Error
+ * message so downstream consumers can discriminate failure categories
+ * structurally (preferred) rather than substring-matching the
+ * message (fragile, see #1096).
+ *
+ * Epic error codes the connector currently reasons about:
+ *
+ *   "59022"  Combination of parameters is not valid for any authorized
+ *            sub-resource. Used by sync-jobs.ts to soft-skip categories
+ *            the registered app doesn't carry a scope for.
+ *
+ *   "59108"  A required element is missing (e.g. Observation without
+ *            category or code). Indicates a request-shape bug, NOT
+ *            a scope issue — must surface, not be swallowed.
+ *
+ * `body` keeps the raw response text for diagnostic logging when the
+ * response wasn't parseable as an OperationOutcome (e.g. Epic returned
+ * an HTML 502 page from a fronting proxy).
+ */
+export class EpicFhirError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+    public readonly operationOutcome?: OperationOutcome,
+  ) {
+    super(message);
+    this.name = "EpicFhirError";
+  }
+
+  /** Structured check: does any issue carry `details.coding[].code === code`? */
+  hasIssueCode(code: string): boolean {
+    return this.operationOutcome
+      ? operationOutcomeHasIssueCode(this.operationOutcome, code)
+      : false;
+  }
+}
+
+function tryParseOperationOutcome(
+  body: string,
+): OperationOutcome | undefined {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { resourceType?: string }).resourceType === "OperationOutcome"
+    ) {
+      return parsed as OperationOutcome;
+    }
+  } catch {
+    // Non-JSON body (HTML error page, plain text) — caller falls back
+    // to the raw string in the Error message.
+  }
+  return undefined;
+}
 
 export interface EpicFhirClientOptions {
   /** Maximum retry attempts on transient (429/5xx) errors. Default: 3. */
@@ -255,9 +318,13 @@ export class EpicFhirClient {
     if (response.status === 429 || response.status >= 500) {
       if (attempt >= this.opts.maxRetries) {
         const body = await safeReadBody(response);
-        throw new Error(
+        throw new EpicFhirError(
           `Epic FHIR request failed after ${attempt + 1} attempts: ` +
             `${response.status} ${response.statusText}${body ? ` — ${body}` : ""}`,
+          response.status,
+          response.statusText,
+          body,
+          tryParseOperationOutcome(body),
         );
       }
       const delay = backoffDelay({
@@ -277,9 +344,13 @@ export class EpicFhirClient {
 
     if (!response.ok) {
       const body = await safeReadBody(response);
-      throw new Error(
+      throw new EpicFhirError(
         `Epic FHIR request returned ${response.status} ${response.statusText}` +
           (body ? ` — ${body}` : ""),
+        response.status,
+        response.statusText,
+        body,
+        tryParseOperationOutcome(body),
       );
     }
 

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -46,15 +46,18 @@ const log = createLogger("epic-fhir-client");
  *            category or code). Indicates a request-shape bug, NOT
  *            a scope issue — must surface, not be swallowed.
  *
- * `body` keeps the raw response text for diagnostic logging when the
- * response wasn't parseable as an OperationOutcome (e.g. Epic returned
- * an HTML 502 page from a fronting proxy).
+ * `body` keeps a truncated snippet (first 500 chars via {@link safeReadBody})
+ * of the raw response text for diagnostic logging when the response wasn't
+ * parseable as an OperationOutcome (e.g. Epic returned an HTML 502 page
+ * from a fronting proxy). NOT the full payload — callers needing the
+ * complete body must re-fetch.
  */
 export class EpicFhirError extends Error {
   constructor(
     message: string,
     public readonly status: number,
     public readonly statusText: string,
+    /** Truncated body snippet (≤500 chars). Do NOT assume full payload. */
     public readonly body: string,
     public readonly operationOutcome?: OperationOutcome,
   ) {

--- a/services/epic-connector/src/fhir-types.ts
+++ b/services/epic-connector/src/fhir-types.ts
@@ -81,11 +81,17 @@ export interface OperationOutcome {
  * True iff `outcome.issue[*].details.coding[*].code` contains the given code.
  * Use this to discriminate Epic failure categories structurally — see
  * the table in {@link EpicFhirError} for the codes the connector cares about.
+ *
+ * Defensive against malformed payloads: returns `false` (not throws) when
+ * `outcome.issue` is missing, null, or not an array. Epic's edge proxies
+ * occasionally return OperationOutcome-shaped JSON with a partial / null
+ * `issue` field, and the error-handling path must NOT itself crash.
  */
 export function operationOutcomeHasIssueCode(
   outcome: OperationOutcome,
   code: string,
 ): boolean {
+  if (!Array.isArray(outcome.issue)) return false;
   for (const issue of outcome.issue) {
     for (const c of issue.details?.coding ?? []) {
       if (c.code === code) return true;

--- a/services/epic-connector/src/fhir-types.ts
+++ b/services/epic-connector/src/fhir-types.ts
@@ -49,15 +49,49 @@ export interface FhirResource {
  * FHIR `OperationOutcome` shape — Epic returns these instead of a
  * resource Bundle when a request fails. We surface the `diagnostics`
  * field in thrown error messages for debugging.
+ *
+ * Epic-specific: `details.coding[]` carries the Epic error code we
+ * use for structured failure detection (e.g. `code: "59022"` for
+ * "Combination of parameters is not valid for any authorized
+ * sub-resource"). Generic FHIR clients ignore coding; we read it to
+ * tell scope-rejection 400s from genuine request-shape 400s.
  */
+export interface OperationOutcomeIssueCoding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+export interface OperationOutcomeIssue {
+  severity: "fatal" | "error" | "warning" | "information";
+  code: string;
+  diagnostics?: string;
+  details?: {
+    text?: string;
+    coding?: OperationOutcomeIssueCoding[];
+  };
+}
+
 export interface OperationOutcome {
   resourceType: "OperationOutcome";
-  issue: Array<{
-    severity: "fatal" | "error" | "warning" | "information";
-    code: string;
-    diagnostics?: string;
-    details?: { text?: string };
-  }>;
+  issue: OperationOutcomeIssue[];
+}
+
+/**
+ * True iff `outcome.issue[*].details.coding[*].code` contains the given code.
+ * Use this to discriminate Epic failure categories structurally — see
+ * the table in {@link EpicFhirError} for the codes the connector cares about.
+ */
+export function operationOutcomeHasIssueCode(
+  outcome: OperationOutcome,
+  code: string,
+): boolean {
+  for (const issue of outcome.issue) {
+    for (const c of issue.details?.coding ?? []) {
+      if (c.code === code) return true;
+    }
+  }
+  return false;
 }
 
 export type EpicSearchParams = Record<

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -40,9 +40,13 @@ export {
 } from "./keygen.js";
 export {
   EpicFhirClient,
+  EpicFhirError,
   type EpicFhirClientOptions,
   type EpicResourceType,
 } from "./fhir-client.js";
+export {
+  operationOutcomeHasIssueCode,
+} from "./fhir-types.js";
 export type {
   FhirBundle,
   FhirBundleEntry,
@@ -50,6 +54,8 @@ export type {
   FhirResource,
   EpicSearchParams,
   OperationOutcome,
+  OperationOutcomeIssue,
+  OperationOutcomeIssueCoding,
 } from "./fhir-types.js";
 export {
   EPIC_SOURCE_SYSTEM_TAG,

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -29,7 +29,11 @@ import type {
   ClinicalEvent,
   ClinicalEventType,
 } from "@carebridge/shared-types";
-import { EpicFhirClient, type EpicResourceType } from "../fhir-client.js";
+import {
+  EpicFhirClient,
+  EpicFhirError,
+  type EpicResourceType,
+} from "../fhir-client.js";
 import { EPIC_SOURCE_SYSTEM_TAG } from "../converters.js";
 import {
   persistAllergy,
@@ -278,24 +282,41 @@ const OBSERVATION_CATEGORY_FANOUT = ["vital-signs", "laboratory"] as const;
  */
 const MEDICATION_REQUEST_DEFAULT_STATUS = "active";
 
+/** Epic error code for "Combination of parameters is not valid for any
+ *  authorized sub-resource. No search was performed." This 400 means
+ *  the registered app doesn't carry the scope for the request's filter
+ *  combination — distinct from a malformed request, which gets 59108
+ *  ("A required element is missing"). */
+const EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE = "59022";
+
 /**
  * Detect Epic's "not authorized for this sub-resource" 400 response so the
  * fan-out can skip categories the registered app doesn't carry the scope
- * for. Epic emits this as a 400 with a 59022 code; we match on the human
- * text since the error code is buried in an OperationOutcome JSON blob
- * which the FHIR client surfaces as the trailing string of the Error.
+ * for, while still surfacing genuine request-shape bugs.
  *
- * Match on the specific "authorized sub-resource" phrase rather than the
- * looser "Combination of parameters is not valid" prefix — the prefix
- * also appears in Epic 400s for genuine request-shape problems (missing
- * required params, unsupported search modifiers), which the soft-skip
- * MUST NOT swallow or we'd silently drop data on a real bug. Structured
- * detection via OperationOutcome.issue.details.coding[].code = "59022"
- * is tracked as a follow-up — see issue #1096.
+ * Preferred: structured check on the parsed OperationOutcome's coding
+ * (`details.coding[].code === "59022"`) — proper FHIR-spec match that
+ * survives Epic rewording the human text.
+ *
+ * Fallback: substring match on `"authorized sub-resource"` in the Error
+ * message — covers cases where Epic returns a non-OperationOutcome body
+ * (HTML 502 from a fronting proxy, plain text from an edge layer) but
+ * the substring still appears verbatim. We deliberately use the more
+ * specific phrase here — the looser "Combination of parameters is not
+ * valid" prefix also fires for genuine request-shape errors (e.g. 59108
+ * "missing required element") and MUST NOT be swallowed.
  */
 function isUnauthorizedSubResourceError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return err.message.includes("authorized sub-resource");
+  if (
+    err instanceof EpicFhirError &&
+    err.hasIssueCode(EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE)
+  ) {
+    return true;
+  }
+  if (err instanceof Error && err.message.includes("authorized sub-resource")) {
+    return true;
+  }
+  return false;
 }
 
 async function collectSearchOrSkipUnauthorized(


### PR DESCRIPTION
## Summary
- Introduces `EpicFhirError extends Error` carrying the parsed `OperationOutcome` so consumers can discriminate Epic failure categories structurally (preferred) instead of substring-matching the human text (#1095's interim fix).
- Rewrites the sync-jobs auth-scope detector to prefer `err.hasIssueCode("59022")` on the typed error, with the substring match retained as a safety fallback for cases where Epic returns a non-OperationOutcome body.
- Adds 7 new sync-jobs tests (+ 1 `it.skip` placeholder) and 3 new fhir-client tests covering the structured + fallback + edge-case paths.

Closes #1096. Closes #1099.

## Why this matters
PR #1095 landed a working soft-skip but matched on substrings — fragile to Epic rewording. This PR closes that loop with proper FHIR-spec discriminators:

```ts
// before (#1095): substring on Error.message
if (err.message.includes("authorized sub-resource")) return true;

// after (#1096): structured check on parsed OperationOutcome
if (err instanceof EpicFhirError && err.hasIssueCode("59022")) return true;
// substring kept as fallback for non-JSON Epic bodies (proxy 502, etc.)
if (err instanceof Error && err.message.includes("authorized sub-resource")) return true;
```

The Epic error-code table the connector now reasons about:

| Code | Meaning | Action |
|---|---|---|
| `59022` | "Combination of parameters is not valid for any authorized sub-resource" | Soft-skip (scope-rejection) |
| `59108` | "A required element is missing" | Surface (request-shape bug) |

## Coverage added per #1099 acceptance criteria
- [x] Structured detection: `EpicFhirError` with code 59022 → soft-skipped
- [x] Structured detection: `EpicFhirError` with code 59108 → surfaced (NOT swallowed)
- [x] Substring fallback when `EpicFhirError.operationOutcome` is undefined but message contains "authorized sub-resource"
- [x] Substring match on the alternate `"Epic returned OperationOutcome:"` shape emitted by `operationOutcomeError()` (acceptance #1)
- [x] Observation dedup invariant over `[A,B] + [B,C] → [A,B,C]` (acceptance #2)
- [x] Soft-skip works when `EpicFhirError` is thrown **synchronously** from `searchAll`, not just from inside the async-generator body (acceptance #3)
- [x] `it.skip` placeholder documenting future multi-status MedicationRequest fan-out (acceptance #4)

## fhir-client changes
- `EpicFhirError` exposes `status`, `statusText`, `body` (raw), `operationOutcome` (parsed or undefined), and `hasIssueCode(code)`.
- `requestWithRetry` now throws `EpicFhirError` from both the 5xx-after-max-retries path and the 4xx-non-401-non-429 path.
- `OperationOutcomeIssue` and `OperationOutcomeIssueCoding` types added; `operationOutcomeHasIssueCode(outcome, code)` helper exported for non-error callsites.

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 145 pass + 1 documented skip (16 test files, including 7 new sync-jobs tests + 3 new fhir-client tests)
- [x] `pnpm typecheck` — full workspace, 38/38 clean (no breakage in downstream consumers of fhir-client errors)
- [x] Live verify against `fhir.epic.com` sandbox (Camila Lopez `erXuFYUfucBZaryVksYEcMg3`) — 5/5 resource types green via the structured detection path; vital-signs + MedicationRequest soft-skipped via `hasIssueCode("59022")` (not substring)