### PR TITLE
feat(epic): cap summarise().skippedDetail + single-pass reducer

### DIFF
--- a/services/epic-connector/src/__tests__/sync-worker-summarise.test.ts
+++ b/services/epic-connector/src/__tests__/sync-worker-summarise.test.ts
@@ -10,7 +10,10 @@
  * without cross-referencing the epic_sync_state DB column.
  */
 import { describe, it, expect } from "vitest";
-import { summarise } from "../workers/sync-worker.js";
+import {
+  summarise,
+  SUMMARISE_SKIPPED_DETAIL_CAP,
+} from "../workers/sync-worker.js";
 
 describe("summarise() (#1107)", () => {
   it("rolls up imported/updated/conflicts/errors as before", () => {
@@ -132,7 +135,7 @@ describe("summarise() (#1107)", () => {
     expect(out.skippedDetail).toEqual([]);
   });
 
-  it("empty results → all zeros, empty skippedDetail", () => {
+  it("empty results → all zeros, empty skippedDetail, zero truncation counter", () => {
     const out = summarise([]);
     expect(out).toEqual({
       imported: 0,
@@ -141,6 +144,112 @@ describe("summarise() (#1107)", () => {
       errors: 0,
       skipped: 0,
       skippedDetail: [],
+      skippedDetailTruncated: 0,
     });
+  });
+
+  // ── #1120: cap skippedDetail to bound BullMQ payload size ────────
+  // The full skipped set still lands on epic_sync_state via
+  // markOk/markFailed, so operators have a recovery path via the DB
+  // for the long tail. The cap protects the Redis-persisted job
+  // result from bloat as fan-out widens (e.g., multi-status
+  // MedicationRequest under #1114).
+
+  it("exposes SUMMARISE_SKIPPED_DETAIL_CAP for callers that need the cap value", () => {
+    expect(typeof SUMMARISE_SKIPPED_DETAIL_CAP).toBe("number");
+    expect(SUMMARISE_SKIPPED_DETAIL_CAP).toBeGreaterThanOrEqual(50);
+  });
+
+  it("skippedDetail count == skipped count when under the cap; truncation counter stays at 0 (#1120)", () => {
+    const skips = Array.from({ length: 5 }, (_, i) => ({
+      resource_type: "Observation" as const,
+      filter: { category: `cat-${i}` },
+      reason: "unauthorized" as const,
+    }));
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 0,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: skips,
+      },
+    ]);
+    expect(out.skippedDetail).toHaveLength(5);
+    expect(out.skipped).toBe(5);
+    expect(out.skippedDetailTruncated).toBe(0);
+  });
+
+  it("caps skippedDetail at SUMMARISE_SKIPPED_DETAIL_CAP and reports the truncated count (#1120)", () => {
+    const total = SUMMARISE_SKIPPED_DETAIL_CAP + 17;
+    const skips = Array.from({ length: total }, (_, i) => ({
+      resource_type: "Observation" as const,
+      filter: { category: `cat-${i}` },
+      reason: "unauthorized" as const,
+    }));
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 0,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: skips,
+      },
+    ]);
+    expect(out.skipped).toBe(total); // count remains the true total
+    expect(out.skippedDetail).toHaveLength(SUMMARISE_SKIPPED_DETAIL_CAP);
+    expect(out.skippedDetailTruncated).toBe(17);
+    // Cap preserves the FIRST N entries (deterministic order, not random sample)
+    expect(out.skippedDetail[0]).toEqual(skips[0]);
+    expect(out.skippedDetail[SUMMARISE_SKIPPED_DETAIL_CAP - 1]).toEqual(
+      skips[SUMMARISE_SKIPPED_DETAIL_CAP - 1],
+    );
+  });
+
+  it("cap applies across multiple SyncResult entries (truncation kicks in mid-input) (#1120)", () => {
+    // Split the skips across two results so the cap triggers
+    // partway through the second. Verifies the reducer respects
+    // the cap across iteration boundaries, not just per-result.
+    const halfPlus = SUMMARISE_SKIPPED_DETAIL_CAP - 10;
+    const overflow = 25;
+    const firstSkips = Array.from({ length: halfPlus }, (_, i) => ({
+      resource_type: "Observation" as const,
+      filter: { category: `first-${i}` },
+      reason: "unauthorized" as const,
+    }));
+    const secondSkips = Array.from({ length: overflow }, (_, i) => ({
+      resource_type: "MedicationRequest" as const,
+      filter: { status: `s-${i}` },
+      reason: "unauthorized" as const,
+    }));
+    const out = summarise([
+      {
+        patient_id: "p1",
+        resource_type: "Observation",
+        imported: 0,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: firstSkips,
+      },
+      {
+        patient_id: "p1",
+        resource_type: "MedicationRequest",
+        imported: 0,
+        updated: 0,
+        conflicts: 0,
+        errors: [],
+        skipped: secondSkips,
+      },
+    ]);
+    expect(out.skipped).toBe(halfPlus + overflow);
+    expect(out.skippedDetail).toHaveLength(SUMMARISE_SKIPPED_DETAIL_CAP);
+    expect(out.skippedDetailTruncated).toBe(
+      halfPlus + overflow - SUMMARISE_SKIPPED_DETAIL_CAP,
+    );
   });
 });

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -208,9 +208,21 @@ interface SyncSummary {
   errors: number;
   /** Count of soft-skipped sub-resource fetches across all resource types (#1107). */
   skipped: number;
-  /** Per-skip detail for ops dashboards that want structured drill-down (#1107). */
+  /** Per-skip detail for ops dashboards that want structured drill-down (#1107). Capped at SUMMARISE_SKIPPED_DETAIL_CAP (#1120). */
   skippedDetail: SkippedSubResource[];
+  /** How many skipped entries were dropped from skippedDetail due to the cap (#1120). 0 when nothing was truncated. */
+  skippedDetailTruncated: number;
 }
+
+/**
+ * Maximum entries in `summarise().skippedDetail` (#1120). The full
+ * set is already persisted to `epic_sync_state.skipped_sub_resources`
+ * via markOk/markFailed — operators have a recovery path via the DB
+ * for the long tail. The cap protects the Redis-persisted BullMQ
+ * job result payload from bloating as fan-out widens (e.g., the
+ * future multi-status MedicationRequest fan-out under #1114).
+ */
+export const SUMMARISE_SKIPPED_DETAIL_CAP = 50;
 
 /**
  * Rolls up a per-resource-type `SyncResult[]` into the single object
@@ -218,27 +230,46 @@ interface SyncSummary {
  *
  * `skipped` + `skippedDetail` (#1107) make sub-resource auth-scope
  * issues visible from the BullMQ dashboard without cross-referencing
- * the `epic_sync_state` Postgres column.
+ * the `epic_sync_state` Postgres column. `skippedDetail` is capped at
+ * SUMMARISE_SKIPPED_DETAIL_CAP entries (#1120); overflow is reported
+ * via `skippedDetailTruncated` so dashboards can render "+N more".
+ *
+ * Single-pass implementation (#1121) — avoids the O(N²) spread-in-reduce
+ * pattern. Not measurable today with N ≤ 5 but matters as fan-out grows.
  *
  * Exported for unit testing — the worker callbacks invoke it directly.
  */
 export function summarise(results: SyncResult[]): SyncSummary {
-  return results.reduce<SyncSummary>(
-    (acc, r) => ({
-      imported: acc.imported + r.imported,
-      updated: acc.updated + r.updated,
-      conflicts: acc.conflicts + r.conflicts,
-      errors: acc.errors + r.errors.length,
-      skipped: acc.skipped + r.skipped.length,
-      skippedDetail: [...acc.skippedDetail, ...r.skipped],
-    }),
-    {
-      imported: 0,
-      updated: 0,
-      conflicts: 0,
-      errors: 0,
-      skipped: 0,
-      skippedDetail: [],
-    },
-  );
+  let imported = 0;
+  let updated = 0;
+  let conflicts = 0;
+  let errors = 0;
+  let skipped = 0;
+  const skippedDetail: SkippedSubResource[] = [];
+  let skippedDetailTruncated = 0;
+
+  for (const r of results) {
+    imported += r.imported;
+    updated += r.updated;
+    conflicts += r.conflicts;
+    errors += r.errors.length;
+    skipped += r.skipped.length;
+    for (const s of r.skipped) {
+      if (skippedDetail.length < SUMMARISE_SKIPPED_DETAIL_CAP) {
+        skippedDetail.push(s);
+      } else {
+        skippedDetailTruncated++;
+      }
+    }
+  }
+
+  return {
+    imported,
+    updated,
+    conflicts,
+    errors,
+    skipped,
+    skippedDetail,
+    skippedDetailTruncated,
+  };
 }

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -254,12 +254,21 @@ export function summarise(results: SyncResult[]): SyncSummary {
     conflicts += r.conflicts;
     errors += r.errors.length;
     skipped += r.skipped.length;
-    for (const s of r.skipped) {
-      if (skippedDetail.length < SUMMARISE_SKIPPED_DETAIL_CAP) {
-        skippedDetail.push(s);
-      } else {
-        skippedDetailTruncated++;
-      }
+
+    // Once the cap is hit, just bump the truncated counter by the
+    // remaining length instead of iterating each entry to do the same
+    // increment. Matters for the future multi-status fan-out (#1114)
+    // where a single SyncResult could carry hundreds of skipped entries.
+    const headroom = SUMMARISE_SKIPPED_DETAIL_CAP - skippedDetail.length;
+    if (headroom <= 0) {
+      skippedDetailTruncated += r.skipped.length;
+      continue;
+    }
+    if (r.skipped.length <= headroom) {
+      for (const s of r.skipped) skippedDetail.push(s);
+    } else {
+      for (let i = 0; i < headroom; i++) skippedDetail.push(r.skipped[i]!);
+      skippedDetailTruncated += r.skipped.length - headroom;
     }
   }
 


### PR DESCRIPTION
## Summary
Bundles two PR #1117 follow-ups around `summarise()` in `sync-worker.ts`. Both touch the same function and integrate naturally — capping needs the reducer to track an overflow counter, single-pass makes the cap check trivial.

- **#1120** — Cap `skippedDetail` at `SUMMARISE_SKIPPED_DETAIL_CAP = 50` so the Redis-persisted BullMQ job result payload stays bounded as fan-out widens. Overflow reported via new `skippedDetailTruncated: number` field; dashboards can render \"+N more\". Full skipped set is still persisted to `epic_sync_state.skipped_sub_resources` via markOk/markFailed — operators have a DB recovery path for the long tail.
- **#1121** — Replaced `[...acc.skippedDetail, ...r.skipped]` spread-in-reduce with a single-pass for-of loop. Old pattern was O(N²) (fresh array allocation + full copy per iteration). Not measurable today with N ≤ 5 but matters as `SUPPORTED_RESOURCE_TYPES` grows, especially combined with the future multi-status fan-out under #1114.

Closes #1120.
Closes #1121.

## API change
- `SyncSummary` adds `skippedDetailTruncated: number` (additive, defaults to 0)
- `SUMMARISE_SKIPPED_DETAIL_CAP` exported so admin tooling can reason about the cap

## Why 50
Today's max fan-out produces ≤5 skipped entries per sync (2 Observation categories + 1 MedicationRequest status). 50 leaves 10× headroom even if every supported resource type starts fanning out, and keeps the typical BullMQ payload at <5KB. If #1114 (multi-status MedicationRequest) ships and pushes the typical case past 20, we can tune up; not worth making it env-configurable yet.

## Cap semantics
- `skipped` (count) — always the true total, regardless of cap
- `skippedDetail` (entries) — first N entries by iteration order, capped at 50
- `skippedDetailTruncated` (overflow count) — `skipped - skippedDetail.length`

Deterministic order matters: the cap preserves the FIRST N entries, not a random sample, so the truncated payload is reproducible across re-runs of the same sync.

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 205 pass + 1 documented skip (was 201, +4 new)
  - New: \"exposes SUMMARISE_SKIPPED_DETAIL_CAP for callers that need the cap value\"
  - New: \"skippedDetail count == skipped count when under the cap; truncation counter stays at 0\"
  - New: \"caps skippedDetail at CAP and reports the truncated count\" (CAP+17 entries → 50 in detail, 17 in truncated)
  - New: \"cap applies across multiple SyncResult entries\" (truncation kicks in mid-iteration, verifies reducer respects cap across boundaries)
  - Existing 5 summarise tests still pass; updated empty-input test to assert `skippedDetailTruncated: 0`
- [x] `pnpm typecheck` — workspace 38/38 clean