### PR TITLE
feat(epic): auth hardening — token-fetch coalescing + PEM validation (#1089)

### DIFF
--- a/services/epic-connector/src/__tests__/config.test.ts
+++ b/services/epic-connector/src/__tests__/config.test.ts
@@ -129,6 +129,69 @@ describe("loadEpicConfig (#389)", () => {
         EPIC_PRIVATE_KEY_PATH: bogus,
         EPIC_JWT_KID: "kid-001",
       }),
-    ).toThrow(/private key must be a PEM/);
+    ).toThrow(/private key/i);
+  });
+
+  it("accepts a valid RSA PKCS#8 private key (#1089)", () => {
+    // beforeEach already produces an RSA PKCS#8 PEM and writes it to
+    // pemPath. This case re-asserts the happy path via the new
+    // crypto.createPrivateKey validation path.
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pemPath,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(privatePem);
+  });
+
+  it("accepts a valid RSA PKCS#1 private key (#1089)", () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pkcs1Pem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    const pkcs1Path = join(tmpDir, "epic-pkcs1.pem");
+    writeFileSync(pkcs1Path, pkcs1Pem, "utf8");
+
+    const cfg = loadEpicConfig({
+      EPIC_CLIENT_ID: "abc-123",
+      EPIC_PRIVATE_KEY_PATH: pkcs1Path,
+      EPIC_JWT_KID: "kid-001",
+    });
+    expect(cfg.privateKeyPem).toBe(pkcs1Pem);
+  });
+
+  it("rejects a non-RSA (EC) private key with a clear message (#1089)", () => {
+    const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const ecPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+    const ecPath = join(tmpDir, "epic-ec.pem");
+    writeFileSync(ecPath, ecPem, "utf8");
+
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: ecPath,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/must be RSA/i);
+  });
+
+  it("rejects an encrypted PEM (passphrase-protected) with a clear message (#1089)", () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const encPem = privateKey
+      .export({
+        type: "pkcs8",
+        format: "pem",
+        cipher: "aes-256-cbc",
+        passphrase: "x",
+      })
+      .toString();
+    const encPath = join(tmpDir, "epic-encrypted.pem");
+    writeFileSync(encPath, encPem, "utf8");
+
+    expect(() =>
+      loadEpicConfig({
+        EPIC_CLIENT_ID: "abc-123",
+        EPIC_PRIVATE_KEY_PATH: encPath,
+        EPIC_JWT_KID: "kid-001",
+      }),
+    ).toThrow(/encrypted|passphrase/i);
   });
 });

--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -151,4 +151,91 @@ describe("EpicTokenClient (#389)", () => {
     );
     expect(body.get("scope")).toBe("system/Patient.read");
   });
+
+  it("coalesces concurrent callers into a single in-flight fetch (#1089)", async () => {
+    // Hold the fetch response until we explicitly resolve it, so all
+    // callers race for the same in-flight promise before any of them
+    // see a cached value.
+    let resolveFetch: (response: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockImplementation(() => pendingResponse);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    // Fire 5 concurrent getAccessToken() calls before the first fetch
+    // resolves.
+    const callers = Array.from({ length: 5 }, () => client.getAccessToken());
+
+    // Now release the underlying token fetch.
+    resolveFetch!(tokenResponse({ access_token: "coalesced-token" }));
+
+    const tokens = await Promise.all(callers);
+
+    // Every caller should receive the same token, and only ONE fetch
+    // should have hit the network.
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(tokens).toEqual([
+      "coalesced-token",
+      "coalesced-token",
+      "coalesced-token",
+      "coalesced-token",
+      "coalesced-token",
+    ]);
+  });
+
+  it("invalidate() clears the in-flight promise so the next call fetches afresh (#1089)", async () => {
+    // Set up a pending fetch that we will invalidate before resolving.
+    // After invalidate(), the next call should kick off its own fetch
+    // rather than reusing the dropped in-flight promise.
+    let resolveFirst: (response: Response) => void;
+    let resolveSecond: (response: Response) => void;
+    const firstPending = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPending = new Promise<Response>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstPending)
+      .mockImplementationOnce(() => secondPending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    // Kick off the first call but do not await it — it is in-flight.
+    const firstCall = client.getAccessToken();
+    // While in-flight, invalidate clears the in-flight reference.
+    client.invalidate();
+    // The next call should NOT reuse the dropped promise; it should
+    // start a brand-new fetch.
+    const secondCall = client.getAccessToken();
+
+    resolveFirst!(tokenResponse({ access_token: "first-token" }));
+    resolveSecond!(tokenResponse({ access_token: "second-token" }));
+
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(first).toBe("first-token");
+    expect(second).toBe("second-token");
+  });
+
+  it("clears the in-flight promise when the token request fails (#1089)", async () => {
+    // After a fetch failure, the in-flight promise must be cleared so a
+    // retry can issue a fresh request — otherwise every subsequent
+    // caller would await (and reject from) the same poisoned promise.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("invalid_client_assertion_or_signature", { status: 400 }),
+      )
+      .mockResolvedValueOnce(tokenResponse({ access_token: "after-retry" }));
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await expect(client.getAccessToken()).rejects.toThrow(/400/);
+    const recovered = await client.getAccessToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(recovered).toBe("after-retry");
+  });
 });

--- a/services/epic-connector/src/config.ts
+++ b/services/epic-connector/src/config.ts
@@ -23,12 +23,51 @@
  *                               registered JWKS has more than one entry.
  */
 import { readFileSync } from "node:fs";
+import { createPrivateKey } from "node:crypto";
 import { z } from "zod";
 
 const SANDBOX_TOKEN_URL =
   "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token";
 const SANDBOX_FHIR_BASE_URL =
   "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+
+/**
+ * Fully parse + validate the private key PEM at config load (#1089).
+ *
+ * Previously this checked only for the presence of PEM-header
+ * substrings, which let non-RSA PKCS#8 keys and passphrase-encrypted
+ * PEMs through to surface as confusing signing errors at the first
+ * token request. We now feed the PEM to `crypto.createPrivateKey` and
+ * assert the resulting KeyObject is RSA so we fail loudly at boot.
+ *
+ * The function throws a plain `Error` with a clear, no-PHI message so
+ * the Zod `refine` wrapper around it can pass the message straight
+ * through to the operator.
+ */
+function assertRsaPrivateKey(pem: string): void {
+  // Encrypted PKCS#8 PEMs are wrapped in `-----BEGIN ENCRYPTED PRIVATE
+  // KEY-----`. Detect this header upfront so we can surface a clear,
+  // stable message — OpenSSL's parse-failure text for missing
+  // passphrases varies by Node/OpenSSL version (e.g. "bad decrypt",
+  // "interrupted or cancelled") and isn't safe to match on.
+  if (/-----BEGIN ENCRYPTED PRIVATE KEY-----/.test(pem)) {
+    throw new Error(
+      "private key must NOT be encrypted (passphrase-protected PEM is not supported; provide a decrypted RSA key)",
+    );
+  }
+  let key;
+  try {
+    key = createPrivateKey({ key: pem, format: "pem" });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`private key is not a valid PEM: ${message}`);
+  }
+  if (key.asymmetricKeyType !== "rsa") {
+    throw new Error(
+      `private key must be RSA (got ${key.asymmetricKeyType ?? "unknown"}); Epic SMART Backend Services requires RS384`,
+    );
+  }
+}
 
 const configSchema = z.object({
   clientId: z.string().min(1, "EPIC_CLIENT_ID is required"),
@@ -37,12 +76,16 @@ const configSchema = z.object({
   privateKeyPem: z
     .string()
     .min(1)
-    .refine(
-      (pem) =>
-        pem.includes("BEGIN RSA PRIVATE KEY") ||
-        pem.includes("BEGIN PRIVATE KEY"),
-      "private key must be a PEM-encoded RSA key",
-    ),
+    .superRefine((pem, ctx) => {
+      try {
+        assertRsaPrivateKey(pem);
+      } catch (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }),
   jwtKid: z.string().min(1, "EPIC_JWT_KID is required"),
 });
 

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -65,6 +65,14 @@ interface CachedToken {
  */
 export class EpicTokenClient {
   private cached: CachedToken | null = null;
+  /**
+   * In-flight token request. Concurrent {@link getAccessToken} callers
+   * that arrive while a fetch is outstanding await the same promise
+   * instead of each kicking off their own request (#1089). Cleared as
+   * soon as the request settles (success or failure) so the cache /
+   * retry path takes over for subsequent callers.
+   */
+  private inFlight: Promise<TokenResponse> | null = null;
 
   constructor(
     private readonly config: EpicConfig,
@@ -77,9 +85,9 @@ export class EpicTokenClient {
   /**
    * Return a usable access token. Uses the cached value when it has
    * more than REFRESH_BUFFER_SEC of lifetime left; otherwise requests
-   * a fresh one. Thread-safe in Node's single-threaded event loop —
-   * concurrent callers within a tick share the same in-flight request
-   * via the cache being populated on resolution.
+   * a fresh one. Concurrent callers that arrive while a fetch is
+   * outstanding coalesce on a shared in-flight promise (#1089) so a
+   * burst of N callers issues a single network round-trip.
    */
   async getAccessToken(scopes: string[] = DEFAULT_SYSTEM_SCOPES): Promise<string> {
     if (this.cached) {
@@ -89,7 +97,38 @@ export class EpicTokenClient {
       }
     }
 
+    // If a refresh is already in flight, every concurrent caller awaits
+    // the same promise. The first caller to enter this branch sets
+    // `inFlight`; later callers in the same tick observe it and join.
+    if (this.inFlight) {
+      const parsed = await this.inFlight;
+      return parsed.access_token;
+    }
+
     const issuedAtMs = this.nowMs();
+    this.inFlight = this.fetchToken(scopes, issuedAtMs);
+    try {
+      const parsed = await this.inFlight;
+      return parsed.access_token;
+    } finally {
+      // Always clear the in-flight slot — whether the fetch resolved or
+      // rejected — so the next caller observes a clean state. On
+      // failure the cache is untouched (no `this.cached` write) and the
+      // next call will issue its own retry; on success the cache has
+      // been populated and the next call is served from it.
+      this.inFlight = null;
+    }
+  }
+
+  /**
+   * Internal fetch helper. Extracted so the in-flight slot can be
+   * tracked as a single `Promise<TokenResponse>` regardless of the
+   * scope override or issued-at timestamp.
+   */
+  private async fetchToken(
+    scopes: string[],
+    issuedAtMs: number,
+  ): Promise<TokenResponse> {
     const assertion = buildClientAssertion({
       clientId: this.config.clientId,
       tokenUrl: this.config.tokenUrl,
@@ -140,18 +179,20 @@ export class EpicTokenClient {
       response: parsed,
       expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
     };
-
-    return parsed.access_token;
+    return parsed;
   }
 
   /**
-   * Drop the cached token. Forces the next {@link getAccessToken} call
-   * to request a fresh one. Useful when the FHIR client receives a 401
-   * (token revoked / org rotated keys) and wants to retry once with a
-   * fresh assertion before failing.
+   * Drop the cached token AND any in-flight refresh promise. Forces
+   * the next {@link getAccessToken} call to request a fresh one.
+   * Useful when the FHIR client receives a 401 (token revoked / org
+   * rotated keys) and wants to retry once with a fresh assertion
+   * before failing. Clearing the in-flight reference too (#1089)
+   * prevents a stale-credential refresh from satisfying the retry.
    */
   invalidate(): void {
     this.cached = null;
+    this.inFlight = null;
   }
 }
 


### PR DESCRIPTION
## Summary
Two hardening items deferred from #1084 review:

1. **EpicTokenClient concurrent fetch coalescing** — Single in-flight promise shared across concurrent `getAccessToken()` callers. `invalidate()` clears it.
2. **PEM validation at config load** — Parse via `crypto.createPrivateKey`, assert RSA. Rejects EC and encrypted keys with clear errors instead of confused later-stage signing failures.

## Test plan
- [x] New: 1 coalescing test (N concurrent callers, 1 fetch) + 2 supporting tests (invalidate clears in-flight, failure clears in-flight)
- [x] New: 4 PEM cases (RSA PKCS#8, RSA PKCS#1, EC rejected, encrypted rejected)
- [x] `pnpm --filter @carebridge/epic-connector test` — 225 passed, 1 skipped (up from 218)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Closes #1089.