### PR TITLE
feat(epic): post-marathon cleanup bundle (#1116 #1124 #1126 #1128 #1129)

### DIFF
--- a/services/epic-connector/src/__tests__/fanout-config.test.ts
+++ b/services/epic-connector/src/__tests__/fanout-config.test.ts
@@ -25,6 +25,7 @@ vi.mock("@carebridge/logger", () => ({
 
 const {
   loadFanoutConfig,
+  parseFanoutConfig,
   getFanoutConfig,
   resetFanoutConfigCacheForTests,
   getObservationCategories,
@@ -245,6 +246,58 @@ describe("loadFanoutConfig — MedicationRequest status (#1098, #1110, #1111)", 
   it("does NOT warn when env is unset", () => {
     loadFanoutConfig({});
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseFanoutConfig — pure-eval mode (#1116)", () => {
+  it("returns the same config as loadFanoutConfig for any given env", () => {
+    const env = {
+      EPIC_OBSERVATION_CATEGORIES: "vital-signs,laboratory,exam",
+      EPIC_MEDICATION_REQUEST_STATUS: "completed",
+    };
+    const loaded = loadFanoutConfig(env);
+    const { config } = parseFanoutConfig(env);
+    expect(config).toEqual(loaded);
+  });
+
+  it("does NOT emit any warnings via the module logger — admin/diagnostics tooling can preview an env safely", () => {
+    parseFanoutConfig({
+      EPIC_OBSERVATION_CATEGORIES: "foo,bar",
+      EPIC_MEDICATION_REQUEST_STATUS: "in-progress",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns warnings as a structured array so admin tooling can render them without scraping log output", () => {
+    const { warnings } = parseFanoutConfig({
+      EPIC_OBSERVATION_CATEGORIES: "vital-signs,foo",
+      EPIC_MEDICATION_REQUEST_STATUS: "in-progress",
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]!.msg).toMatch(/unknown FHIR observation-category/);
+    expect(warnings[0]!.meta).toMatchObject({
+      invalidCodes: ["foo"],
+      kept: ["vital-signs"],
+    });
+    expect(warnings[1]!.msg).toMatch(/not a known FHIR medication-request-status/);
+    expect(warnings[1]!.meta).toMatchObject({
+      raw: "in-progress",
+      fallback: "active",
+    });
+  });
+
+  it("returns an empty warnings array when env is unset (no operator intent to override)", () => {
+    const { warnings } = parseFanoutConfig({});
+    expect(warnings).toEqual([]);
+  });
+
+  it("loadFanoutConfig is a thin wrapper — it forwards parseFanoutConfig's warnings to the logger", () => {
+    loadFanoutConfig({
+      EPIC_OBSERVATION_CATEGORIES: "foo,bar",
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [msg] = warnSpy.mock.calls[0]!;
+    expect(msg).toMatch(/EPIC_OBSERVATION_CATEGORIES/);
   });
 });
 

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -1027,6 +1027,56 @@ describe("Epic sync-jobs (#391)", () => {
   // mutates the result's skipped array as it goes, so partial collection
   // survives the throw and is persisted alongside the failure status.
 
+  it("MISSING_REQUIRED_ELEMENT (59108) surfaces with the diagnostic in markFailed's errorMessage (#1124)", async () => {
+    // Simulates Epic responding with a structured 400-with-OO carrying
+    // the 59108 code and an Epic diagnostic naming the missing field.
+    // syncResourceType should NOT swallow this (it's a code bug, not a
+    // scope issue) and the persisted error message should name the
+    // missing element so an operator can fix the request shape upstream.
+    const client = {
+      readPatient: vi.fn(),
+      searchAll: vi.fn().mockImplementation(() =>
+        (async function* () {
+          throw new EpicFhirError(
+            "Epic FHIR request returned 400 Bad Request — A required element is missing.",
+            400,
+            "Bad Request",
+            "{...}",
+            {
+              resourceType: "OperationOutcome",
+              issue: [
+                {
+                  severity: "fatal",
+                  code: "required",
+                  diagnostics: "MedicationRequest.intent",
+                  details: {
+                    text: "A required element is missing.",
+                    coding: [{ system: "epic", code: "59108" }],
+                  },
+                },
+              ],
+            } satisfies OperationOutcome,
+          );
+        })(),
+      ),
+    } as unknown as Parameters<typeof runFullSync>[1]["client"];
+
+    await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "Condition",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(markFailed).toHaveBeenCalledOnce();
+    const args = markFailed.mock.calls[0]![0] as { errorMessage: string };
+    expect(args.errorMessage).toMatch(/Epic required element missing/);
+    expect(args.errorMessage).toMatch(/MedicationRequest\.intent/);
+  });
+
   it("first-category soft-skip + second-category genuine error → result.skipped + markFailed both carry the partial soft-skip", async () => {
     const client = {
       readPatient: vi.fn(),

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -52,12 +52,21 @@ const log = createLogger("epic-fhir-client");
  * from a fronting proxy). NOT the full payload — callers needing the
  * complete body must re-fetch.
  */
+/**
+ * Maximum bytes captured in `EpicFhirError.body` / surfaced from
+ * `safeReadBody` / serialised by `operationOutcomeError` (#1126).
+ * Keeps log lines + error dialogs bounded while preserving enough
+ * context to identify the failure. The full payload is in worker
+ * logs / DLQ for forensics.
+ */
+const MAX_BODY_SNIPPET_BYTES = 500;
+
 export class EpicFhirError extends Error {
   constructor(
     message: string,
     public readonly status: number,
     public readonly statusText: string,
-    /** Truncated body snippet (≤500 chars). Do NOT assume full payload. */
+    /** Truncated body snippet (≤MAX_BODY_SNIPPET_BYTES chars). Do NOT assume full payload. */
     public readonly body: string,
     public readonly operationOutcome?: OperationOutcome,
   ) {
@@ -509,7 +518,7 @@ function joinUrl(base: string, path: string): string {
 async function safeReadBody(response: Response): Promise<string> {
   try {
     const text = await response.text();
-    return text.slice(0, 500);
+    return text.slice(0, MAX_BODY_SNIPPET_BYTES);
   } catch {
     return "";
   }
@@ -545,7 +554,7 @@ function operationOutcomeError(
     message,
     status,
     statusText,
-    JSON.stringify(outcome).slice(0, 500),
+    JSON.stringify(outcome).slice(0, MAX_BODY_SNIPPET_BYTES),
     outcome,
   );
 }

--- a/services/epic-connector/src/fhir-client.ts
+++ b/services/epic-connector/src/fhir-client.ts
@@ -53,20 +53,26 @@ const log = createLogger("epic-fhir-client");
  * complete body must re-fetch.
  */
 /**
- * Maximum bytes captured in `EpicFhirError.body` / surfaced from
- * `safeReadBody` / serialised by `operationOutcomeError` (#1126).
- * Keeps log lines + error dialogs bounded while preserving enough
- * context to identify the failure. The full payload is in worker
- * logs / DLQ for forensics.
+ * Maximum characters (UTF-16 code units, per JS `String.slice`)
+ * captured in `EpicFhirError.body` / surfaced from `safeReadBody` /
+ * serialised by `operationOutcomeError` (#1126, #1131). Keeps log
+ * lines and error dialogs bounded while preserving enough context
+ * to identify the failure. The full payload is in worker logs / DLQ
+ * for forensics.
+ *
+ * Character-based (not byte-based) so multi-byte UTF-8 payloads land
+ * with predictable string length; if Postgres' UTF-8 byte budget for
+ * `last_error_message` is ever the binding constraint, swap to a
+ * `TextEncoder`-backed byte cap and rename.
  */
-const MAX_BODY_SNIPPET_BYTES = 500;
+const MAX_BODY_SNIPPET_CHARS = 500;
 
 export class EpicFhirError extends Error {
   constructor(
     message: string,
     public readonly status: number,
     public readonly statusText: string,
-    /** Truncated body snippet (≤MAX_BODY_SNIPPET_BYTES chars). Do NOT assume full payload. */
+    /** Truncated body snippet (≤MAX_BODY_SNIPPET_CHARS UTF-16 code units). Do NOT assume full payload. */
     public readonly body: string,
     public readonly operationOutcome?: OperationOutcome,
   ) {
@@ -518,7 +524,7 @@ function joinUrl(base: string, path: string): string {
 async function safeReadBody(response: Response): Promise<string> {
   try {
     const text = await response.text();
-    return text.slice(0, MAX_BODY_SNIPPET_BYTES);
+    return text.slice(0, MAX_BODY_SNIPPET_CHARS);
   } catch {
     return "";
   }
@@ -554,7 +560,7 @@ function operationOutcomeError(
     message,
     status,
     statusText,
-    JSON.stringify(outcome).slice(0, MAX_BODY_SNIPPET_BYTES),
+    JSON.stringify(outcome).slice(0, MAX_BODY_SNIPPET_CHARS),
     outcome,
   );
 }

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -97,6 +97,7 @@ export {
 } from "./sync/sync-state-repo.js";
 export {
   loadFanoutConfig,
+  parseFanoutConfig,
   getFanoutConfig,
   getObservationCategories,
   getMedicationRequestStatus,
@@ -105,6 +106,8 @@ export {
   VALID_OBSERVATION_CATEGORIES,
   VALID_MEDICATION_REQUEST_STATUSES,
   type FanoutConfig,
+  type FanoutConfigWarning,
+  type ParsedFanoutConfig,
 } from "./sync/fanout-config.js";
 export {
   persistPatient,
@@ -121,8 +124,11 @@ export {
   enqueueFullSync,
   enqueueIncrementalSync,
   enqueueSingleResourceSync,
+  summarise,
+  SUMMARISE_SKIPPED_DETAIL_CAP,
   EPIC_SYNC_QUEUE_NAME,
   type EpicSyncJobData,
+  type SyncSummary,
 } from "./workers/sync-worker.js";
 export { epicSyncRouter, type EpicSyncRouter } from "./router.js";
 export {

--- a/services/epic-connector/src/sync/fanout-config.ts
+++ b/services/epic-connector/src/sync/fanout-config.ts
@@ -167,21 +167,58 @@ function parseMedicationRequestStatus(raw: string | undefined): ParseResult<stri
   return { value: trimmed };
 }
 
+/** One structured warning emitted while parsing a fan-out env (#1116). */
+export interface FanoutConfigWarning {
+  msg: string;
+  meta: Record<string, unknown>;
+}
+
+/** Result of `parseFanoutConfig` — config + warnings, no side effects (#1116). */
+export interface ParsedFanoutConfig {
+  config: FanoutConfig;
+  warnings: FanoutConfigWarning[];
+}
+
 /**
- * Parse + validate fan-out env. Pure with respect to the supplied env
- * map (no caching). Logs warnings as a side-effect for misconfigs.
+ * Pure parse + validate (#1116) — no logger side effects. Useful for
+ * admin / diagnostics tooling that wants to PREVIEW what a candidate
+ * env override would produce (e.g. CLI `dry-run this
+ * EPIC_OBSERVATION_CATEGORIES value`) without emitting the warnings
+ * into the worker's real log.
+ *
+ * The boot path (`loadFanoutConfig`) is a thin wrapper that calls
+ * this and forwards warnings to the module logger, so the production
+ * behaviour is unchanged.
+ */
+export function parseFanoutConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ParsedFanoutConfig {
+  const cats = parseObservationCategories(env.EPIC_OBSERVATION_CATEGORIES);
+  const status = parseMedicationRequestStatus(env.EPIC_MEDICATION_REQUEST_STATUS);
+  const warnings: FanoutConfigWarning[] = [];
+  if (cats.warning) warnings.push(cats.warning);
+  if (status.warning) warnings.push(status.warning);
+  return {
+    config: {
+      observationCategories: cats.value,
+      medicationRequestStatus: status.value,
+    },
+    warnings,
+  };
+}
+
+/**
+ * Parse + validate fan-out env AND emit warnings to the module logger.
+ * Thin wrapper around `parseFanoutConfig` (#1116) — production boot
+ * path. Admin tooling that wants pure-eval semantics should call
+ * `parseFanoutConfig` directly.
  */
 export function loadFanoutConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): FanoutConfig {
-  const cats = parseObservationCategories(env.EPIC_OBSERVATION_CATEGORIES);
-  const status = parseMedicationRequestStatus(env.EPIC_MEDICATION_REQUEST_STATUS);
-  if (cats.warning) log.warn(cats.warning.msg, cats.warning.meta);
-  if (status.warning) log.warn(status.warning.msg, status.warning.meta);
-  return {
-    observationCategories: cats.value,
-    medicationRequestStatus: status.value,
-  };
+  const { config, warnings } = parseFanoutConfig(env);
+  for (const w of warnings) log.warn(w.msg, w.meta);
+  return config;
 }
 
 let cached: FanoutConfig | null = null;

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -272,11 +272,20 @@ async function syncResourceType(
       skipped: result.skipped.map(({ filter, reason }) => ({ filter, reason })),
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const baseMessage = err instanceof Error ? err.message : String(err);
+    // #1124: when Epic returns the structured "required element missing"
+    // code (59108), prefix the persisted error with the missing-element
+    // diagnostic so the failed row in epic_sync_state names the field
+    // (not just a generic 400 message). Helps the operator/dev fix the
+    // upstream request-shape bug without spelunking through job logs.
+    const message = isMissingRequiredElementError(err)
+      ? `Epic required element missing: ${describeMissingElement(err)} — ${baseMessage}`
+      : baseMessage;
     log.error("Epic sync — resource-type failure", {
       patientId: args.patientId,
       resourceType: args.resourceType,
       error: message,
+      missingRequiredElement: isMissingRequiredElementError(err),
     });
     await markFailed({
       patientId: args.patientId,
@@ -343,6 +352,39 @@ function isUnauthorizedSubResourceError(err: unknown): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Detect Epic's "A required element is missing" 400 (#1124). Distinct
+ * from the unauthorized-sub-resource code in policy: 59022 → soft-skip
+ * (registered app lacks scope), 59108 → SURFACE (request shape is
+ * wrong, almost always a code bug).
+ *
+ * The discrimination is structural — pure FHIR-spec match on the
+ * coding — and only fires on a structurally trusted OperationOutcome
+ * (see `tryParseOperationOutcome` for the gate). No substring fallback
+ * because 59108 indicates a code bug that we WANT to surface as a
+ * loud failure rather than rescue with a fragile heuristic.
+ */
+function isMissingRequiredElementError(err: unknown): boolean {
+  return (
+    err instanceof EpicFhirError &&
+    err.hasIssueCode(EPIC_ERROR_CODES.MISSING_REQUIRED_ELEMENT)
+  );
+}
+
+/**
+ * Extract the missing-element diagnostic from an Epic 59108
+ * OperationOutcome so the error message names the field — turns a
+ * generic "A required element is missing" into actionable feedback
+ * ("Required element missing: MedicationRequest.intent").
+ */
+function describeMissingElement(err: unknown): string {
+  if (!(err instanceof EpicFhirError) || !err.operationOutcome) {
+    return "missing element (no diagnostics)";
+  }
+  const issue = err.operationOutcome.issue?.[0];
+  return issue?.diagnostics ?? issue?.details?.text ?? "missing element (no diagnostics)";
 }
 
 /**

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -278,14 +278,15 @@ async function syncResourceType(
     // diagnostic so the failed row in epic_sync_state names the field
     // (not just a generic 400 message). Helps the operator/dev fix the
     // upstream request-shape bug without spelunking through job logs.
-    const message = isMissingRequiredElementError(err)
+    const missingRequiredElement = isMissingRequiredElementError(err);
+    const message = missingRequiredElement
       ? `Epic required element missing: ${describeMissingElement(err)} — ${baseMessage}`
       : baseMessage;
     log.error("Epic sync — resource-type failure", {
       patientId: args.patientId,
       resourceType: args.resourceType,
       error: message,
-      missingRequiredElement: isMissingRequiredElementError(err),
+      missingRequiredElement,
     });
     await markFailed({
       patientId: args.patientId,

--- a/services/epic-connector/src/workers/sync-worker.ts
+++ b/services/epic-connector/src/workers/sync-worker.ts
@@ -201,7 +201,13 @@ export function startEpicSyncWorker(): Worker<EpicSyncJobData> | null {
   return worker;
 }
 
-interface SyncSummary {
+/**
+ * Public shape of the BullMQ job-result payload. Re-exported from the
+ * package root so dashboards / admin tooling can type
+ * `job.returnvalue` against this directly instead of redefining the
+ * shape (which drifts when fields are added — #1128).
+ */
+export interface SyncSummary {
   imported: number;
   updated: number;
   conflicts: number;
@@ -219,8 +225,14 @@ interface SyncSummary {
  * set is already persisted to `epic_sync_state.skipped_sub_resources`
  * via markOk/markFailed — operators have a recovery path via the DB
  * for the long tail. The cap protects the Redis-persisted BullMQ
- * job result payload from bloating as fan-out widens (e.g., the
- * future multi-status MedicationRequest fan-out under #1114).
+ * job result payload from bloating as fan-out widens.
+ *
+ * Re-evaluate once #1114 (multi-status MedicationRequest fan-out)
+ * lands (#1129): today's typical fan-out produces ≤5 skipped entries,
+ * leaving 10× headroom. Post-#1114 the typical case could reach 20-30
+ * and a single auth-scope flap could fill the cap — at that point
+ * consider raising or making env-configurable via
+ * `EPIC_SUMMARISE_SKIPPED_DETAIL_CAP`.
  */
 export const SUMMARISE_SKIPPED_DETAIL_CAP = 50;
 
@@ -235,7 +247,17 @@ export const SUMMARISE_SKIPPED_DETAIL_CAP = 50;
  * via `skippedDetailTruncated` so dashboards can render "+N more".
  *
  * Single-pass implementation (#1121) — avoids the O(N²) spread-in-reduce
- * pattern. Not measurable today with N ≤ 5 but matters as fan-out grows.
+ * pattern. Past the cap the inner loop is skipped (#1127) so very
+ * large skipped arrays don't pay per-item iteration cost.
+ *
+ * **Iteration-order stability** (#1129): the cap keeps the FIRST N
+ * entries by iteration order, not a random sample. Order is the
+ * caller's `results: SyncResult[]` order — typically the
+ * `SUPPORTED_RESOURCE_TYPES` order set by `runFullSync` /
+ * `runIncrementalSync`. Truncated payloads are reproducible across
+ * re-runs of the same sync; consumers depending on truncation
+ * stability should not silently reorder fan-out without bumping a
+ * versioned field on the result.
  *
  * Exported for unit testing — the worker callbacks invoke it directly.
  */


### PR DESCRIPTION
## Summary
Wraps up five small follow-ups from the Epic marathon into one cleanup commit. Each touches a different file; bundled because they're all small, all under the epic-connector scope, and integration risk is independent.

- **#1116** — Extracted `parseFanoutConfig` as a pure side-effect-free parse + validate function returning `{ config, warnings }`. `loadFanoutConfig` becomes a thin wrapper that calls it + forwards warnings to the module logger. Admin / diagnostics tooling that wants to PREVIEW a candidate env override now has a pure path without log spam into the worker's real output. Existing `loadFanoutConfig` signature/behaviour unchanged.
- **#1124** — Wired `EPIC_ERROR_CODES.MISSING_REQUIRED_ELEMENT` (59108) at the sync-jobs catch site. When Epic returns the structured code, the persisted error message is prefixed with the missing-element diagnostic — turns a generic 400 into actionable feedback (\"Epic required element missing: `MedicationRequest.intent` — ...\").
- **#1126** — Replaced two magic-number 500-char truncation literals in `fhir-client.ts` with a named `MAX_BODY_SNIPPET_BYTES` constant.
- **#1128** — Re-exported `summarise`, `SUMMARISE_SKIPPED_DETAIL_CAP`, and `SyncSummary` from the package root so dashboards/admin tooling can type `job.returnvalue` without redefining the shape.
- **#1129** — JSDoc updates: documented iteration-order stability on `summarise` and cross-referenced #1114 from the cap constant for future re-evaluation.

Closes #1116.
Closes #1124.
Closes #1126.
Closes #1128.
Closes #1129.

## Why bundle five issues
All within `epic-connector`, all small, all post-marathon polish. Bundling avoids 5 separate `/full-review` cycles for changes that don't interact. Each issue is reviewable in isolation by the file it touches:

| Issue | File |
|---|---|
| #1116 | `sync/fanout-config.ts` + tests |
| #1124 | `sync/sync-jobs.ts` + tests |
| #1126 | `fhir-client.ts` |
| #1128 | `index.ts` + `workers/sync-worker.ts` (type changed from `interface` to `export interface`) |
| #1129 | `workers/sync-worker.ts` (JSDoc only) |

## Test plan
- [x] `pnpm --filter @carebridge/epic-connector test` — 211 pass + 1 documented skip (was 205, +6 new)
  - parseFanoutConfig pure-eval: 5 new tests (same-as-loadFanoutConfig, no-side-effects, structured warnings, empty case, loadFanoutConfig wrapper forwarding)
  - MISSING_REQUIRED_ELEMENT: 1 new sync-jobs test asserting the prefixed error message
- [x] `pnpm typecheck` — workspace 38/38 clean
- [x] No live Epic verification needed — pure refactors + observability additions