### PR TITLE
feat(fhir): add US Core meta.profile to exported resources

### DIFF
--- a/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
+++ b/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
@@ -1,0 +1,287 @@
+/**
+ * US Core meta.profile coverage (#938).
+ *
+ * Every exported FHIR resource must declare conformance to a US Core
+ * StructureDefinition via `resource.meta.profile`. These tests pin the
+ * expected profile URL per generator so a regression — dropping the meta
+ * block, swapping the URL, or forgetting to update a new generator — fails
+ * loudly rather than shipping a silently non-conformant export.
+ *
+ * Practitioner is intentionally excluded — see issue #947.
+ * MedicationStatement is intentionally excluded — US Core 5+ deprecated the
+ * profile and no canonical URL exists; documented in us-core-profiles.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toFhirPatient } from "../generators/patient.js";
+import { toFhirCondition } from "../generators/condition.js";
+import { toFhirMedicationRequest } from "../generators/medication-request.js";
+import { toFhirMedicationStatement } from "../generators/medication-statement.js";
+import { toFhirAllergyIntolerance } from "../generators/allergy-intolerance.js";
+import {
+  toFhirVitalObservation,
+  toFhirLabObservation,
+} from "../generators/observation.js";
+import { toFhirEncounter } from "../generators/encounter.js";
+import { toFhirProcedure } from "../generators/procedure.js";
+import {
+  US_CORE_PATIENT,
+  US_CORE_CONDITION,
+  US_CORE_MEDICATION_REQUEST,
+  US_CORE_ALLERGY_INTOLERANCE,
+  US_CORE_VITAL_SIGNS,
+  US_CORE_LABORATORY_RESULT,
+  US_CORE_ENCOUNTER,
+  US_CORE_PROCEDURE,
+} from "../generators/us-core-profiles.js";
+import type { Vital, LabResult } from "@carebridge/shared-types";
+
+// ── Builders (one per generator) ───────────────────────────────────────────
+
+type Patient = Parameters<typeof toFhirPatient>[0];
+function makePatient(): Patient {
+  return {
+    id: "pat-1",
+    name: "Jane Doe",
+    date_of_birth: "1980-05-12",
+    biological_sex: "female",
+    mrn: "MRN-12345",
+  };
+}
+
+type Diagnosis = Parameters<typeof toFhirCondition>[0];
+function makeDiagnosis(): Diagnosis {
+  return {
+    id: "d1",
+    patient_id: "p1",
+    description: "Type 2 diabetes",
+    icd10_code: "E11.9",
+    snomed_code: null,
+    status: "active",
+    onset_date: "2020-01-01",
+    resolved_date: null,
+    diagnosed_by: null,
+    notes: null,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+  } as Diagnosis;
+}
+
+type Medication = Parameters<typeof toFhirMedicationRequest>[0];
+function makeMedication(): Medication {
+  return {
+    id: "m1",
+    patient_id: "p1",
+    name: "Amoxicillin",
+    brand_name: null,
+    dose_amount: 500,
+    dose_unit: "mg",
+    route: "oral",
+    frequency: "TID",
+    status: "active",
+    started_at: "2026-04-10T00:00:00.000Z",
+    ended_at: null,
+    prescribed_by: null,
+    notes: null,
+    rxnorm_code: "723",
+    ordering_provider_id: "prov1",
+    encounter_id: null,
+    source_system: "internal",
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+  } as Medication;
+}
+
+type Allergy = Parameters<typeof toFhirAllergyIntolerance>[0];
+function makeAllergy(): Allergy {
+  return {
+    id: "a1",
+    allergen: "Peanut",
+    snomed_code: "91935009",
+    rxnorm_code: null,
+    reaction: null,
+    severity: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+  } as Allergy;
+}
+
+function makeVital(): Vital {
+  return {
+    id: "v1",
+    patient_id: "p1",
+    type: "heart_rate",
+    value_primary: 72,
+    unit: "bpm",
+    recorded_at: "2026-05-21T12:00:00.000Z",
+    created_at: "2026-05-21T12:00:00.000Z",
+  };
+}
+
+function makeLab(): LabResult {
+  return {
+    id: "l1",
+    panel_id: "panel-1",
+    test_name: "Hemoglobin",
+    test_code: "718-7",
+    value: 14.2,
+    unit: "g/dL",
+    reference_low: 12,
+    reference_high: 17,
+    created_at: "2026-05-21T12:00:00.000Z",
+  };
+}
+
+type EncounterRow = Parameters<typeof toFhirEncounter>[0];
+function makeEncounter(): EncounterRow {
+  return {
+    id: "e1",
+    patient_id: "p1",
+    encounter_type: "outpatient",
+    status: "finished",
+    start_time: "2026-04-10T10:00:00.000Z",
+    end_time: "2026-04-10T10:45:00.000Z",
+    provider_id: null,
+    location: null,
+    reason: null,
+    notes: null,
+    created_at: "2026-04-10T10:00:00.000Z",
+  } as EncounterRow;
+}
+
+type ProcedureRow = Parameters<typeof toFhirProcedure>[0];
+function makeProcedure(): ProcedureRow {
+  return {
+    id: "p1",
+    patient_id: "pat1",
+    name: "Appendectomy",
+    cpt_code: "44970",
+    icd10_codes: ["K35.80"],
+    status: "completed",
+    performed_at: "2026-04-10T14:00:00.000Z",
+    performed_by: null,
+    provider_id: null,
+    encounter_id: null,
+    notes: null,
+    source_system: "internal",
+    created_at: "2026-04-10T14:00:00.000Z",
+  } as ProcedureRow;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("US Core meta.profile (#938)", () => {
+  describe("Patient", () => {
+    it("emits the US Core Patient profile URL", () => {
+      const p = toFhirPatient(makePatient());
+      expect(p.meta?.profile).toEqual([US_CORE_PATIENT]);
+      expect(p.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+      );
+    });
+  });
+
+  describe("Condition", () => {
+    it("emits the US Core Condition (encounter-diagnosis) profile URL", () => {
+      const c = toFhirCondition(makeDiagnosis(), "p1");
+      expect(c.meta?.profile).toEqual([US_CORE_CONDITION]);
+      expect(c.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis",
+      );
+    });
+  });
+
+  describe("MedicationRequest", () => {
+    it("emits the US Core MedicationRequest profile URL", () => {
+      const r = toFhirMedicationRequest(makeMedication(), "p1");
+      expect(r.meta?.profile).toEqual([US_CORE_MEDICATION_REQUEST]);
+      expect(r.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+      );
+    });
+  });
+
+  describe("MedicationStatement", () => {
+    it("does NOT declare a US Core profile (deprecated in US Core 5+)", () => {
+      const s = toFhirMedicationStatement(makeMedication(), "p1");
+      // MedicationStatement has no current US Core profile; emitting one
+      // would be a false conformance claim. The local resource type doesn't
+      // even carry a meta property — confirm it's truly absent rather than
+      // empty.
+      const meta = (s as { meta?: unknown }).meta;
+      expect(meta).toBeUndefined();
+    });
+  });
+
+  describe("AllergyIntolerance", () => {
+    it("emits the US Core AllergyIntolerance profile URL", () => {
+      const a = toFhirAllergyIntolerance(makeAllergy(), "p1");
+      expect(a.meta?.profile).toEqual([US_CORE_ALLERGY_INTOLERANCE]);
+      expect(a.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
+      );
+    });
+  });
+
+  describe("Observation (vital)", () => {
+    it("emits the US Core Vital Signs profile URL", () => {
+      const o = toFhirVitalObservation(makeVital(), "p1");
+      expect(o.meta?.profile).toEqual([US_CORE_VITAL_SIGNS]);
+      expect(o.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+      );
+    });
+  });
+
+  describe("Observation (lab result)", () => {
+    it("emits the US Core Laboratory Result Observation profile URL", () => {
+      const o = toFhirLabObservation(makeLab(), "p1");
+      expect(o.meta?.profile).toEqual([US_CORE_LABORATORY_RESULT]);
+      expect(o.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-laboratory-result-observation",
+      );
+    });
+
+    it("does NOT emit the vital-signs profile on a lab observation", () => {
+      const o = toFhirLabObservation(makeLab(), "p1");
+      expect(o.meta?.profile).not.toContain(US_CORE_VITAL_SIGNS);
+    });
+  });
+
+  describe("Encounter", () => {
+    it("emits the US Core Encounter profile URL", () => {
+      const e = toFhirEncounter(makeEncounter(), "p1");
+      expect(e.meta?.profile).toEqual([US_CORE_ENCOUNTER]);
+      expect(e.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+      );
+    });
+  });
+
+  describe("Procedure", () => {
+    it("emits the US Core Procedure profile URL", () => {
+      const p = toFhirProcedure(makeProcedure(), "p1");
+      expect(p.meta?.profile).toEqual([US_CORE_PROCEDURE]);
+      expect(p.meta?.profile?.[0]).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+      );
+    });
+  });
+
+  describe("profile URL constants", () => {
+    it("all URLs share the US Core StructureDefinition base", () => {
+      const base = "http://hl7.org/fhir/us/core/StructureDefinition/";
+      for (const url of [
+        US_CORE_PATIENT,
+        US_CORE_CONDITION,
+        US_CORE_MEDICATION_REQUEST,
+        US_CORE_ALLERGY_INTOLERANCE,
+        US_CORE_VITAL_SIGNS,
+        US_CORE_LABORATORY_RESULT,
+        US_CORE_ENCOUNTER,
+        US_CORE_PROCEDURE,
+      ]) {
+        expect(url.startsWith(base)).toBe(true);
+      }
+    });
+  });
+});

--- a/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
+++ b/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
@@ -152,7 +152,7 @@ type ProcedureRow = Parameters<typeof toFhirProcedure>[0];
 function makeProcedure(): ProcedureRow {
   return {
     id: "p1",
-    patient_id: "pat1",
+    patient_id: "p1",
     name: "Appendectomy",
     cpt_code: "44970",
     icd10_codes: ["K35.80"],

--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -7,7 +7,8 @@
  */
 
 import type { allergies } from "@carebridge/db-schema";
-import type { Coding } from "../types/fhir-r4.js";
+import type { Coding, Meta } from "../types/fhir-r4.js";
+import { US_CORE_ALLERGY_INTOLERANCE } from "./us-core-profiles.js";
 
 type Allergy = typeof allergies.$inferSelect;
 
@@ -31,6 +32,7 @@ type FhirAllergyCategory = "food" | "medication" | "environment" | "biologic";
 interface FhirAllergyIntolerance {
   resourceType: "AllergyIntolerance";
   id: string;
+  meta?: Meta;
   clinicalStatus: {
     coding: FhirCoding[];
   };
@@ -262,6 +264,9 @@ export function toFhirAllergyIntolerance(
   const resource: FhirAllergyIntolerance = {
     resourceType: "AllergyIntolerance",
     id: allergy.id,
+    meta: {
+      profile: [US_CORE_ALLERGY_INTOLERANCE],
+    },
     clinicalStatus: {
       coding: [
         {

--- a/services/fhir-gateway/src/generators/condition.ts
+++ b/services/fhir-gateway/src/generators/condition.ts
@@ -7,7 +7,8 @@
  */
 
 import type { diagnoses } from "@carebridge/db-schema";
-import type { Coding } from "../types/fhir-r4.js";
+import type { Coding, Meta } from "../types/fhir-r4.js";
+import { US_CORE_CONDITION } from "./us-core-profiles.js";
 
 type Diagnosis = typeof diagnoses.$inferSelect;
 
@@ -17,6 +18,7 @@ type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "disp
 interface FhirCondition {
   resourceType: "Condition";
   id: string;
+  meta?: Meta;
   clinicalStatus: {
     coding: FhirCoding[];
   };
@@ -95,6 +97,9 @@ export function toFhirCondition(
   const condition: FhirCondition = {
     resourceType: "Condition",
     id: diagnosis.id,
+    meta: {
+      profile: [US_CORE_CONDITION],
+    },
     clinicalStatus: {
       coding: [
         {

--- a/services/fhir-gateway/src/generators/encounter.ts
+++ b/services/fhir-gateway/src/generators/encounter.ts
@@ -10,6 +10,7 @@
 
 import type { encounters } from "@carebridge/db-schema";
 import type { FhirEncounter } from "../types/fhir-r4.js";
+import { US_CORE_ENCOUNTER } from "./us-core-profiles.js";
 
 type EncounterRow = typeof encounters.$inferSelect;
 
@@ -78,6 +79,9 @@ export function toFhirEncounter(
   const resource: FhirEncounter = {
     resourceType: "Encounter",
     id: encounter.id,
+    meta: {
+      profile: [US_CORE_ENCOUNTER],
+    },
     status: mapEncounterStatus(encounter.status),
     class: {
       system: ACT_CODE_SYSTEM,

--- a/services/fhir-gateway/src/generators/medication-request.ts
+++ b/services/fhir-gateway/src/generators/medication-request.ts
@@ -19,6 +19,7 @@ import type {
   DosageInstruction,
 } from "../types/fhir-r4.js";
 import { toDoseQuantity } from "./ucum.js";
+import { US_CORE_MEDICATION_REQUEST } from "./us-core-profiles.js";
 
 type Medication = typeof medications.$inferSelect;
 
@@ -96,6 +97,9 @@ export function toFhirMedicationRequest(
   const resource: FhirMedicationRequest = {
     resourceType: "MedicationRequest",
     id: medication.id,
+    meta: {
+      profile: [US_CORE_MEDICATION_REQUEST],
+    },
     status: mapRequestStatus(medication.status),
     // CareBridge-internal medications are prescription orders; there's no
     // plan-vs-order distinction in the current data model, so we emit

--- a/services/fhir-gateway/src/generators/observation.ts
+++ b/services/fhir-gateway/src/generators/observation.ts
@@ -6,7 +6,12 @@ import type {
   Quantity,
   Reference,
   ObservationComponent,
+  Meta,
 } from "../types/fhir-r4.js";
+import {
+  US_CORE_VITAL_SIGNS,
+  US_CORE_LABORATORY_RESULT,
+} from "./us-core-profiles.js";
 
 const UNIT_TO_UCUM: Record<string, string> = {
   "K/uL": "10*3/uL",
@@ -44,6 +49,7 @@ interface ObservationReferenceRange {
 export interface FhirObservation {
   resourceType: "Observation";
   id?: string;
+  meta?: Meta;
   status: "final" | "preliminary" | "registered" | "amended";
   category?: CodeableConcept[];
   code: CodeableConcept;
@@ -198,6 +204,9 @@ export function toFhirVitalObservation(
   const observation: FhirObservation = {
     resourceType: "Observation",
     id: vital.id,
+    meta: {
+      profile: [US_CORE_VITAL_SIGNS],
+    },
     status: "final",
     category: [vitalSignsCategory()],
     code: {
@@ -244,6 +253,9 @@ export function toFhirLabObservation(
   const observation: FhirObservation = {
     resourceType: "Observation",
     id: labResult.id,
+    meta: {
+      profile: [US_CORE_LABORATORY_RESULT],
+    },
     status: "final",
     category: [laboratoryCategory()],
     code: {

--- a/services/fhir-gateway/src/generators/patient.ts
+++ b/services/fhir-gateway/src/generators/patient.ts
@@ -1,5 +1,6 @@
 import type { FhirPatient } from "../types/index.js";
 import { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
+import { US_CORE_PATIENT } from "./us-core-profiles.js";
 
 /** Shape of a row from the `patients` table after decryption. */
 interface PatientRow {
@@ -49,9 +50,7 @@ export function toFhirPatient(patient: PatientRow): FhirPatient {
     resourceType: "Patient",
     id: patient.id,
     meta: {
-      profile: [
-        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-      ],
+      profile: [US_CORE_PATIENT],
     },
     identifier: patient.mrn
       ? [

--- a/services/fhir-gateway/src/generators/procedure.ts
+++ b/services/fhir-gateway/src/generators/procedure.ts
@@ -9,6 +9,7 @@
 
 import type { procedures } from "@carebridge/db-schema";
 import type { FhirProcedure } from "../types/fhir-r4.js";
+import { US_CORE_PROCEDURE } from "./us-core-profiles.js";
 
 type ProcedureRow = typeof procedures.$inferSelect;
 
@@ -57,6 +58,9 @@ export function toFhirProcedure(
   const resource: FhirProcedure = {
     resourceType: "Procedure",
     id: procedure.id,
+    meta: {
+      profile: [US_CORE_PROCEDURE],
+    },
     status: mapProcedureStatus(procedure.status),
     subject: {
       reference: `Patient/${patientId}`,

--- a/services/fhir-gateway/src/generators/us-core-profiles.ts
+++ b/services/fhir-gateway/src/generators/us-core-profiles.ts
@@ -1,0 +1,57 @@
+/**
+ * US Core (HL7 FHIR R4) StructureDefinition URLs.
+ *
+ * Each exported FHIR resource declares conformance to a US Core profile via
+ * `Resource.meta.profile`. Centralising the URLs here keeps every generator
+ * in lock-step with the same canonical references and makes it easy to
+ * audit the set of profiles CareBridge claims to support.
+ *
+ * Resource-level notes:
+ *  - Patient, Condition, AllergyIntolerance, Encounter, Procedure,
+ *    MedicationRequest each have a single canonical US Core profile.
+ *  - Observation depends on category — vitals declare `us-core-vital-signs`,
+ *    lab results declare `us-core-laboratory-result-observation`.
+ *  - MedicationStatement was deprecated in US Core 5+ and has no current
+ *    US Core profile; that generator intentionally does not populate
+ *    meta.profile.
+ *  - Practitioner is handled separately (issue #947).
+ *
+ * Reference: https://hl7.org/fhir/us/core/
+ */
+
+const BASE = "http://hl7.org/fhir/us/core/StructureDefinition";
+
+/** US Core Patient profile URL. */
+export const US_CORE_PATIENT = `${BASE}/us-core-patient`;
+
+/**
+ * US Core Condition profile URL.
+ *
+ * The condition generator currently emits diagnoses without a category
+ * coding, so we cannot disambiguate between
+ * `us-core-condition-encounter-diagnosis` and
+ * `us-core-condition-problems-and-health-concerns` from the resource shape
+ * alone. Encounter-diagnosis is the more conservative default for the
+ * inbound `diagnoses` table (which is sourced from clinical encounters).
+ */
+export const US_CORE_CONDITION =
+  `${BASE}/us-core-condition-encounter-diagnosis`;
+
+/** US Core MedicationRequest profile URL. */
+export const US_CORE_MEDICATION_REQUEST = `${BASE}/us-core-medicationrequest`;
+
+/** US Core AllergyIntolerance profile URL. */
+export const US_CORE_ALLERGY_INTOLERANCE = `${BASE}/us-core-allergyintolerance`;
+
+/** US Core Encounter profile URL. */
+export const US_CORE_ENCOUNTER = `${BASE}/us-core-encounter`;
+
+/** US Core Procedure profile URL. */
+export const US_CORE_PROCEDURE = `${BASE}/us-core-procedure`;
+
+/** US Core Vital Signs Observation profile URL. */
+export const US_CORE_VITAL_SIGNS = `${BASE}/us-core-vital-signs`;
+
+/** US Core Laboratory Result Observation profile URL. */
+export const US_CORE_LABORATORY_RESULT =
+  `${BASE}/us-core-laboratory-result-observation`;


### PR DESCRIPTION
## Summary
- Populate `resource.meta.profile` on every exported FHIR resource with the appropriate US Core StructureDefinition URL.
- Centralise URL constants in `services/fhir-gateway/src/generators/us-core-profiles.ts` so every generator references the same canonical strings.
- Practitioner is excluded — covered by #947.
- MedicationStatement is excluded — US Core 5+ deprecated the profile; emitting any URL would be a false conformance claim.

## Profile choices
| Resource | Profile URL |
| --- | --- |
| Patient | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient` |
| Condition | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis` |
| MedicationRequest | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest` |
| MedicationStatement | *(omitted — no current US Core profile)* |
| AllergyIntolerance | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance` |
| Observation (vital) | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs` |
| Observation (lab) | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-laboratory-result-observation` |
| Encounter | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter` |
| Procedure | `http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure` |

### Notes on the Condition choice
The condition generator does not currently emit a `category` coding, so we cannot programmatically disambiguate `us-core-condition-encounter-diagnosis` vs `us-core-condition-problems-and-health-concerns`. The encounter-diagnosis profile is the more conservative default given that the internal `diagnoses` table is sourced from clinical encounters. If a future change adds a problem-list category, the condition generator can branch on it the same way the observation generator already does for vital-signs vs laboratory.

### Notes on the Observation branching
Vital observations and lab observations are produced by two separate exported functions (`toFhirVitalObservation` and `toFhirLabObservation`), so the branch on profile URL falls out naturally — no runtime category lookup required.

## Test plan
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 27 files, 435 tests pass (was 26/424; +11 tests covering meta.profile on each generator including the deliberate MedicationStatement omission)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Closes #938.