### PR TITLE
feat(epic): error-handling consolidation — EPIC_ERROR_CODES + tightened parser + unified error type

### DIFF
--- a/services/epic-connector/src/__tests__/epic-error-codes.test.ts
+++ b/services/epic-connector/src/__tests__/epic-error-codes.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for the Epic error-code registry (#1102).
+ *
+ * Sanity check that the canonical codes haven't drifted from what
+ * sync-jobs / fhir-client actually use. If a future PR changes a
+ * literal in either place without updating the registry (or vice
+ * versa), this test surfaces the drift before runtime.
+ */
+import { describe, it, expect } from "vitest";
+import { EPIC_ERROR_CODES, type EpicErrorCode } from "../epic-error-codes.js";
+
+describe("EPIC_ERROR_CODES (#1102)", () => {
+  it("UNAUTHORIZED_SUB_RESOURCE matches Epic's documented code 59022", () => {
+    expect(EPIC_ERROR_CODES.UNAUTHORIZED_SUB_RESOURCE).toBe("59022");
+  });
+
+  it("MISSING_REQUIRED_ELEMENT matches Epic's documented code 59108", () => {
+    expect(EPIC_ERROR_CODES.MISSING_REQUIRED_ELEMENT).toBe("59108");
+  });
+
+  it("EpicErrorCode type narrows to the registry values", () => {
+    // Type-level assertion: any string literal that matches a registry
+    // value is assignable to EpicErrorCode; arbitrary strings are not.
+    const ok: EpicErrorCode = "59022";
+    expect(ok).toBe("59022");
+    // @ts-expect-error — arbitrary strings must not satisfy EpicErrorCode
+    const bad: EpicErrorCode = "not-a-real-code";
+    expect(bad).toBe("not-a-real-code");
+  });
+
+  it("registry codes are all unique", () => {
+    const values = Object.values(EPIC_ERROR_CODES);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -284,15 +284,15 @@ describe("EpicFhirClient (#390)", () => {
     expect(err.message).toContain("400");
   });
 
-  it("EpicFhirError.hasIssueCode returns false (no throw) when OperationOutcome.issue is malformed", async () => {
+  it("tryParseOperationOutcome rejects shapes where issue is not an array (#1103); hasIssueCode still safely returns false", async () => {
     // Epic edge proxies occasionally return OperationOutcome-shaped
-    // JSON with a partial / null `issue` field. The error-handling
-    // path must be defensive: hasIssueCode should return false, not
-    // crash on `outcome.issue` being non-iterable.
+    // JSON with a partial / null `issue` field. With the tightened
+    // parser (#1103) such payloads are NOT promoted to a typed
+    // OperationOutcome — `err.operationOutcome` stays undefined and
+    // the sync-jobs substring fallback handles them.
     const malformed = {
       resourceType: "OperationOutcome",
-      // issue intentionally not an array
-      issue: null,
+      issue: null, // not an array → parser rejects
     };
     const { client } = setup([
       new Response(JSON.stringify(malformed), {
@@ -308,8 +308,7 @@ describe("EpicFhirClient (#390)", () => {
     }
     expect(thrown).toBeInstanceOf(EpicFhirError);
     const err = thrown as EpicFhirError;
-    expect(err.operationOutcome).toBeDefined();
-    // Must NOT throw on malformed shape — should just return false.
+    expect(err.operationOutcome).toBeUndefined();
     expect(() => err.hasIssueCode("59022")).not.toThrow();
     expect(err.hasIssueCode("59022")).toBe(false);
   });
@@ -332,6 +331,168 @@ describe("EpicFhirClient (#390)", () => {
     expect(err.operationOutcome).toBeUndefined();
     expect(err.body).toContain("502 Bad Gateway");
     expect(err.hasIssueCode("59022")).toBe(false);
+  });
+
+  // ── #1103: tryParseOperationOutcome edge-case rejection ─────────
+  // The parser is the trust boundary between raw Epic bodies and typed
+  // OperationOutcome data downstream consumers `hasIssueCode()` against.
+  // If the parser accepts a malformed shape, `hasIssueCode` would
+  // either silently misreport or throw on iteration. After tightening
+  // (#1103, #1104) the parser only promotes payloads that pass these
+  // structural checks:
+  //   1. JSON parses to a plain object (not "string" / number / array / null)
+  //   2. resourceType === "OperationOutcome"
+  //   3. Array.isArray(issue)
+  //   4. every issue.details.coding[*] has a `code` string
+
+  it("tryParseOperationOutcome rejects valid-JSON string body (not an object)", async () => {
+    const { client } = setup([
+      new Response('"just a string"', {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  it("tryParseOperationOutcome rejects valid-JSON array body (not an object)", async () => {
+    const { client } = setup([
+      new Response("[1,2,3]", {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  it("tryParseOperationOutcome rejects valid-JSON null body", async () => {
+    const { client } = setup([
+      new Response("null", {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  it("tryParseOperationOutcome rejects object without resourceType", async () => {
+    const { client } = setup([
+      new Response(JSON.stringify({ issue: [] }), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  it("tryParseOperationOutcome rejects object with resourceType !== OperationOutcome", async () => {
+    const { client } = setup([
+      new Response(JSON.stringify({ resourceType: "Patient", id: "p-1" }), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  // ── #1104: tightened OperationOutcomeIssueCoding.code ───────────
+  // Epic always emits a `code` on its coding entries; if a payload
+  // lacks one in any coding, that signals the response isn't from
+  // Epic (or Epic edge proxy mangled it). Reject rather than promote
+  // a half-valid OperationOutcome that future hasIssueCode() callers
+  // might rely on.
+
+  it("tryParseOperationOutcome rejects OperationOutcome where any coding entry lacks `code` (#1104)", async () => {
+    const malformed = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "invalid",
+          details: {
+            coding: [
+              { system: "urn:oid:1.2.840.114350.1.13.0.1.7.2.657369" /* code: missing */ },
+            ],
+          },
+        },
+      ],
+    };
+    const { client } = setup([
+      new Response(JSON.stringify(malformed), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeUndefined();
+  });
+
+  it("tryParseOperationOutcome accepts an OperationOutcome whose issue has no coding at all (details.text-only)", async () => {
+    // No coding to validate → the #1104 guard doesn't apply; payload
+    // is still a structurally valid OperationOutcome.
+    const valid = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "invalid",
+          details: { text: "Some Epic error" },
+        },
+      ],
+    };
+    const { client } = setup([
+      new Response(JSON.stringify(valid), {
+        status: 400,
+        headers: { "Content-Type": "application/fhir+json" },
+      }),
+    ]);
+    let thrown: unknown;
+    try { await client.read("Patient", "p-1"); } catch (err) { thrown = err; }
+    expect((thrown as EpicFhirError).operationOutcome).toBeDefined();
+    expect((thrown as EpicFhirError).hasIssueCode("59022")).toBe(false);
+  });
+
+  // ── #1101: operationOutcomeError throws EpicFhirError ───────────
+  // Pre-#1101, `client.read()` against a 200 response with an
+  // OperationOutcome body threw a plain Error — defeating the whole
+  // structured-error story for the read/create/update paths.
+  // After #1101 it throws EpicFhirError with operationOutcome
+  // populated, so the same hasIssueCode() check works for 2xx-with-OO
+  // responses as for 4xx-with-OO responses.
+
+  it("client.read against a 200 with OperationOutcome body throws EpicFhirError (#1101)", async () => {
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "fatal",
+          code: "not-found",
+          details: {
+            text: "Resource not found",
+            coding: [{ system: "epic", code: "59022" }],
+          },
+        },
+      ],
+    };
+    const { client } = setup([jsonResponse(oo, { status: 200 })]);
+    let thrown: unknown;
+    try { await client.read("Patient", "missing-id"); } catch (err) { thrown = err; }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.status).toBe(200);
+    expect(err.operationOutcome).toBeDefined();
+    expect(err.hasIssueCode("59022")).toBe(true);
   });
 
   it("throws EpicFhirError with parsed OperationOutcome after exhausting 5xx retries", async () => {

--- a/services/epic-connector/src/__tests__/fhir-client.test.ts
+++ b/services/epic-connector/src/__tests__/fhir-client.test.ts
@@ -495,6 +495,73 @@ describe("EpicFhirClient (#390)", () => {
     expect(err.hasIssueCode("59022")).toBe(true);
   });
 
+  it("client.createResource against a 2xx with OperationOutcome body throws EpicFhirError with status=201 Created (#1101)", async () => {
+    // POST resource creation expected-success status is 201 — the
+    // synthetic error should report that, not the 200 default that the
+    // read path uses. Locks the per-call-site context in.
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "error",
+          code: "business-rule",
+          details: {
+            text: "Resource conflict",
+            coding: [{ system: "epic", code: "59022" }],
+          },
+        },
+      ],
+    };
+    const { client } = setup([jsonResponse(oo, { status: 201 })]);
+    let thrown: unknown;
+    try {
+      await client.createResource("Flag", {
+        resourceType: "Flag",
+        status: "active",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.status).toBe(201);
+    expect(err.statusText).toBe("Created");
+    expect(err.hasIssueCode("59022")).toBe(true);
+  });
+
+  it("client.updateResource against a 2xx with OperationOutcome body throws EpicFhirError with status=200 OK (#1101)", async () => {
+    // PUT expected-success status is 200 OK in the typical Epic case.
+    const oo: OperationOutcome = {
+      resourceType: "OperationOutcome",
+      issue: [
+        {
+          severity: "error",
+          code: "conflict",
+          details: {
+            text: "Version mismatch",
+            coding: [{ system: "epic", code: "59108" }],
+          },
+        },
+      ],
+    };
+    const { client } = setup([jsonResponse(oo, { status: 200 })]);
+    let thrown: unknown;
+    try {
+      await client.updateResource("Flag", "flag-1", {
+        resourceType: "Flag",
+        id: "flag-1",
+        status: "inactive",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(EpicFhirError);
+    const err = thrown as EpicFhirError;
+    expect(err.status).toBe(200);
+    expect(err.statusText).toBe("OK");
+    expect(err.hasIssueCode("59108")).toBe(true);
+  });
+
   it("throws EpicFhirError with parsed OperationOutcome after exhausting 5xx retries", async () => {
     const oo: OperationOutcome = {
       resourceType: "OperationOutcome",

--- a/services/epic-connector/src/epic-error-codes.ts
+++ b/services/epic-connector/src/epic-error-codes.ts
@@ -1,0 +1,43 @@
+/**
+ * Epic FHIR error codes the connector reasons about structurally (#1102).
+ *
+ * Epic returns OperationOutcome resources on failure with a numeric code
+ * in `issue[*].details.coding[*].code`. The connector uses these codes
+ * to discriminate failure categories — soft-skip vs surface, retry vs
+ * fail — without depending on Epic's human-readable error text.
+ *
+ * Add to this registry rather than hardcoding the literal in a call
+ * site so future code-based checks stay searchable + autocomplete-aware,
+ * and so each entry's policy (skip / surface / retry) lives next to
+ * the code it applies to.
+ *
+ * Reference: Epic on FHIR error codes (`open.epic.com` → API docs →
+ * Error Handling). Codes are stable across Epic versions.
+ */
+
+export const EPIC_ERROR_CODES = {
+  /**
+   * "Combination of parameters is not valid for any authorized
+   * sub-resource. No search was performed."
+   *
+   * Policy: SOFT-SKIP. The registered Epic app lacks the scope for the
+   * requested filter combination (e.g. `Observation?category=vital-signs`
+   * when the app's contracts cover laboratory only). The sync worker
+   * records the skip in `epic_sync_state.skipped_sub_resources` and
+   * keeps the rest of the patient's sync going.
+   */
+  UNAUTHORIZED_SUB_RESOURCE: "59022",
+
+  /**
+   * "A required element is missing."
+   *
+   * Policy: SURFACE. The request shape is wrong — typically a missing
+   * required search parameter. Distinct from 59022 because the app
+   * may have the scope; the request itself is malformed. Bubbles up
+   * to BullMQ as a sync error so it's investigated, not silenced.
+   */
+  MISSING_REQUIRED_ELEMENT: "59108",
+} as const;
+
+export type EpicErrorCode =
+  (typeof EPIC_ERROR_CODES)[keyof typeof EPIC_ERROR_CODES];

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -73,24 +73,48 @@ export class EpicFhirError extends Error {
   }
 }
 
+/**
+ * Promote a raw Epic response body to a typed OperationOutcome, or
+ * return undefined if it doesn't pass our structural trust checks
+ * (#1103, #1104). The trust boundary matters: downstream
+ * `hasIssueCode()` calls iterate `issue[*].details.coding[*]` and
+ * compare `code`; if we accept a half-shaped payload, those checks
+ * either silently misreport or throw on iteration.
+ *
+ * Promotion requires ALL of:
+ *   1. JSON parses to a plain object (not "string" / number / array / null)
+ *   2. resourceType === "OperationOutcome"
+ *   3. Array.isArray(issue)
+ *   4. every issue.details.coding[*] has a `code` string
+ *
+ * If any check fails, return undefined and let the caller fall back
+ * to the raw body string in the Error message.
+ */
 function tryParseOperationOutcome(
   body: string,
 ): OperationOutcome | undefined {
   if (!body) return undefined;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(body) as unknown;
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      (parsed as { resourceType?: string }).resourceType === "OperationOutcome"
-    ) {
-      return parsed as OperationOutcome;
-    }
+    parsed = JSON.parse(body);
   } catch {
-    // Non-JSON body (HTML error page, plain text) — caller falls back
-    // to the raw string in the Error message.
+    return undefined;
   }
-  return undefined;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.resourceType !== "OperationOutcome") return undefined;
+  if (!Array.isArray(candidate.issue)) return undefined;
+  for (const issue of candidate.issue as Array<{ details?: { coding?: Array<{ code?: unknown }> } }>) {
+    const coding = issue?.details?.coding;
+    if (!coding) continue;
+    if (!Array.isArray(coding)) return undefined;
+    for (const c of coding) {
+      if (typeof c?.code !== "string") return undefined;
+    }
+  }
+  return parsed as OperationOutcome;
 }
 
 export interface EpicFhirClientOptions {
@@ -481,12 +505,27 @@ async function safeReadBody(response: Response): Promise<string> {
   }
 }
 
-function operationOutcomeError(outcome: OperationOutcome): Error {
+/**
+ * Build an EpicFhirError from an OperationOutcome returned in a 2xx
+ * response body (#1101). FHIR allows servers to indicate semantic
+ * failure on an HTTP 200 by returning an OperationOutcome instead of
+ * the requested resource — Epic does this for /Patient/[id] on a
+ * deleted patient, certain create/update edge cases, etc. Returning
+ * EpicFhirError (not a plain Error) means downstream
+ * `err.hasIssueCode("59022")` works for the 200-with-OO case the
+ * same way it works for the 4xx-with-OO case.
+ */
+function operationOutcomeError(outcome: OperationOutcome): EpicFhirError {
   const issue = outcome.issue?.[0];
   const detail =
     issue?.diagnostics ?? issue?.details?.text ?? "no diagnostics";
-  return new Error(
-    `Epic returned OperationOutcome: ${issue?.code ?? "unknown"} — ${detail}`,
+  const message = `Epic returned OperationOutcome: ${issue?.code ?? "unknown"} — ${detail}`;
+  return new EpicFhirError(
+    message,
+    200,
+    "OK",
+    JSON.stringify(outcome).slice(0, 500),
+    outcome,
   );
 }
 

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -181,7 +181,10 @@ export class EpicFhirClient {
       `${resourceType}/${encodeURIComponent(id)}`,
     );
     if (resource.resourceType === "OperationOutcome") {
-      throw operationOutcomeError(resource as OperationOutcome);
+      // read() expects 200 OK on success; pass it explicitly so the
+      // synthetic EpicFhirError reports a contextually accurate status
+      // instead of the always-200 placeholder (#1123).
+      throw operationOutcomeError(resource as OperationOutcome, 200, "OK");
     }
     return resource as T;
   }
@@ -269,7 +272,10 @@ export class EpicFhirClient {
       resp !== null &&
       (resp as { resourceType?: string }).resourceType === "OperationOutcome"
     ) {
-      throw operationOutcomeError(resp as OperationOutcome);
+      // POST resource creation typically returns 201 Created on success
+      // — report that on the synthetic error instead of the 200 default
+      // so log/dashboard consumers see honest status data (#1123).
+      throw operationOutcomeError(resp as OperationOutcome, 201, "Created");
     }
     return resp as TResp;
   }
@@ -302,7 +308,11 @@ export class EpicFhirClient {
       resp !== null &&
       (resp as { resourceType?: string }).resourceType === "OperationOutcome"
     ) {
-      throw operationOutcomeError(resp as OperationOutcome);
+      // PUT typically returns 200 OK on success (some Epic deployments
+      // return 201 Created when the put creates a new resource). Use
+      // 200 as the per-call default; full plumb of the real wire
+      // status lives in #1123.
+      throw operationOutcomeError(resp as OperationOutcome, 200, "OK");
     }
     return resp as TResp;
   }
@@ -508,22 +518,33 @@ async function safeReadBody(response: Response): Promise<string> {
 /**
  * Build an EpicFhirError from an OperationOutcome returned in a 2xx
  * response body (#1101). FHIR allows servers to indicate semantic
- * failure on an HTTP 200 by returning an OperationOutcome instead of
- * the requested resource — Epic does this for /Patient/[id] on a
- * deleted patient, certain create/update edge cases, etc. Returning
- * EpicFhirError (not a plain Error) means downstream
- * `err.hasIssueCode("59022")` works for the 200-with-OO case the
- * same way it works for the 4xx-with-OO case.
+ * failure on a successful HTTP status by returning an OperationOutcome
+ * instead of the requested resource — Epic does this for /Patient/[id]
+ * on a deleted patient, certain create/update edge cases, etc.
+ * Returning EpicFhirError (not a plain Error) means downstream
+ * `err.hasIssueCode("59022")` works for the 2xx-with-OO case the same
+ * way it works for the 4xx-with-OO case.
+ *
+ * Status/statusText are the OPERATION'S expected success codes
+ * (200 OK for read/update, 201 Created for create) — passed by the
+ * caller because `requestWithRetry` discards the underlying Response
+ * after parsing. A full plumb of the real wire status lives in
+ * #1123; the per-caller default is honest about operation context
+ * (read → 200, create → 201) and removes the "always 200" misreport.
  */
-function operationOutcomeError(outcome: OperationOutcome): EpicFhirError {
+function operationOutcomeError(
+  outcome: OperationOutcome,
+  status: number,
+  statusText: string,
+): EpicFhirError {
   const issue = outcome.issue?.[0];
   const detail =
     issue?.diagnostics ?? issue?.details?.text ?? "no diagnostics";
   const message = `Epic returned OperationOutcome: ${issue?.code ?? "unknown"} — ${detail}`;
   return new EpicFhirError(
     message,
-    200,
-    "OK",
+    status,
+    statusText,
     JSON.stringify(outcome).slice(0, 500),
     outcome,
   );

--- a/services/epic-connector/src/fhir-types.ts
+++ b/services/epic-connector/src/fhir-types.ts
@@ -58,7 +58,14 @@ export interface FhirResource {
  */
 export interface OperationOutcomeIssueCoding {
   system?: string;
-  code?: string;
+  /**
+   * Required by Epic convention (#1104): Epic always emits a code on
+   * its OperationOutcome coding entries, and structured hasIssueCode
+   * checks rely on it. `tryParseOperationOutcome` rejects payloads
+   * with a coding entry missing `code` rather than promoting a
+   * half-valid OperationOutcome that downstream callers might trust.
+   */
+  code: string;
   display?: string;
 }
 

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -45,6 +45,10 @@ export {
   type EpicResourceType,
 } from "./fhir-client.js";
 export {
+  EPIC_ERROR_CODES,
+  type EpicErrorCode,
+} from "./epic-error-codes.js";
+export {
   operationOutcomeHasIssueCode,
 } from "./fhir-types.js";
 export type {

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -53,6 +53,7 @@ import {
   getObservationCategories,
   getMedicationRequestStatus,
 } from "./fanout-config.js";
+import { EPIC_ERROR_CODES } from "../epic-error-codes.js";
 import type { FhirResource } from "../fhir-types.js";
 
 const log = createLogger("epic-sync-jobs");
@@ -313,13 +314,6 @@ async function syncResourceType(
  * {@link getMedicationRequestStatus}.
  */
 
-/** Epic error code for "Combination of parameters is not valid for any
- *  authorized sub-resource. No search was performed." This 400 means
- *  the registered app doesn't carry the scope for the request's filter
- *  combination — distinct from a malformed request, which gets 59108
- *  ("A required element is missing"). */
-const EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE = "59022";
-
 /**
  * Detect Epic's "not authorized for this sub-resource" 400 response so the
  * fan-out can skip categories the registered app doesn't carry the scope
@@ -327,7 +321,8 @@ const EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE = "59022";
  *
  * Preferred: structured check on the parsed OperationOutcome's coding
  * (`details.coding[].code === "59022"`) — proper FHIR-spec match that
- * survives Epic rewording the human text.
+ * survives Epic rewording the human text. After #1102 the literal lives
+ * in {@link EPIC_ERROR_CODES.UNAUTHORIZED_SUB_RESOURCE}.
  *
  * Fallback: substring match on `"authorized sub-resource"` in the Error
  * message — covers cases where Epic returns a non-OperationOutcome body
@@ -340,7 +335,7 @@ const EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE = "59022";
 function isUnauthorizedSubResourceError(err: unknown): boolean {
   if (
     err instanceof EpicFhirError &&
-    err.hasIssueCode(EPIC_UNAUTHORIZED_SUB_RESOURCE_CODE)
+    err.hasIssueCode(EPIC_ERROR_CODES.UNAUTHORIZED_SUB_RESOURCE)
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
Bundles four PR #1100 follow-ups around the structured-error story. All touch `fhir-client.ts` / `fhir-types.ts` / `sync-jobs.ts` and would conflict if shipped separately.

- **#1101** — `operationOutcomeError` returns `EpicFhirError` instead of plain `Error`. FHIR-spec semantic-failure-on-200 (Epic does this for read/create/update edge cases) now flows through the structured-error pipeline; downstream `err.hasIssueCode("59022")` works for the 200-with-OO case the same way it works for 4xx-with-OO.
- **#1102** — New `epic-error-codes.ts` registry: `EPIC_ERROR_CODES.UNAUTHORIZED_SUB_RESOURCE` (59022) and `MISSING_REQUIRED_ELEMENT` (59108), each with policy docs. `sync-jobs.ts` swaps its inline `"59022"` literal for the registry symbol.
- **#1103** — `tryParseOperationOutcome` tightened with structural checks: rejects non-object JSON, missing/wrong `resourceType`, non-array `issue`. Five new direct edge-case tests lock the trust boundary in.
- **#1104** — `OperationOutcomeIssueCoding.code` tightened from optional to required. Parser rejects payloads with a coding entry missing `code`. Downstream code can trust that any promoted OperationOutcome has string codes throughout.

Closes #1101.
Closes #1102.
Closes #1103.
Closes #1104.

## Why bundle these
The four issues are facets of the same underlying problem: the structured-error story PR #1100 introduced was load-bearing but had four gaps. Fix any one in isolation and you still have the others. Bundled, the invariant becomes:

> Any \`EpicFhirError.operationOutcome\` that exists is structurally trustworthy — \`issue\` is an array, every \`coding[*]\` has a string \`code\`. Soft-skip / surface decisions can rely on \`hasIssueCode()\` instead of substring-matching error messages.

The substring fallback in `isUnauthorizedSubResourceError` stays — it's still needed for non-OperationOutcome edge cases (HTML 502 from a fronting proxy, plain-text errors from an edge layer where the OO body never made it through). The fallback is no longer covering for our own \"plain Error\" path though, which is the gap #1101 closed.

## API additions
- New module export: `EPIC_ERROR_CODES` + `EpicErrorCode` type (re-exported from package root)
- `OperationOutcomeIssueCoding.code` is now required — purely tightening the existing type, no runtime change
- `operationOutcomeError` is internal; the visible change is that `client.read/createResource/updateResource` against a 2xx-with-OO body now throws `EpicFhirError` instead of `Error`

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 199 pass + 1 documented skip (was 187, +12 new)
  - 4 new EPIC_ERROR_CODES sanity tests
  - 5 new `tryParseOperationOutcome` rejection tests (string body, array body, null body, no resourceType, wrong resourceType)
  - 1 new `tryParseOperationOutcome` rejection test for coding-without-code (#1104)
  - 1 new acceptance test for coding-less OperationOutcome still being valid
  - 1 new acceptance test for 200-with-OO throwing EpicFhirError (#1101)
  - Updated existing \"issue: null\" test to reflect the new strict semantics (operationOutcome is now undefined, not defined)
- [x] `pnpm typecheck` — workspace 38/38 clean