### PR TITLE
docs(gateway): correct @lhncbc/ucum-lhc license attribution (#1149)

### DIFF
--- a/services/fhir-gateway/NOTICES.md
+++ b/services/fhir-gateway/NOTICES.md
@@ -60,18 +60,22 @@ The `@lhncbc/ucum-lhc` package bundles `data/ucumDefs.min.json`, which is
 derived from the UCUM table; consequently this notice applies to the
 fhir-gateway distribution.
 
-### Sub-license: LOINC content (conditional)
+### Sub-license: LOINC content
 
-If LOINC ® content is included, that content is copyright © 1995–2016
-Regenstrief Institute, Inc. and the LOINC Committee, and is distributed
-under the LOINC terms of use:
+The bundled `data/ucumDefs.min.json` in `@lhncbc/ucum-lhc` v7.1.6
+declares (in its own `license` field) that the data was generated
+from "the UCUM data and selected LOINC combinations of UCUM units".
+The LOINC sub-license therefore applies to this fhir-gateway
+distribution.
+
+LOINC content is copyright © 1995–2016 Regenstrief Institute, Inc.
+and the Logical Observation Identifiers Names and Codes (LOINC)
+Committee, and is distributed under the LOINC terms of use:
 
 - LOINC terms: <https://loinc.org/terms-of-use>
 
-LOINC ® is a registered United States trademark of Regenstrief Institute,
-Inc. As of `@lhncbc/ucum-lhc` v7.1.6, the runtime files shipped to the
-fhir-gateway are UCUM-only; the LOINC condition is reproduced here for
-completeness because the upstream license enumerates it.
+LOINC ® is a registered United States trademark of Regenstrief
+Institute, Inc.
 
 ### Citation request
 
@@ -83,5 +87,8 @@ completeness because the upstream license enumerates it.
 A previous internal discussion (issue #978, closed by PR #1138) referred
 to `@lhncbc/ucum-lhc` as "MIT-licensed". That characterisation was
 incorrect. The package is distributed under the BSD-derived LHNCBC/NLM
-license reproduced above, with the UCUM and LOINC sub-licenses noted. This
-file supersedes any prior claim in PRs, issue comments, or commit messages.
+license summarised above, with the UCUM and LOINC sub-licenses noted.
+For the full authoritative text (including the warranty disclaimer),
+refer to the upstream `LICENSE.md` shipped inside the package. This
+file supersedes any prior claim in PRs, issue comments, or commit
+messages.

--- a/services/fhir-gateway/NOTICES.md
+++ b/services/fhir-gateway/NOTICES.md
@@ -1,0 +1,87 @@
+# Third-Party Notices — @carebridge/fhir-gateway
+
+This service bundles or links against the following third-party open-source
+software. The full license text for each dependency is shipped inside its
+package in `node_modules`; this file summarises the obligations and provides
+the canonical license URLs.
+
+## @lhncbc/ucum-lhc
+
+Used by `src/generators/ucum.ts` to validate Unified Code for Units of
+Measure (UCUM) codes for FHIR `Quantity.code` outputs.
+
+- Package: [`@lhncbc/ucum-lhc`](https://www.npmjs.com/package/@lhncbc/ucum-lhc)
+- Upstream repository: <https://github.com/lhncbc/ucum-lhc>
+- License file (canonical): <https://github.com/lhncbc/ucum-lhc/blob/master/LICENSE.md>
+- License declared in `package.json`: `SEE LICENSE IN LICENSE.md` (NOT MIT)
+
+### Owner notice (required by license)
+
+> This software (including any associated website-service or downloadable
+> source/code) was developed by the Lister Hill National Center for
+> Biomedical Communications (LHNCBC), a research and development division
+> of the U.S. National Library of Medicine (NLM), with the permission and
+> based on the copyrighted content of the Regenstrief Institute.
+
+### License terms
+
+The terms and conditions in `LICENSE.md` are **based on the BSD open-source
+license** (a custom BSD-derived license, not MIT). Redistribution and use
+in source and binary forms — with or without modification, for commercial
+and non-commercial purposes — are permitted, provided that:
+
+- Redistributions of source code retain the Owner Notice, the conditions,
+  and the disclaimer, and display them prominently.
+- Redistributions in binary form prominently reproduce the Owner Notice,
+  the conditions, and the disclaimer in the documentation and/or other
+  materials provided with the distribution.
+- **Non-endorsement clause**: Neither the names of the National Library of
+  Medicine (NLM), the Lister Hill National Center for Biomedical
+  Communications (LHNCBC), the National Institutes of Health (NIH), nor
+  the names of any of the software contributors may be used to endorse or
+  promote products derived from this software without specific prior
+  written permission.
+
+The software is provided "AS IS" without warranty of any kind. See the
+upstream `LICENSE.md` for the full disclaimer.
+
+### Sub-license: UCUM table content
+
+If a redistribution includes all or a portion of the UCUM table, UCUM
+codes, or UCUM definitions, that content is additionally subject to a
+license from **Regenstrief Institute, Inc.** and **The UCUM Organization**:
+
+- UCUM license: <https://ucum.org/license>
+- Current UCUM table and specification: <https://ucum.org>
+- Copyright: © 1995–2009, Regenstrief Institute, Inc. and the Unified
+  Codes for Units of Measures (UCUM) Organization. All rights reserved.
+
+The `@lhncbc/ucum-lhc` package bundles `data/ucumDefs.min.json`, which is
+derived from the UCUM table; consequently this notice applies to the
+fhir-gateway distribution.
+
+### Sub-license: LOINC content (conditional)
+
+If LOINC ® content is included, that content is copyright © 1995–2016
+Regenstrief Institute, Inc. and the LOINC Committee, and is distributed
+under the LOINC terms of use:
+
+- LOINC terms: <https://loinc.org/terms-of-use>
+
+LOINC ® is a registered United States trademark of Regenstrief Institute,
+Inc. As of `@lhncbc/ucum-lhc` v7.1.6, the runtime files shipped to the
+fhir-gateway are UCUM-only; the LOINC condition is reproduced here for
+completeness because the upstream license enumerates it.
+
+### Citation request
+
+> If publishing research that used this software, please include a
+> citation that acknowledges it.
+
+## Corrections
+
+A previous internal discussion (issue #978, closed by PR #1138) referred
+to `@lhncbc/ucum-lhc` as "MIT-licensed". That characterisation was
+incorrect. The package is distributed under the BSD-derived LHNCBC/NLM
+license reproduced above, with the UCUM and LOINC sub-licenses noted. This
+file supersedes any prior claim in PRs, issue comments, or commit messages.

--- a/services/fhir-gateway/README.md
+++ b/services/fhir-gateway/README.md
@@ -25,6 +25,6 @@ In particular, [`@lhncbc/ucum-lhc`](https://github.com/lhncbc/ucum-lhc)
 is distributed under a BSD-derived license from the U.S. National Library
 of Medicine's Lister Hill National Center for Biomedical Communications
 (LHNCBC), with sub-licenses for UCUM table content (Regenstrief Institute
-+ UCUM Organization) and, where applicable, LOINC content. Any
-redistribution of CareBridge that includes this service must reproduce
-the notices in `NOTICES.md`.
++ UCUM Organization) and LOINC content (the bundled `ucumDefs.min.json`
+includes LOINC-derived combinations). Any redistribution of CareBridge
+that includes this service must reproduce the notices in `NOTICES.md`.

--- a/services/fhir-gateway/README.md
+++ b/services/fhir-gateway/README.md
@@ -1,0 +1,30 @@
+# @carebridge/fhir-gateway
+
+FHIR R4 / US Core mappers and generators that translate CareBridge's
+internal clinical model to FHIR resources for the patient portal,
+outbound API consumers, and the Epic connector.
+
+## Layout
+
+- `src/*-mapper.ts` — Per-resource mappers (Patient, Condition, Allergy,
+  Observation, Medication, DiagnosticReport).
+- `src/generators/` — Helpers that produce FHIR primitives (e.g.
+  `ucum.ts` for `Quantity.code` validation).
+- `src/schemas/`, `src/types/` — Zod schemas and TypeScript types for
+  outbound payloads.
+- `src/router.ts` — tRPC router exposing the gateway to internal
+  services.
+
+## Third-party licenses
+
+This service bundles or links against third-party packages with custom
+or non-MIT licenses. See [`NOTICES.md`](./NOTICES.md) for full
+attribution.
+
+In particular, [`@lhncbc/ucum-lhc`](https://github.com/lhncbc/ucum-lhc)
+is distributed under a BSD-derived license from the U.S. National Library
+of Medicine's Lister Hill National Center for Biomedical Communications
+(LHNCBC), with sub-licenses for UCUM table content (Regenstrief Institute
++ UCUM Organization) and, where applicable, LOINC content. Any
+redistribution of CareBridge that includes this service must reproduce
+the notices in `NOTICES.md`.


### PR DESCRIPTION
Closes #1149.

## Why

Issue #978 (closed by PR #1138, which introduced the
`@lhncbc/ucum-lhc` dependency) described the package as
"MIT-licensed". That characterisation was wrong. Verified directly from
`node_modules/@lhncbc/ucum-lhc/LICENSE.md` (v7.1.6), the package is
distributed under a **BSD-derived custom license** from the U.S.
National Library of Medicine's Lister Hill National Center for
Biomedical Communications (LHNCBC). The `package.json` itself declares
`"license": "SEE LICENSE IN LICENSE.md"`, not MIT.

The license additionally carries:
- A non-endorsement clause naming NLM, LHNCBC, and NIH.
- A sub-license for UCUM table content (Regenstrief Institute + The
  UCUM Organization, <https://ucum.org/license>) — relevant because
  the package ships `data/ucumDefs.min.json`.
- A conditional sub-license for LOINC content under
  <https://loinc.org/terms-of-use>.
- A citation request for research publications.

Without explicit attribution, redistributions of CareBridge that
include `fhir-gateway` would be out of compliance with the upstream
terms.

## What changed

- New `services/fhir-gateway/NOTICES.md` — full third-party
  attribution sourced verbatim from the upstream `LICENSE.md`, with
  links to canonical license URLs and an explicit correction note for
  the prior MIT claim.
- New `services/fhir-gateway/README.md` — describes the service
  layout and points to `NOTICES.md` for license obligations.

No source code is touched. `services/fhir-gateway/src/generators/ucum.ts`
is intentionally untouched to avoid conflict with PR #1148, which is
working that file concurrently.

## Verification

- `pnpm typecheck` — passes (38/38 tasks).
- `pnpm lint` — passes (21/21 tasks; only unrelated pre-existing
  warnings in the clinician-portal app).
- License facts cross-checked against
  `node_modules/.pnpm/@lhncbc+ucum-lhc@7.1.6/node_modules/@lhncbc/ucum-lhc/LICENSE.md`.