### PR TITLE
fix(epic): token-client generation counter (#1143)

### DIFF
--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -188,6 +188,13 @@ describe("EpicTokenClient (#389)", () => {
     // Set up a pending fetch that we will invalidate before resolving.
     // After invalidate(), the next call should kick off its own fetch
     // rather than reusing the dropped in-flight promise.
+    //
+    // CRITICAL ordering (#1143): we resolve the SECOND fetch FIRST and
+    // the FIRST (invalidated) fetch LAST. This is the real-world race —
+    // the dropped promise often settles after the retry has already
+    // populated the cache with a fresh token. Without a generation
+    // guard, the late-resolving first fetch overwrites the fresh cache
+    // with stale data and the next caller reads a stale token.
     let resolveFirst: (response: Response) => void;
     let resolveSecond: (response: Response) => void;
     const firstPending = new Promise<Response>((resolve) => {
@@ -210,14 +217,68 @@ describe("EpicTokenClient (#389)", () => {
     // start a brand-new fetch.
     const secondCall = client.getAccessToken();
 
-    resolveFirst!(tokenResponse({ access_token: "first-token" }));
+    // Resolve the SECOND (retry) fetch first — it populates the cache
+    // with the fresh token.
     resolveSecond!(tokenResponse({ access_token: "second-token" }));
-
-    const [first, second] = await Promise.all([firstCall, secondCall]);
+    await secondCall;
+    // NOW resolve the FIRST (invalidated, stale) fetch. It must NOT
+    // overwrite the cache.
+    resolveFirst!(tokenResponse({ access_token: "first-token" }));
+    const first = await firstCall;
+    const second = await secondCall;
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(first).toBe("first-token");
     expect(second).toBe("second-token");
+
+    // The race-critical assertion: after both promises settle, a
+    // subsequent caller must see the FRESH (second) token from cache,
+    // not the stale (first) one that resolved last.
+    const subsequent = await client.getAccessToken();
+    expect(subsequent).toBe("second-token");
+    // No additional fetch — third call served from cache.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not overwrite cache when an invalidated fetch resolves after a fresh fetch (#1143)", async () => {
+    // Race sequence:
+    //   1. Call A starts -> in-flight P1
+    //   2. (Server 401 elsewhere) -> tokens.invalidate() drops P1 + cache
+    //   3. Retry: Call B starts -> in-flight P2 -> P2 resolves fresh
+    //   4. P1 finally resolves with STALE token
+    //   5. Next caller must read the FRESH token, not the stale one.
+    let resolveFirst: (response: Response) => void;
+    let resolveSecond: (response: Response) => void;
+    const firstPending = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPending = new Promise<Response>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstPending)
+      .mockImplementationOnce(() => secondPending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const firstCall = client.getAccessToken();
+    client.invalidate();
+    const secondCall = client.getAccessToken();
+
+    // Fresh retry resolves first and populates the cache.
+    resolveSecond!(tokenResponse({ access_token: "fresh-token" }));
+    expect(await secondCall).toBe("fresh-token");
+
+    // Now the stale, invalidated fetch finally settles. It MUST NOT
+    // write back to this.cached — that would be a stale overwrite.
+    resolveFirst!(tokenResponse({ access_token: "stale-token" }));
+    await firstCall;
+
+    // The fresh token from the retry remains cached.
+    const nextToken = await client.getAccessToken();
+    expect(nextToken).toBe("fresh-token");
+    // Still only 2 underlying fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("clears the in-flight promise when the token request fails (#1089)", async () => {

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -73,6 +73,16 @@ export class EpicTokenClient {
    * retry path takes over for subsequent callers.
    */
   private inFlight: Promise<TokenResponse> | null = null;
+  /**
+   * Monotonic generation counter (#1143). Incremented every time
+   * {@link invalidate} is called so any fetch already running when
+   * invalidate() fired can tell that its result is stale and must NOT
+   * overwrite the cache (which a successful retry may have already
+   * populated with a fresh token). Each fetch captures the generation
+   * it was started under and only writes back to `cached` / `inFlight`
+   * if that generation is still current.
+   */
+  private generation = 0;
 
   constructor(
     private readonly config: EpicConfig,
@@ -106,17 +116,24 @@ export class EpicTokenClient {
     }
 
     const issuedAtMs = this.nowMs();
-    this.inFlight = this.fetchToken(scopes, issuedAtMs);
+    // Capture the generation BEFORE kicking off the fetch (#1143). If
+    // invalidate() fires while we're awaiting, `this.generation` will
+    // have advanced; fetchToken() checks that and refuses to write
+    // back stale results to either the cache or the in-flight slot.
+    const myGen = this.generation;
+    const pending = this.fetchToken(scopes, issuedAtMs, myGen);
+    this.inFlight = pending;
     try {
-      const parsed = await this.inFlight;
+      const parsed = await pending;
       return parsed.access_token;
     } finally {
-      // Always clear the in-flight slot — whether the fetch resolved or
-      // rejected — so the next caller observes a clean state. On
-      // failure the cache is untouched (no `this.cached` write) and the
-      // next call will issue its own retry; on success the cache has
-      // been populated and the next call is served from it.
-      this.inFlight = null;
+      // Only clear the in-flight slot if it's still ours. If
+      // invalidate() ran while we were awaiting, the slot has already
+      // been cleared (or a newer fetch from the same generation has
+      // populated it) and we must not stomp on the newer state.
+      if (this.generation === myGen && this.inFlight === pending) {
+        this.inFlight = null;
+      }
     }
   }
 
@@ -128,6 +145,7 @@ export class EpicTokenClient {
   private async fetchToken(
     scopes: string[],
     issuedAtMs: number,
+    startedAtGen: number,
   ): Promise<TokenResponse> {
     const assertion = buildClientAssertion({
       clientId: this.config.clientId,
@@ -175,10 +193,17 @@ export class EpicTokenClient {
     }
 
     const parsed = (await response.json()) as TokenResponse;
-    this.cached = {
-      response: parsed,
-      expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
-    };
+    // Only write back to the cache if our generation is still current
+    // (#1143). If invalidate() fired while we were awaiting fetch /
+    // response.json(), our result is stale — a subsequent retry may
+    // already have populated `cached` with a fresh token and we must
+    // not stomp on it.
+    if (this.generation === startedAtGen) {
+      this.cached = {
+        response: parsed,
+        expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
+      };
+    }
     return parsed;
   }
 
@@ -193,6 +218,12 @@ export class EpicTokenClient {
   invalidate(): void {
     this.cached = null;
     this.inFlight = null;
+    // Bump the generation so any fetch that is already in flight when
+    // invalidate() fires will see `this.generation !== startedAtGen`
+    // when it tries to write its result back. That prevents the dropped
+    // promise from overwriting a fresh token that a subsequent retry
+    // may have already cached (#1143).
+    this.generation += 1;
   }
 }
 


### PR DESCRIPTION
Closes #1143

## The race

`EpicTokenClient.invalidate()` clears `this.inFlight` and `this.cached`, but the in-flight fetch promise it dropped is still scheduled to resolve. Its body unconditionally writes `this.cached = { response, expiresAtMs }` once the network resolves.

Sequence:
1. Call A starts -> `inFlight = P1`, awaits fetch.
2. Server 401 elsewhere -> fhir-client invokes `tokens.invalidate()` -> `inFlight = null`, `cached = null`.
3. Retry: Call B starts -> `inFlight = P2`. P2 resolves first, sets `cached = {fresh}`.
4. P1 finally resolves and overwrites `cached = {stale}`.
5. Next caller reads stale -> 401 loop.

## The fix

Monotonic generation counter on the client:
- `invalidate()` bumps `this.generation`.
- `getAccessToken()` captures `myGen = this.generation` before assigning `this.inFlight = pending`. The `finally` clearer only nulls the slot when `this.generation === myGen && this.inFlight === pending` so a newer fetch isn't stomped.
- `fetchToken()` receives the generation it started under and only writes `this.cached = ...` when `this.generation === startedAtGen`. Stale resolves are dropped on the floor.

The fetch is still awaited so its promise can settle / be observed by the original caller; only the side-effect write to shared cache state is gated.

## Tests

- New `#1143` test simulates the exact race: P1 in-flight -> `invalidate()` -> P2 starts and resolves with fresh token first -> P1 resolves with stale token last. Asserts the next `getAccessToken()` reads the fresh token from cache (and that no third fetch is issued).
- The existing `#1089` "invalidate clears in-flight" test was tightened — it previously resolved the invalidated first fetch BEFORE the second, which let stale writes go undetected. The fresh fetch now resolves first; the invalidated one resolves last; a follow-on call must still see the fresh token cached.

Full epic-connector suite: 240/240 pass. `pnpm typecheck` and `pnpm lint` both green from the worktree root.