### PR TITLE
feat(epic): surface soft-skipped sub-resources on SyncResult + epic_sync_state

### DIFF
--- a/packages/db-schema/drizzle/0051_epic_sync_state_skipped.sql
+++ b/packages/db-schema/drizzle/0051_epic_sync_state_skipped.sql
@@ -1,0 +1,17 @@
+-- #1097: surface soft-skipped Epic sub-resource fetches.
+--
+-- When the Epic sync worker calls a sub-resource search (e.g.
+-- Observation?category=vital-signs) and Epic rejects it with 400
+-- "not authorized for this sub-resource" (code 59022), the worker
+-- soft-skips it so the rest of the batch still runs. Before this
+-- migration that skip was logged at WARN only; operators couldn't
+-- tell "we have no data because Epic refused" from "we have no data
+-- because the patient has none."
+--
+-- This column records the most recent batch's skipped sub-resource
+-- filters as a JSONB array of {filter: Record<string,string>,
+-- reason: "unauthorized"} entries. Cleared each markOk() write so it
+-- reflects the latest batch only — historical drift is captured by
+-- the BullMQ job logs, not this column.
+ALTER TABLE "epic_sync_state"
+  ADD COLUMN IF NOT EXISTS "skipped_sub_resources" jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1747930020000,
       "tag": "0050_clinical_flags_epic_push",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1747930080000,
+      "tag": "0051_epic_sync_state_skipped",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/schema/epic-sync.ts
+++ b/packages/db-schema/src/schema/epic-sync.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, primaryKey, index } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, jsonb, primaryKey, index } from "drizzle-orm/pg-core";
 import { patients } from "./patients.js";
 
 /**
@@ -34,6 +34,14 @@ export const epicSyncState = pgTable(
     error_count: integer("error_count").notNull().default(0),
     last_error_message: text("last_error_message"),
     last_error_at: text("last_error_at"),
+    // #1097: Most recent batch's sub-resource fetches that Epic refused
+    // with 400 "not authorized for this sub-resource" (code 59022).
+    // Each entry shape: { filter: Record<string,string>, reason: "unauthorized" }.
+    // Empty array = nothing soft-skipped this run.
+    skipped_sub_resources: jsonb("skipped_sub_resources")
+      .notNull()
+      .default([])
+      .$type<Array<{ filter: Record<string, string>; reason: "unauthorized" }>>(),
   },
   (table) => [
     primaryKey({ columns: [table.patient_id, table.resource_type] }),

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -866,6 +866,115 @@ describe("Epic sync-jobs (#391)", () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  // ── #1097: surface soft-skipped sub-resources on SyncResult ─────
+  // Operators need to see which Epic scopes were refused, distinct
+  // from "this resource type had no data." Soft-skipped fetches now
+  // populate `result.skipped[]` and flow into the persisted
+  // `epic_sync_state.skipped_sub_resources` column via markOk.
+
+  it("SyncResult.skipped[] records every soft-skipped Observation category", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi
+        .fn()
+        .mockImplementation((_rt: string, params: Record<string, string>) => {
+          if (params.category === "vital-signs") {
+            return (async function* () {
+              throw new Error(
+                "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+              );
+            })();
+          }
+          return (async function* () {
+            yield { resourceType: "Observation", id: "lab-1" };
+          })();
+        }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    persistObservation.mockResolvedValue({
+      internalId: "obs-internal",
+      kind: "lab",
+      inserted: true,
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({
+      resource_type: "Observation",
+      reason: "unauthorized",
+      filter: { category: "vital-signs" },
+    });
+    // PHI hygiene: the `patient` Epic ID must NEVER appear in the
+    // surfaced filter (this row may be exposed via tRPC to the portal).
+    expect(result.skipped[0]!.filter).not.toHaveProperty("patient");
+    expect(result.imported).toBe(1);
+  });
+
+  it("SyncResult.skipped[] is empty when nothing was soft-skipped", async () => {
+    const client = makeFakeClient({
+      Condition: [{ resourceType: "Condition", id: "cond-1" }],
+    });
+    persistCondition.mockResolvedValue({
+      internalId: "internal",
+      kind: "diagnosis",
+      inserted: true,
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("skipped[] flows into markOk so it lands on epic_sync_state", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw new Error(
+            "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+          );
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markOk).toHaveBeenCalledOnce();
+    const markOkArgs = markOk.mock.calls[0]![0] as {
+      skipped?: Array<{ filter: Record<string, string>; reason: string }>;
+    };
+    expect(markOkArgs.skipped).toHaveLength(1);
+    expect(markOkArgs.skipped![0]).toEqual({
+      filter: { status: "active" },
+      reason: "unauthorized",
+    });
+  });
+
   // #1099 acceptance #4: documented placeholder for multi-status fan-out
   it.skip(
     "MedicationRequest fan-out supports multi-status override (active + on-hold + completed) — future",

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -975,6 +975,46 @@ describe("Epic sync-jobs (#391)", () => {
     });
   });
 
+  it("sanitizeFilterForReport strips _lastUpdated (and other underscore-prefixed control params) so the surfaced filter stays stable across incremental syncs", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi
+        .fn()
+        .mockImplementation((_rt: string, params: Record<string, string>) => {
+          if (params.category === "vital-signs") {
+            return (async function* () {
+              throw new Error(
+                "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+              );
+            })();
+          }
+          return (async function* () {
+            // empty
+          })();
+        }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        // Watermark set → fetchResources injects `_lastUpdated=gt<...>`
+        // into baseParams. Without sanitization, that timestamp would
+        // leak into every persisted/surfaced filter and explode
+        // `skipped_sub_resources` cardinality across runs.
+        watermark: "2026-05-22T10:00:00Z",
+      },
+      { client, emit },
+    );
+
+    expect(result.skipped).toHaveLength(1);
+    const filter = result.skipped[0]!.filter;
+    expect(filter).toEqual({ category: "vital-signs" });
+    expect(filter).not.toHaveProperty("_lastUpdated");
+    expect(filter).not.toHaveProperty("patient");
+  });
+
   // #1099 acceptance #4: documented placeholder for multi-status fan-out
   it.skip(
     "MedicationRequest fan-out supports multi-status override (active + on-hold + completed) — future",

--- a/services/epic-connector/src/__tests__/sync-state-repo.test.ts
+++ b/services/epic-connector/src/__tests__/sync-state-repo.test.ts
@@ -94,6 +94,31 @@ describe("epic_sync_state repo (#391)", () => {
     expect(values.status).toBe("ok");
     expect(values.last_fhir_lastupdated).toBe("2026-05-20T12:00:00Z");
     expect(values.resources_synced_count).toBe(7);
+    // #1097: defaults to empty array when caller doesn't pass `skipped`.
+    expect(values.skipped_sub_resources).toEqual([]);
+  });
+
+  it("markOk persists the skipped sub-resources array when provided (#1097)", async () => {
+    db.willInsert();
+    await markOk({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      highWatermark: null,
+      importedCount: 3,
+      skipped: [
+        { filter: { category: "vital-signs" }, reason: "unauthorized" },
+      ],
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.skipped_sub_resources).toEqual([
+      { filter: { category: "vital-signs" }, reason: "unauthorized" },
+    ]);
+    // onConflictDoUpdate `set` also carries the latest skipped state so
+    // re-runs replace stale entries instead of merging them.
+    const setClause = db.insert.calls[0]!.chainArgs[1]![0] as { set: Record<string, unknown> };
+    expect(setClause.set.skipped_sub_resources).toEqual([
+      { filter: { category: "vital-signs" }, reason: "unauthorized" },
+    ]);
   });
 
   it("markFailed truncates very long error messages to 1KiB", async () => {

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -78,6 +78,7 @@ export {
   type SyncResult,
   type SyncJobDeps,
   type EmitFn,
+  type SkippedSubResource,
 } from "./sync/sync-jobs.js";
 export {
   getSyncState,
@@ -88,6 +89,7 @@ export {
   markFailed,
   type EpicSyncStateRow,
   type EpicSyncStatusValue,
+  type SkippedSubResourceRecord,
 } from "./sync/sync-state-repo.js";
 export {
   persistPatient,

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -76,6 +76,23 @@ export interface SyncJobDeps {
   emit: EmitFn;
 }
 
+/**
+ * Sub-resource fetch that Epic rejected as unauthorized for the
+ * registered scopes. Recorded on the SyncResult so admin tooling can
+ * distinguish "scope registered but no data" from "scope not registered
+ * — Epic refused to even run the search."
+ *
+ * `filter` carries the search params we sent EXCLUDING the patient id
+ * (PHI hygiene — Epic FHIR ids aren't strict HIPAA PHI but treating
+ * them conservatively is the safer default for surfacing this field
+ * via tRPC to the clinician portal).
+ */
+export interface SkippedSubResource {
+  resource_type: SyncResourceType;
+  filter: Record<string, string>;
+  reason: "unauthorized";
+}
+
 export interface SyncResult {
   patient_id: string;
   resource_type: SyncResourceType;
@@ -83,6 +100,8 @@ export interface SyncResult {
   updated: number;
   conflicts: number;
   errors: string[];
+  /** Sub-resource searches Epic refused (scope mismatch); not a sync failure. */
+  skipped: SkippedSubResource[];
 }
 
 /**
@@ -180,11 +199,13 @@ async function syncResourceType(
     updated: 0,
     conflicts: 0,
     errors: [],
+    skipped: [],
   };
   let highWatermark: string | null = args.watermark;
 
   try {
-    const resources = await fetchResources(args, deps.client);
+    const { resources, skipped } = await fetchResources(args, deps.client);
+    result.skipped = skipped;
 
     for (const resource of resources) {
       try {
@@ -237,6 +258,10 @@ async function syncResourceType(
       resourceType: args.resourceType,
       highWatermark,
       importedCount: result.imported,
+      // Persist sub-resources Epic refused so the clinician portal can
+      // distinguish "no data because patient has none" from "no data
+      // because scope X wasn't registered" (#1097).
+      skipped: result.skipped.map(({ filter, reason }) => ({ filter, reason })),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -319,44 +344,64 @@ function isUnauthorizedSubResourceError(err: unknown): boolean {
   return false;
 }
 
+/** Strip undefined values + the `patient` PHI field for safe external surfacing. */
+function sanitizeFilterForReport(
+  params: Record<string, string | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (k === "patient") continue;
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+type SearchOutcome =
+  | { kind: "resources"; resources: FhirResource[] }
+  | { kind: "skipped"; entry: SkippedSubResource };
+
 async function collectSearchOrSkipUnauthorized(
   client: EpicFhirClient,
   resourceType: SyncResourceType,
   params: Record<string, string | undefined>,
-): Promise<FhirResource[] | null> {
+): Promise<SearchOutcome> {
   const out: FhirResource[] = [];
   try {
     for await (const r of client.searchAll(resourceType, params)) {
       out.push(r);
     }
-    return out;
+    return { kind: "resources", resources: out };
   } catch (err) {
     if (isUnauthorizedSubResourceError(err)) {
+      const filter = sanitizeFilterForReport(params);
       log.warn(
         "Epic sync — skipping unauthorized sub-resource (registered scopes don't cover this filter)",
-        {
-          resourceType,
-          params: Object.entries(params)
-            .filter(([k]) => k !== "patient")
-            .reduce<Record<string, string | undefined>>((acc, [k, v]) => {
-              acc[k] = v;
-              return acc;
-            }, {}),
-        },
+        { resourceType, params: filter },
       );
-      return null;
+      return {
+        kind: "skipped",
+        entry: { resource_type: resourceType, filter, reason: "unauthorized" },
+      };
     }
     throw err;
   }
 }
 
+interface FetchResult {
+  resources: FhirResource[];
+  skipped: SkippedSubResource[];
+}
+
 async function fetchResources(
   args: SyncOneArgs,
   client: EpicFhirClient,
-): Promise<FhirResource[]> {
+): Promise<FetchResult> {
   if (args.resourceType === "Patient") {
-    if (!args.epicPatientFhirId) return [];
-    return [await client.readPatient(args.epicPatientFhirId)];
+    if (!args.epicPatientFhirId) return { resources: [], skipped: [] };
+    return {
+      resources: [await client.readPatient(args.epicPatientFhirId)],
+      skipped: [],
+    };
   }
 
   const patient = args.epicPatientFhirId ?? args.patientId;
@@ -373,21 +418,25 @@ async function fetchResources(
   if (args.resourceType === "Observation") {
     const seen = new Set<string>();
     const out: FhirResource[] = [];
+    const skipped: SkippedSubResource[] = [];
     for (const category of OBSERVATION_CATEGORY_FANOUT) {
       const params = { ...baseParams, category };
-      const batch = await collectSearchOrSkipUnauthorized(
+      const outcome = await collectSearchOrSkipUnauthorized(
         client,
         args.resourceType,
         params,
       );
-      if (batch === null) continue;
-      for (const r of batch) {
+      if (outcome.kind === "skipped") {
+        skipped.push(outcome.entry);
+        continue;
+      }
+      for (const r of outcome.resources) {
         if (r.id && seen.has(r.id)) continue;
         if (r.id) seen.add(r.id);
         out.push(r);
       }
     }
-    return out;
+    return { resources: out, skipped };
   }
 
   // MedicationRequest: Epic requires `status` for unfiltered patient
@@ -396,19 +445,22 @@ async function fetchResources(
   // the rest of the sync still runs.
   if (args.resourceType === "MedicationRequest") {
     const params = { ...baseParams, status: MEDICATION_REQUEST_DEFAULT_STATUS };
-    const batch = await collectSearchOrSkipUnauthorized(
+    const outcome = await collectSearchOrSkipUnauthorized(
       client,
       args.resourceType,
       params,
     );
-    return batch ?? [];
+    if (outcome.kind === "skipped") {
+      return { resources: [], skipped: [outcome.entry] };
+    }
+    return { resources: outcome.resources, skipped: [] };
   }
 
   const resources: FhirResource[] = [];
   for await (const r of client.searchAll(args.resourceType, baseParams)) {
     resources.push(r);
   }
-  return resources;
+  return { resources, skipped: [] };
 }
 
 async function persistOne(

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -344,13 +344,22 @@ function isUnauthorizedSubResourceError(err: unknown): boolean {
   return false;
 }
 
-/** Strip undefined values + the `patient` PHI field for safe external surfacing. */
+/**
+ * Strip undefined values, the `patient` PHI field, and FHIR control
+ * params (`_lastUpdated`, etc.) for safe external surfacing.
+ *
+ * Control params (underscore-prefixed) are run-specific watermarks
+ * that would make `skipped_sub_resources` high-cardinality across
+ * incremental syncs — defeating the cross-patient aggregation signal
+ * the column is meant to provide.
+ */
 function sanitizeFilterForReport(
   params: Record<string, string | undefined>,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(params)) {
     if (k === "patient") continue;
+    if (k.startsWith("_")) continue;
     if (typeof v === "string") out[k] = v;
   }
   return out;

--- a/services/epic-connector/src/sync/sync-state-repo.ts
+++ b/services/epic-connector/src/sync/sync-state-repo.ts
@@ -22,6 +22,11 @@ import type { EpicResourceType } from "../fhir-client.js";
 
 export type EpicSyncStatusValue = "pending" | "running" | "ok" | "failed";
 
+export interface SkippedSubResourceRecord {
+  filter: Record<string, string>;
+  reason: "unauthorized";
+}
+
 export interface EpicSyncStateRow {
   patient_id: string;
   resource_type: EpicResourceType;
@@ -32,6 +37,8 @@ export interface EpicSyncStateRow {
   error_count: number;
   last_error_message: string | null;
   last_error_at: string | null;
+  /** Sub-resource fetches Epic refused on the most recent batch (#1097). */
+  skipped_sub_resources: SkippedSubResourceRecord[];
 }
 
 export async function getSyncState(
@@ -89,9 +96,16 @@ export async function markOk(args: {
   highWatermark: string | null;
   /** Number of resources successfully imported on this pull. */
   importedCount: number;
+  /**
+   * Sub-resources Epic refused on this batch (#1097). Replaces the
+   * previous value so the column reflects the latest run only —
+   * historical drift lives in BullMQ job logs, not here.
+   */
+  skipped?: SkippedSubResourceRecord[];
 }): Promise<void> {
   const db = getDb();
   const now = new Date().toISOString();
+  const skipped = args.skipped ?? [];
   await db
     .insert(epicSyncState)
     .values({
@@ -101,6 +115,7 @@ export async function markOk(args: {
       last_synced_at: now,
       last_fhir_lastupdated: args.highWatermark,
       resources_synced_count: args.importedCount,
+      skipped_sub_resources: skipped,
     })
     .onConflictDoUpdate({
       target: [epicSyncState.patient_id, epicSyncState.resource_type],
@@ -109,6 +124,7 @@ export async function markOk(args: {
         last_synced_at: now,
         last_fhir_lastupdated: args.highWatermark ?? sql`epic_sync_state.last_fhir_lastupdated`,
         resources_synced_count: sql`epic_sync_state.resources_synced_count + ${args.importedCount}`,
+        skipped_sub_resources: skipped,
       },
     });
 }


### PR DESCRIPTION
## Summary
- Adds `SyncResult.skipped: SkippedSubResource[]` carrying `{ resource_type, filter, reason: "unauthorized" }` for every Epic sub-resource fetch the registered scopes refused.
- New column `epic_sync_state.skipped_sub_resources jsonb` (migration 0051) so the existing `epicSyncRouter.getSyncStatus` tRPC query surfaces the field to the clinician portal automatically.
- PHI hygiene: `sanitizeFilterForReport` strips the `patient` Epic ID before recording — only non-identifying search params (category, status, etc.) flow into the surfaced field.

Closes #1097.

## Why this matters
Before this PR, the Epic sync worker would soft-skip an unauthorized sub-resource fetch with only a `log.warn`, and the resource_type's `SyncResult` would show `imported: 0, errors: []` — indistinguishable from "patient has no data." Operators couldn't tell "scope I registered is silently not returning data" from "patient genuinely has no data," which makes it hard to alert on misconfigured app registrations.

## Live verification against fhir.epic.com sandbox (Camila Lopez)

After the sync:

```
   resource_type    | status |                        skipped_sub_resources
--------------------+--------+---------------------------------------------------------------------
 AllergyIntolerance | ok     | []
 Condition          | ok     | []
 MedicationRequest  | ok     | [{"filter": {"status": "active"}, "reason": "unauthorized"}]
 Observation        | ok     | [{"filter": {"category": "vital-signs"}, "reason": "unauthorized"}]
 Patient            | ok     | []
```

The two unauthorized scopes are now visible structured data; an admin dashboard can group across patients to surface "vital-signs is never authorized" as a systemic config issue rather than a per-patient anomaly.

## Architecture notes
- `collectSearchOrSkipUnauthorized` now returns a discriminated `SearchOutcome` (`{kind: "resources"}` or `{kind: "skipped"}`) instead of `null`, so the caller can decide whether to record the skip or treat as empty. `fetchResources` aggregates skipped entries across the fan-out and returns them alongside resources via `FetchResult`.
- `markOk` accepts the skipped array and replaces the column value each run — the column reflects the latest batch only, historical drift is captured by BullMQ job logs.
- `SkippedSubResource` and `SkippedSubResourceRecord` are exported from the package entry for tRPC consumers / admin tooling.

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 150 pass + 1 documented skip (3 new sync-jobs tests, 1 new sync-state-repo test)
- [x] `pnpm typecheck` — full workspace 38/38 clean
- [x] Live verify against fhir.epic.com sandbox — 5/5 resource types green, skipped JSONB column correctly populated for Observation (vital-signs) + MedicationRequest (status=active)
- [x] PHI hygiene: regression test asserts `patient` Epic ID never appears in `result.skipped[].filter`

## Follow-ups (not in this PR)
- #1098 — per-tenant configurability of fan-out lists (Observation categories, MedicationRequest statuses)
- The `it.skip` placeholder from PR #1100 still tracks the future multi-status MedicationRequest fan-out under #1105