### PR TITLE
feat(infra): patient-education URL rot detection (#1151)

### DIFF
--- a/.github/workflows/patient-education-url-check.yml
+++ b/.github/workflows/patient-education-url-check.yml
@@ -1,0 +1,97 @@
+name: Patient Education URL Check
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of every month.
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: patient-education-url-check-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-urls:
+    name: Check curated education URLs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run URL rot check
+        id: check
+        run: |
+          set +e
+          pnpm --filter @carebridge/medical-logic run check:education-urls \
+            > url-check.log 2>&1
+          status=$?
+          cat url-check.log
+          echo "exit_status=$status" >> "$GITHUB_OUTPUT"
+          # The script already appends to $GITHUB_STEP_SUMMARY itself,
+          # so no extra summary step needed here.
+          exit 0
+
+      - name: Open or update tracking issue on failure
+        if: steps.check.outputs.exit_status != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          title="fhir: patient-education URL rot detected (auto)"
+          body_file=$(mktemp)
+          {
+            echo "Automated URL rot check found one or more curated"
+            echo "patient-education URLs that did not respond with a 2xx."
+            echo ""
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            echo '```'
+            cat url-check.log
+            echo '```'
+          } > "$body_file"
+
+          # Make sure the url-rot label exists (no-op if already there).
+          # `from-review` is created by other workflows already.
+          gh label create url-rot \
+            --color "B60205" \
+            --description "Detected URL rot in curated content" \
+            2>/dev/null || true
+
+          # Idempotency: if an open issue with the canonical title prefix
+          # already exists, comment on it instead of opening a duplicate.
+          existing=$(gh issue list \
+            --state open \
+            --search "in:title \"fhir: patient-education URL rot detected\"" \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("fhir: patient-education URL rot detected")) | .number' \
+            | head -n1)
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue comment "$existing" --body-file "$body_file"
+          else
+            echo "Creating new tracking issue"
+            gh issue create \
+              --title "$title" \
+              --label "url-rot,from-review" \
+              --body-file "$body_file"
+          fi
+
+      - name: Fail job if URL check failed
+        if: steps.check.outputs.exit_status != '0'
+        run: exit 1

--- a/packages/medical-logic/package.json
+++ b/packages/medical-logic/package.json
@@ -13,14 +13,17 @@
   },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "test": "vitest run",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "check:education-urls": "tsx scripts/check-education-urls.ts"
   },
   "dependencies": {
     "@carebridge/shared-types": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/packages/medical-logic/scripts/check-education-urls.ts
+++ b/packages/medical-logic/scripts/check-education-urls.ts
@@ -1,0 +1,230 @@
+/**
+ * Patient-education URL rot detector (issue #1151).
+ *
+ * Walks every `links[*].url` in DIAGNOSIS_EDUCATION_TABLE +
+ * MEDICATION_EDUCATION_TABLE and HEADs each one. Health-domain CDNs
+ * (notably the Cloudflare front in front of `heart.org`) sometimes reject
+ * HEAD with 405, so we fall back to a GET on 405. Followed redirects up
+ * to 5 hops count as PASS.
+ *
+ * Designed to be driven by `.github/workflows/patient-education-url-check.yml`
+ * on the first of every month. Not part of CI — live HTTP would be flaky.
+ *
+ * The helper functions below (`classifyStatus`, `checkUrl`, `formatReport`)
+ * are exported so the vitest suite can exercise the 405-fallback and
+ * report-formatting logic with a mocked fetch.
+ */
+
+import { pathToFileURL } from "node:url";
+import {
+  DIAGNOSIS_EDUCATION_TABLE,
+  MEDICATION_EDUCATION_TABLE,
+  type EducationContent,
+} from "../src/patient-education.js";
+
+const TIMEOUT_MS = 10_000;
+const MAX_REDIRECTS = 5;
+
+export interface UrlCheckResult {
+  url: string;
+  ok: boolean;
+  /** Final HTTP status code we observed, or null if the request never produced one. */
+  status: number | null;
+  /** Short reason string for non-ok results. */
+  reason?: string;
+  /** Which method ultimately produced `status` ("HEAD" or "GET"). */
+  method: "HEAD" | "GET";
+}
+
+/**
+ * Decide whether a status code counts as PASS. 2xx is the obvious yes;
+ * 3xx only reaches this function when redirects are exhausted (fetch
+ * follows them by default, but we cap at MAX_REDIRECTS), so a leftover
+ * 3xx is treated as a redirect-loop failure. 405 is the sentinel for
+ * "HEAD not supported — caller should retry with GET".
+ */
+export function classifyStatus(status: number): "pass" | "retry-with-get" | "fail" {
+  if (status >= 200 && status < 300) return "pass";
+  if (status === 405) return "retry-with-get";
+  return "fail";
+}
+
+/**
+ * Single-URL probe with HEAD-then-GET-on-405 semantics. `fetchImpl` is
+ * injectable so tests can drive the 405-fallback branch deterministically.
+ */
+export async function checkUrl(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs: number = TIMEOUT_MS,
+): Promise<UrlCheckResult> {
+  const attempt = async (method: "HEAD" | "GET"): Promise<UrlCheckResult> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(url, {
+        method,
+        redirect: "follow",
+        // Some health sites bot-block missing UA; identify the check politely.
+        headers: {
+          "user-agent":
+            "carebridge-url-rot-check/1.0 (+https://github.com/blamechris/carebridge)",
+          accept: "*/*",
+        },
+        signal: controller.signal,
+      });
+      const verdict = classifyStatus(res.status);
+      if (verdict === "pass") {
+        return { url, ok: true, status: res.status, method };
+      }
+      if (verdict === "retry-with-get" && method === "HEAD") {
+        // Surface the 405 trigger by returning a sentinel; outer driver
+        // re-calls with method=GET. Easier to test than a recursive call.
+        return {
+          url,
+          ok: false,
+          status: 405,
+          reason: "HEAD rejected; will retry with GET",
+          method,
+        };
+      }
+      return {
+        url,
+        ok: false,
+        status: res.status,
+        reason: `HTTP ${res.status}`,
+        method,
+      };
+    } catch (err) {
+      const reason =
+        err instanceof Error
+          ? err.name === "AbortError"
+            ? `timeout after ${timeoutMs}ms`
+            : err.message
+          : "unknown fetch error";
+      return { url, ok: false, status: null, reason, method };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  const head = await attempt("HEAD");
+  if (head.ok) return head;
+  if (head.status === 405) {
+    return attempt("GET");
+  }
+  return head;
+}
+
+export interface Report {
+  total: number;
+  passed: number;
+  failed: UrlCheckResult[];
+}
+
+/**
+ * Markdown-flavoured summary safe to drop into `$GITHUB_STEP_SUMMARY`
+ * and into the body of a tracking issue. Kept text-only so a plaintext
+ * reader (e.g. a notification email) still gets the meaningful content.
+ */
+export function formatReport(report: Report): string {
+  const lines: string[] = [];
+  lines.push(`# Patient-education URL check`);
+  lines.push("");
+  lines.push(`- Total URLs checked: **${report.total}**`);
+  lines.push(`- Passed: **${report.passed}**`);
+  lines.push(`- Failed: **${report.failed.length}**`);
+  lines.push("");
+  if (report.failed.length === 0) {
+    lines.push(`All curated patient-education URLs responded with 2xx.`);
+    return lines.join("\n");
+  }
+  lines.push(`## Broken URLs`);
+  lines.push("");
+  lines.push(`| URL | Status | Method | Reason |`);
+  lines.push(`| --- | --- | --- | --- |`);
+  for (const f of report.failed) {
+    const status = f.status === null ? "—" : String(f.status);
+    const reason = (f.reason ?? "").replace(/\|/g, "\\|");
+    lines.push(`| ${f.url} | ${status} | ${f.method} | ${reason} |`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Pull every curated URL out of both education tables. De-duped because
+ * a few entries genuinely share the same MedlinePlus landing page.
+ */
+export function collectCuratedUrls(
+  diagnosis: Record<string, EducationContent> = DIAGNOSIS_EDUCATION_TABLE,
+  medication: Record<string, EducationContent> = MEDICATION_EDUCATION_TABLE,
+): string[] {
+  const urls = new Set<string>();
+  for (const entry of Object.values(diagnosis)) {
+    for (const link of entry.links ?? []) urls.add(link.url);
+  }
+  for (const entry of Object.values(medication)) {
+    for (const link of entry.links ?? []) urls.add(link.url);
+  }
+  return [...urls].sort();
+}
+
+async function main(): Promise<void> {
+  const urls = collectCuratedUrls();
+  const failed: UrlCheckResult[] = [];
+  let passed = 0;
+
+  // Sequential — 31ish URLs × 10s worst case is still under five minutes
+  // and keeps us off any host's "too many concurrent requests" radar.
+  for (const url of urls) {
+    process.stdout.write(`Checking ${url} ... `);
+    const result = await checkUrl(url);
+    if (result.ok) {
+      passed += 1;
+      process.stdout.write(`OK (${result.status} via ${result.method})\n`);
+    } else {
+      failed.push(result);
+      process.stdout.write(
+        `FAIL (status=${result.status ?? "—"}, ${result.reason ?? "unknown"})\n`,
+      );
+    }
+  }
+
+  const report: Report = { total: urls.length, passed, failed };
+  const markdown = formatReport(report);
+  process.stdout.write("\n");
+  process.stdout.write(markdown);
+  process.stdout.write("\n");
+
+  // GitHub Actions: write the markdown into the step summary so the run
+  // page shows the table without a re-run-with-logs round trip.
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(summaryPath, `${markdown}\n`);
+  }
+
+  if (failed.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+// Only auto-run when invoked as a script (not when imported by tests).
+// `import.meta.url` matches `process.argv[1]` exactly when this file is
+// the entry point — works for both `tsx` and a future `node dist/...`.
+const invokedAsScript = (() => {
+  const arg = process.argv[1];
+  if (!arg) return false;
+  try {
+    return import.meta.url === pathToFileURL(arg).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedAsScript) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/packages/medical-logic/src/__tests__/check-education-urls.test.ts
+++ b/packages/medical-logic/src/__tests__/check-education-urls.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the URL-rot detector (issue #1151). The HTTP layer is
+ * exercised with a stubbed fetch so the suite never touches the network.
+ * The cron workflow drives the real-network run on its own schedule.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyStatus,
+  checkUrl,
+  formatReport,
+  collectCuratedUrls,
+  type Report,
+  type UrlCheckResult,
+} from "../../scripts/check-education-urls.js";
+
+describe("classifyStatus", () => {
+  it("treats 200, 204, 299 as pass", () => {
+    expect(classifyStatus(200)).toBe("pass");
+    expect(classifyStatus(204)).toBe("pass");
+    expect(classifyStatus(299)).toBe("pass");
+  });
+
+  it("treats 405 as the HEAD-not-supported sentinel", () => {
+    expect(classifyStatus(405)).toBe("retry-with-get");
+  });
+
+  it("treats 404 / 500 / leftover 3xx as fail", () => {
+    expect(classifyStatus(404)).toBe("fail");
+    expect(classifyStatus(500)).toBe("fail");
+    expect(classifyStatus(301)).toBe("fail");
+  });
+});
+
+describe("checkUrl 405 → GET fallback", () => {
+  /** Build a fake `fetch` that returns scripted responses, one per call. */
+  function scriptedFetch(statuses: number[]): typeof fetch {
+    let i = 0;
+    return (async () => {
+      const status = statuses[i++] ?? 500;
+      return new Response(null, { status }) as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("returns pass on a HEAD 200 without a GET retry", async () => {
+    let calls = 0;
+    const stub = (async () => {
+      calls += 1;
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await checkUrl("https://example.test/a", stub);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.method).toBe("HEAD");
+    expect(calls).toBe(1);
+  });
+
+  it("retries with GET when HEAD returns 405 and succeeds on GET", async () => {
+    const stub = scriptedFetch([405, 200]);
+    const result = await checkUrl("https://www.heart.org/example", stub);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.method).toBe("GET");
+  });
+
+  it("retries with GET when HEAD returns 405 and still fails on GET", async () => {
+    const stub = scriptedFetch([405, 404]);
+    const result = await checkUrl("https://example.test/missing", stub);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.method).toBe("GET");
+  });
+
+  it("does not retry on a non-405 HEAD failure", async () => {
+    let calls = 0;
+    const stub = (async () => {
+      calls += 1;
+      return new Response(null, { status: 404 });
+    }) as unknown as typeof fetch;
+    const result = await checkUrl("https://example.test/gone", stub);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(result.method).toBe("HEAD");
+    expect(calls).toBe(1);
+  });
+
+  it("surfaces fetch errors (network down, DNS failure) as failures", async () => {
+    const stub = (async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+    const result = await checkUrl("https://example.invalid/", stub);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.reason).toMatch(/fetch failed/);
+  });
+
+  it("reports a timeout when fetch is aborted", async () => {
+    const stub = ((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        // Honour the abort signal so the test doesn't hang.
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      })) as unknown as typeof fetch;
+    const result = await checkUrl("https://slow.test/", stub, 5);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.reason).toMatch(/timeout/);
+  });
+});
+
+describe("formatReport", () => {
+  it("reports a clean all-pass run", () => {
+    const report: Report = { total: 5, passed: 5, failed: [] };
+    const md = formatReport(report);
+    expect(md).toMatch(/Total URLs checked.*5/);
+    expect(md).toMatch(/Passed.*5/);
+    expect(md).toMatch(/Failed.*0/);
+    expect(md).toMatch(/All curated patient-education URLs/);
+  });
+
+  it("renders failures as a markdown table", () => {
+    const failed: UrlCheckResult[] = [
+      {
+        url: "https://medlineplus.gov/bad.html",
+        ok: false,
+        status: 404,
+        reason: "HTTP 404",
+        method: "HEAD",
+      },
+      {
+        url: "https://www.cdc.gov/missing",
+        ok: false,
+        status: null,
+        reason: "fetch failed",
+        method: "GET",
+      },
+    ];
+    const md = formatReport({ total: 7, passed: 5, failed });
+    expect(md).toMatch(/\| URL \| Status \| Method \| Reason \|/);
+    expect(md).toMatch(/medlineplus\.gov\/bad\.html.*404.*HEAD.*HTTP 404/);
+    expect(md).toMatch(/cdc\.gov\/missing.*—.*GET.*fetch failed/);
+  });
+
+  it("escapes pipe characters in reason text", () => {
+    const md = formatReport({
+      total: 1,
+      passed: 0,
+      failed: [
+        {
+          url: "https://example.test/",
+          ok: false,
+          status: 500,
+          reason: "weird | reason",
+          method: "HEAD",
+        },
+      ],
+    });
+    expect(md).toMatch(/weird \\\| reason/);
+  });
+});
+
+describe("collectCuratedUrls", () => {
+  it("dedupes URLs that appear in multiple education entries", () => {
+    const diag = {
+      X1: {
+        title: "X1",
+        summary: "",
+        self_care: [],
+        when_to_contact_provider: [],
+        links: [
+          { label: "a", url: "https://medlineplus.gov/a" },
+          { label: "b", url: "https://medlineplus.gov/b" },
+        ],
+      },
+      X2: {
+        title: "X2",
+        summary: "",
+        self_care: [],
+        when_to_contact_provider: [],
+        links: [{ label: "a-again", url: "https://medlineplus.gov/a" }],
+      },
+    };
+    const meds = {
+      M1: {
+        title: "M1",
+        summary: "",
+        self_care: [],
+        when_to_contact_provider: [],
+        links: [{ label: "c", url: "https://medlineplus.gov/c" }],
+      },
+    };
+    const urls = collectCuratedUrls(diag, meds);
+    expect(urls).toEqual([
+      "https://medlineplus.gov/a",
+      "https://medlineplus.gov/b",
+      "https://medlineplus.gov/c",
+    ]);
+  });
+
+  it("handles entries without links", () => {
+    const diag = {
+      X1: {
+        title: "X1",
+        summary: "",
+        self_care: [],
+        when_to_contact_provider: [],
+      },
+    };
+    const urls = collectCuratedUrls(diag, {});
+    expect(urls).toEqual([]);
+  });
+});

--- a/packages/medical-logic/src/patient-education.ts
+++ b/packages/medical-logic/src/patient-education.ts
@@ -45,6 +45,18 @@ export interface EducationContent {
 // ── Diagnosis content, keyed by ICD-10 prefix ───────────────────
 
 /**
+ * URL maintenance (issue #1151):
+ *   Curated `links[*].url` values below are HEAD-checked monthly by
+ *   `.github/workflows/patient-education-url-check.yml`. The job opens
+ *   (or comments on) an issue titled "fhir: patient-education URL rot
+ *   detected (auto)" whenever a curated URL returns a non-2xx.
+ *
+ *   When updating or adding links, stick to authoritative health domains
+ *   — MedlinePlus (medlineplus.gov), CDC (cdc.gov), American Heart
+ *   Association (heart.org), National Stroke Association (stroke.org),
+ *   988 Lifeline (988lifeline.org), NIMH (nimh.nih.gov). The invariant
+ *   test in `patient-education.test.ts` enforces this allowlist.
+ *
  * ICD-10 prefixes are matched in descending length order so a more
  * specific code wins over a broader family. For example, `I25.10`
  * (CAD without angina) matches the `I25` entry; `I63` would match a

--- a/packages/medical-logic/tsconfig.check.json
+++ b/packages/medical-logic/tsconfig.check.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "scripts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/medical-logic/tsconfig.json
+++ b/packages/medical-logic/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__", "dist", "node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,12 @@ importers:
         specifier: workspace:*
         version: link:../shared-types
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
Closes #1151

## Summary
- New monthly GitHub Actions workflow (`.github/workflows/patient-education-url-check.yml`) HEAD-checks every curated `links[*].url` in `DIAGNOSIS_EDUCATION_TABLE` + `MEDICATION_EDUCATION_TABLE` and opens (or comments on) a tracking issue when any URL returns non-2xx.
- Script lives at `packages/medical-logic/scripts/check-education-urls.ts`, runnable via `pnpm --filter @carebridge/medical-logic run check:education-urls`. Sequential, 10s timeout per URL, follows redirects, falls back from HEAD to GET on 405 (CDN-fronted health sites like AHA reject HEAD).
- Idempotent issue handling: workflow searches for an open issue whose title starts with `fhir: patient-education URL rot detected` and comments on the existing one instead of creating duplicates. The `url-rot` label is created at workflow runtime if missing; `from-review` already exists.
- 14 new unit tests with mocked fetch cover `classifyStatus`, `checkUrl` (HEAD pass, HEAD-405-then-GET success, HEAD-405-then-GET fail, non-405 HEAD fail, network error, timeout), `formatReport` (clean run + failure table + pipe-escape), and `collectCuratedUrls` (dedupe + no-links case). No live network in CI — the cron is intentionally separate.
- Header comment on `patient-education.ts` documents the monthly check and the authoritative-domain convention for future curated links.

## Test plan
- [x] `pnpm typecheck` — 38/38 passing
- [x] `pnpm --filter @carebridge/medical-logic test` — 502/502 passing (14 new)
- [x] `pnpm --filter @carebridge/medical-logic build` — clean dist, no scripts/ bleed
- [x] `pnpm lint` — clean (pre-existing portal warnings unchanged)
- [x] Local smoke run hit MedlinePlus URLs and returned 200 via HEAD
- [ ] First scheduled run on the 1st of next month (or trigger manually via Actions tab)