### PR TITLE
chore(medical-logic): tsconfig.check.json test-exclude parity (#1163)

### DIFF
--- a/packages/medical-logic/tsconfig.check.json
+++ b/packages/medical-logic/tsconfig.check.json
@@ -5,5 +5,5 @@
     "types": ["node"]
   },
   "include": ["src", "scripts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "src/__tests__"]
 }


### PR DESCRIPTION
## Summary

Adds `src/__tests__` to the `exclude` array of `packages/medical-logic/tsconfig.check.json` so its typecheck pass mirrors the `packages/ai-prompts/tsconfig.check.json` precedent. The check-config overrides `include` to `["src", "scripts"]` (without a `**/*.test.ts` filter), so without this exclusion the typecheck would pull test files into the build graph — inconsistent with the sibling package.

## Other tsconfig.check.json audits

Repo-wide search (`find packages services apps -name 'tsconfig.check.json'`) turns up exactly two files. Both now agree on excluding `src/__tests__`:

| File | include | exclude |
| --- | --- | --- |
| `packages/ai-prompts/tsconfig.check.json` | `["src", "evals"]` | `["dist", "node_modules", "src/__tests__"]` |
| `packages/medical-logic/tsconfig.check.json` (this PR) | `["src", "scripts"]` | `["dist", "node_modules", "src/__tests__"]` |

No further drift to flag — no other `tsconfig.check.json` files exist under `packages/`, `services/`, or `apps/`.

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic exec tsc -p tsconfig.check.json --noEmit` passes both before and after the change
- [x] `pnpm typecheck` (38/38 tasks)
- [x] `pnpm lint` (21/21 tasks; only pre-existing Next.js warnings)

Closes #1163