### PR TITLE
feat(epic): observability for dropped stale cache writes (#1161)

### DIFF
--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -488,4 +488,66 @@ describe("EpicTokenClient (#389)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(recovered).toBe("after-retry");
   });
+
+  it("emits a debug log when a stale-generation fetch is dropped (#1161)", async () => {
+    // After #1143 introduced the generation guard, a stale fetch that
+    // resolves AFTER invalidate() silently refuses to write back to the
+    // cache. Operators need observability into how often that happens —
+    // during a 401-driven invalidate storm the silent skip looked like a
+    // black hole. Assert that the skip path emits a structured debug log
+    // carrying both the captured and current generation counters so the
+    // churn is visible in log aggregators.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    let resolveFirst: (response: Response) => void;
+    let resolveSecond: (response: Response) => void;
+    const firstPending = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPending = new Promise<Response>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstPending)
+      .mockImplementationOnce(() => secondPending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    // P1 in-flight -> invalidate() bumps generation -> P2 in-flight ->
+    // resolve P2 first (fresh) then P1 last (stale, must be dropped +
+    // logged).
+    const firstCall = client.getAccessToken();
+    client.invalidate();
+    const secondCall = client.getAccessToken();
+
+    resolveSecond!(tokenResponse({ access_token: "fresh-token" }));
+    await secondCall;
+    resolveFirst!(tokenResponse({ access_token: "stale-token" }));
+    await firstCall;
+
+    // Find the debug log emitted from the stale-skip branch. Other debug
+    // lines may exist in the future — filter by the expected msg.
+    const debugEntries = logSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string) as Record<string, unknown>;
+        } catch {
+          return undefined;
+        }
+      })
+      .filter(
+        (entry): entry is Record<string, unknown> =>
+          !!entry &&
+          entry.level === "debug" &&
+          typeof entry.msg === "string" &&
+          (entry.msg as string).includes("stale"),
+      );
+
+    expect(debugEntries.length).toBeGreaterThanOrEqual(1);
+    const entry = debugEntries[0]!;
+    expect(entry.startedAtGen).toBe(0);
+    expect(entry.currentGen).toBe(1);
+
+    logSpy.mockRestore();
+  });
 });

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -244,6 +244,19 @@ export class EpicTokenClient {
         response: parsed,
         expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
       });
+    } else {
+      // The generation advanced while we were awaiting the network /
+      // JSON parse — invalidate() (typically a 401-driven retry path)
+      // fired mid-fetch and our result is stale (#1143). Skipping the
+      // cache write is correct, but the skip was previously silent;
+      // under 401 churn that hid useful signal from operators. Emit a
+      // structured debug line carrying both the captured and current
+      // generation so log aggregators can surface the rate of dropped
+      // stale writes during invalidate storms (#1161).
+      log.debug("Dropping stale Epic token cache write after invalidate", {
+        startedAtGen,
+        currentGen: this.generation,
+      });
     }
     return parsed;
   }


### PR DESCRIPTION
## Summary

Adds a debug log line when `fetchToken` skips a cache write because `invalidate()` advanced the generation mid-fetch. Includes `startedAtGen` + `currentGen` in the structured payload so operators can see invalidate churn during 401-driven outages.

## Test plan

- [ ] New test asserts the debug log fires on the stale-write path
- [ ] Existing #1143 race tests still pass

Closes #1161