### PR TITLE
fix(epic): token-client scope-keyed coalescing (#1144)

### DIFF
--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -281,6 +281,195 @@ describe("EpicTokenClient (#389)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not coalesce concurrent callers requesting different scope sets (#1144)", async () => {
+    // Two concurrent callers with different scope sets must each receive
+    // a token fetched with their own scopes — not be served whichever
+    // narrow-scope token happened to be in flight first. Otherwise a
+    // caller that requested ["system/Patient.read", "system/Observation.read"]
+    // could receive a token issued only for ["system/Patient.read"] and
+    // then fail mid-call when it tried to read Observation resources.
+    let resolveNarrow: (response: Response) => void;
+    let resolveWide: (response: Response) => void;
+    const narrowPending = new Promise<Response>((resolve) => {
+      resolveNarrow = resolve;
+    });
+    const widePending = new Promise<Response>((resolve) => {
+      resolveWide = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => narrowPending)
+      .mockImplementationOnce(() => widePending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const narrowCall = client.getAccessToken(["system/Patient.read"]);
+    const wideCall = client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+
+    // Each scope set must drive its OWN fetch — coalescing would
+    // collapse these to one.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    resolveNarrow!(tokenResponse({ access_token: "narrow-token" }));
+    resolveWide!(tokenResponse({ access_token: "wide-token" }));
+
+    expect(await narrowCall).toBe("narrow-token");
+    expect(await wideCall).toBe("wide-token");
+
+    // Verify each fetch carried the correct scope string.
+    const narrowBody = new URLSearchParams(
+      fetchMock.mock.calls[0]![1].body as string,
+    );
+    const wideBody = new URLSearchParams(
+      fetchMock.mock.calls[1]![1].body as string,
+    );
+    expect(narrowBody.get("scope")).toBe("system/Patient.read");
+    expect(wideBody.get("scope")?.split(" ").sort()).toEqual(
+      ["system/Observation.read", "system/Patient.read"],
+    );
+  });
+
+  it("coalesces concurrent callers with the same scopes regardless of order (#1144)", async () => {
+    // ["a", "b"] and ["b", "a"] are semantically identical scope sets —
+    // both must hash to the same key and share the in-flight fetch.
+    let resolveFetch: (response: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockImplementation(() => pendingResponse);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const callA = client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+    const callB = client.getAccessToken([
+      "system/Observation.read",
+      "system/Patient.read",
+    ]);
+
+    resolveFetch!(tokenResponse({ access_token: "shared-token" }));
+
+    expect(await callA).toBe("shared-token");
+    expect(await callB).toBe("shared-token");
+    // Only ONE network round-trip despite two callers.
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("caches per scope key — different scope sets don't reuse each other's cache (#1144)", async () => {
+    // Sequential calls (not concurrent) with different scope sets must
+    // each issue their own fetch, because the cached token for one scope
+    // set may not satisfy a different scope set.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "narrow-token" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "wide-token" }));
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const narrow = await client.getAccessToken(["system/Patient.read"]);
+    const wide = await client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+
+    expect(narrow).toBe("narrow-token");
+    expect(wide).toBe("wide-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Repeating the narrow request should hit the per-scope cache, not
+    // refetch and not be served the wide token.
+    const narrowAgain = await client.getAccessToken(["system/Patient.read"]);
+    expect(narrowAgain).toBe("narrow-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate() clears all per-scope cache entries (#1144)", async () => {
+    // After invalidate() drops the per-scope cache, the next call for
+    // ANY scope set must refetch — no scope key should survive.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "narrow-1" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "wide-1" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "narrow-2" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "wide-2" }));
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    await client.getAccessToken(["system/Patient.read"]);
+    await client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    client.invalidate();
+
+    const narrow = await client.getAccessToken(["system/Patient.read"]);
+    const wide = await client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+    expect(narrow).toBe("narrow-2");
+    expect(wide).toBe("wide-2");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("generation guard works per scope key — stale write to one key doesn't pollute another (#1144)", async () => {
+    // Race sequence:
+    //   1. Caller A starts -> in-flight P_narrow for narrow scopes
+    //   2. Caller B starts -> in-flight P_wide for wide scopes
+    //   3. invalidate() drops both in-flight slots + cache, bumps generation
+    //   4. Retry for narrow scopes resolves first -> fresh narrow token cached
+    //   5. STALE P_wide finally resolves -> must NOT write to the wide
+    //      cache entry (its generation no longer matches), and must NOT
+    //      pollute the unrelated narrow entry either.
+    let resolveNarrow1: (response: Response) => void;
+    let resolveWide1: (response: Response) => void;
+    let resolveNarrow2: (response: Response) => void;
+    const narrow1Pending = new Promise<Response>((resolve) => {
+      resolveNarrow1 = resolve;
+    });
+    const wide1Pending = new Promise<Response>((resolve) => {
+      resolveWide1 = resolve;
+    });
+    const narrow2Pending = new Promise<Response>((resolve) => {
+      resolveNarrow2 = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => narrow1Pending)
+      .mockImplementationOnce(() => wide1Pending)
+      .mockImplementationOnce(() => narrow2Pending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const narrowCall1 = client.getAccessToken(["system/Patient.read"]);
+    const wideCall1 = client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+
+    // Drop both in-flight requests; bumps generation.
+    client.invalidate();
+
+    // Retry just the narrow scope.
+    const narrowCall2 = client.getAccessToken(["system/Patient.read"]);
+    resolveNarrow2!(tokenResponse({ access_token: "narrow-fresh" }));
+    expect(await narrowCall2).toBe("narrow-fresh");
+
+    // Late-arriving STALE responses from the invalidated fetches.
+    resolveNarrow1!(tokenResponse({ access_token: "narrow-stale" }));
+    resolveWide1!(tokenResponse({ access_token: "wide-stale" }));
+    await narrowCall1;
+    await wideCall1;
+
+    // Cached narrow token must remain the fresh one.
+    const narrowAgain = await client.getAccessToken(["system/Patient.read"]);
+    expect(narrowAgain).toBe("narrow-fresh");
+    // No extra fetches — served from cache.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("clears the in-flight promise when the token request fails (#1089)", async () => {
     // After a fetch failure, the in-flight promise must be cleared so a
     // retry can issue a fresh request — otherwise every subsequent

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -64,15 +64,27 @@ interface CachedToken {
  * separately per (clientId, tokenUrl) pair.
  */
 export class EpicTokenClient {
-  private cached: CachedToken | null = null;
   /**
-   * In-flight token request. Concurrent {@link getAccessToken} callers
-   * that arrive while a fetch is outstanding await the same promise
-   * instead of each kicking off their own request (#1089). Cleared as
-   * soon as the request settles (success or failure) so the cache /
-   * retry path takes over for subsequent callers.
+   * Per-scope cached tokens (#1144). Keyed by a normalized (sorted,
+   * space-joined) scopes string so concurrent callers asking for
+   * different scope sets never share a cache entry — otherwise a
+   * caller that requested ["system/Patient.read", "system/Observation.read"]
+   * could be served a narrower token cached from an earlier
+   * single-scope fetch and then fail mid-call when reading an
+   * Observation. Sorting before join means ["a","b"] and ["b","a"]
+   * map to the same key.
    */
-  private inFlight: Promise<TokenResponse> | null = null;
+  private cached: Map<string, CachedToken> = new Map();
+  /**
+   * Per-scope in-flight token requests (#1144). Keyed the same way as
+   * {@link cached}: concurrent callers asking for the same scope set
+   * (in any order) coalesce on a shared promise (#1089); callers
+   * asking for a DIFFERENT scope set each get their own fetch and
+   * their own correctly-scoped token. Cleared as soon as each request
+   * settles (success or failure) so the cache / retry path takes over
+   * for subsequent callers.
+   */
+  private inFlight: Map<string, Promise<TokenResponse>> = new Map();
   /**
    * Monotonic generation counter (#1143). Incremented every time
    * {@link invalidate} is called so any fetch already running when
@@ -80,7 +92,10 @@ export class EpicTokenClient {
    * overwrite the cache (which a successful retry may have already
    * populated with a fresh token). Each fetch captures the generation
    * it was started under and only writes back to `cached` / `inFlight`
-   * if that generation is still current.
+   * if that generation is still current. With per-scope keying (#1144)
+   * the generation guard still operates globally — bumping it on
+   * invalidate() invalidates EVERY in-flight fetch across every scope
+   * key, which is correct since invalidate() clears all entries.
    */
   private generation = 0;
 
@@ -93,25 +108,46 @@ export class EpicTokenClient {
   ) {}
 
   /**
+   * Normalize a scope set to a stable cache key. Sorting before join
+   * means callers passing the same scopes in different orders share a
+   * single cache + in-flight slot (#1144). Empty arrays produce an
+   * empty string, which is a valid Map key distinct from any non-empty
+   * scope set — matching pre-existing behaviour that passes the empty
+   * string through as the `scope` form field.
+   */
+  private normalizeScopes(scopes: readonly string[]): string {
+    return [...scopes].sort().join(" ");
+  }
+
+  /**
    * Return a usable access token. Uses the cached value when it has
    * more than REFRESH_BUFFER_SEC of lifetime left; otherwise requests
    * a fresh one. Concurrent callers that arrive while a fetch is
-   * outstanding coalesce on a shared in-flight promise (#1089) so a
-   * burst of N callers issues a single network round-trip.
+   * outstanding AND requested the same scope set coalesce on a shared
+   * in-flight promise (#1089, #1144) so a burst of N same-scope
+   * callers issues a single network round-trip. Concurrent callers
+   * with DIFFERENT scope sets each get their own correctly-scoped
+   * fetch — coalescing across scope sets would silently hand a caller
+   * a token missing scopes it explicitly asked for.
    */
   async getAccessToken(scopes: string[] = DEFAULT_SYSTEM_SCOPES): Promise<string> {
-    if (this.cached) {
-      const remainingMs = this.cached.expiresAtMs - this.nowMs();
+    const key = this.normalizeScopes(scopes);
+
+    const cachedEntry = this.cached.get(key);
+    if (cachedEntry) {
+      const remainingMs = cachedEntry.expiresAtMs - this.nowMs();
       if (remainingMs > REFRESH_BUFFER_SEC * 1000) {
-        return this.cached.response.access_token;
+        return cachedEntry.response.access_token;
       }
     }
 
-    // If a refresh is already in flight, every concurrent caller awaits
-    // the same promise. The first caller to enter this branch sets
-    // `inFlight`; later callers in the same tick observe it and join.
-    if (this.inFlight) {
-      const parsed = await this.inFlight;
+    // If a refresh is already in flight for THIS scope key, every
+    // concurrent caller asking for the same scopes awaits the same
+    // promise. Different-scope callers fall through to start their own
+    // fetch below.
+    const existingInFlight = this.inFlight.get(key);
+    if (existingInFlight) {
+      const parsed = await existingInFlight;
       return parsed.access_token;
     }
 
@@ -121,8 +157,8 @@ export class EpicTokenClient {
     // have advanced; fetchToken() checks that and refuses to write
     // back stale results to either the cache or the in-flight slot.
     const myGen = this.generation;
-    const pending = this.fetchToken(scopes, issuedAtMs, myGen);
-    this.inFlight = pending;
+    const pending = this.fetchToken(scopes, issuedAtMs, myGen, key);
+    this.inFlight.set(key, pending);
     try {
       const parsed = await pending;
       return parsed.access_token;
@@ -131,8 +167,8 @@ export class EpicTokenClient {
       // invalidate() ran while we were awaiting, the slot has already
       // been cleared (or a newer fetch from the same generation has
       // populated it) and we must not stomp on the newer state.
-      if (this.generation === myGen && this.inFlight === pending) {
-        this.inFlight = null;
+      if (this.generation === myGen && this.inFlight.get(key) === pending) {
+        this.inFlight.delete(key);
       }
     }
   }
@@ -140,12 +176,15 @@ export class EpicTokenClient {
   /**
    * Internal fetch helper. Extracted so the in-flight slot can be
    * tracked as a single `Promise<TokenResponse>` regardless of the
-   * scope override or issued-at timestamp.
+   * scope override or issued-at timestamp. The `key` argument is the
+   * pre-computed normalized scope key (#1144) used to write the
+   * cache entry on success.
    */
   private async fetchToken(
     scopes: string[],
     issuedAtMs: number,
     startedAtGen: number,
+    key: string,
   ): Promise<TokenResponse> {
     const assertion = buildClientAssertion({
       clientId: this.config.clientId,
@@ -196,33 +235,40 @@ export class EpicTokenClient {
     // Only write back to the cache if our generation is still current
     // (#1143). If invalidate() fired while we were awaiting fetch /
     // response.json(), our result is stale — a subsequent retry may
-    // already have populated `cached` with a fresh token and we must
-    // not stomp on it.
+    // already have populated `cached` with a fresh token for THIS
+    // scope key (#1144) and we must not stomp on it. Per-key writes
+    // also mean a late, stale wide-scope fetch cannot pollute the
+    // unrelated narrow-scope cache entry.
     if (this.generation === startedAtGen) {
-      this.cached = {
+      this.cached.set(key, {
         response: parsed,
         expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
-      };
+      });
     }
     return parsed;
   }
 
   /**
-   * Drop the cached token AND any in-flight refresh promise. Forces
-   * the next {@link getAccessToken} call to request a fresh one.
+   * Drop ALL cached tokens (every scope key) AND every in-flight
+   * refresh promise. Forces the next {@link getAccessToken} call to
+   * request a fresh one regardless of which scope set it asks for.
    * Useful when the FHIR client receives a 401 (token revoked / org
    * rotated keys) and wants to retry once with a fresh assertion
-   * before failing. Clearing the in-flight reference too (#1089)
-   * prevents a stale-credential refresh from satisfying the retry.
+   * before failing. Clearing the in-flight references too (#1089)
+   * prevents a stale-credential refresh from satisfying the retry,
+   * and clearing across every scope key (#1144) prevents a different-
+   * scope cache entry from outliving a credential rotation.
    */
   invalidate(): void {
-    this.cached = null;
-    this.inFlight = null;
+    this.cached.clear();
+    this.inFlight.clear();
     // Bump the generation so any fetch that is already in flight when
     // invalidate() fires will see `this.generation !== startedAtGen`
     // when it tries to write its result back. That prevents the dropped
     // promise from overwriting a fresh token that a subsequent retry
-    // may have already cached (#1143).
+    // may have already cached (#1143). The generation is global, not
+    // per-scope-key — invalidate() really does invalidate every
+    // outstanding fetch across every scope set.
     this.generation += 1;
   }
 }


### PR DESCRIPTION
## Summary

Keys `inFlight` and `cached` in `EpicTokenClient` by normalized (sorted+joined) scopes string so concurrent callers with different scope sets do not share a token and unkeyed cache cannot serve a wrong-scope token to a subsequent caller.

Builds on the generation counter from #1143 (stale-write guard now operates per-key).

## Test plan

- [ ] Two concurrent fetches with different scopes -> two `fetch` calls, each correct
- [ ] Two concurrent fetches with same scopes (any order) -> coalesces to one
- [ ] `invalidate()` clears all keys
- [ ] Generation guard from #1143 still works per-key

Closes #1144
Depends on #1152