### PR TITLE
feat(epic): persist partial soft-skips on failure + surface skipped in BullMQ summary

### DIFF
--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -269,6 +269,9 @@ describe("Epic sync-jobs (#391)", () => {
       patientId: PATIENT_ID,
       resourceType: "Condition",
       errorMessage: "network down",
+      // No partial soft-skips were collected before the throw (Condition
+      // doesn't fan out), so the skipped array is empty.
+      skipped: [],
     });
     expect(result.errors).toContain("network down");
   });
@@ -1013,6 +1016,75 @@ describe("Epic sync-jobs (#391)", () => {
     expect(filter).toEqual({ category: "vital-signs" });
     expect(filter).not.toHaveProperty("_lastUpdated");
     expect(filter).not.toHaveProperty("patient");
+  });
+
+  // ── #1108: partial-skipped survives a sibling-throw ─────────────
+  // Before this fix, `fetchResources` returned `{ resources, skipped }`
+  // and the caller assigned `result.skipped = skipped` only on the happy
+  // path. If the first Observation category soft-skipped but the second
+  // category threw a genuine error, the skipped signal was discarded
+  // when the outer try/catch ran `markFailed()`. Now `fetchResources`
+  // mutates the result's skipped array as it goes, so partial collection
+  // survives the throw and is persisted alongside the failure status.
+
+  it("first-category soft-skip + second-category genuine error → result.skipped + markFailed both carry the partial soft-skip", async () => {
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi
+        .fn()
+        .mockImplementation((_rt: string, params: Record<string, string>) => {
+          if (params.category === "vital-signs") {
+            return (async function* () {
+              throw new Error(
+                "Epic FHIR request returned 400 Bad Request — Combination of parameters is not valid for any authorized sub-resource.",
+              );
+            })();
+          }
+          if (params.category === "laboratory") {
+            return (async function* () {
+              throw new Error(
+                "Epic FHIR request returned 500 Internal Server Error — ECONNREFUSED",
+              );
+            })();
+          }
+          return (async function* () {})();
+        }),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Observation",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    // result.skipped captured the vital-signs soft-skip even though
+    // laboratory's throw aborted the fan-out before completion.
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]).toMatchObject({
+      resource_type: "Observation",
+      reason: "unauthorized",
+      filter: { category: "vital-signs" },
+    });
+
+    // markFailed received the partial skipped so it lands on the
+    // epic_sync_state row — operator gets the auth-scope signal even
+    // when the sync as a whole failed.
+    expect(markFailed).toHaveBeenCalledOnce();
+    const markFailedArgs = markFailed.mock.calls[0]![0] as {
+      skipped?: Array<{ filter: Record<string, string>; reason: string }>;
+      errorMessage: string;
+    };
+    expect(markFailedArgs.skipped).toEqual([
+      { filter: { category: "vital-signs" }, reason: "unauthorized" },
+    ]);
+    expect(markFailedArgs.errorMessage).toMatch(/ECONNREFUSED/);
+
+    // markOk must NOT have been called on the failure path.
+    expect(markOk).not.toHaveBeenCalled();
   });
 
   // #1099 acceptance #4: documented placeholder for multi-status fan-out

--- a/services/epic-connector/src/__tests__/sync-state-repo.test.ts
+++ b/services/epic-connector/src/__tests__/sync-state-repo.test.ts
@@ -133,6 +133,31 @@ describe("epic_sync_state repo (#391)", () => {
     expect((values.last_error_message as string).length).toBe(1024);
     expect(values.status).toBe("failed");
     expect(values.error_count).toBe(1);
+    // #1108: defaults to empty array when caller doesn't pass `skipped`.
+    expect(values.skipped_sub_resources).toEqual([]);
+  });
+
+  it("markFailed persists the partial soft-skipped array when provided (#1108)", async () => {
+    db.willInsert();
+    await markFailed({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      errorMessage: "ECONNREFUSED",
+      skipped: [
+        { filter: { category: "vital-signs" }, reason: "unauthorized" },
+      ],
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values.skipped_sub_resources).toEqual([
+      { filter: { category: "vital-signs" }, reason: "unauthorized" },
+    ]);
+    // onConflictDoUpdate `set` carries the latest skipped state so a
+    // re-run replaces stale data instead of merging it.
+    const setClause = db.insert.calls[0]!.chainArgs[1]![0] as { set: Record<string, unknown> };
+    expect(setClause.set.skipped_sub_resources).toEqual([
+      { filter: { category: "vital-signs" }, reason: "unauthorized" },
+    ]);
+    expect(setClause.set.status).toBe("failed");
   });
 
   it("listRecentFailures filters status=failed and orders by last_error_at desc", async () => {

--- a/services/epic-connector/src/__tests__/sync-state-repo.test.ts
+++ b/services/epic-connector/src/__tests__/sync-state-repo.test.ts
@@ -133,8 +133,37 @@ describe("epic_sync_state repo (#391)", () => {
     expect((values.last_error_message as string).length).toBe(1024);
     expect(values.status).toBe("failed");
     expect(values.error_count).toBe(1);
-    // #1108: defaults to empty array when caller doesn't pass `skipped`.
-    expect(values.skipped_sub_resources).toEqual([]);
+  });
+
+  it("markFailed does NOT write skipped_sub_resources when nothing partial was collected (#1118 — preserves prior successful sync's skipped data)", async () => {
+    db.willInsert();
+    await markFailed({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      errorMessage: "ECONNREFUSED",
+      // No skipped collected — most failure modes (network down, token
+      // refresh fail, 500 on the first call). Repo must leave the
+      // column untouched so a prior successful sync's recorded skips
+      // aren't wiped to [] by every subsequent failed run.
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values).not.toHaveProperty("skipped_sub_resources");
+    const setClause = db.insert.calls[0]!.chainArgs[1]![0] as { set: Record<string, unknown> };
+    expect(setClause.set).not.toHaveProperty("skipped_sub_resources");
+  });
+
+  it("markFailed does NOT write skipped_sub_resources when caller passes an explicit empty array (#1118)", async () => {
+    db.willInsert();
+    await markFailed({
+      patientId: PATIENT_ID,
+      resourceType: "Observation",
+      errorMessage: "ECONNREFUSED",
+      skipped: [],
+    });
+    const values = db.insert.calls[0]!.chainArgs[0]![0] as Record<string, unknown>;
+    expect(values).not.toHaveProperty("skipped_sub_resources");
+    const setClause = db.insert.calls[0]!.chainArgs[1]![0] as { set: Record<string, unknown> };
+    expect(setClause.set).not.toHaveProperty("skipped_sub_resources");
   });
 
   it("markFailed persists the partial soft-skipped array when provided (#1108)", async () => {

--- a/services/epic-connector/src/__tests__/sync-worker-summarise.test.ts
+++ b/services/epic-connector/src/__tests__/sync-worker-summarise.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the BullMQ sync worker's summarise() helper (#1107).
+ *
+ * summarise() rolls up the per-resource-type SyncResult[] into the
+ * single object that gets returned as the BullMQ job result and shows
+ * up in `job.returnvalue` for dashboards and ops tooling. PR #1106
+ * added `SyncResult.skipped` for sub-resource scopes Epic refused —
+ * this test suite enforces that skipped flows into the job-result
+ * rollup so operators monitoring BullMQ see the auth-scope signal
+ * without cross-referencing the epic_sync_state DB column.
+ */
+import { describe, it, expect } from "vitest";
+import { summarise } from "../workers/sync-worker.js";
+
+describe("summarise() (#1107)", () => {
+  it("rolls up imported/updated/conflicts/errors as before", () => {
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 5,
+        updated: 1,
+        conflicts: 0,
+        errors: [],
+        skipped: [],
+      },
+      {
+        patient_id: "p1",
+        resource_type: "Condition",
+        imported: 2,
+        updated: 0,
+        conflicts: 1,
+        errors: ["boom"],
+        skipped: [],
+      },
+    ]);
+    expect(out).toMatchObject({
+      imported: 7,
+      updated: 1,
+      conflicts: 1,
+      errors: 1,
+    });
+  });
+
+  it("includes skipped count rolled up across resource types", () => {
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 87,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: [
+          {
+            resource_type: "Observation",
+            filter: { category: "vital-signs" },
+            reason: "unauthorized",
+          },
+        ],
+      },
+      {
+        patient_id: "p1",
+        resource_type: "MedicationRequest",
+        imported: 0,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: [
+          {
+            resource_type: "MedicationRequest",
+            filter: { status: "active" },
+            reason: "unauthorized",
+          },
+        ],
+      },
+      {
+        patient_id: "p1",
+        resource_type: "Condition",
+        imported: 3,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: [],
+      },
+    ]);
+
+    expect(out.skipped).toBe(2);
+  });
+
+  it("includes the full skipped detail list for dashboards needing structured drill-down", () => {
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 87,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: [
+          {
+            resource_type: "Observation",
+            filter: { category: "vital-signs" },
+            reason: "unauthorized",
+          },
+        ],
+      },
+    ]);
+
+    expect(out.skippedDetail).toEqual([
+      {
+        resource_type: "Observation",
+        filter: { category: "vital-signs" },
+        reason: "unauthorized",
+      },
+    ]);
+  });
+
+  it("skipped=0 + skippedDetail=[] when nothing was soft-skipped", () => {
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Condition",
+        imported: 5,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: [],
+      },
+    ]);
+    expect(out.skipped).toBe(0);
+    expect(out.skippedDetail).toEqual([]);
+  });
+
+  it("empty results → all zeros, empty skippedDetail", () => {
+    const out = summarise([]);
+    expect(out).toEqual({
+      imported: 0,
+      updated: 0,
+      conflicts: 0,
+      errors: 0,
+      skipped: 0,
+      skippedDetail: [],
+    });
+  });
+});

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -208,8 +208,11 @@ async function syncResourceType(
   let highWatermark: string | null = args.watermark;
 
   try {
-    const { resources, skipped } = await fetchResources(args, deps.client);
-    result.skipped = skipped;
+    // fetchResources pushes into result.skipped as it goes, so a
+    // sibling fan-out throw mid-way (#1108) doesn't drop the partial
+    // skipped collection — the catch block below persists what was
+    // captured before the failure.
+    const resources = await fetchResources(args, deps.client, result.skipped);
 
     for (const resource of resources) {
       try {
@@ -278,6 +281,11 @@ async function syncResourceType(
       patientId: args.patientId,
       resourceType: args.resourceType,
       errorMessage: message,
+      // Persist whatever soft-skips were collected before the throw
+      // (#1108) so the auth-scope signal survives a partial-failure
+      // sync and is visible in the epic_sync_state row alongside the
+      // error status.
+      skipped: result.skipped.map(({ filter, reason }) => ({ filter, reason })),
     });
     result.errors.push(message);
   }
@@ -394,21 +402,25 @@ async function collectSearchOrSkipUnauthorized(
   }
 }
 
-interface FetchResult {
-  resources: FhirResource[];
-  skipped: SkippedSubResource[];
-}
-
+/**
+ * Fetch the FHIR resources for one (patient, resource_type) pair.
+ *
+ * `skippedOut` is mutated as soft-skips are collected (#1108) — pushing
+ * to a caller-owned array means partial collection survives a throw
+ * partway through the fan-out, so a sibling fan-out call that fails
+ * with a genuine error (ECONNREFUSED, 500, etc.) doesn't discard the
+ * earlier auth-scope signals. The outer try/catch in
+ * `syncResourceType` reads from the same array to persist whatever
+ * was collected before the failure.
+ */
 async function fetchResources(
   args: SyncOneArgs,
   client: EpicFhirClient,
-): Promise<FetchResult> {
+  skippedOut: SkippedSubResource[],
+): Promise<FhirResource[]> {
   if (args.resourceType === "Patient") {
-    if (!args.epicPatientFhirId) return { resources: [], skipped: [] };
-    return {
-      resources: [await client.readPatient(args.epicPatientFhirId)],
-      skipped: [],
-    };
+    if (!args.epicPatientFhirId) return [];
+    return [await client.readPatient(args.epicPatientFhirId)];
   }
 
   const patient = args.epicPatientFhirId ?? args.patientId;
@@ -425,7 +437,6 @@ async function fetchResources(
   if (args.resourceType === "Observation") {
     const seen = new Set<string>();
     const out: FhirResource[] = [];
-    const skipped: SkippedSubResource[] = [];
     for (const category of getObservationCategories()) {
       const params = { ...baseParams, category };
       const outcome = await collectSearchOrSkipUnauthorized(
@@ -434,7 +445,7 @@ async function fetchResources(
         params,
       );
       if (outcome.kind === "skipped") {
-        skipped.push(outcome.entry);
+        skippedOut.push(outcome.entry);
         continue;
       }
       for (const r of outcome.resources) {
@@ -443,7 +454,7 @@ async function fetchResources(
         out.push(r);
       }
     }
-    return { resources: out, skipped };
+    return out;
   }
 
   // MedicationRequest: Epic requires `status` for unfiltered patient
@@ -458,16 +469,17 @@ async function fetchResources(
       params,
     );
     if (outcome.kind === "skipped") {
-      return { resources: [], skipped: [outcome.entry] };
+      skippedOut.push(outcome.entry);
+      return [];
     }
-    return { resources: outcome.resources, skipped: [] };
+    return outcome.resources;
   }
 
   const resources: FhirResource[] = [];
   for await (const r of client.searchAll(args.resourceType, baseParams)) {
     resources.push(r);
   }
-  return { resources, skipped: [] };
+  return resources;
 }
 
 async function persistOne(

--- a/services/epic-connector/src/sync/sync-state-repo.ts
+++ b/services/epic-connector/src/sync/sync-state-repo.ts
@@ -139,7 +139,11 @@ export async function markFailed(args: {
    * throws a genuine error, the earlier auth-scope soft-skips still
    * need to surface — persisting them here means the operator sees
    * both signals on the failed row instead of only the error.
-   * Defaults to empty when caller has nothing to record.
+   *
+   * Only written to the row when non-empty (#1118): the common
+   * failure case (network down, token refresh fail, 500 on the first
+   * call) collects no skips, and writing `[]` would wipe the prior
+   * successful sync's recorded skips on the row.
    */
   skipped?: SkippedSubResourceRecord[];
 }): Promise<void> {
@@ -150,6 +154,14 @@ export async function markFailed(args: {
   // traces live in the worker logs / DLQ.
   const truncated = args.errorMessage.slice(0, 1024);
   const skipped = args.skipped ?? [];
+  // Only set skipped_sub_resources when there's actually new partial
+  // collection to record. Otherwise leave the column untouched so the
+  // prior run's value (often a successful sync's skipped scopes) is
+  // preserved (#1118).
+  const partialSkipFields = skipped.length > 0
+    ? { skipped_sub_resources: skipped }
+    : {};
+
   await db
     .insert(epicSyncState)
     .values({
@@ -160,7 +172,7 @@ export async function markFailed(args: {
       last_error_message: truncated,
       last_error_at: now,
       error_count: 1,
-      skipped_sub_resources: skipped,
+      ...partialSkipFields,
     })
     .onConflictDoUpdate({
       target: [epicSyncState.patient_id, epicSyncState.resource_type],
@@ -170,7 +182,7 @@ export async function markFailed(args: {
         last_error_message: truncated,
         last_error_at: now,
         error_count: sql`epic_sync_state.error_count + 1`,
-        skipped_sub_resources: skipped,
+        ...partialSkipFields,
       },
     });
 }

--- a/services/epic-connector/src/sync/sync-state-repo.ts
+++ b/services/epic-connector/src/sync/sync-state-repo.ts
@@ -133,6 +133,15 @@ export async function markFailed(args: {
   patientId: string;
   resourceType: EpicResourceType;
   errorMessage: string;
+  /**
+   * Soft-skipped sub-resources captured BEFORE the failing call
+   * (#1108). When the fan-out is partway through and a sibling call
+   * throws a genuine error, the earlier auth-scope soft-skips still
+   * need to surface — persisting them here means the operator sees
+   * both signals on the failed row instead of only the error.
+   * Defaults to empty when caller has nothing to record.
+   */
+  skipped?: SkippedSubResourceRecord[];
 }): Promise<void> {
   const db = getDb();
   const now = new Date().toISOString();
@@ -140,6 +149,7 @@ export async function markFailed(args: {
   // status column to gigabytes. 1KiB is plenty for triage; full stack
   // traces live in the worker logs / DLQ.
   const truncated = args.errorMessage.slice(0, 1024);
+  const skipped = args.skipped ?? [];
   await db
     .insert(epicSyncState)
     .values({
@@ -150,6 +160,7 @@ export async function markFailed(args: {
       last_error_message: truncated,
       last_error_at: now,
       error_count: 1,
+      skipped_sub_resources: skipped,
     })
     .onConflictDoUpdate({
       target: [epicSyncState.patient_id, epicSyncState.resource_type],
@@ -159,6 +170,7 @@ export async function markFailed(args: {
         last_error_message: truncated,
         last_error_at: now,
         error_count: sql`epic_sync_state.error_count + 1`,
+        skipped_sub_resources: skipped,
       },
     });
 }

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -28,6 +28,7 @@ import {
   runIncrementalSync,
   runSingleResourceSync,
   type SyncResourceType,
+  type SyncResult,
 } from "../sync/sync-jobs.js";
 
 const log = createLogger("epic-sync-worker");
@@ -199,27 +200,50 @@ export function startEpicSyncWorker(): Worker<EpicSyncJobData> | null {
   return worker;
 }
 
-function summarise(
-  results: Array<{
-    resource_type: string;
-    imported: number;
-    updated: number;
-    conflicts: number;
-    errors: string[];
-  }>,
-): {
+interface SkippedDetail {
+  resource_type: string;
+  filter: Record<string, string>;
+  reason: string;
+}
+
+interface SyncSummary {
   imported: number;
   updated: number;
   conflicts: number;
   errors: number;
-} {
-  return results.reduce(
+  /** Count of soft-skipped sub-resource fetches across all resource types (#1107). */
+  skipped: number;
+  /** Per-skip detail for ops dashboards that want structured drill-down (#1107). */
+  skippedDetail: SkippedDetail[];
+}
+
+/**
+ * Rolls up a per-resource-type `SyncResult[]` into the single object
+ * returned as the BullMQ job result and surfaced via `job.returnvalue`.
+ *
+ * `skipped` + `skippedDetail` (#1107) make sub-resource auth-scope
+ * issues visible from the BullMQ dashboard without cross-referencing
+ * the `epic_sync_state` Postgres column.
+ *
+ * Exported for unit testing — the worker callbacks invoke it directly.
+ */
+export function summarise(results: SyncResult[]): SyncSummary {
+  return results.reduce<SyncSummary>(
     (acc, r) => ({
       imported: acc.imported + r.imported,
       updated: acc.updated + r.updated,
       conflicts: acc.conflicts + r.conflicts,
       errors: acc.errors + r.errors.length,
+      skipped: acc.skipped + r.skipped.length,
+      skippedDetail: [...acc.skippedDetail, ...r.skipped],
     }),
-    { imported: 0, updated: 0, conflicts: 0, errors: 0 },
+    {
+      imported: 0,
+      updated: 0,
+      conflicts: 0,
+      errors: 0,
+      skipped: 0,
+      skippedDetail: [],
+    },
   );
 }

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -29,6 +29,7 @@ import {
   runSingleResourceSync,
   type SyncResourceType,
   type SyncResult,
+  type SkippedSubResource,
 } from "../sync/sync-jobs.js";
 
 const log = createLogger("epic-sync-worker");
@@ -200,12 +201,6 @@ export function startEpicSyncWorker(): Worker<EpicSyncJobData> | null {
   return worker;
 }
 
-interface SkippedDetail {
-  resource_type: string;
-  filter: Record<string, string>;
-  reason: string;
-}
-
 interface SyncSummary {
   imported: number;
   updated: number;
@@ -214,7 +209,7 @@ interface SyncSummary {
   /** Count of soft-skipped sub-resource fetches across all resource types (#1107). */
   skipped: number;
   /** Per-skip detail for ops dashboards that want structured drill-down (#1107). */
-  skippedDetail: SkippedDetail[];
+  skippedDetail: SkippedSubResource[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Bundles two PR #1106 follow-ups around skipped sub-resource observability — both touch `sync-jobs.ts` / `sync-worker.ts` and complete the operator-visibility story for soft-skipped scopes.

- **#1108** — `fetchResources` now mutates a `skippedOut` accumulator passed by the caller, so partial collection survives a mid-fan-out throw. `markFailed` accepts the partial skipped and persists it on the failed-row update. An Observation sync where `vital-signs` soft-skips and `laboratory` then throws now lands in `epic_sync_state` with `status=failed AND skipped_sub_resources=[{filter: {category: vital-signs}, reason: unauthorized}]` — operator sees both signals, not just the error.
- **#1107** — `summarise()` (BullMQ job-result rollup) gains `skipped: number` and `skippedDetail: SkippedSubResource[]`. Dashboards reading `job.returnvalue` now show the auth-scope signal without an additional Postgres query.

Closes #1107.
Closes #1108.

## Why bundle these
Both close the gap that opened in PR #1106: skipped flowed into the DB and tRPC, but not into the failure path (#1108) or the BullMQ job-result rollup (#1107). Fixing them separately would leave half-done observability for whichever ships first. Bundled, they restore the principle that any soft-skip is visible in every operator-facing surface: DB column, tRPC, BullMQ dashboard, and worker logs.

## API change
- `fetchResources(args, client)` → `fetchResources(args, client, skippedOut)` (internal helper, only one caller — `syncResourceType`)
- `markFailed({ patientId, resourceType, errorMessage })` → adds optional `skipped?: SkippedSubResourceRecord[]` (defaults to `[]`)
- `summarise()` return type widens from `{imported, updated, conflicts, errors}` to add `skipped: number, skippedDetail: SkippedDetail[]` — additive, no breaking change to existing dashboard consumers; new dashboards opt in.

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 185 pass + 1 documented skip (was 178)
  - New: \"first-category soft-skip + second-category genuine error → result.skipped + markFailed both carry the partial soft-skip\"
  - New: \"markFailed persists the partial soft-skipped array when provided (#1108)\"
  - New: sync-worker-summarise.test.ts (5 tests covering rollup + skipped count + skippedDetail + empty cases)
  - Existing markFailed test updated to assert default `skipped: []`
- [x] `pnpm typecheck` — workspace 38/38 clean
- [x] Pre-existing 28 sync-jobs tests still pass — happy-path behaviour preserved

## Follow-ups (not in this PR)
- #1116 (pure-eval mode for loadFanoutConfig) — separate concern, not related
- #1114 (multi-status MedicationRequest fan-out) — separate implementation tracker