### PR TITLE
feat(epic): env-overridable sync fan-out config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,10 @@ NODE_ENV=development
 # NEVER set this in CI, staging, or preview environments — doing so allows
 # zero-credential admin takeover of any hardcoded dev identity.
 # CAREBRIDGE_DEV_AUTH=true
+
+# Epic sync fan-out overrides (#1098)
+# Override which Observation categories / MedicationRequest status the Epic
+# sync worker fans out over. Defaults match the CareBridge MVP. See
+# services/epic-connector/README.md for details.
+# EPIC_OBSERVATION_CATEGORIES=vital-signs,laboratory
+# EPIC_MEDICATION_REQUEST_STATUS=active

--- a/services/epic-connector/README.md
+++ b/services/epic-connector/README.md
@@ -59,7 +59,9 @@ without a code change.
 | Env var | Default | Notes |
 |---|---|---|
 | `EPIC_OBSERVATION_CATEGORIES` | `vital-signs,laboratory` | Comma-separated FHIR observation-category codes. Whitespace trimmed; empty segments and duplicates dropped. All-empty or whitespace-only values fall back to the default (silently disabling Observation sync is worse than refusing the misconfig). |
-| `EPIC_MEDICATION_REQUEST_STATUS` | `active` | Single FHIR MedicationRequest status. Multi-status fan-out is tracked in #1105. |
+| `EPIC_MEDICATION_REQUEST_STATUS` | `active` | Single FHIR MedicationRequest status. Multi-status fan-out implementation is tracked under #1114 (#1105 covers the related test-placeholder cleanup). |
+
+> **Note:** widening either set fetches more from Epic, but the CareBridge persistence layer today only maps `Observation.category` ∈ `{vital-signs, laboratory}` (→ `vitals`/`lab_results`) and `MedicationRequest.status = "active"` (→ AI oversight pipeline). Categories or statuses outside that set are fetched and counted in `SyncResult` but won't appear in internal tables — useful for surfacing scope/auth issues via `skipped_sub_resources` (#1097), not for end-user data display, until the matching persistence work lands.
 
 Examples:
 

--- a/services/epic-connector/README.md
+++ b/services/epic-connector/README.md
@@ -47,6 +47,30 @@ const token = await client.getAccessToken();
 The token client caches the response and refreshes 60s before expiry.
 Call `client.invalidate()` after a 401 to force a fresh assertion.
 
+## Sync fan-out overrides (#1098)
+
+Epic enforces per-resource search-parameter restrictions, so the sync
+worker fans out across a small set of values for `Observation` and
+`MedicationRequest`. The defaults match CareBridge's MVP (what the
+persistence layer maps + what the AI oversight pipeline acts on); a
+tenant whose workflow needs other categories/statuses can override
+without a code change.
+
+| Env var | Default | Notes |
+|---|---|---|
+| `EPIC_OBSERVATION_CATEGORIES` | `vital-signs,laboratory` | Comma-separated FHIR observation-category codes. Whitespace trimmed; empty segments and duplicates dropped. All-empty or whitespace-only values fall back to the default (silently disabling Observation sync is worse than refusing the misconfig). |
+| `EPIC_MEDICATION_REQUEST_STATUS` | `active` | Single FHIR MedicationRequest status. Multi-status fan-out is tracked in #1105. |
+
+Examples:
+
+```bash
+# Primary-care tenant — adds social history and exam findings
+EPIC_OBSERVATION_CATEGORIES=vital-signs,laboratory,social-history,exam
+
+# Med-rec tenant — wants completed/stopped MedicationRequest history
+EPIC_MEDICATION_REQUEST_STATUS=completed
+```
+
 ## Test
 
 ```bash

--- a/services/epic-connector/src/__tests__/fanout-config.test.ts
+++ b/services/epic-connector/src/__tests__/fanout-config.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for Epic sync fan-out config (#1098).
+ *
+ * The fan-out config controls which Observation categories and which
+ * MedicationRequest status the Epic sync worker fans out over.
+ * Defaults match CareBridge's MVP scope; env overrides let an operator
+ * widen/narrow the set without code changes (e.g., a primary-care
+ * tenant might want `social-history` and `survey` in addition to
+ * `vital-signs`).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  getObservationCategories,
+  getMedicationRequestStatus,
+  DEFAULT_OBSERVATION_CATEGORIES,
+  DEFAULT_MEDICATION_REQUEST_STATUS,
+} from "../sync/fanout-config.js";
+
+describe("getObservationCategories (#1098)", () => {
+  it("returns the MVP defaults when EPIC_OBSERVATION_CATEGORIES is unset", () => {
+    expect(getObservationCategories({})).toEqual([
+      "vital-signs",
+      "laboratory",
+    ]);
+  });
+
+  it("DEFAULT_OBSERVATION_CATEGORIES matches the documented MVP set", () => {
+    // Sanity check so a refactor that bumps the default doesn't silently
+    // change the value seen by every existing tenant.
+    expect(DEFAULT_OBSERVATION_CATEGORIES).toEqual([
+      "vital-signs",
+      "laboratory",
+    ]);
+  });
+
+  it("parses a comma-separated env override", () => {
+    expect(
+      getObservationCategories({
+        EPIC_OBSERVATION_CATEGORIES: "vital-signs,social-history,survey",
+      }),
+    ).toEqual(["vital-signs", "social-history", "survey"]);
+  });
+
+  it("trims whitespace around comma-separated entries", () => {
+    expect(
+      getObservationCategories({
+        EPIC_OBSERVATION_CATEGORIES: " vital-signs , laboratory , exam ",
+      }),
+    ).toEqual(["vital-signs", "laboratory", "exam"]);
+  });
+
+  it("drops empty segments (trailing comma, double comma)", () => {
+    expect(
+      getObservationCategories({
+        EPIC_OBSERVATION_CATEGORIES: "vital-signs,,laboratory,",
+      }),
+    ).toEqual(["vital-signs", "laboratory"]);
+  });
+
+  it("falls back to defaults when env is set but contains only whitespace/commas", () => {
+    // Mis-configured env (e.g., `EPIC_OBSERVATION_CATEGORIES=,,,`) must
+    // not produce an empty fan-out list — that would silently disable
+    // Observation sync for the affected tenant. Fall back to defaults.
+    expect(
+      getObservationCategories({
+        EPIC_OBSERVATION_CATEGORIES: "   ,  ,  ",
+      }),
+    ).toEqual(["vital-signs", "laboratory"]);
+  });
+
+  it("falls back to defaults when env is the empty string", () => {
+    expect(
+      getObservationCategories({ EPIC_OBSERVATION_CATEGORIES: "" }),
+    ).toEqual(["vital-signs", "laboratory"]);
+  });
+
+  it("deduplicates repeated categories", () => {
+    expect(
+      getObservationCategories({
+        EPIC_OBSERVATION_CATEGORIES: "vital-signs,vital-signs,laboratory",
+      }),
+    ).toEqual(["vital-signs", "laboratory"]);
+  });
+});
+
+describe("getMedicationRequestStatus (#1098)", () => {
+  it("returns the MVP default 'active' when env is unset", () => {
+    expect(getMedicationRequestStatus({})).toBe("active");
+  });
+
+  it("DEFAULT_MEDICATION_REQUEST_STATUS matches the documented MVP value", () => {
+    expect(DEFAULT_MEDICATION_REQUEST_STATUS).toBe("active");
+  });
+
+  it("uses the EPIC_MEDICATION_REQUEST_STATUS override when set", () => {
+    expect(
+      getMedicationRequestStatus({ EPIC_MEDICATION_REQUEST_STATUS: "on-hold" }),
+    ).toBe("on-hold");
+  });
+
+  it("trims whitespace around the override", () => {
+    expect(
+      getMedicationRequestStatus({
+        EPIC_MEDICATION_REQUEST_STATUS: "  completed  ",
+      }),
+    ).toBe("completed");
+  });
+
+  it("falls back to the default when env is the empty string", () => {
+    expect(
+      getMedicationRequestStatus({ EPIC_MEDICATION_REQUEST_STATUS: "" }),
+    ).toBe("active");
+  });
+
+  it("falls back to the default when env is only whitespace", () => {
+    expect(
+      getMedicationRequestStatus({ EPIC_MEDICATION_REQUEST_STATUS: "   " }),
+    ).toBe("active");
+  });
+});

--- a/services/epic-connector/src/sync/fanout-config.ts
+++ b/services/epic-connector/src/sync/fanout-config.ts
@@ -1,0 +1,70 @@
+/**
+ * Epic sync fan-out configuration (#1098).
+ *
+ * Epic enforces per-resource-type search-parameter restrictions, so the
+ * sync worker fans out across a small set of values for the resource
+ * types that need it:
+ *
+ *   - `Observation` — one search per `category` (Epic refuses an
+ *     un-categorised search). Defaults: `vital-signs`, `laboratory`.
+ *   - `MedicationRequest` — Epic refuses an un-`status`-scoped search.
+ *     Defaults: `active`.
+ *
+ * The MVP defaults match what the persistence layer can actually
+ * import (vitals + lab_results, active meds) and what the AI oversight
+ * pipeline acts on. A primary-care or med-rec tenant whose workflow
+ * needs other categories/statuses can override via env without a code
+ * change.
+ *
+ * Env vars:
+ *   EPIC_OBSERVATION_CATEGORIES       — Comma-separated FHIR
+ *     observation-category codes (e.g. `vital-signs,social-history`).
+ *     Whitespace around entries is trimmed; empty segments and
+ *     duplicates are dropped. An all-empty value falls back to the
+ *     default (silently disabling Observation sync is worse than
+ *     refusing the misconfig).
+ *   EPIC_MEDICATION_REQUEST_STATUS    — Single FHIR MedicationRequest
+ *     status code. Multi-status fan-out lives in #1105 (skipped test
+ *     placeholder in sync-jobs.test.ts).
+ */
+
+export const DEFAULT_OBSERVATION_CATEGORIES: readonly string[] = [
+  "vital-signs",
+  "laboratory",
+];
+
+export const DEFAULT_MEDICATION_REQUEST_STATUS = "active";
+
+function parseList(raw: string | undefined): string[] | null {
+  if (raw === undefined) return null;
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (parts.length === 0) return null;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of parts) {
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+  }
+  return out;
+}
+
+export function getObservationCategories(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const override = parseList(env.EPIC_OBSERVATION_CATEGORIES);
+  return override ?? [...DEFAULT_OBSERVATION_CATEGORIES];
+}
+
+export function getMedicationRequestStatus(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = env.EPIC_MEDICATION_REQUEST_STATUS;
+  if (raw === undefined) return DEFAULT_MEDICATION_REQUEST_STATUS;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return DEFAULT_MEDICATION_REQUEST_STATUS;
+  return trimmed;
+}

--- a/services/epic-connector/src/sync/fanout-config.ts
+++ b/services/epic-connector/src/sync/fanout-config.ts
@@ -24,8 +24,9 @@
  *     default (silently disabling Observation sync is worse than
  *     refusing the misconfig).
  *   EPIC_MEDICATION_REQUEST_STATUS    — Single FHIR MedicationRequest
- *     status code. Multi-status fan-out lives in #1105 (skipped test
- *     placeholder in sync-jobs.test.ts).
+ *     status code. Multi-status fan-out implementation is tracked
+ *     under #1114; the related `it.skip` test-placeholder cleanup
+ *     is tracked under #1105.
  */
 
 export const DEFAULT_OBSERVATION_CATEGORIES: readonly string[] = [

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -49,6 +49,10 @@ import {
   markOk,
   markRunning,
 } from "./sync-state-repo.js";
+import {
+  getObservationCategories,
+  getMedicationRequestStatus,
+} from "./fanout-config.js";
 import type { FhirResource } from "../fhir-types.js";
 
 const log = createLogger("epic-sync-jobs");
@@ -295,17 +299,10 @@ async function syncResourceType(
  * {@link isUnauthorizedSubResourceError}. Such failures are swallowed
  * per category so a sync registered with only one of the two categories
  * still imports what it's authorized for.
+ *
+ * The default set + status are overridable per deployment via env
+ * (#1098) — see {@link ../fanout-config}.
  */
-const OBSERVATION_CATEGORY_FANOUT = ["vital-signs", "laboratory"] as const;
-
-/**
- * Epic's R4 endpoint rejects `MedicationRequest?patient=X` without a
- * `status` filter ("Combination of parameters is not valid"). Default
- * to `active` since stopped/cancelled meds aren't clinically actionable
- * for the AI oversight pipeline. Callers needing the full history can
- * pass an override via the worker dispatch in a future iteration.
- */
-const MEDICATION_REQUEST_DEFAULT_STATUS = "active";
 
 /** Epic error code for "Combination of parameters is not valid for any
  *  authorized sub-resource. No search was performed." This 400 means
@@ -428,7 +425,7 @@ async function fetchResources(
     const seen = new Set<string>();
     const out: FhirResource[] = [];
     const skipped: SkippedSubResource[] = [];
-    for (const category of OBSERVATION_CATEGORY_FANOUT) {
+    for (const category of getObservationCategories()) {
       const params = { ...baseParams, category };
       const outcome = await collectSearchOrSkipUnauthorized(
         client,
@@ -453,7 +450,7 @@ async function fetchResources(
   // for example) won't accept any `?patient=X` query — fail soft so
   // the rest of the sync still runs.
   if (args.resourceType === "MedicationRequest") {
-    const params = { ...baseParams, status: MEDICATION_REQUEST_DEFAULT_STATUS };
+    const params = { ...baseParams, status: getMedicationRequestStatus() };
     const outcome = await collectSearchOrSkipUnauthorized(
       client,
       args.resourceType,

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -301,7 +301,8 @@ async function syncResourceType(
  * still imports what it's authorized for.
  *
  * The default set + status are overridable per deployment via env
- * (#1098) — see {@link ../fanout-config}.
+ * (#1098) — see {@link getObservationCategories} and
+ * {@link getMedicationRequestStatus}.
  */
 
 /** Epic error code for "Combination of parameters is not valid for any


### PR DESCRIPTION
## Summary
- Extract the hardcoded `OBSERVATION_CATEGORY_FANOUT` and `MEDICATION_REQUEST_DEFAULT_STATUS` constants out of `sync-jobs.ts` into a dedicated `fanout-config.ts` module.
- Add two env vars for per-deployment overrides — `EPIC_OBSERVATION_CATEGORIES` (comma-separated) and `EPIC_MEDICATION_REQUEST_STATUS` (single value).
- Defaults match the previous hardcoded values (`vital-signs,laboratory` / `active`), so the change is fully backwards-compatible.

Closes #1098.

## Why this matters
Different Epic tenants need different fan-out sets:
- **Primary-care** workflows want `social-history`, `exam`, `survey` Observations.
- **Med-rec** workflows want `MedicationRequest` history with `completed` / `stopped` statuses, not just `active`.

Before this PR a tenant change would require a code edit, PR, and deploy. With env overrides, an operator flips the value on the deployment target and restarts the worker.

## Env vars

| Var | Default | Notes |
|---|---|---|
| `EPIC_OBSERVATION_CATEGORIES` | `vital-signs,laboratory` | Comma-separated FHIR observation-category codes. Whitespace trimmed; empty segments and duplicates dropped. All-empty or whitespace-only values fall back to default (silently disabling the fan-out is worse than refusing the misconfig). |
| `EPIC_MEDICATION_REQUEST_STATUS` | `active` | Single FHIR MedicationRequest status. Multi-status fan-out lives in #1105 (existing `it.skip` placeholder). |

## Architecture notes
- `fanout-config.ts` is a pure helper module: pure functions, takes `env: NodeJS.ProcessEnv` as an arg (defaulting to `process.env`), no side effects.
- All sanitisation lives in one place (`parseList`): split → trim → drop empty → dedupe. Easy to extend if a future override grows a list shape.
- The MVP defaults are exported as `DEFAULT_OBSERVATION_CATEGORIES` and `DEFAULT_MEDICATION_REQUEST_STATUS` so a sanity-check test catches drift, and so other modules that need the same default (admin tooling, dashboards) don't duplicate the list.
- No DB schema change — env-only override matches the single-tenant MVP. A per-tenant DB-column override stays a future option (a richer multi-tenant story would layer on top: env = platform default, DB column = per-tenant override).

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 165 pass + 1 documented skip (14 new fanout-config tests)
- [x] `pnpm typecheck` — full workspace 38/38 clean
- [x] Existing 28 sync-jobs tests still pass unchanged (default values preserved exactly)
- [x] Docs updated: README "Sync fan-out overrides" section + `.env.example` entries

## Out of scope (intentional)
- Multi-status MedicationRequest fan-out — stays under #1105.
- Per-tenant DB-column override — stays under the broader #1098 acceptance for a future multi-tenant milestone.