### PR TITLE
feat(epic): expose missing-element helpers + harden it.skip placeholder (#1105 #1133)

### DIFF
--- a/services/epic-connector/src/__tests__/index-exports.test.ts
+++ b/services/epic-connector/src/__tests__/index-exports.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Package-surface sanity test for the helpers re-exported from
+ * `services/epic-connector/src/index.ts` so that admin tooling and
+ * downstream consumers do not have to deep-import from `sync/sync-jobs.js`
+ * (#1133).
+ *
+ * Re-export drift between the named helper definitions and the package
+ * barrel is silent at the type level — this guard surfaces it.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isMissingRequiredElementError,
+  describeMissingElement,
+  EpicFhirError,
+  EPIC_ERROR_CODES,
+} from "../index.js";
+
+describe("epic-connector index surface (#1133)", () => {
+  it("re-exports isMissingRequiredElementError", () => {
+    expect(typeof isMissingRequiredElementError).toBe("function");
+  });
+
+  it("re-exports describeMissingElement", () => {
+    expect(typeof describeMissingElement).toBe("function");
+  });
+
+  it("isMissingRequiredElementError detects an EpicFhirError carrying 59108", () => {
+    const outcome = {
+      resourceType: "OperationOutcome" as const,
+      issue: [
+        {
+          severity: "error" as const,
+          code: "required",
+          details: {
+            coding: [
+              {
+                system: "https://open.epic.com/error-codes",
+                code: EPIC_ERROR_CODES.MISSING_REQUIRED_ELEMENT,
+              },
+            ],
+            text: "A required element is missing",
+          },
+          diagnostics: "MedicationRequest.intent is required",
+        },
+      ],
+    };
+    const err = new EpicFhirError(
+      "Epic returned OperationOutcome",
+      400,
+      "Bad Request",
+      JSON.stringify(outcome),
+      outcome,
+    );
+    expect(isMissingRequiredElementError(err)).toBe(true);
+  });
+
+  it("isMissingRequiredElementError rejects non-Epic errors", () => {
+    expect(isMissingRequiredElementError(new Error("boom"))).toBe(false);
+    expect(isMissingRequiredElementError(undefined)).toBe(false);
+  });
+
+  it("describeMissingElement extracts the diagnostics field", () => {
+    const outcome = {
+      resourceType: "OperationOutcome" as const,
+      issue: [
+        {
+          severity: "error" as const,
+          code: "required",
+          diagnostics: "Observation.category is required",
+        },
+      ],
+    };
+    const err = new EpicFhirError("x", 400, "Bad Request", "{}", outcome);
+    expect(describeMissingElement(err)).toBe("Observation.category is required");
+  });
+
+  it("describeMissingElement returns a fallback for errors without an OperationOutcome", () => {
+    expect(describeMissingElement(new Error("boom"))).toBe(
+      "missing element (no diagnostics)",
+    );
+  });
+});

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -1137,16 +1137,15 @@ describe("Epic sync-jobs (#391)", () => {
     expect(markOk).not.toHaveBeenCalled();
   });
 
-  // #1099 acceptance #4: documented placeholder for multi-status fan-out
+  // #1099 acceptance #4: documented placeholder for multi-status fan-out.
+  // Tracked separately as #1114 (multi-status fan-out implementation) and
+  // #1097 (related sync_result signalling). The body uses expect.fail so
+  // accidentally un-skipping surfaces the tracking ID rather than a bare
+  // boolean (#1105).
   it.skip(
     "MedicationRequest fan-out supports multi-status override (active + on-hold + completed) — future",
     async () => {
-      // When the worker dispatch grows a `medication_request_statuses?:
-      // string[]` override, this test should drive the fan-out across
-      // each status as a separate searchAll call. Today the default is
-      // hardcoded to "active" and there's no per-job override channel
-      // — see issue #1097 for the related sync_result signalling work.
-      expect(false).toBe(true);
+      expect.fail("not yet implemented — tracked as #1114");
     },
   );
 });

--- a/services/epic-connector/src/index.ts
+++ b/services/epic-connector/src/index.ts
@@ -77,6 +77,8 @@ export {
   runFullSync,
   runIncrementalSync,
   runSingleResourceSync,
+  isMissingRequiredElementError,
+  describeMissingElement,
   SUPPORTED_RESOURCE_TYPES,
   type SyncResourceType,
   type SyncResult,

--- a/services/epic-connector/src/sync/sync-jobs.ts
+++ b/services/epic-connector/src/sync/sync-jobs.ts
@@ -367,7 +367,7 @@ function isUnauthorizedSubResourceError(err: unknown): boolean {
  * because 59108 indicates a code bug that we WANT to surface as a
  * loud failure rather than rescue with a fragile heuristic.
  */
-function isMissingRequiredElementError(err: unknown): boolean {
+export function isMissingRequiredElementError(err: unknown): boolean {
   return (
     err instanceof EpicFhirError &&
     err.hasIssueCode(EPIC_ERROR_CODES.MISSING_REQUIRED_ELEMENT)
@@ -380,7 +380,7 @@ function isMissingRequiredElementError(err: unknown): boolean {
  * generic "A required element is missing" into actionable feedback
  * ("Required element missing: MedicationRequest.intent").
  */
-function describeMissingElement(err: unknown): string {
+export function describeMissingElement(err: unknown): string {
   if (!(err instanceof EpicFhirError) || !err.operationOutcome) {
     return "missing element (no diagnostics)";
   }


### PR DESCRIPTION
## Summary

Trivial cleanup bundle. Closes two `from-review` follow-ups in one PR.

### #1133 — re-export missing-element helpers

Re-export `isMissingRequiredElementError` and `describeMissingElement` from `services/epic-connector/src/index.ts`. They were added in #1130 as module-private helpers for the catch block in `sync-jobs.ts`, but the same discrimination logic + presentation string are needed by admin tooling and any future clinician-portal query that wants to group `epic_sync_state` failures by category (scope rejection vs request-shape bug).

Mirrors the surface decision already made in #1128 for `summarise` / `SyncSummary` / `SUMMARISE_SKIPPED_DETAIL_CAP`.

### #1105 — harden multi-status fan-out placeholder

The placeholder `it.skip` for multi-status MedicationRequest fan-out (added in #1100 per #1099 acceptance #4) had a `expect(false).toBe(true)` body that would emit a meaningless failure if anyone removed `.skip` without writing the real test. Replaced with `expect.fail("not yet implemented — tracked as #1114")` so the failure mode names the tracking issue.

`#1114` is the existing follow-up that tracks the multi-status fan-out implementation work itself.

## Test plan
- [x] New surface test (`src/__tests__/index-exports.test.ts`, 6 cases) covers both helpers being callable from the package root + EpicFhirError → 59108 discrimination round-trip
- [x] `pnpm --filter @carebridge/epic-connector test` — 20 files, 217 pass + 1 skipped
- [x] `pnpm --filter @carebridge/epic-connector typecheck` — clean

Closes #1105.
Closes #1133.