### PR TITLE
feat(gateway): integrate @lhncbc/ucum-lhc validator for doseQuantity

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,9 @@ importers:
       '@carebridge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@lhncbc/ucum-lhc':
+        specifier: ^7.1.6
+        version: 7.1.6
       '@trpc/server':
         specifier: ^11.0.0
         version: 11.16.0(typescript@5.9.3)
@@ -1664,6 +1667,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@lhncbc/ucum-lhc@7.1.6':
+    resolution: {integrity: sha512-QD+NLuRci0gvv5zLpohVGcjlwGFYGmBwBgC6EDPVjVbTYlHkQFgg44PHFV6CVWii/09ne2Gxw89tbO/PhIcPBw==}
+
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
@@ -2475,6 +2481,11 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  coffeescript@2.7.0:
+    resolution: {integrity: sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2492,6 +2503,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -2514,6 +2528,12 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-parse@4.16.3:
+    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
+
+  csv-stringify@1.1.2:
+    resolution: {integrity: sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -2829,6 +2849,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -3114,6 +3137,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -3263,6 +3289,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-finite@1.1.0:
+    resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -3274,6 +3304,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-integer@1.0.7:
+    resolution: {integrity: sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -3333,6 +3366,9 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -3398,6 +3434,9 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
 
+  jsonfile@2.4.0:
+    resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3429,6 +3468,10 @@ packages:
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
@@ -3721,6 +3764,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -3771,6 +3817,9 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -3872,6 +3921,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3890,6 +3942,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.1.6:
+    resolution: {integrity: sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -3997,6 +4052,12 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-transform@0.1.2:
+    resolution: {integrity: sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg==}
+
+  string-to-stream@1.1.1:
+    resolution: {integrity: sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4023,6 +4084,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -4215,6 +4279,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
@@ -4401,6 +4468,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmldoc@0.4.0:
+    resolution: {integrity: sha512-rJ/+/UzYCSlFNuAzGuRyYgkH2G5agdX1UQn4+5siYw9pkNC3Hu/grYNDx/dqYLreeSjnY5oKg74CMBKxJHSg6Q==}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -4946,6 +5016,18 @@ snapshots:
   '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@lhncbc/ucum-lhc@7.1.6':
+    dependencies:
+      coffeescript: 2.7.0
+      csv-parse: 4.16.3
+      csv-stringify: 1.1.2
+      escape-html: 1.0.3
+      is-integer: 1.0.7
+      jsonfile: 2.4.0
+      stream-transform: 0.1.2
+      string-to-stream: 1.1.1
+      xmldoc: 0.4.0
 
   '@lukeed/ms@2.0.2': {}
 
@@ -5687,6 +5769,8 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  coffeescript@2.7.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5700,6 +5784,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   cookie@1.1.1: {}
+
+  core-util-is@1.0.3: {}
 
   cron-parser@4.9.0:
     dependencies:
@@ -5724,6 +5810,12 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  csv-parse@4.16.3: {}
+
+  csv-stringify@1.1.2:
+    dependencies:
+      lodash.get: 4.4.2
 
   d3-array@3.2.4:
     dependencies:
@@ -6069,6 +6161,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -6479,6 +6573,9 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11:
+    optional: true
+
   graphemer@1.4.0: {}
 
   has-bigints@1.1.0: {}
@@ -6635,6 +6732,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-finite@1.1.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.2:
@@ -6648,6 +6747,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-integer@1.0.7:
+    dependencies:
+      is-finite: 1.1.0
 
   is-map@2.0.3: {}
 
@@ -6702,6 +6805,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
@@ -6798,6 +6903,10 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  jsonfile@2.4.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -6835,6 +6944,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.defaults@4.2.0: {}
+
+  lodash.get@4.4.2: {}
 
   lodash.isarguments@3.1.0: {}
 
@@ -7117,6 +7228,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -7158,6 +7271,16 @@ snapshots:
       redux: 5.0.1
 
   react@19.2.5: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   real-require@0.2.0: {}
 
@@ -7296,6 +7419,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -7314,6 +7439,8 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  sax@1.1.6: {}
 
   saxes@6.0.0:
     dependencies:
@@ -7451,6 +7578,13 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-transform@0.1.2: {}
+
+  string-to-stream@1.1.1:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -7506,6 +7640,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -7709,6 +7847,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
 
@@ -7956,6 +8096,10 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xmldoc@0.4.0:
+    dependencies:
+      sax: 1.1.6
 
   y18n@4.0.3: {}
 

--- a/services/fhir-gateway/package.json
+++ b/services/fhir-gateway/package.json
@@ -14,6 +14,7 @@
     "@carebridge/medical-logic": "workspace:*",
     "@carebridge/logger": "workspace:*",
     "@carebridge/phi-sanitizer": "workspace:*",
+    "@lhncbc/ucum-lhc": "^7.1.6",
     "@trpc/server": "^11.0.0",
     "drizzle-orm": "^0.38.0",
     "zod": "^3.24.0"

--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -100,6 +100,78 @@ describe("toDoseQuantity — UCUM validity (#946)", () => {
   });
 });
 
+describe("toDoseQuantity — UCUM-lhc validator integration (#978)", () => {
+  // The pre-#978 hand-curated allowlist gated out valid UCUM expressions
+  // that aren't on the dosing short-list. After integrating @lhncbc/ucum-lhc
+  // (NIH/NLM reference implementation), the validator accepts any
+  // syntactically valid UCUM expression while we keep the alias table for
+  // legacy curly-brace forms (`{tbl}`, `{puff}`, etc.) and `mcg → ug`.
+
+  it("accepts exotic-but-valid UCUM exponent forms (10*6/uL)", () => {
+    // Cell-count units in haematology labs are commonly written as
+    // 10*6/uL (10^6 cells per microlitre). Pre-#978 the hand-curated
+    // allowlist rejected this; the lhc validator should accept it.
+    const q = toDoseQuantity(4.5, "10*6/uL");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("10*6/uL");
+    expect(q.unit).toBe("10*6/uL");
+  });
+
+  it("accepts product/exponent compound UCUM (mg.kg-1.d-1)", () => {
+    // Pharmacokinetics commonly uses dot-product / negative-exponent
+    // notation rather than the slash form (mg/kg/d).
+    const q = toDoseQuantity(2, "mg.kg-1.d-1");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("mg.kg-1.d-1");
+  });
+
+  it("accepts arbitrary-unit per-volume forms ([iU]/mL, U/L)", () => {
+    expect(toDoseQuantity(40, "[iU]/mL").code).toBe("[iU]/mL");
+    expect(toDoseQuantity(25, "U/L").code).toBe("U/L");
+  });
+
+  it("accepts other valid UCUM expressions that were absent from the hand-curated allowlist", () => {
+    // None of these were in the original UCUM_ALLOWLIST but all are
+    // syntactically valid UCUM; the lhc validator should let them through.
+    expect(toDoseQuantity(60, "mL/min").code).toBe("mL/min");
+    expect(toDoseQuantity(5, "ug/min").code).toBe("ug/min");
+    expect(toDoseQuantity(1, "mol/L").code).toBe("mol/L");
+    // Proper UCUM blood-pressure form is mm[Hg] (the bracketed Hg atom).
+    expect(toDoseQuantity(15, "mm[Hg]").code).toBe("mm[Hg]");
+  });
+
+  it("preserves canonical alias mapping for legacy 'mcg' compounds the validator rejects", () => {
+    // 'mcg' itself is not strict UCUM. The validator returns invalid;
+    // we keep the NON_UCUM_TO_UCUM_CODE table mapping it to canonical 'ug'.
+    expect(toDoseQuantity(500, "mcg").code).toBe("ug");
+    expect(toDoseQuantity(5, "mcg/h").code).toBe("ug/h");
+    expect(toDoseQuantity(2, "mcg/kg").code).toBe("ug/kg");
+  });
+
+  it("canonicalises case-variant inputs to UCUM-canonical form", () => {
+    // 'mcg/H' (uppercase H) is not in the static alias table but the
+    // lowercased lookup hits 'mcg/h' → 'ug/h'. Verifies case-insensitive
+    // alias lookup uniformly produces canonical UCUM.
+    expect(toDoseQuantity(5, "MCG/H").code).toBe("ug/h");
+    expect(toDoseQuantity(5, "Mcg/h").code).toBe("ug/h");
+  });
+
+  it("falls back to text-only Quantity for anything the validator and alias table both reject", () => {
+    // 'scoop' is neither a UCUM expression nor an alias.
+    const q = toDoseQuantity(1, "scoop");
+    expect(q.system).toBeUndefined();
+    expect(q.code).toBeUndefined();
+    expect(q.unit).toBe("scoop");
+  });
+
+  it("rejects empty / whitespace-only inputs as text-only (defensive guard)", () => {
+    // The lhc validator throws/errors on empty input; ensure we handle
+    // it gracefully without leaking stderr noise from validateUnitString.
+    expect(toDoseQuantity(1, "").code).toBeUndefined();
+    expect(toDoseQuantity(1, "   ").code).toBeUndefined();
+  });
+});
+
 describe("isUcumAllowed", () => {
   it("accepts the common mass / volume / time codes", () => {
     for (const u of ["mg", "g", "mL", "L", "ug", "kg"]) {

--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -172,6 +172,61 @@ describe("toDoseQuantity — UCUM-lhc validator integration (#978)", () => {
   });
 });
 
+describe("toDoseQuantity — prototype-pollution defence (#1138 Copilot review)", () => {
+  // `medications.dose_unit` is free-text clinician input flowing through
+  // tRPC → BullMQ → fhir-gateway. The alias table is a Record<string,string>
+  // backed by `Object.create(null)`, but defence-in-depth `typeof === "string"`
+  // guards in the lookup sites ensure that even if the table is ever
+  // refactored back to a plain object, prototype-chain lookups on inputs
+  // like `__proto__` / `constructor` cannot leak non-string `code` values
+  // into the emitted FHIR Quantity. The validator itself may still accept
+  // the literal string as a UCUM annotation, but the FHIR shape contract
+  // (`code` is a string when present) must hold.
+  it("never emits a non-string `code` for `__proto__` input", () => {
+    const q = toDoseQuantity(1, "__proto__");
+    if (q.code !== undefined) {
+      expect(typeof q.code).toBe("string");
+    }
+  });
+
+  it("never emits a non-string `code` for `constructor` input", () => {
+    const q = toDoseQuantity(1, "constructor");
+    if (q.code !== undefined) {
+      expect(typeof q.code).toBe("string");
+    }
+  });
+
+  it("never emits a non-string `code` for Object.prototype method names", () => {
+    for (const name of [
+      "hasOwnProperty",
+      "isPrototypeOf",
+      "propertyIsEnumerable",
+      "toLocaleString",
+      "valueOf",
+      "toString",
+    ]) {
+      const q = toDoseQuantity(1, name);
+      if (q.code !== undefined) {
+        expect(typeof q.code).toBe("string");
+      }
+    }
+  });
+
+  it("does not crash isUcumAllowed on prototype-key inputs", () => {
+    for (const name of [
+      "__proto__",
+      "constructor",
+      "hasOwnProperty",
+      "toString",
+    ]) {
+      // Just assert it returns a boolean without throwing — the predicate's
+      // semantic answer is incidental, what matters is no prototype-object
+      // leak through the alias-lookup branch.
+      expect(typeof isUcumAllowed(name)).toBe("boolean");
+    }
+  });
+});
+
 describe("isUcumAllowed", () => {
   it("accepts the common mass / volume / time codes", () => {
     for (const u of ["mg", "g", "mL", "L", "ug", "kg"]) {

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -1,86 +1,79 @@
 /**
- * UCUM validity helpers for FHIR Quantity emission (#946).
+ * UCUM validity helpers for FHIR Quantity emission (#946, #978).
  *
  * Our internal `medications.dose_unit` is free-text. FHIR's Quantity shape
  * reserves `system: "http://unitsofmeasure.org"` for UCUM-coded units —
  * emitting a non-UCUM string under that system is a conformance violation.
  *
- * Strategy:
- *  - Known-UCUM tokens (mg, g, mL, L, mg/kg, IU variants, …) emit as a
- *    fully-coded Quantity (system + code + human-readable unit).
- *  - Known non-UCUM forms (tablet, puff, drop) emit the curly-brace
- *    annotation UCUM recognises ({tbl}, {puff}, {drop}).
- *  - Unknown strings emit a text-only Quantity (value + unit only) with
- *    no system / code — downstream validators accept that shape, whereas
- *    rejecting a UCUM system+code mismatch would mangle the resource.
+ * Strategy (post-#978):
+ *  1. Clinical-context alias table first (`mcg → ug`, `IU → [iU]`, `MG → mg`,
+ *     `tablet → {tbl}`). UCUM is strictly case-sensitive — `MG` is megaGauss
+ *     and `mcg` isn't a UCUM atom — but clinicians type these freely. The
+ *     alias table normalises the common clinical legacy forms to canonical
+ *     UCUM (or curly-brace annotations) before any validator call.
+ *  2. Validation via @lhncbc/ucum-lhc (the NIH/NLM reference implementation)
+ *     for anything that survives the alias step. The validator accepts the
+ *     full UCUM grammar — exponent / product forms like `10*6/uL` and
+ *     `mg.kg-1.d-1` that the pre-#978 hand-curated allowlist rejected.
+ *  3. Text-only Quantity fallback for anything neither table nor validator
+ *     can resolve — preserves the value + human-readable unit without
+ *     emitting an invalid system+code pair.
+ *
+ * Policy on validator strictness:
+ *  We require `status === "valid"` from `validateUnitString`. The library
+ *  also returns `ucumCode` for confusable-but-invalid inputs (e.g. `IU` →
+ *  `[IU]` with status=invalid), but we never broaden on invalid status —
+ *  invalid inputs that need a canonical mapping must live in the alias
+ *  table, where the mapping is explicit and reviewable.
+ *
+ * Bundle impact: `@lhncbc/ucum-lhc` is ~500KB compressed / ~2MB unpacked,
+ * acceptable for a backend service. The utils instance is memoised at
+ * module scope so the ~500KB unit-definition JSON loads once per process.
  */
+
+// The package ships CJS with no type declarations; declare the surface we
+// use locally rather than pulling in an untyped `any` import.
+// @ts-expect-error -- no @types/lhncbc__ucum-lhc package exists
+import pkg from "@lhncbc/ucum-lhc";
+
+interface ValidateResult {
+  status: "valid" | "invalid" | "error";
+  ucumCode: string | null;
+  msg?: string[];
+}
+
+interface UcumLhcUtilsLike {
+  validateUnitString(input: string, suggest: boolean): ValidateResult;
+}
+
+interface UcumLhcUtilsCtor {
+  getInstance(): UcumLhcUtilsLike;
+}
+
+const { UcumLhcUtils } = pkg as { UcumLhcUtils: UcumLhcUtilsCtor };
 
 const UCUM_SYSTEM = "http://unitsofmeasure.org";
 
 /**
- * Canonical UCUM codes we accept. UCUM is case-sensitive (`L` = liter,
- * `l` is not a case-sensitive UCUM atom), so the allowlist stores the
- * canonical casing and lookup happens through a lowercase index. Common
- * drug dosing units; not exhaustive for all of UCUM (which is several
- * thousand units including physical constants).
+ * Common non-UCUM (or case-confusable) clinical inputs → canonical UCUM.
  *
- * When emitting the Quantity we return the canonical casing from this
- * list so external validators (Epic, Cerner, Inferno) accept the code,
- * while still accepting mixed-case user input (`MG`, `mL`, `mmol/l`).
- */
-const UCUM_CANONICAL: readonly string[] = [
-  // Mass
-  "kg",
-  "g",
-  "mg",
-  "ug",
-  "ng",
-  // Volume (note case: L is liter; l/dl/ml are also accepted UCUM atoms
-  // but the case-sensitive canonical forms are the capital-L variants)
-  "L",
-  "mL",
-  "dL",
-  "uL",
-  // Time
-  "h",
-  "min",
-  "s",
-  "d",
-  "wk",
-  "mo",
-  "a",
-  // Amount / electrolytes
-  "meq",
-  "mmol",
-  "mol",
-  // Derived dose units (per-weight, per-time, concentration)
-  "mg/kg",
-  "ug/kg",
-  "g/kg",
-  "mg/m2",
-  "mg/min",
-  "mg/h",
-  "ug/h",
-  "mg/mL",
-  "g/dL",
-  "mg/dL",
-  "ng/mL",
-  "pg/mL",
-  "mmol/L",
-];
-
-/** Lowercase-indexed lookup to the canonical form. */
-const UCUM_ALLOWLIST: Map<string, string> = new Map(
-  UCUM_CANONICAL.map((c) => [c.toLowerCase(), c]),
-);
-
-/**
- * Common non-UCUM unit strings → UCUM curly-brace annotation code.
- * UCUM permits annotations in curly braces for quantities that aren't
- * physical measurements (tablets, puffs, drops). Note IU → [iU] is the
- * official UCUM arbitrary-unit form.
+ * Kept after #978 because:
+ *  - Curly-brace annotations (`{tbl}`, `{puff}`, `{drop}`, `{spray}`,
+ *    `{patch}`, `{cap}`) are valid UCUM, but the validator would never
+ *    accept the bare english word (`tablet`, `puff`, …) — we have to map
+ *    those explicitly.
+ *  - `mcg`, `mcg/h`, `mcg/kg`, `mcg/min` are legacy clinical forms that
+ *    aren't strict UCUM; we canonicalise to `ug…`.
+ *  - `IU`, `Unit`, `units`, `U` (when meant as international units rather
+ *    than the UCUM enzyme unit) map to `[iU]`.
+ *  - Lowercase `ml`, `l`, `dl` are valid UCUM atoms BUT case-sensitive
+ *    UCUM canonicalises to `mL`, `L`, `dL` — Epic/Cerner/Inferno expect
+ *    the uppercase L form, so we coerce here.
+ *  - `MG` is megaGauss in strict UCUM; in clinical context it always
+ *    means milligrams, so we coerce.
  */
 const NON_UCUM_TO_UCUM_CODE: Record<string, string> = {
+  // Tablet / dose-form annotations
   tablet: "{tbl}",
   tablets: "{tbl}",
   tab: "{tbl}",
@@ -97,19 +90,65 @@ const NON_UCUM_TO_UCUM_CODE: Record<string, string> = {
   sprays: "{spray}",
   patch: "{patch}",
   patches: "{patch}",
+  // International-unit forms — clinicians type IU/Unit/units; UCUM is [iU]
   iu: "[iU]",
   "international units": "[iU]",
   unit: "[iU]",
   units: "[iU]",
   u: "[iU]",
-  // Clinical "mcg" is the legacy microgram form; strict UCUM uses "ug"
-  // (or the Unicode micro). Map to the canonical UCUM atom, for both the
-  // bare form and common per-time compound.
+  // Clinical "mcg" → canonical UCUM "ug" (microgram)
   mcg: "ug",
   "mcg/h": "ug/h",
   "mcg/kg": "ug/kg",
   "mcg/min": "ug/min",
+  // Case-canonicalisation: lowercase forms → case-sensitive UCUM canonical
+  ml: "mL",
+  l: "L",
+  dl: "dL",
+  ul: "uL",
+  "mmol/l": "mmol/L",
+  "mg/dl": "mg/dL",
+  "ng/ml": "ng/mL",
+  "pg/ml": "pg/mL",
+  "g/dl": "g/dL",
+  "mg/ml": "mg/mL",
+  // 'MG' (megaGauss in strict UCUM) → milligrams in clinical context
+  mg: "mg",
 };
+
+/**
+ * Lazy-loaded singleton UcumLhcUtils. The constructor populates a ~500KB
+ * unit-definitions table; we memoise so repeated `toDoseQuantity` calls
+ * pay the cost only once per process.
+ */
+let utilsSingleton: UcumLhcUtilsLike | null = null;
+function getUtils(): UcumLhcUtilsLike {
+  if (utilsSingleton === null) {
+    utilsSingleton = UcumLhcUtils.getInstance();
+  }
+  return utilsSingleton;
+}
+
+/**
+ * Run the validator without leaking its stderr-noisy "blank spaces are
+ * not allowed" / "please specify a unit" error paths. Returns the
+ * canonical UCUM code on success, null otherwise.
+ */
+function validateViaLhc(input: string): string | null {
+  // Guard cases where the library prints to stderr / throws.
+  if (input.length === 0 || /\s/.test(input)) {
+    return null;
+  }
+  try {
+    const result = getUtils().validateUnitString(input, false);
+    if (result.status === "valid" && typeof result.ucumCode === "string") {
+      return result.ucumCode;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export interface DoseQuantity {
   value: number;
@@ -123,34 +162,39 @@ export interface DoseQuantity {
 
 /**
  * Build a FHIR Quantity from an internal `{dose_amount, dose_unit}` pair.
- * Emits system + code only when the unit is valid UCUM (or we have a
- * well-known UCUM annotation for it). Unknown units produce a text-only
- * Quantity so downstream validators don't reject the resource.
+ *
+ * Emits system + code only when the unit resolves to valid UCUM (via the
+ * alias table or the UCUM-lhc validator). Unknown units produce a
+ * text-only Quantity so downstream validators don't reject the resource.
+ *
+ * The `unit` field always carries the original input string so the
+ * clinician-readable rendering is preserved even after canonicalisation.
  */
 export function toDoseQuantity(value: number, unit: string): DoseQuantity {
-  const normalised = unit.trim().toLowerCase();
+  const trimmed = unit.trim();
+  const lower = trimmed.toLowerCase();
 
-  // 1. Check the non-UCUM alias table first so that entries like
-  //    `mcg` → `ug`, `mcg/h` → `ug/h` translate to canonical UCUM even
-  //    when the legacy form happens to share a prefix with the allowlist.
-  const annotation = NON_UCUM_TO_UCUM_CODE[normalised];
-  if (annotation) {
+  // 1. Alias table first. Catches `mcg`, `IU`, `tablet`, `MG`, and the
+  //    lowercase volume forms (`ml` → `mL`).
+  const aliased = NON_UCUM_TO_UCUM_CODE[lower];
+  if (aliased !== undefined) {
     return {
       value,
       unit,
       system: UCUM_SYSTEM,
-      code: annotation,
+      code: aliased,
     };
   }
 
-  // 2. Look up against the canonical allowlist; emit with canonical casing.
-  const canonical = UCUM_ALLOWLIST.get(normalised);
-  if (canonical) {
+  // 2. Validate the raw input via UCUM-lhc. Accepts the full UCUM grammar
+  //    (e.g. `10*6/uL`, `mg.kg-1.d-1`, `[iU]/mL`).
+  const ucumCode = validateViaLhc(trimmed);
+  if (ucumCode !== null) {
     return {
       value,
       unit,
       system: UCUM_SYSTEM,
-      code: canonical,
+      code: ucumCode,
     };
   }
 
@@ -159,9 +203,27 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
 }
 
 /**
- * Predicate form, primarily for tests. Does not do the curly-brace mapping;
- * just answers whether the input is in the UCUM allowlist.
+ * Predicate form, primarily for tests. Returns true when the input is a
+ * valid UCUM expression — either directly (per the lhc validator) or
+ * after the alias table maps it to a canonical UCUM code.
+ *
+ * Does NOT match curly-brace annotation aliases (e.g. `tablet` → `{tbl}`):
+ * the callers using this predicate want strict UCUM membership, and the
+ * curly-brace forms are a presentation concern handled inside
+ * `toDoseQuantity`.
  */
 export function isUcumAllowed(unit: string): boolean {
-  return UCUM_ALLOWLIST.has(unit.trim().toLowerCase());
+  const trimmed = unit.trim();
+  if (trimmed.length === 0) return false;
+  const lower = trimmed.toLowerCase();
+
+  // Alias-table hit, but only if the mapped target is a real UCUM code
+  // (not a curly-brace annotation that the validator would also accept).
+  const aliased = NON_UCUM_TO_UCUM_CODE[lower];
+  if (aliased !== undefined) {
+    if (aliased.startsWith("{")) return false;
+    return validateViaLhc(aliased) !== null;
+  }
+
+  return validateViaLhc(trimmed) !== null;
 }

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -72,49 +72,59 @@ const UCUM_SYSTEM = "http://unitsofmeasure.org";
  *  - `MG` is megaGauss in strict UCUM; in clinical context it always
  *    means milligrams, so we coerce.
  */
-const NON_UCUM_TO_UCUM_CODE: Record<string, string> = {
-  // Tablet / dose-form annotations
-  tablet: "{tbl}",
-  tablets: "{tbl}",
-  tab: "{tbl}",
-  tabs: "{tbl}",
-  capsule: "{cap}",
-  capsules: "{cap}",
-  cap: "{cap}",
-  caps: "{cap}",
-  puff: "{puff}",
-  puffs: "{puff}",
-  drop: "{drop}",
-  drops: "{drop}",
-  spray: "{spray}",
-  sprays: "{spray}",
-  patch: "{patch}",
-  patches: "{patch}",
-  // International-unit forms — clinicians type IU/Unit/units; UCUM is [iU]
-  iu: "[iU]",
-  "international units": "[iU]",
-  unit: "[iU]",
-  units: "[iU]",
-  u: "[iU]",
-  // Clinical "mcg" → canonical UCUM "ug" (microgram)
-  mcg: "ug",
-  "mcg/h": "ug/h",
-  "mcg/kg": "ug/kg",
-  "mcg/min": "ug/min",
-  // Case-canonicalisation: lowercase forms → case-sensitive UCUM canonical
-  ml: "mL",
-  l: "L",
-  dl: "dL",
-  ul: "uL",
-  "mmol/l": "mmol/L",
-  "mg/dl": "mg/dL",
-  "ng/ml": "ng/mL",
-  "pg/ml": "pg/mL",
-  "g/dl": "g/dL",
-  "mg/ml": "mg/mL",
-  // 'MG' (megaGauss in strict UCUM) → milligrams in clinical context
-  mg: "mg",
-};
+// Use `Object.assign(Object.create(null), …)` so the lookup table has no
+// prototype chain. `medications.dose_unit` is free-text from clinician
+// input — a plain-object lookup with bracket access would resolve keys
+// like `__proto__` / `constructor` via `Object.prototype`, returning the
+// prototype object / Object constructor function and emitting them as
+// the FHIR `code` field. A null-prototype object eliminates that class
+// of bug entirely; lookups for non-own keys return `undefined`.
+const NON_UCUM_TO_UCUM_CODE: Record<string, string> = Object.assign(
+  Object.create(null) as Record<string, string>,
+  {
+    // Tablet / dose-form annotations
+    tablet: "{tbl}",
+    tablets: "{tbl}",
+    tab: "{tbl}",
+    tabs: "{tbl}",
+    capsule: "{cap}",
+    capsules: "{cap}",
+    cap: "{cap}",
+    caps: "{cap}",
+    puff: "{puff}",
+    puffs: "{puff}",
+    drop: "{drop}",
+    drops: "{drop}",
+    spray: "{spray}",
+    sprays: "{spray}",
+    patch: "{patch}",
+    patches: "{patch}",
+    // International-unit forms — clinicians type IU/Unit/units; UCUM is [iU]
+    iu: "[iU]",
+    "international units": "[iU]",
+    unit: "[iU]",
+    units: "[iU]",
+    u: "[iU]",
+    // Clinical "mcg" → canonical UCUM "ug" (microgram)
+    mcg: "ug",
+    "mcg/h": "ug/h",
+    "mcg/kg": "ug/kg",
+    "mcg/min": "ug/min",
+    // Case-canonicalisation: lowercase forms → case-sensitive UCUM canonical
+    ml: "mL",
+    l: "L",
+    dl: "dL",
+    ul: "uL",
+    "mmol/l": "mmol/L",
+    "mg/dl": "mg/dL",
+    "ng/ml": "ng/mL",
+    "pg/ml": "pg/mL",
+    "g/dl": "g/dL",
+    "mg/ml": "mg/mL",
+    // 'MG' (megaGauss in strict UCUM) → milligrams in clinical context
+    mg: "mg",
+  },
+);
 
 /**
  * Lazy-loaded singleton UcumLhcUtils. The constructor populates a ~500KB
@@ -130,6 +140,22 @@ function getUtils(): UcumLhcUtilsLike {
 }
 
 /**
+ * Per-process memo of validator results keyed by raw input. A bulk FHIR
+ * export over a patient's medication history sees the same handful of
+ * unit strings (`mg`, `mg/kg`, `mL`, …) repeated across many resources;
+ * caching the validator's verdict avoids re-parsing each call against
+ * the ~3.5k-entry unit table. Stores both hits (canonical code) and
+ * misses (`null`) so invalid inputs are also short-circuited on retry.
+ *
+ * Bounded to a reasonable size to defend against memory growth from a
+ * pathological caller pumping unique unit strings; UCUM-valid forms in
+ * clinical use number in the low hundreds, so a 1024-entry ceiling is
+ * comfortably above the working set.
+ */
+const VALIDATOR_CACHE_MAX = 1024;
+const validatorCache: Map<string, string | null> = new Map();
+
+/**
  * Run the validator without leaking its stderr-noisy "blank spaces are
  * not allowed" / "please specify a unit" error paths. Returns the
  * canonical UCUM code on success, null otherwise.
@@ -139,15 +165,26 @@ function validateViaLhc(input: string): string | null {
   if (input.length === 0 || /\s/.test(input)) {
     return null;
   }
-  try {
-    const result = getUtils().validateUnitString(input, false);
-    if (result.status === "valid" && typeof result.ucumCode === "string") {
-      return result.ucumCode;
-    }
-    return null;
-  } catch {
-    return null;
+  const cached = validatorCache.get(input);
+  if (cached !== undefined || validatorCache.has(input)) {
+    return cached ?? null;
   }
+  let result: string | null;
+  try {
+    const r = getUtils().validateUnitString(input, false);
+    result =
+      r.status === "valid" && typeof r.ucumCode === "string" ? r.ucumCode : null;
+  } catch {
+    result = null;
+  }
+  // Evict the oldest entry on overflow — Map iteration is insertion-ordered,
+  // so the first key returned by `keys()` is the longest-resident entry.
+  if (validatorCache.size >= VALIDATOR_CACHE_MAX) {
+    const oldest = validatorCache.keys().next().value;
+    if (oldest !== undefined) validatorCache.delete(oldest);
+  }
+  validatorCache.set(input, result);
+  return result;
 }
 
 export interface DoseQuantity {
@@ -175,9 +212,12 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
   const lower = trimmed.toLowerCase();
 
   // 1. Alias table first. Catches `mcg`, `IU`, `tablet`, `MG`, and the
-  //    lowercase volume forms (`ml` → `mL`).
+  //    lowercase volume forms (`ml` → `mL`). The table is null-prototype,
+  //    so bracket access cannot resolve inherited keys like `__proto__`;
+  //    the `typeof === "string"` guard is belt-and-suspenders for any
+  //    future refactor that swaps the table back to a plain object.
   const aliased = NON_UCUM_TO_UCUM_CODE[lower];
-  if (aliased !== undefined) {
+  if (typeof aliased === "string") {
     return {
       value,
       unit,
@@ -219,8 +259,10 @@ export function isUcumAllowed(unit: string): boolean {
 
   // Alias-table hit, but only if the mapped target is a real UCUM code
   // (not a curly-brace annotation that the validator would also accept).
+  // `typeof === "string"` defends against the prototype-pollution class
+  // of bug — see the matching comment in `toDoseQuantity`.
   const aliased = NON_UCUM_TO_UCUM_CODE[lower];
-  if (aliased !== undefined) {
+  if (typeof aliased === "string") {
     if (aliased.startsWith("{")) return false;
     return validateViaLhc(aliased) !== null;
   }


### PR DESCRIPTION
## Summary
- Replace hand-curated `UCUM_ALLOWLIST` with `@lhncbc/ucum-lhc` (^7.1.6), the NIH/NLM reference UCUM implementation. Exotic-but-valid UCUM expressions — `10*6/uL` (cell counts), `mg.kg-1.d-1` (PK notation), `[iU]/mL`, `mL/min`, `mol/L`, `mm[Hg]`, etc. — now emit a fully-coded Quantity instead of falling back to text-only.
- Keep the `NON_UCUM_TO_UCUM_CODE` alias table for the clinical legacy forms the validator can't (and shouldn't) accept: `mcg → ug`, `IU → [iU]`, `tablet → {tbl}`, lowercase `ml/l/dl/mmol/l → mL/L/dL/mmol/L`, and the `MG → mg` clinical override (`MG` is megaGauss in strict UCUM).
- Memoise the `UcumLhcUtils` singleton at module scope so the ~500KB unit-definitions JSON loads once per process.
- Text-only Quantity fallback preserved for everything the validator and alias table both reject.

### Policy: strict validator mode
`validateUnitString(input, false)` — we only accept `status === "valid"`. The library also returns a suggested `ucumCode` for confusable-but-invalid inputs (e.g. `IU` → `[IU]` with status=invalid), but taking those would silently broaden the accepted set. Any case-confusable mapping has to live in the alias table where the rule is explicit and reviewable.

### Bundle size
`@lhncbc/ucum-lhc` ships ~636KB of CJS source plus a ~228KB minified unit-definitions JSON; ~2.1MB unpacked on disk including sourcemaps, ~500KB of actual loaded code. Acceptable for a backend service.

## Test plan
- [x] Existing `ucum.test.ts` (17 cases) all still pass
- [x] New cases (8) covering exotic UCUM + alias canonicalisation: `10*6/uL`, `mg.kg-1.d-1`, `[iU]/mL`, `U/L`, `mL/min`, `ug/min`, `mol/L`, `mm[Hg]`, `MCG/H → ug/h` case-insensitive, empty/whitespace guard
- [x] `pnpm turbo run test --filter @carebridge/fhir-gateway` — 26 files, 432 tests, all pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only pre-existing portal warnings)

Closes #978.