### PR TITLE
refactor(gateway): consolidate FHIR resource interfaces in shared types (#1146)

### DIFF
--- a/services/fhir-gateway/src/__tests__/shared-types.test.ts
+++ b/services/fhir-gateway/src/__tests__/shared-types.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared FHIR resource types (#1146).
+ *
+ * Compile-time assertion that the FHIR resource interfaces previously
+ * declared inside generator modules now live in the shared
+ * `../types/fhir-r4.js` module alongside the other Fhir* resource types.
+ * Drift across modules forced PR #1137 to add `meta?: Meta` in three
+ * places — keeping these in one file prevents that class of bug.
+ *
+ * Each assertion checks both that the type is importable from the
+ * shared module and that it carries the post-#1137 `meta?: Meta` field.
+ */
+
+import { describe, it } from "vitest";
+import type {
+  FhirCondition,
+  FhirAllergyIntolerance,
+  FhirObservation,
+  Meta,
+} from "../types/fhir-r4.js";
+
+describe("shared FHIR resource types (#1146)", () => {
+  it("FhirCondition has meta?: Meta", () => {
+    type Check = FhirCondition["meta"];
+    const _: Meta | undefined = {} as Check;
+    void _;
+  });
+
+  it("FhirAllergyIntolerance has meta?: Meta", () => {
+    type Check = FhirAllergyIntolerance["meta"];
+    const _: Meta | undefined = {} as Check;
+    void _;
+  });
+
+  it("FhirObservation has meta?: Meta", () => {
+    type Check = FhirObservation["meta"];
+    const _: Meta | undefined = {} as Check;
+    void _;
+  });
+});

--- a/services/fhir-gateway/src/generators/allergy-intolerance.ts
+++ b/services/fhir-gateway/src/generators/allergy-intolerance.ts
@@ -7,50 +7,19 @@
  */
 
 import type { allergies } from "@carebridge/db-schema";
-import type { Coding, Meta } from "../types/fhir-r4.js";
+import type {
+  FhirAllergyCategory,
+  FhirAllergyIntolerance,
+  FhirAllergyReaction,
+  FhirRequiredCoding,
+} from "../types/fhir-r4.js";
 import { US_CORE_ALLERGY_INTOLERANCE } from "./us-core-profiles.js";
 
 type Allergy = typeof allergies.$inferSelect;
 
 // Local alias: AllergyIntolerance codings are always fully populated.
-type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
-
-interface FhirReaction {
-  substance?: {
-    coding: FhirCoding[];
-    text: string;
-  };
-  manifestation: {
-    coding: FhirCoding[];
-    text: string;
-  }[];
-  severity?: "mild" | "moderate" | "severe";
-}
-
-type FhirAllergyCategory = "food" | "medication" | "environment" | "biologic";
-
-interface FhirAllergyIntolerance {
-  resourceType: "AllergyIntolerance";
-  id: string;
-  meta?: Meta;
-  clinicalStatus: {
-    coding: FhirCoding[];
-  };
-  verificationStatus: {
-    coding: FhirCoding[];
-  };
-  category?: FhirAllergyCategory[];
-  code: {
-    coding: FhirCoding[];
-    text: string;
-  };
-  patient: {
-    reference: string;
-  };
-  recordedDate?: string;
-  criticality?: "low" | "high" | "unable-to-assess";
-  reaction?: FhirReaction[];
-}
+type FhirCoding = FhirRequiredCoding;
+type FhirReaction = FhirAllergyReaction;
 
 const CLINICAL_STATUS_SYSTEM =
   "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical";

--- a/services/fhir-gateway/src/generators/condition.ts
+++ b/services/fhir-gateway/src/generators/condition.ts
@@ -7,38 +7,13 @@
  */
 
 import type { diagnoses } from "@carebridge/db-schema";
-import type { Coding, Meta } from "../types/fhir-r4.js";
+import type { FhirCondition, FhirRequiredCoding } from "../types/fhir-r4.js";
 import { US_CORE_CONDITION } from "./us-core-profiles.js";
 
 type Diagnosis = typeof diagnoses.$inferSelect;
 
 // Local alias: Condition codings are always fully populated.
-type FhirCoding = Required<Pick<Coding, "system" | "code">> & Pick<Coding, "display">;
-
-interface FhirCondition {
-  resourceType: "Condition";
-  id: string;
-  meta?: Meta;
-  clinicalStatus: {
-    coding: FhirCoding[];
-  };
-  verificationStatus: {
-    coding: FhirCoding[];
-  };
-  code: {
-    coding: FhirCoding[];
-    text: string;
-  };
-  subject: {
-    reference: string;
-  };
-  onsetDateTime?: string;
-  abatementDateTime?: string;
-  recordedDate?: string;
-  recorder?: {
-    reference: string;
-  };
-}
+type FhirCoding = FhirRequiredCoding;
 
 const CLINICAL_STATUS_SYSTEM =
   "http://terminology.hl7.org/CodeSystem/condition-clinical";

--- a/services/fhir-gateway/src/generators/observation.ts
+++ b/services/fhir-gateway/src/generators/observation.ts
@@ -4,14 +4,15 @@ import type {
   Coding,
   CodeableConcept,
   Quantity,
-  Reference,
-  ObservationComponent,
-  Meta,
+  FhirObservation,
+  ObservationReferenceRange,
 } from "../types/fhir-r4.js";
 import {
   US_CORE_VITAL_SIGNS,
   US_CORE_LABORATORY_RESULT,
 } from "./us-core-profiles.js";
+
+export type { FhirObservation };
 
 const UNIT_TO_UCUM: Record<string, string> = {
   "K/uL": "10*3/uL",
@@ -39,25 +40,6 @@ const UNIT_TO_UCUM: Record<string, string> = {
 function toUcumCode(unit: string | null): string {
   if (!unit) return "{unknown}";
   return UNIT_TO_UCUM[unit] ?? unit;
-}
-
-interface ObservationReferenceRange {
-  low?: Quantity;
-  high?: Quantity;
-}
-
-export interface FhirObservation {
-  resourceType: "Observation";
-  id?: string;
-  meta?: Meta;
-  status: "final" | "preliminary" | "registered" | "amended";
-  category?: CodeableConcept[];
-  code: CodeableConcept;
-  subject?: Reference;
-  effectiveDateTime?: string;
-  valueQuantity?: Quantity;
-  component?: ObservationComponent[];
-  referenceRange?: ObservationReferenceRange[];
 }
 
 // ─── UCUM unit mapping ──────────────────────────────────────────

--- a/services/fhir-gateway/src/types/fhir-r4.ts
+++ b/services/fhir-gateway/src/types/fhir-r4.ts
@@ -234,3 +234,99 @@ export interface FhirDocumentReference {
   author?: Reference[];
   content: DocumentReferenceContent[];
 }
+
+// ─── Observation resource ───────────────────────────────────────
+export interface ObservationReferenceRange {
+  low?: Quantity;
+  high?: Quantity;
+}
+
+export interface FhirObservation {
+  resourceType: "Observation";
+  id?: string;
+  meta?: Meta;
+  status: "final" | "preliminary" | "registered" | "amended";
+  category?: CodeableConcept[];
+  code: CodeableConcept;
+  subject?: Reference;
+  effectiveDateTime?: string;
+  valueQuantity?: Quantity;
+  component?: ObservationComponent[];
+  referenceRange?: ObservationReferenceRange[];
+}
+
+// ─── Condition resource ─────────────────────────────────────────
+/**
+ * Local coding shape used by Condition / AllergyIntolerance generators:
+ * Condition and AllergyIntolerance codings are always emitted with both
+ * `system` and `code` populated (display is optional).
+ */
+export type FhirRequiredCoding = Required<Pick<Coding, "system" | "code">> &
+  Pick<Coding, "display">;
+
+export interface FhirCondition {
+  resourceType: "Condition";
+  id: string;
+  meta?: Meta;
+  clinicalStatus: {
+    coding: FhirRequiredCoding[];
+  };
+  verificationStatus: {
+    coding: FhirRequiredCoding[];
+  };
+  code: {
+    coding: FhirRequiredCoding[];
+    text: string;
+  };
+  subject: {
+    reference: string;
+  };
+  onsetDateTime?: string;
+  abatementDateTime?: string;
+  recordedDate?: string;
+  recorder?: {
+    reference: string;
+  };
+}
+
+// ─── AllergyIntolerance resource ────────────────────────────────
+export type FhirAllergyCategory =
+  | "food"
+  | "medication"
+  | "environment"
+  | "biologic";
+
+export interface FhirAllergyReaction {
+  substance?: {
+    coding: FhirRequiredCoding[];
+    text: string;
+  };
+  manifestation: {
+    coding: FhirRequiredCoding[];
+    text: string;
+  }[];
+  severity?: "mild" | "moderate" | "severe";
+}
+
+export interface FhirAllergyIntolerance {
+  resourceType: "AllergyIntolerance";
+  id: string;
+  meta?: Meta;
+  clinicalStatus: {
+    coding: FhirRequiredCoding[];
+  };
+  verificationStatus: {
+    coding: FhirRequiredCoding[];
+  };
+  category?: FhirAllergyCategory[];
+  code: {
+    coding: FhirRequiredCoding[];
+    text: string;
+  };
+  patient: {
+    reference: string;
+  };
+  recordedDate?: string;
+  criticality?: "low" | "high" | "unable-to-assess";
+  reaction?: FhirAllergyReaction[];
+}


### PR DESCRIPTION
Closes #1146

## Summary
Move `FhirCondition`, `FhirAllergyIntolerance`, and `FhirObservation` from their respective generator modules into the shared `services/fhir-gateway/src/types/fhir-r4.ts` file, alongside every other `Fhir*` resource interface. This eliminates the drift that forced PR #1137 to patch `meta?: Meta` into three separate generator files.

## Changes
- `services/fhir-gateway/src/types/fhir-r4.ts`: add `FhirObservation`, `ObservationReferenceRange`, `FhirCondition`, `FhirAllergyIntolerance`, `FhirAllergyReaction`, `FhirAllergyCategory`, and a small `FhirRequiredCoding` helper alias used by Condition / AllergyIntolerance codings.
- `services/fhir-gateway/src/generators/condition.ts`: drop local `FhirCondition` declaration, import from shared types.
- `services/fhir-gateway/src/generators/allergy-intolerance.ts`: drop local `FhirAllergyIntolerance` / `FhirReaction` / `FhirAllergyCategory` declarations, import from shared types.
- `services/fhir-gateway/src/generators/observation.ts`: drop local `FhirObservation` / `ObservationReferenceRange` declarations, import from shared types, re-export `FhirObservation` to preserve the existing public surface (`services/fhir-gateway/src/index.ts` and `generators/index.ts` re-export it from this path).
- `services/fhir-gateway/src/__tests__/shared-types.test.ts`: new compile-time assertions that the three interfaces are importable from `../types/fhir-r4.js` and carry `meta?: Meta` (added via TDD; failed against the unmodified code before the move).

Field shapes are preserved exactly — only the location and a small amount of de-duplication around the shared "required coding" alias changed.

## Test plan
- [x] `pnpm typecheck` (all 19 packages)
- [x] `pnpm lint` (clean, only pre-existing portal warnings)
- [x] `pnpm --filter @carebridge/fhir-gateway test` (459/459 pass, includes new shared-types test)
- [x] `pnpm --filter @carebridge/api-gateway test` (530/530 pass — downstream consumer of `toFhirCondition` / `toFhirAllergyIntolerance` via `fhir-rest.ts`)