### PR TITLE
feat(epic): restore deprecated medicationRequestStatus field (#1147)

### DIFF
--- a/services/epic-connector/src/__tests__/fanout-config.test.ts
+++ b/services/epic-connector/src/__tests__/fanout-config.test.ts
@@ -7,6 +7,9 @@
  * Defaults match CareBridge's MVP scope; env overrides let an operator
  * widen/narrow the set without code changes.
  */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // Capture log.warn calls before fanout-config imports/creates its
@@ -405,5 +408,88 @@ describe("getFanoutConfig caching (#1112)", () => {
     expect(() => {
       (cfg.medicationRequestStatuses as string[]).push("stopped");
     }).toThrow(TypeError);
+  });
+});
+
+describe("FanoutConfig.medicationRequestStatus — deprecated singular field (#1147)", () => {
+  // PR #1140 removed the singular `medicationRequestStatus` field from
+  // the `FanoutConfig` interface in favour of the plural array. The
+  // interface is re-exported from the package root, so any external
+  // consumer reading `cfg.medicationRequestStatus` would break at
+  // compile time. #1147 restores it as a deprecated alias for
+  // `medicationRequestStatuses[0]`.
+
+  it("loadFanoutConfig exposes the singular field equal to medicationRequestStatuses[0] (default)", () => {
+    const cfg = loadFanoutConfig({});
+    expect(cfg.medicationRequestStatus).toBe(cfg.medicationRequestStatuses[0]);
+    expect(cfg.medicationRequestStatus).toBe(DEFAULT_MEDICATION_REQUEST_STATUS);
+  });
+
+  it("singular field reflects the first element of a multi-status env override", () => {
+    const cfg = loadFanoutConfig({
+      EPIC_MEDICATION_REQUEST_STATUS: "draft,active",
+    });
+    expect(cfg.medicationRequestStatuses).toEqual(["draft", "active"]);
+    expect(cfg.medicationRequestStatus).toBe("draft");
+  });
+
+  it("singular field reflects a single-value env override", () => {
+    const cfg = loadFanoutConfig({
+      EPIC_MEDICATION_REQUEST_STATUS: "completed",
+    });
+    expect(cfg.medicationRequestStatus).toBe("completed");
+    expect(cfg.medicationRequestStatus).toBe(cfg.medicationRequestStatuses[0]);
+  });
+
+  it("singular field falls back to DEFAULT_MEDICATION_REQUEST_STATUS when env is empty/invalid", () => {
+    // Empty/all-invalid env triggers the fall-back path which seeds the
+    // array with the default, so the singular alias should reflect that
+    // default rather than being undefined.
+    const cfgEmpty = loadFanoutConfig({ EPIC_MEDICATION_REQUEST_STATUS: "" });
+    expect(cfgEmpty.medicationRequestStatus).toBe(
+      DEFAULT_MEDICATION_REQUEST_STATUS,
+    );
+    warnSpy.mockClear();
+    const cfgInvalid = loadFanoutConfig({
+      EPIC_MEDICATION_REQUEST_STATUS: "foo,bar",
+    });
+    expect(cfgInvalid.medicationRequestStatus).toBe(
+      DEFAULT_MEDICATION_REQUEST_STATUS,
+    );
+  });
+
+  it("parseFanoutConfig exposes the singular field on the returned config", () => {
+    const { config } = parseFanoutConfig({
+      EPIC_MEDICATION_REQUEST_STATUS: "on-hold,active",
+    });
+    expect(config.medicationRequestStatus).toBe("on-hold");
+    expect(config.medicationRequestStatus).toBe(config.medicationRequestStatuses[0]);
+  });
+
+  it("getFanoutConfig (cached) exposes the singular field equal to the plural first element", () => {
+    const cfg = getFanoutConfig();
+    expect(cfg.medicationRequestStatus).toBe(cfg.medicationRequestStatuses[0]);
+  });
+
+  it("source declares @deprecated JSDoc on the singular field so consumers see the upgrade hint", () => {
+    // Read the source file so we can assert the interface field carries
+    // a @deprecated tag — back-compat shims that ship without a
+    // deprecation marker tend to become permanent.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sourcePath = resolve(here, "..", "sync", "fanout-config.ts");
+    const src = readFileSync(sourcePath, "utf8");
+    // Find the FanoutConfig interface body.
+    const ifaceMatch = src.match(
+      /export interface FanoutConfig \{([\s\S]*?)\n\}/,
+    );
+    expect(ifaceMatch, "FanoutConfig interface not found").not.toBeNull();
+    const body = ifaceMatch![1]!;
+    // The singular field must be declared inside the interface body.
+    expect(body).toMatch(/medicationRequestStatus\s*:/);
+    // And it must carry a @deprecated tag in a JSDoc immediately above
+    // its declaration.
+    expect(body).toMatch(
+      /@deprecated[\s\S]*?medicationRequestStatus\s*:\s*string/,
+    );
   });
 });

--- a/services/epic-connector/src/__tests__/fanout-config.test.ts
+++ b/services/epic-connector/src/__tests__/fanout-config.test.ts
@@ -477,10 +477,14 @@ describe("FanoutConfig.medicationRequestStatus — deprecated singular field (#1
     // deprecation marker tend to become permanent.
     const here = dirname(fileURLToPath(import.meta.url));
     const sourcePath = resolve(here, "..", "sync", "fanout-config.ts");
-    const src = readFileSync(sourcePath, "utf8");
-    // Find the FanoutConfig interface body.
+    // Normalise CRLF→LF so the regex below isn't sensitive to whether
+    // the checkout used `core.autocrlf=true` on Windows (#1153 review).
+    const src = readFileSync(sourcePath, "utf8").replace(/\r\n/g, "\n");
+    // Find the FanoutConfig interface body. The opener match is
+    // whitespace-tolerant so a future `prettier`/`tsc` reflow that
+    // adds/removes spaces around the brace doesn't break the regex.
     const ifaceMatch = src.match(
-      /export interface FanoutConfig \{([\s\S]*?)\n\}/,
+      /export\s+interface\s+FanoutConfig\s*\{([\s\S]*?)\n\}/,
     );
     expect(ifaceMatch, "FanoutConfig interface not found").not.toBeNull();
     const body = ifaceMatch![1]!;

--- a/services/epic-connector/src/sync/fanout-config.ts
+++ b/services/epic-connector/src/sync/fanout-config.ts
@@ -95,6 +95,17 @@ export const DEFAULT_MEDICATION_REQUEST_STATUS: string =
 
 export interface FanoutConfig {
   readonly observationCategories: readonly string[];
+  /**
+   * Back-compat alias for the pre-#1114 singular field (#1147). Equal
+   * to `medicationRequestStatuses[0]`, falling back to
+   * {@link DEFAULT_MEDICATION_REQUEST_STATUS} if the plural array is
+   * empty. Retained as a deprecated shim so downstream consumers that
+   * destructure `cfg.medicationRequestStatus` keep compiling; new code
+   * should read the plural array.
+   * @deprecated Use `medicationRequestStatuses` (plural) instead.
+   *   Returns the first element of that array.
+   */
+  readonly medicationRequestStatus: string;
   readonly medicationRequestStatuses: readonly string[];
 }
 
@@ -260,6 +271,12 @@ export function parseFanoutConfig(
   return {
     config: {
       observationCategories: cats.value,
+      // Back-compat singular alias (#1147): first element of the
+      // plural array, or DEFAULT_MEDICATION_REQUEST_STATUS if the
+      // array somehow ends up empty (defensive — parse logic above
+      // already guarantees a non-empty fallback).
+      medicationRequestStatus:
+        statuses.value[0] ?? DEFAULT_MEDICATION_REQUEST_STATUS,
       medicationRequestStatuses: statuses.value,
     },
     warnings,
@@ -292,11 +309,15 @@ let cached: FanoutConfig | null = null;
 export function getFanoutConfig(): FanoutConfig {
   if (cached === null) {
     const fresh = loadFanoutConfig();
+    const frozenStatuses = Object.freeze([...fresh.medicationRequestStatuses]);
     cached = Object.freeze({
       observationCategories: Object.freeze([...fresh.observationCategories]),
-      medicationRequestStatuses: Object.freeze([
-        ...fresh.medicationRequestStatuses,
-      ]),
+      // Back-compat singular alias (#1147) — mirrors the value already
+      // populated by `loadFanoutConfig`, kept here so the cached
+      // frozen instance carries the same shape as the parsed one.
+      medicationRequestStatus:
+        frozenStatuses[0] ?? DEFAULT_MEDICATION_REQUEST_STATUS,
+      medicationRequestStatuses: frozenStatuses,
     });
   }
   return cached;


### PR DESCRIPTION
Closes #1147

## Summary
PR #1140 dropped `medicationRequestStatus: string` (singular) from the `FanoutConfig` interface in favour of the plural `medicationRequestStatuses: readonly string[]`. The singular getter and the `DEFAULT_MEDICATION_REQUEST_STATUS` constant were kept as back-compat shims, but the interface field itself was removed — and `FanoutConfig` is re-exported from the package root, so any downstream consumer reading `cfg.medicationRequestStatus` would break at compile time.

This PR restores the field as a deprecated alias:

```ts
export interface FanoutConfig {
  readonly observationCategories: readonly string[];
  /** @deprecated Use `medicationRequestStatuses` (plural) instead. Returns the first element. */
  readonly medicationRequestStatus: string;
  readonly medicationRequestStatuses: readonly string[];
}
```

`parseFanoutConfig` and `getFanoutConfig` both populate the singular field as `medicationRequestStatuses[0]`, falling back to `DEFAULT_MEDICATION_REQUEST_STATUS` if the array is empty (defensive — the parse layer already guarantees a non-empty fallback).

## TDD
- Added 7 tests covering: default → `"active"`, single-value override → `"completed"`, multi-status override `draft,active` → `"draft"`, empty/invalid env → default, `parseFanoutConfig` pure path, the cached `getFanoutConfig` path, and a static assertion that the source carries the `@deprecated` JSDoc tag.
- Confirmed red against unmodified code (7 failing), then green after the interface + populate change.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing warnings unrelated to this change)
- [x] `pnpm --filter @carebridge/epic-connector test` — all 246 tests pass