### PR TITLE
fix(gateway): UCUM case-variant inputs after #1138 (#1148)

### DIFF
--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -172,6 +172,85 @@ describe("toDoseQuantity — UCUM-lhc validator integration (#978)", () => {
   });
 });
 
+describe("toDoseQuantity — clinical case-variant aliases (#1148)", () => {
+  // PR #1138 replaced the hand-curated allowlist with the @lhncbc/ucum-lhc
+  // validator, which is strictly case-sensitive. Several case-variant inputs
+  // the pre-#1138 allowlist accepted now lose their system+code:
+  //  - mEq → text-only (was: meq)
+  //  - KG → text-only (was: kg)
+  //  - mg/Kg, Mg/Kg → text-only (was: mg/kg)
+  //  - G → 'G' (gauss, magnetic flux density!) instead of 'g' (gram)
+  //
+  // The clinical-context fix is a small alias table consulted BEFORE the
+  // strict validator: case-variants that are unambiguously clinical
+  // (clinicians never mean magnetic flux when typing "G" in a dose_unit)
+  // are normalised to their canonical UCUM atom.
+  it("maps 'mEq' to UCUM 'meq' (milliequivalent)", () => {
+    const q = toDoseQuantity(10, "mEq");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("meq");
+    expect(q.unit).toBe("mEq"); // original casing preserved
+  });
+
+  it("maps 'mEq/L' to UCUM 'meq/L'", () => {
+    const q = toDoseQuantity(140, "mEq/L");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("meq/L");
+    expect(q.unit).toBe("mEq/L");
+  });
+
+  it("maps 'KG' to UCUM 'kg' (kilogram)", () => {
+    const q = toDoseQuantity(70, "KG");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("kg");
+    expect(q.unit).toBe("KG");
+  });
+
+  it("maps 'mg/Kg' to UCUM 'mg/kg'", () => {
+    const q = toDoseQuantity(2.5, "mg/Kg");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("mg/kg");
+    expect(q.unit).toBe("mg/Kg");
+  });
+
+  it("maps 'Mg/Kg' to UCUM 'mg/kg'", () => {
+    const q = toDoseQuantity(2.5, "Mg/Kg");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("mg/kg");
+    expect(q.unit).toBe("Mg/Kg");
+  });
+
+  it("maps bare 'G' to UCUM 'g' (gram, NOT gauss)", () => {
+    // CRITICAL semantic-regression guard. The strict UCUM atom 'G' is
+    // gauss (magnetic flux density). In any clinical dose_unit context,
+    // a clinician typing 'G' means grams. Without the case-alias map,
+    // toDoseQuantity(1, "G") would emit code: "G" (gauss) — silently
+    // re-interpreting "1 gram" as "1 gauss" in the FHIR export.
+    const q = toDoseQuantity(1, "G");
+    expect(q.system).toBe("http://unitsofmeasure.org");
+    expect(q.code).toBe("g"); // gram, NOT gauss ("G")
+    expect(q.unit).toBe("G"); // original input preserved
+  });
+
+  it("does not pollute the alias map via prototype keys", () => {
+    // Defence-in-depth: a null-prototype alias map should never return
+    // anything for __proto__ / constructor, so even an alias-table-only
+    // path cannot leak a non-string code.
+    const q = toDoseQuantity(1, "__proto__");
+    if (q.code !== undefined) {
+      expect(typeof q.code).toBe("string");
+    }
+  });
+
+  it("leaves unknown case variants to the strict validator", () => {
+    // 'scoop' is not in any alias table; the validator rejects it; result
+    // must remain text-only Quantity (no system, no code).
+    const q = toDoseQuantity(1, "scoop");
+    expect(q.system).toBeUndefined();
+    expect(q.code).toBeUndefined();
+  });
+});
+
 describe("toDoseQuantity — prototype-pollution defence (#1138 Copilot review)", () => {
   // `medications.dose_unit` is free-text clinician input flowing through
   // tRPC → BullMQ → fhir-gateway. The alias table is a Record<string,string>

--- a/services/fhir-gateway/src/generators/ucum.test.ts
+++ b/services/fhir-gateway/src/generators/ucum.test.ts
@@ -333,4 +333,18 @@ describe("isUcumAllowed", () => {
     expect(isUcumAllowed("scoop")).toBe(false);
     expect(isUcumAllowed("")).toBe(false);
   });
+
+  it("accepts clinical case-variants restored by #1148 (mirror of toDoseQuantity)", () => {
+    // Predicate must stay aligned with toDoseQuantity — anything the
+    // emitter encodes as system+code MUST be reported allowed here, or
+    // callers gating on `isUcumAllowed` get a different verdict than
+    // what shows up in the emitted FHIR Quantity. Covers the new
+    // CLINICAL_CASE_ALIASES branch in isUcumAllowed.
+    expect(isUcumAllowed("G")).toBe(true); // gram, not gauss
+    expect(isUcumAllowed("KG")).toBe(true);
+    expect(isUcumAllowed("mEq")).toBe(true);
+    expect(isUcumAllowed("mEq/L")).toBe(true);
+    expect(isUcumAllowed("mg/Kg")).toBe(true);
+    expect(isUcumAllowed("Mg/Kg")).toBe(true);
+  });
 });

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -142,8 +142,8 @@ const NON_UCUM_TO_UCUM_CODE: Record<string, string> = Object.assign(
  * always wins. Keys preserve their original casing; values are canonical
  * UCUM codes (case-sensitive). Conservative — only entries where the
  * case-variant is unambiguously clinical: clinicians never mean magnetic
- * flux density when typing "G" in a dose_unit field, and never mean a
- * pico-Tesla equivalent when typing "KG".
+ * flux density (gauss / kilo-gauss) when typing "G" or "KG" in a
+ * dose_unit field.
  *
  * Null-prototype object (same `Object.create(null)` pattern as the main
  * alias table) to keep `medications.dose_unit` free-text input from

--- a/services/fhir-gateway/src/generators/ucum.ts
+++ b/services/fhir-gateway/src/generators/ucum.ts
@@ -1,5 +1,5 @@
 /**
- * UCUM validity helpers for FHIR Quantity emission (#946, #978).
+ * UCUM validity helpers for FHIR Quantity emission (#946, #978, #1148).
  *
  * Our internal `medications.dose_unit` is free-text. FHIR's Quantity shape
  * reserves `system: "http://unitsofmeasure.org"` for UCUM-coded units —
@@ -127,6 +127,48 @@ const NON_UCUM_TO_UCUM_CODE: Record<string, string> = Object.assign(
 );
 
 /**
+ * Clinical case-variant aliases (#1148).
+ *
+ * UCUM is strictly case-sensitive, but several case-variants the pre-#1138
+ * hand-curated allowlist accepted are now rejected by the strict validator,
+ * losing their `system + code` and falling back to text-only Quantity.
+ * The lower-cased lookup table above is also too aggressive to catch
+ * inputs like `mg/Kg` (the slash form prevents a single lowercase rewrite),
+ * and crucially the bare token `G` IS a valid UCUM atom — it means gauss
+ * (magnetic flux density). Without an explicit alias, `toDoseQuantity(1, "G")`
+ * silently re-codes "1 gram" as "1 gauss" in the FHIR export.
+ *
+ * Consulted BEFORE the strict validator so the clinical interpretation
+ * always wins. Keys preserve their original casing; values are canonical
+ * UCUM codes (case-sensitive). Conservative — only entries where the
+ * case-variant is unambiguously clinical: clinicians never mean magnetic
+ * flux density when typing "G" in a dose_unit field, and never mean a
+ * pico-Tesla equivalent when typing "KG".
+ *
+ * Null-prototype object (same `Object.create(null)` pattern as the main
+ * alias table) to keep `medications.dose_unit` free-text input from
+ * resolving prototype keys like `__proto__` / `constructor`.
+ */
+const CLINICAL_CASE_ALIASES: Record<string, string> = Object.assign(
+  Object.create(null) as Record<string, string>,
+  {
+    // Mass — clinical "G" / "KG" never means gauss / kilo-gauss
+    G: "g",
+    KG: "kg",
+    // Milliequivalent — common mixed-case clinician form
+    mEq: "meq",
+    "mEq/L": "meq/L",
+    "mEq/l": "meq/L",
+    // mg/kg compounds — slash form blocks a single lowercase coercion
+    "mg/Kg": "mg/kg",
+    "Mg/Kg": "mg/kg",
+    "Mg/kg": "mg/kg",
+    "MG/KG": "mg/kg",
+    "MG/kg": "mg/kg",
+  },
+);
+
+/**
  * Lazy-loaded singleton UcumLhcUtils. The constructor populates a ~500KB
  * unit-definitions table; we memoise so repeated `toDoseQuantity` calls
  * pay the cost only once per process.
@@ -211,11 +253,27 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
   const trimmed = unit.trim();
   const lower = trimmed.toLowerCase();
 
-  // 1. Alias table first. Catches `mcg`, `IU`, `tablet`, `MG`, and the
-  //    lowercase volume forms (`ml` → `mL`). The table is null-prototype,
-  //    so bracket access cannot resolve inherited keys like `__proto__`;
-  //    the `typeof === "string"` guard is belt-and-suspenders for any
-  //    future refactor that swaps the table back to a plain object.
+  // 1. Clinical case-variant alias table (#1148). Consulted BEFORE the
+  //    strict validator so a clinician's `G` always means gram (not the
+  //    UCUM `G` atom, which is gauss / magnetic flux density), `KG` means
+  //    kilogram, `mEq` means milliequivalent, etc. Keyed by ORIGINAL
+  //    casing — the slash form (`mg/Kg`) blocks a lowercase coercion in
+  //    the main table.
+  const clinicalAliased = CLINICAL_CASE_ALIASES[trimmed];
+  if (typeof clinicalAliased === "string") {
+    return {
+      value,
+      unit,
+      system: UCUM_SYSTEM,
+      code: clinicalAliased,
+    };
+  }
+
+  // 2. Lower-cased alias table. Catches `mcg`, `IU`, `tablet`, `MG`, and
+  //    the lowercase volume forms (`ml` → `mL`). The table is null-
+  //    prototype, so bracket access cannot resolve inherited keys like
+  //    `__proto__`; the `typeof === "string"` guard is belt-and-suspenders
+  //    for any future refactor that swaps the table back to a plain object.
   const aliased = NON_UCUM_TO_UCUM_CODE[lower];
   if (typeof aliased === "string") {
     return {
@@ -226,7 +284,7 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
     };
   }
 
-  // 2. Validate the raw input via UCUM-lhc. Accepts the full UCUM grammar
+  // 3. Validate the raw input via UCUM-lhc. Accepts the full UCUM grammar
   //    (e.g. `10*6/uL`, `mg.kg-1.d-1`, `[iU]/mL`).
   const ucumCode = validateViaLhc(trimmed);
   if (ucumCode !== null) {
@@ -238,7 +296,7 @@ export function toDoseQuantity(value: number, unit: string): DoseQuantity {
     };
   }
 
-  // 3. Unknown. Emit value + human-readable unit only — valid FHIR Quantity.
+  // 4. Unknown. Emit value + human-readable unit only — valid FHIR Quantity.
   return { value, unit };
 }
 
@@ -256,6 +314,13 @@ export function isUcumAllowed(unit: string): boolean {
   const trimmed = unit.trim();
   if (trimmed.length === 0) return false;
   const lower = trimmed.toLowerCase();
+
+  // Clinical case-variant aliases (#1148). Mirror `toDoseQuantity` so the
+  // predicate stays consistent with what we actually emit.
+  const clinicalAliased = CLINICAL_CASE_ALIASES[trimmed];
+  if (typeof clinicalAliased === "string") {
+    return validateViaLhc(clinicalAliased) !== null;
+  }
 
   // Alias-table hit, but only if the mapped target is a real UCUM code
   // (not a curly-brace annotation that the validator would also accept).


### PR DESCRIPTION
Closes #1148

## Summary

PR #1138 replaced the hand-curated `UCUM_ALLOWLIST` with the strict `@lhncbc/ucum-lhc` validator. Because UCUM is case-sensitive, several case-variants the old allowlist accepted now lose their `system + code` and fall back to text-only Quantity. Most critically, the bare token `G` IS a valid UCUM atom — it means **gauss** (magnetic flux density). Without an explicit alias, `toDoseQuantity(1, "G")` silently re-coded "1 gram" as "1 gauss" in the FHIR export.

This PR introduces `CLINICAL_CASE_ALIASES` (null-prototype, keyed by original casing) consulted **before** the strict validator, restoring the pre-#1138 behaviour for five clinical case-variant inputs.

## Restored case-variants

| Input | Pre-#1138 | After #1138 (bug) | After this fix |
|---|---|---|---|
| `mEq` | code: meq | text-only | code: meq |
| `KG` | code: kg | text-only | code: kg |
| `mg/Kg` | code: mg/kg | text-only | code: mg/kg |
| `Mg/Kg` | code: mg/kg | text-only | code: mg/kg |
| `G` | code: g (gram) | **code: G (gauss!)** | code: g (gram) |

The G → gauss flip is a silent semantic shift that would impact any production row with `dose_unit = "G"`; the conservative clinical-context assumption (clinicians never mean magnetic flux density in a `dose_unit` field) is documented inline.

## Design

- New `CLINICAL_CASE_ALIASES` map mirrors the existing `NON_UCUM_TO_UCUM_CODE` pattern: `Object.assign(Object.create(null), {…})` so free-text input can't resolve `__proto__` / `constructor` through the prototype chain.
- Keyed by original casing (not lower-cased) so `mg/Kg` and `Mg/Kg` — where a single lowercase rewrite would defeat the slash-form — match correctly.
- Conservative entries only: mass (`G`, `KG`), milliequivalents (`mEq`, `mEq/L`), and `mg/Kg` compound variants. Anything else still hits the strict validator with original casing.
- `isUcumAllowed` updated to mirror `toDoseQuantity` so the predicate stays consistent with what we emit.

## Test plan

- [x] Added 8 new tests covering all 5 regression inputs plus the critical G→gram semantic-regression guard, prototype-pollution defence, and unknown-variant fallback.
- [x] All existing 29 ucum tests still pass.
- [x] Full `@carebridge/fhir-gateway` suite: 464/464 passing.
- [x] `pnpm typecheck` clean (38 tasks).
- [x] `pnpm lint` clean (no new warnings).