### PR TITLE
feat(fhir): VitalType + US Core sub-profiles extension (#1165)

### DIFF
--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -42,6 +42,18 @@ export const VITAL_DANGER_ZONES: Record<VitalType, VitalRange> = {
   respiratory_rate: { min: 4, max: 60, criticalLow: 8, criticalHigh: 30 },
   pain_level: { min: 0, max: 10 },
   blood_glucose: { min: 10, max: 800, criticalLow: 54, criticalHigh: 350, warningLow: 70, warningHigh: 250 },
+  // US Core 5+ vital types (#1165). Bounds are plausibility checks only —
+  // no critical/warning thresholds because a single anthropometric
+  // measurement isn't a critical-value signal on its own. The min/max
+  // exist to reject sensor / unit-conversion noise.
+  // body_height: 20 cm (extreme preemie at ~22 wks ≈ 28 cm; pad down)
+  //              to 280 cm (tallest documented human, Robert Wadlow, 272 cm).
+  body_height: { min: 20, max: 280 },
+  // bmi: 5 kg/m² (extreme cachexia) to 150 kg/m² (super-morbid obesity).
+  bmi: { min: 5, max: 150 },
+  // head_circumference: 20 cm (extreme microcephaly preemie) to 80 cm
+  //                     (extreme macrocephaly; covers hydrocephalus).
+  head_circumference: { min: 20, max: 80 },
 };
 
 // ─── Age-Stratified Vital Ranges (Pediatric) ───────────────────

--- a/packages/shared-types/src/__tests__/clinical-data.test.ts
+++ b/packages/shared-types/src/__tests__/clinical-data.test.ts
@@ -88,6 +88,8 @@ describe("createVitalSchema", () => {
     const types = [
       "blood_pressure", "heart_rate", "o2_sat", "temperature",
       "weight", "respiratory_rate", "pain_level", "blood_glucose",
+      // US Core 5+ child-profile types (#1165)
+      "body_height", "bmi", "head_circumference",
     ];
     for (const type of types) {
       const result = vitalTypeSchema.safeParse(type);

--- a/packages/shared-types/src/clinical-data.schemas.ts
+++ b/packages/shared-types/src/clinical-data.schemas.ts
@@ -12,6 +12,11 @@ export const icd10CodeSchema = z
 export const vitalTypeSchema = z.enum([
   "blood_pressure", "heart_rate", "o2_sat", "temperature",
   "weight", "respiratory_rate", "pain_level", "blood_glucose",
+  // US Core 5+ child-profile types (#1165) — body_height, BMI, and
+  // head_circumference complete the umbrella+child slicing introduced
+  // in #1160. Keep this enum in lock-step with the `VitalType` union
+  // in clinical-data.ts.
+  "body_height", "bmi", "head_circumference",
 ]);
 
 export const createVitalSchema = z.object({

--- a/packages/shared-types/src/clinical-data.ts
+++ b/packages/shared-types/src/clinical-data.ts
@@ -96,7 +96,10 @@ export type VitalType =
   | "weight"
   | "respiratory_rate"
   | "pain_level"
-  | "blood_glucose";
+  | "blood_glucose"
+  | "body_height"
+  | "bmi"
+  | "head_circumference";
 
 export const VITAL_UNITS: Record<VitalType, string> = {
   blood_pressure: "mmHg",
@@ -107,6 +110,15 @@ export const VITAL_UNITS: Record<VitalType, string> = {
   respiratory_rate: "breaths/min",
   pain_level: "/10",
   blood_glucose: "mg/dL",
+  // SI canonical units. US Core 5+ vital-sign profiles for these three
+  // metrics align with UCUM cm / kg/m2, and pediatric growth charts
+  // (which depend on head_circumference + body_height) are universally
+  // metric — keeping the canonical unit metric avoids a conversion step
+  // on the AI-oversight side. Conversion to imperial happens at the
+  // presentation layer where needed.
+  body_height: "cm",
+  bmi: "kg/m2",
+  head_circumference: "cm",
 };
 
 /** LOINC codes for standard vital sign types (FHIR R4 Observation.code) */
@@ -119,6 +131,13 @@ export const VITAL_LOINC_CODES: Record<VitalType, string | null> = {
   respiratory_rate: "9279-1",
   pain_level: "72514-3",
   blood_glucose: "2339-0",
+  // US Core 5+ vital-sign child profiles fix these LOINC codes (#1165).
+  // head_circumference uses 9843-4 (Head Occipital-frontal circumference,
+  // no specified method) per us-core-head-circumference — NOT 8287-5,
+  // which is the tape-measure-specific variant.
+  body_height: "8302-2",
+  bmi: "39156-5",
+  head_circumference: "9843-4",
 };
 
 export interface Vital extends BaseRecord {

--- a/services/clinical-data/src/__tests__/validators.test.ts
+++ b/services/clinical-data/src/__tests__/validators.test.ts
@@ -52,6 +52,8 @@ describe("vitalTypeSchema", () => {
     const validTypes = [
       "blood_pressure", "heart_rate", "o2_sat", "temperature",
       "weight", "respiratory_rate", "pain_level", "blood_glucose",
+      // US Core 5+ child-profile types (#1165)
+      "body_height", "bmi", "head_circumference",
     ];
     for (const type of validTypes) {
       expect(vitalTypeSchema.safeParse(type).success).toBe(true);

--- a/services/fhir-gateway/src/__tests__/us-core-vital-sub-profiles.test.ts
+++ b/services/fhir-gateway/src/__tests__/us-core-vital-sub-profiles.test.ts
@@ -25,6 +25,9 @@ import {
   US_CORE_RESPIRATORY_RATE,
   US_CORE_BODY_TEMPERATURE,
   US_CORE_BODY_WEIGHT,
+  US_CORE_BODY_HEIGHT,
+  US_CORE_BMI,
+  US_CORE_HEAD_CIRCUMFERENCE,
   US_CORE_VITAL_SUB_PROFILES,
 } from "../generators/us-core-profiles.js";
 import type { Vital, VitalType } from "@carebridge/shared-types";
@@ -87,6 +90,24 @@ describe("US Core vital-signs sub-profiles (#1145)", () => {
         value_primary: 75,
         unit: "kg",
       },
+      {
+        type: "body_height",
+        subProfile: US_CORE_BODY_HEIGHT,
+        value_primary: 175,
+        unit: "cm",
+      },
+      {
+        type: "bmi",
+        subProfile: US_CORE_BMI,
+        value_primary: 24.5,
+        unit: "kg/m2",
+      },
+      {
+        type: "head_circumference",
+        subProfile: US_CORE_HEAD_CIRCUMFERENCE,
+        value_primary: 35,
+        unit: "cm",
+      },
     ];
 
     for (const c of cases) {
@@ -126,11 +147,11 @@ describe("US Core vital-signs sub-profiles (#1145)", () => {
       // future / unrecognised values, but the generator must still be
       // defensive at runtime so an unexpected payload from a legacy import
       // or upstream system does not crash the exporter.
-      const unknown = "head_circumference" as unknown as VitalType;
+      const unknown = "waist_circumference" as unknown as VitalType;
       const o = toFhirVitalObservation(
         makeVital({
           type: unknown,
-          value_primary: 35,
+          value_primary: 80,
           unit: "cm",
         }),
         "p1",
@@ -153,6 +174,11 @@ describe("US Core vital-signs sub-profiles (#1145)", () => {
         US_CORE_BODY_TEMPERATURE,
       );
       expect(US_CORE_VITAL_SUB_PROFILES.weight).toBe(US_CORE_BODY_WEIGHT);
+      expect(US_CORE_VITAL_SUB_PROFILES.body_height).toBe(US_CORE_BODY_HEIGHT);
+      expect(US_CORE_VITAL_SUB_PROFILES.bmi).toBe(US_CORE_BMI);
+      expect(US_CORE_VITAL_SUB_PROFILES.head_circumference).toBe(
+        US_CORE_HEAD_CIRCUMFERENCE,
+      );
     });
 
     it("all sub-profile URLs share the US Core StructureDefinition base", () => {
@@ -164,6 +190,9 @@ describe("US Core vital-signs sub-profiles (#1145)", () => {
         US_CORE_RESPIRATORY_RATE,
         US_CORE_BODY_TEMPERATURE,
         US_CORE_BODY_WEIGHT,
+        US_CORE_BODY_HEIGHT,
+        US_CORE_BMI,
+        US_CORE_HEAD_CIRCUMFERENCE,
       ]) {
         expect(url.startsWith(base)).toBe(true);
       }
@@ -187,6 +216,15 @@ describe("US Core vital-signs sub-profiles (#1145)", () => {
       );
       expect(US_CORE_BODY_WEIGHT).toBe(
         "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+      );
+      expect(US_CORE_BODY_HEIGHT).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+      );
+      expect(US_CORE_BMI).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+      );
+      expect(US_CORE_HEAD_CIRCUMFERENCE).toBe(
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
       );
     });
   });

--- a/services/fhir-gateway/src/generators/observation.ts
+++ b/services/fhir-gateway/src/generators/observation.ts
@@ -101,6 +101,19 @@ const VITAL_UNIT_TO_UCUM: Record<string, string> = {
   // Glucose / concentration
   "mg/dl": "mg/dL",
   "mmol/l": "mmol/L",
+  // Length — body_height, head_circumference (#1165)
+  "cm": "cm",
+  "centimeter": "cm",
+  "centimeters": "cm",
+  "centimetre": "cm",
+  "centimetres": "cm",
+  "m": "m",
+  "in": "[in_i]",
+  "inch": "[in_i]",
+  "inches": "[in_i]",
+  // BMI (#1165) — UCUM kg/m2
+  "kg/m2": "kg/m2",
+  "kg/m²": "kg/m2",
 };
 
 function vitalUnitToUcum(unit: string | null | undefined): string | undefined {
@@ -117,6 +130,11 @@ const VITAL_DISPLAY: Record<VitalType, string> = {
   respiratory_rate: "Respiratory rate",
   pain_level: "Pain severity rating",
   blood_glucose: "Glucose [Mass/volume] in Blood",
+  // US Core 5+ child-profile display strings (#1165). Mirror the LOINC
+  // term names for 8302-2, 39156-5, and 9843-4 respectively.
+  body_height: "Body height",
+  bmi: "Body mass index (BMI) [Ratio]",
+  head_circumference: "Head Occipital-frontal circumference",
 };
 
 // ─── Helpers ────────────────────────────────────────────────────

--- a/services/fhir-gateway/src/generators/us-core-profiles.ts
+++ b/services/fhir-gateway/src/generators/us-core-profiles.ts
@@ -73,6 +73,9 @@ export const US_CORE_PULSE_OXIMETRY = `${BASE}/us-core-pulse-oximetry`;
 export const US_CORE_RESPIRATORY_RATE = `${BASE}/us-core-respiratory-rate`;
 export const US_CORE_BODY_TEMPERATURE = `${BASE}/us-core-body-temperature`;
 export const US_CORE_BODY_WEIGHT = `${BASE}/us-core-body-weight`;
+export const US_CORE_BODY_HEIGHT = `${BASE}/us-core-body-height`;
+export const US_CORE_BMI = `${BASE}/us-core-bmi`;
+export const US_CORE_HEAD_CIRCUMFERENCE = `${BASE}/us-core-head-circumference`;
 
 /**
  * Lookup from local `VitalType` to its US Core child profile URL.
@@ -81,10 +84,6 @@ export const US_CORE_BODY_WEIGHT = `${BASE}/us-core-body-weight`;
  * exist in the schema but have NO matching US Core child profile (e.g.
  * `pain_level`, `blood_glucose`) are intentionally absent — the generator
  * falls back to the umbrella alone for those.
- *
- * Body-height, BMI, and head-circumference profiles exist in US Core but
- * are not in the local `VitalType` enum yet, so they're not listed here.
- * Add them once the corresponding schema values land.
  */
 export const US_CORE_VITAL_SUB_PROFILES: Partial<Record<VitalType, string>> = {
   blood_pressure: US_CORE_BLOOD_PRESSURE,
@@ -93,6 +92,9 @@ export const US_CORE_VITAL_SUB_PROFILES: Partial<Record<VitalType, string>> = {
   respiratory_rate: US_CORE_RESPIRATORY_RATE,
   temperature: US_CORE_BODY_TEMPERATURE,
   weight: US_CORE_BODY_WEIGHT,
+  body_height: US_CORE_BODY_HEIGHT,
+  bmi: US_CORE_BMI,
+  head_circumference: US_CORE_HEAD_CIRCUMFERENCE,
 };
 
 /** US Core Laboratory Result Observation profile URL. */

--- a/services/fhir-gateway/src/medlens-bridge.ts
+++ b/services/fhir-gateway/src/medlens-bridge.ts
@@ -24,6 +24,9 @@ const VITAL_TYPES: readonly VitalType[] = [
   "respiratory_rate",
   "pain_level",
   "blood_glucose",
+  "body_height",
+  "bmi",
+  "head_circumference",
 ] as const;
 
 function isVitalType(t: string): t is VitalType {


### PR DESCRIPTION
## Summary

Closes the gap left by #1160 — adds `body_height`, `bmi`, and `head_circumference` to `VitalType`, `VITAL_UNITS`, `VITAL_LOINC_CODES`, `vitalTypeSchema`, and `US_CORE_VITAL_SUB_PROFILES`. Three new tests pin the umbrella + child profile combo per vital, plus three lookup-table assertions.

LOINC verification (US Core 5+ canonical):
- `body_height` → `8302-2`
- `bmi` → `39156-5`
- `head_circumference` → `9843-4` (NOT `8287-5` as suggested in the issue — `8287-5` is the tape-measure-specific variant; US Core fixes the code to the unmethodised `9843-4`)

Downstream `Record<VitalType, _>` consumers updated in lock-step: `VITAL_UNITS`, `VITAL_LOINC_CODES`, `VITAL_DANGER_ZONES` (plausibility bounds only — these aren't critical-value triggers on a single reading), `VITAL_DISPLAY`, and the `medlens-bridge` runtime guard list. UCUM map gains `cm` and `kg/m2`.

## Test plan

- [x] body_height → us-core-vital-signs + us-core-body-height
- [x] bmi → us-core-vital-signs + us-core-bmi
- [x] head_circumference → us-core-vital-signs + us-core-head-circumference
- [x] LOINC codes match US Core 5+ IG (verified via WebFetch against hl7.org/fhir/us/core/STU5)
- [x] `pnpm typecheck` clean (38/38)
- [x] `pnpm lint` clean
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 500/500 passing
- [x] `pnpm --filter @carebridge/shared-types test` — 214/214 passing
- [x] `pnpm --filter @carebridge/medical-logic test` — 502/502 passing
- [x] `pnpm --filter @carebridge/clinical-data test` — 46/46 passing
- [x] `pnpm --filter @carebridge/ai-oversight test` — 938/938 passing

Closes #1165