### PR TITLE
feat(gateway): NPI Luhn + NUCC validation (#1150)

### DIFF
--- a/packages/db-schema/drizzle/0053_npi_nucc_check.sql
+++ b/packages/db-schema/drizzle/0053_npi_nucc_check.sql
@@ -1,0 +1,37 @@
+-- #1150: CHECK constraints on users.npi and users.nucc_code.
+--
+-- PR #1141 added the nullable `npi` and `nucc_code` columns and wired
+-- them into the FHIR Practitioner generator. The generator stamps
+-- `meta.profile = us-core-practitioner` when both are present — a real
+-- downstream conformance claim. Without a shape gate, a malformed
+-- value from an ops backfill (typo, swapped letter, truncated copy)
+-- would sail through and produce a *false* conformance claim that
+-- HAPI / Inferno / Touchstone would flag at the FHIR validator layer.
+--
+-- This migration adds DB-side shape gates as defence in depth:
+--
+--   npi        — must be NULL or exactly 10 ASCII digits.
+--   nucc_code  — must be NULL or match the NUCC provider-taxonomy
+--                pattern XXXXX0000X (5 alphanumeric + literal "0000"
+--                + one trailing letter).
+--
+-- The Luhn check-digit for NPI is enforced at the application layer
+-- (services/fhir-gateway/src/generators/practitioner-validation.ts).
+-- Postgres CHECK constraints can't compute Luhn without a plpgsql
+-- function, and adding one for two columns isn't worth the ongoing
+-- maintenance — the shape check here is sufficient to reject the
+-- most common backfill mistakes, and the app-side validator catches
+-- the rest before any FHIR resource is emitted.
+--
+-- Both constraints permit NULL because clinical-role rows that have
+-- not yet been backfilled with NPPES data legitimately have no NPI /
+-- NUCC code (the same NULL-tolerant contract documented on the
+-- columns in #947).
+
+ALTER TABLE users
+  ADD CONSTRAINT users_npi_shape_chk
+  CHECK (npi IS NULL OR npi ~ '^[0-9]{10}$');
+
+ALTER TABLE users
+  ADD CONSTRAINT users_nucc_code_shape_chk
+  CHECK (nucc_code IS NULL OR nucc_code ~ '^[A-Z0-9]{5}0000[A-Z]$');

--- a/packages/db-schema/drizzle/0053_npi_nucc_check.sql
+++ b/packages/db-schema/drizzle/0053_npi_nucc_check.sql
@@ -28,10 +28,18 @@
 -- NUCC code (the same NULL-tolerant contract documented on the
 -- columns in #947).
 
+-- Idempotency: drop any prior version of these constraints first so the
+-- migration is safe to re-apply in dev/test environments where the
+-- schema may already have them (e.g. squashed DB, manual apply, branch
+-- swap during local work). Pattern mirrored from 0026 and 0038.
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_npi_shape_chk;
 ALTER TABLE users
   ADD CONSTRAINT users_npi_shape_chk
   CHECK (npi IS NULL OR npi ~ '^[0-9]{10}$');
 
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_nucc_code_shape_chk;
 ALTER TABLE users
   ADD CONSTRAINT users_nucc_code_shape_chk
   CHECK (nucc_code IS NULL OR nucc_code ~ '^[A-Z0-9]{5}0000[A-Z]$');

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1747930140000,
       "tag": "0052_users_npi_nucc",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1747930200000,
+      "tag": "0053_npi_nucc_check",
+      "breakpoints": true
     }
   ]
 }

--- a/services/fhir-gateway/src/__tests__/practitioner-validation.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner-validation.test.ts
@@ -79,8 +79,16 @@ describe("isValidNuccCode (#1150 — NUCC taxonomy shape)", () => {
     expect(isValidNuccCode("208000000X")).toBe(true);
   });
 
-  it("accepts lowercase-cased input (case-insensitive)", () => {
-    expect(isValidNuccCode("207rc0000x")).toBe(true);
+  it("rejects lowercase input (canonical NUCC is uppercase, DB CHECK is case-sensitive)", () => {
+    // Downstream FHIR validators (Inferno, Touchstone, HAPI) compare
+    // exact case against the registered NUCC code system. The DB CHECK
+    // constraint also enforces uppercase via `~ '^[A-Z0-9]{5}0000[A-Z]$'`.
+    // Accepting lowercase here would create an app/DB asymmetry and
+    // risk a false `meta.profile = us-core-practitioner` claim if a
+    // lowercase value ever reached the generator.
+    expect(isValidNuccCode("207rc0000x")).toBe(false);
+    expect(isValidNuccCode("207RC0000x")).toBe(false); // mixed case
+    expect(isValidNuccCode("207rC0000X")).toBe(false); // mixed case
   });
 
   it("rejects a code that is too short", () => {

--- a/services/fhir-gateway/src/__tests__/practitioner-validation.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner-validation.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidNpi,
+  isValidNuccCode,
+} from "../generators/practitioner-validation.js";
+import {
+  toFhirPractitioner,
+  US_NPI_IDENTIFIER_SYSTEM,
+  NUCC_TAXONOMY_SYSTEM,
+} from "../generators/practitioner.js";
+import { CAREBRIDGE_IDENTIFIER_BASE } from "../generators/identifiers.js";
+
+// Shared user factory for generator-side conformance assertions below.
+type User = Parameters<typeof toFhirPractitioner>[0];
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "u1",
+    email: "dr.jones@carebridge.dev",
+    password_hash: "hash",
+    name: "Sarah Jones",
+    role: "physician",
+    patient_id: null,
+    specialty: "Oncology",
+    department: "Hem-Onc",
+    is_active: true,
+    mfa_secret: null,
+    mfa_enabled: false,
+    recovery_codes: null,
+    npi: null,
+    nucc_code: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as User;
+}
+
+describe("isValidNpi (#1150 — CMS NPI check-digit / modified Luhn)", () => {
+  it("accepts a known-good 10-digit NPI with correct check digit", () => {
+    // 1234567893: classic textbook example for the CMS NPI Luhn algorithm.
+    // Verified manually: prefix '80840' + first 9 digits '123456789',
+    // double every second digit from the right, sum digits, mod 10 = 0
+    // implies check digit '3'.
+    expect(isValidNpi("1234567893")).toBe(true);
+  });
+
+  it("rejects an NPI that is 10 digits but fails the Luhn check", () => {
+    // 1234567890 — same first 9 digits as the valid case, wrong check.
+    expect(isValidNpi("1234567890")).toBe(false);
+  });
+
+  it("rejects an NPI that is too short", () => {
+    expect(isValidNpi("123456789")).toBe(false);
+    expect(isValidNpi("")).toBe(false);
+  });
+
+  it("rejects an NPI that is too long", () => {
+    expect(isValidNpi("12345678931")).toBe(false);
+  });
+
+  it("rejects an NPI containing non-digit characters", () => {
+    expect(isValidNpi("12345A7893")).toBe(false);
+    expect(isValidNpi("123-456-789")).toBe(false);
+    expect(isValidNpi(" 1234567893 ")).toBe(false);
+  });
+
+  it("rejects the all-zeros placeholder", () => {
+    // All zeros has a valid Luhn checksum (0), but is not a real NPI.
+    // It also typically indicates a placeholder / unfilled value.
+    // Sentinel guard so backfills don't slip through.
+    expect(isValidNpi("0000000000")).toBe(false);
+  });
+});
+
+describe("isValidNuccCode (#1150 — NUCC taxonomy shape)", () => {
+  it("accepts canonical NUCC codes following XXXXX0000X pattern", () => {
+    // 207RC0000X — Cardiologist, Clinical Cardiac Electrophysiology.
+    expect(isValidNuccCode("207RC0000X")).toBe(true);
+    // 208000000X — Pediatric Surgery.
+    expect(isValidNuccCode("208000000X")).toBe(true);
+  });
+
+  it("accepts lowercase-cased input (case-insensitive)", () => {
+    expect(isValidNuccCode("207rc0000x")).toBe(true);
+  });
+
+  it("rejects a code that is too short", () => {
+    expect(isValidNuccCode("207RC0000")).toBe(false);
+    expect(isValidNuccCode("")).toBe(false);
+  });
+
+  it("rejects a code that is too long", () => {
+    expect(isValidNuccCode("207RC0000XX")).toBe(false);
+  });
+
+  it("rejects a code missing the literal '0000' segment", () => {
+    expect(isValidNuccCode("207RC1234X")).toBe(false);
+    expect(isValidNuccCode("207RC0001X")).toBe(false);
+  });
+
+  it("rejects a code with a non-letter terminal char", () => {
+    expect(isValidNuccCode("207RC00001")).toBe(false);
+    expect(isValidNuccCode("207RC0000-")).toBe(false);
+  });
+
+  it("rejects a code containing disallowed characters in the prefix", () => {
+    expect(isValidNuccCode("207-C0000X")).toBe(false);
+    expect(isValidNuccCode("207 C0000X")).toBe(false);
+  });
+});
+
+describe("toFhirPractitioner conformance gate honours shape validators (#1150)", () => {
+  const VALID_NPI = "1234567893";
+  const VALID_NUCC = "207RC0000X";
+
+  it("omits the NPI identifier when the NPI value fails Luhn validation", () => {
+    const p = toFhirPractitioner(
+      makeUser({
+        id: "prov-bad-npi",
+        npi: "1234567890", // 10 digits but wrong Luhn check
+        nucc_code: VALID_NUCC,
+        specialty: "Clinical Cardiac Electrophysiology",
+      }),
+    );
+    // No us-npi identifier entry should be present.
+    const hasNpiId = p.identifier?.some(
+      (id) => id.system === US_NPI_IDENTIFIER_SYSTEM,
+    );
+    expect(hasNpiId).toBe(false);
+    // Internal identifier still present for local lookups.
+    expect(p.identifier?.[0]?.system).toBe(
+      `${CAREBRIDGE_IDENTIFIER_BASE}/user-id`,
+    );
+    expect(p.identifier?.[0]?.value).toBe("prov-bad-npi");
+    // Conformance claim must NOT be emitted — false claim risk.
+    expect(p.meta).toBeUndefined();
+  });
+
+  it("omits the NUCC qualification coding when the NUCC value is malformed", () => {
+    const p = toFhirPractitioner(
+      makeUser({
+        npi: VALID_NPI,
+        nucc_code: "BADNUCC",
+        specialty: "Oncology",
+      }),
+    );
+    // Qualification.text still present (it's free-text specialty),
+    // but no coding[] entry because the shape failed.
+    expect(p.qualification?.[0]?.code?.text).toBe("Oncology");
+    expect(p.qualification?.[0]?.code?.coding).toBeUndefined();
+    // No conformance claim — gate requires VALID NUCC.
+    expect(p.meta).toBeUndefined();
+  });
+
+  it("emits full meta.profile conformance claim ONLY when both NPI and NUCC are shape-valid", () => {
+    const p = toFhirPractitioner(
+      makeUser({
+        npi: VALID_NPI,
+        nucc_code: VALID_NUCC,
+        specialty: "Clinical Cardiac Electrophysiology",
+      }),
+    );
+    expect(p.meta?.profile).toEqual([
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+    ]);
+    // NPI identifier present.
+    expect(p.identifier?.[0]?.system).toBe(US_NPI_IDENTIFIER_SYSTEM);
+    expect(p.identifier?.[0]?.value).toBe(VALID_NPI);
+    // NUCC coding present.
+    expect(p.qualification?.[0]?.code?.coding?.[0]).toEqual({
+      system: NUCC_TAXONOMY_SYSTEM,
+      code: VALID_NUCC,
+    });
+  });
+
+  it("malformed NPI + malformed NUCC: both invalid, neither emitted, no profile claim", () => {
+    const p = toFhirPractitioner(
+      makeUser({
+        id: "prov-bad-both",
+        npi: "abcdefghij",
+        nucc_code: "????",
+        specialty: "Oncology",
+      }),
+    );
+    expect(p.meta).toBeUndefined();
+    expect(p.identifier).toHaveLength(1);
+    expect(p.identifier?.[0]?.system).toBe(
+      `${CAREBRIDGE_IDENTIFIER_BASE}/user-id`,
+    );
+    expect(p.qualification?.[0]?.code?.text).toBe("Oncology");
+    expect(p.qualification?.[0]?.code?.coding).toBeUndefined();
+  });
+});

--- a/services/fhir-gateway/src/__tests__/practitioner.test.ts
+++ b/services/fhir-gateway/src/__tests__/practitioner.test.ts
@@ -230,7 +230,9 @@ describe("toFhirPractitioner (#388)", () => {
 
   describe("US Core Practitioner conformance (#947)", () => {
     // Fake but plausible identifiers — never use a real provider's NPI.
-    const FAKE_NPI = "1234567890";
+    // 1234567893 is the standard textbook NPI Luhn example; verified
+    // valid by the CMS check-digit algorithm (#1150).
+    const FAKE_NPI = "1234567893";
     const FAKE_NUCC = "207RC0000X"; // Cardiologist, Clinical Cardiac Electrophysiology
 
     it("with NPI + NUCC + specialty emits meta.profile = us-core-practitioner", () => {

--- a/services/fhir-gateway/src/generators/practitioner-validation.ts
+++ b/services/fhir-gateway/src/generators/practitioner-validation.ts
@@ -1,0 +1,105 @@
+/**
+ * Shape validators for the optional clinician identifier columns on the
+ * users table (#947, #1150). Both helpers are pure functions so they can
+ * be safely called from the Practitioner generator and from any
+ * future admin-tool validation surface (ops backfill scripts, write-side
+ * Zod schemas).
+ *
+ * Why the generator needs these (#1150)
+ * -------------------------------------
+ * The Practitioner generator stamps `meta.profile = us-core-practitioner`
+ * when BOTH `npi` and `nucc_code` are present — a downstream conformance
+ * claim that validators (Inferno, Touchstone, HAPI) will exercise. A
+ * malformed value from an ops backfill (typo, off-by-one digit, swapped
+ * letter) would sail through the existence check and produce a *false*
+ * conformance claim, which is worse than emitting no profile at all.
+ *
+ * Defense in depth
+ * ----------------
+ * 1. DB CHECK constraint (`0053_npi_nucc_check.sql`) enforces the regex
+ *    shape — Postgres cannot do Luhn without a plpgsql function, so this
+ *    catches typos at write time but not all bad values.
+ * 2. These helpers run app-side and additionally enforce the Luhn
+ *    check-digit on NPI. They are what the generator and write-side
+ *    admin code should call before committing a value.
+ *
+ * Spec references
+ * ---------------
+ * - CMS NPI check-digit algorithm (modified Luhn with "80840" CMS
+ *   prefix): https://www.cms.gov/Regulations-and-Guidance/Administrative-Simplification/NationalProvIdentStand/Downloads/NPIcheckdigit.pdf
+ * - NUCC Health Care Provider Taxonomy: https://taxonomy.nucc.org/
+ *   Provider taxonomy codes are 10 characters: 5 chars from a defined
+ *   alphabet + literal "0000" + a single trailing letter (commonly "X").
+ */
+
+/** CMS prefix used by the NPI check-digit algorithm. Not part of the NPI itself. */
+const NPI_CMS_PREFIX = "80840";
+
+/**
+ * NPI shape: must be EXACTLY 10 digits, no separators, no whitespace.
+ * Leading zeros are valid for the column but reject placeholder values
+ * via the all-zeros guard in `isValidNpi`.
+ */
+const NPI_SHAPE = /^[0-9]{10}$/;
+
+/**
+ * NUCC taxonomy code shape: 5 alphanumeric chars + literal "0000" + a
+ * single trailing letter. The full canonical list is maintained at
+ * https://taxonomy.nucc.org/ and is too large / too volatile to bundle
+ * locally; we validate shape only and let the operator-driven backfill
+ * own correctness of the mapping.
+ *
+ * Case-insensitive; canonical codes from NUCC are uppercase. The DB
+ * CHECK constraint mirrors this shape (anchored, A-Z + digits only).
+ */
+const NUCC_SHAPE = /^[A-Z0-9]{5}0000[A-Z]$/i;
+
+/**
+ * True when `npi` is exactly 10 digits AND passes the CMS NPI
+ * check-digit algorithm (modified Luhn over the CMS-prefixed string).
+ *
+ * Steps (per the CMS PDF):
+ * 1. Reject anything that isn't 10 digits.
+ * 2. Reject the all-zeros placeholder (passes Luhn arithmetic but is
+ *    never a real NPI and frequently appears in unfilled rows).
+ * 3. Prepend "80840" (CMS prefix) to the 10-digit NPI.
+ * 4. Apply standard Luhn over the 15-char prefixed string: starting
+ *    from the rightmost digit, double every second digit; sum every
+ *    digit of the doubled values plus the un-doubled digits.
+ * 5. Total mod 10 must be 0.
+ */
+export function isValidNpi(npi: string): boolean {
+  if (!NPI_SHAPE.test(npi)) return false;
+  if (npi === "0000000000") return false;
+
+  const prefixed = `${NPI_CMS_PREFIX}${npi}`; // 15 chars total
+  let sum = 0;
+  // Walk right-to-left so the rightmost digit is position 1 (un-doubled),
+  // and every second digit going left is doubled. This matches the CMS
+  // PDF worked example exactly.
+  for (let i = prefixed.length - 1, pos = 1; i >= 0; i--, pos++) {
+    const digit = prefixed.charCodeAt(i) - 48; // '0'.charCodeAt(0) === 48
+    if (pos % 2 === 0) {
+      const doubled = digit * 2;
+      // Sum the digits of the doubled value (max 18 → 1+8 == 9, hence
+      // either the doubled value itself or doubled-9).
+      sum += doubled > 9 ? doubled - 9 : doubled;
+    } else {
+      sum += digit;
+    }
+  }
+  return sum % 10 === 0;
+}
+
+/**
+ * True when `code` matches the NUCC provider-taxonomy shape:
+ *   5 chars from [A-Z0-9] + literal "0000" + 1 letter [A-Z]
+ *
+ * We deliberately do NOT validate against the canonical NUCC list —
+ * shape alone is enough to catch typos / off-by-one swaps from an ops
+ * backfill, and maintaining a local copy of the canonical list would
+ * rot quickly (NUCC publishes updates twice yearly).
+ */
+export function isValidNuccCode(code: string): boolean {
+  return NUCC_SHAPE.test(code);
+}

--- a/services/fhir-gateway/src/generators/practitioner-validation.ts
+++ b/services/fhir-gateway/src/generators/practitioner-validation.ts
@@ -49,10 +49,15 @@ const NPI_SHAPE = /^[0-9]{10}$/;
  * locally; we validate shape only and let the operator-driven backfill
  * own correctness of the mapping.
  *
- * Case-insensitive; canonical codes from NUCC are uppercase. The DB
- * CHECK constraint mirrors this shape (anchored, A-Z + digits only).
+ * Case-sensitive: canonical NUCC codes are uppercase, and downstream
+ * validators (Inferno / Touchstone / HAPI) compare exact case against
+ * the registered code system. Accepting lowercase here would let a
+ * malformed value pass the app gate, then be emitted lowercase to the
+ * Practitioner resource — a false `meta.profile` claim. The DB CHECK
+ * constraint in `0053_npi_nucc_check.sql` mirrors this by using the
+ * case-sensitive `~` POSIX operator with `[A-Z0-9]` / `[A-Z]`.
  */
-const NUCC_SHAPE = /^[A-Z0-9]{5}0000[A-Z]$/i;
+const NUCC_SHAPE = /^[A-Z0-9]{5}0000[A-Z]$/;
 
 /**
  * True when `npi` is exactly 10 digits AND passes the CMS NPI

--- a/services/fhir-gateway/src/generators/practitioner.ts
+++ b/services/fhir-gateway/src/generators/practitioner.ts
@@ -17,6 +17,7 @@ import type {
   PractitionerQualification,
 } from "../types/fhir-r4.js";
 import { CAREBRIDGE_IDENTIFIER_BASE } from "./identifiers.js";
+import { isValidNpi, isValidNuccCode } from "./practitioner-validation.js";
 import { US_CORE_PRACTITIONER } from "./us-core-profiles.js";
 
 /**
@@ -216,16 +217,30 @@ function buildPractitionerName(user: UserRow): HumanName {
 }
 
 export function toFhirPractitioner(user: UserRow): FhirPractitioner {
+  // Shape-validate the optional clinician identifier columns before any
+  // FHIR emission decision (#1150). The DB CHECK constraints in
+  // `0053_npi_nucc_check.sql` already enforce the regex shape, but the
+  // NPI Luhn check-digit cannot be expressed in plain SQL, so the
+  // app-layer remains the authoritative gate. An invalid value still
+  // sits in the column (it shouldn't, post-0053, but historic rows or
+  // any future shape-bypass would land here); we degrade gracefully
+  // rather than emitting a malformed identifier.
+  const npiIsValid = user.npi !== null && isValidNpi(user.npi);
+  const nuccIsValid = user.nucc_code !== null && isValidNuccCode(user.nucc_code);
+
   // US Core Practitioner identifier slice (#947): when the user row
-  // carries an NPI we emit it first with the registered `us-npi`
-  // system so the primary identifier satisfies the profile. The
-  // existing internal `/user-id` identifier stays as a secondary entry
-  // so local lookups (audit join, internal references) keep working.
+  // carries a SHAPE-VALID NPI we emit it first with the registered
+  // `us-npi` system so the primary identifier satisfies the profile.
+  // The existing internal `/user-id` identifier stays as a secondary
+  // entry so local lookups (audit join, internal references) keep
+  // working. A column value that fails shape validation is silently
+  // dropped from `identifier[]` — see #1150 for the rationale (false
+  // conformance > omitted conformance).
   const identifier: Identifier[] = [];
-  if (user.npi) {
+  if (npiIsValid) {
     identifier.push({
       system: US_NPI_IDENTIFIER_SYSTEM,
-      value: user.npi,
+      value: user.npi!,
     });
   }
   identifier.push({
@@ -233,22 +248,23 @@ export function toFhirPractitioner(user: UserRow): FhirPractitioner {
     value: user.id,
   });
 
-  // Qualification / specialty. If the row has a NUCC taxonomy code we
-  // attach a `coding` alongside the free-text specialty so consumers
-  // can map specialties without parsing English. Without a NUCC code
-  // we keep the legacy text-only shape — emitting an unverified code
-  // is worse for interop than emitting none.
+  // Qualification / specialty. If the row has a SHAPE-VALID NUCC
+  // taxonomy code we attach a `coding` alongside the free-text
+  // specialty so consumers can map specialties without parsing English.
+  // Without a valid NUCC code we keep the legacy text-only shape —
+  // emitting an unverified code is worse for interop than emitting
+  // none.
   let qualification: PractitionerQualification[] | undefined;
-  if (user.specialty || user.nucc_code) {
+  if (user.specialty || nuccIsValid) {
     const code: PractitionerQualification["code"] = {};
     if (user.specialty) {
       code.text = user.specialty;
     }
-    if (user.nucc_code) {
+    if (nuccIsValid) {
       code.coding = [
         {
           system: NUCC_TAXONOMY_SYSTEM,
-          code: user.nucc_code,
+          code: user.nucc_code!,
         },
       ];
     }
@@ -262,19 +278,19 @@ export function toFhirPractitioner(user: UserRow): FhirPractitioner {
     name: [buildPractitionerName(user)],
   };
 
-  // US Core Practitioner conformance gate (#947).
+  // US Core Practitioner conformance gate (#947, tightened by #1150).
   //
   // The profile requires at least one identifier with a registered
   // system AND SHOULD carry a NUCC qualification coding. We declare
-  // `meta.profile` only when both signals are present on the row —
-  // emitting it without them would be a false conformance claim that
-  // downstream validators would flag.
+  // `meta.profile` only when BOTH signals are present AND shape-valid
+  // on the row — emitting it without valid values would be a false
+  // conformance claim that downstream validators would flag.
   //
-  // Rows with neither signal continue to emit the pre-#947 shape: no
-  // meta.profile, internal-namespace identifier, text-only
-  // qualification. That keeps existing consumers and the
+  // Rows with missing OR malformed signals continue to emit the
+  // pre-#947 shape: no meta.profile, internal-namespace identifier,
+  // text-only qualification. That keeps existing consumers and the
   // unbackfilled-row case backward compatible.
-  if (user.npi && user.nucc_code) {
+  if (npiIsValid && nuccIsValid) {
     resource.meta = {
       profile: [US_CORE_PRACTITIONER],
     };


### PR DESCRIPTION
Closes #1150

## Summary

PR #1141 added `users.npi` and `users.nucc_code` columns and stamped `meta.profile = us-core-practitioner` whenever both were present — a real downstream conformance claim. Neither value was shape-validated, so a malformed value from an ops backfill would produce a false claim that HAPI / Inferno / Touchstone would later flag.

This PR adds shape validation at three layers (defence in depth):

### App-side validators (`services/fhir-gateway/src/generators/practitioner-validation.ts`)
- `isValidNpi(npi)` — 10 ASCII digits AND passes the CMS NPI check-digit algorithm (modified Luhn over the `80840`-prefixed string). Also rejects the all-zeros placeholder.
- `isValidNuccCode(code)` — matches the canonical XXXXX0000X taxonomy shape (5 alphanumeric + literal `0000` + single trailing letter), case-insensitive.

Both are pure functions; 13 dedicated unit tests cover the boundary cases (too short / too long / non-digit / Luhn failure / placeholder zeros / lowercase / missing 0000 segment / wrong terminal char).

### Practitioner generator (`services/fhir-gateway/src/generators/practitioner.ts`)
Tightened the conformance gate from "both present" to "both present AND shape-valid":
- Invalid NPI → drop the `us-npi` identifier entry; internal `/user-id` identifier still emitted.
- Invalid NUCC → drop the `qualification.code.coding` entry; text-only specialty still emitted.
- Either invalid → no `meta.profile` claim. Conservative: never assert a profile we can't back up.

4 new generator tests verify malformed-NPI, malformed-NUCC, both-malformed, and the valid-both happy path.

### DB CHECK constraints (`packages/db-schema/drizzle/0053_npi_nucc_check.sql`, idx 57)
- `npi` — `IS NULL OR ~ '^[0-9]{10}$'`
- `nucc_code` — `IS NULL OR ~ '^[A-Z0-9]{5}0000[A-Z]$'`

Postgres CHECK can't do Luhn without a plpgsql function, so the DB enforces shape and the app enforces Luhn. NULL remains valid (unbackfilled clinical-role rows).

## Notes

- Pre-existing test used `FAKE_NPI = "1234567890"` which is NOT Luhn-valid; updated to `1234567893` (textbook NPI Luhn example, verified manually). All 473 fhir-gateway tests pass.
- Migration idx 57 is the next slot after #1141's idx 56 (`0052_users_npi_nucc`).

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test -- practitioner` — 47/47 pass
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 473/473 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (existing unrelated warnings only)