### PR TITLE
fix(epic): normalizeScopes dedupe before sort (#1164)

### DIFF
--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -488,4 +488,66 @@ describe("EpicTokenClient (#389)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(recovered).toBe("after-retry");
   });
+
+  it("emits a debug log when a stale-generation fetch is dropped (#1161)", async () => {
+    // After #1143 introduced the generation guard, a stale fetch that
+    // resolves AFTER invalidate() silently refuses to write back to the
+    // cache. Operators need observability into how often that happens —
+    // during a 401-driven invalidate storm the silent skip looked like a
+    // black hole. Assert that the skip path emits a structured debug log
+    // carrying both the captured and current generation counters so the
+    // churn is visible in log aggregators.
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    let resolveFirst: (response: Response) => void;
+    let resolveSecond: (response: Response) => void;
+    const firstPending = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondPending = new Promise<Response>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstPending)
+      .mockImplementationOnce(() => secondPending);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    // P1 in-flight -> invalidate() bumps generation -> P2 in-flight ->
+    // resolve P2 first (fresh) then P1 last (stale, must be dropped +
+    // logged).
+    const firstCall = client.getAccessToken();
+    client.invalidate();
+    const secondCall = client.getAccessToken();
+
+    resolveSecond!(tokenResponse({ access_token: "fresh-token" }));
+    await secondCall;
+    resolveFirst!(tokenResponse({ access_token: "stale-token" }));
+    await firstCall;
+
+    // Find the debug log emitted from the stale-skip branch. Other debug
+    // lines may exist in the future — filter by the expected msg.
+    const debugEntries = logSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string) as Record<string, unknown>;
+        } catch {
+          return undefined;
+        }
+      })
+      .filter(
+        (entry): entry is Record<string, unknown> =>
+          !!entry &&
+          entry.level === "debug" &&
+          typeof entry.msg === "string" &&
+          (entry.msg as string).includes("stale"),
+      );
+
+    expect(debugEntries.length).toBeGreaterThanOrEqual(1);
+    const entry = debugEntries[0]!;
+    expect(entry.startedAtGen).toBe(0);
+    expect(entry.currentGen).toBe(1);
+
+    logSpy.mockRestore();
+  });
 });

--- a/services/epic-connector/src/__tests__/token-client.test.ts
+++ b/services/epic-connector/src/__tests__/token-client.test.ts
@@ -470,6 +470,78 @@ describe("EpicTokenClient (#389)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("dedupes duplicate scopes when computing the cache key (#1164)", async () => {
+    // ["a", "a"] and ["a"] are semantically identical scope requests —
+    // Epic issues the same token for both — and must therefore share a
+    // cache slot. Without dedupe the duplicate-input variant lands in a
+    // distinct Map key and forces a needless re-fetch.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "single-token" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "should-not-fetch" }));
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const first = await client.getAccessToken(["system/Patient.read"]);
+    const second = await client.getAccessToken([
+      "system/Patient.read",
+      "system/Patient.read",
+    ]);
+
+    expect(first).toBe("single-token");
+    // Cached hit — duplicate variant resolves the same key.
+    expect(second).toBe("single-token");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces concurrent callers when one passes duplicate scopes (#1164)", async () => {
+    // Concurrent calls with ["x"] and ["x", "x"] must share the same
+    // in-flight slot so a single network round-trip serves both callers.
+    let resolveFetch: (response: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockImplementation(() => pendingResponse);
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const plainCall = client.getAccessToken(["system/Patient.read"]);
+    const dupeCall = client.getAccessToken([
+      "system/Patient.read",
+      "system/Patient.read",
+    ]);
+
+    resolveFetch!(tokenResponse({ access_token: "shared-token" }));
+
+    expect(await plainCall).toBe("shared-token");
+    expect(await dupeCall).toBe("shared-token");
+    // Single fetch despite two distinct-looking input arrays.
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes order + dedupe together so equivalent scope sets share a key (#1164)", async () => {
+    // ["b", "a", "a"] and ["a", "b"] are the same scope set — order and
+    // dedupe combined must collapse them to a single cache + in-flight
+    // slot.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(tokenResponse({ access_token: "ordered-token" }))
+      .mockResolvedValueOnce(tokenResponse({ access_token: "should-not-fetch" }));
+    const client = new EpicTokenClient(makeConfig(privatePem), fetchMock);
+
+    const first = await client.getAccessToken([
+      "system/Observation.read",
+      "system/Patient.read",
+      "system/Patient.read",
+    ]);
+    const second = await client.getAccessToken([
+      "system/Patient.read",
+      "system/Observation.read",
+    ]);
+
+    expect(first).toBe("ordered-token");
+    expect(second).toBe("ordered-token");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("clears the in-flight promise when the token request fails (#1089)", async () => {
     // After a fetch failure, the in-flight promise must be cleared so a
     // retry can issue a fresh request — otherwise every subsequent

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -244,6 +244,19 @@ export class EpicTokenClient {
         response: parsed,
         expiresAtMs: issuedAtMs + parsed.expires_in * 1000,
       });
+    } else {
+      // The generation advanced while we were awaiting the network /
+      // JSON parse — invalidate() (typically a 401-driven retry path)
+      // fired mid-fetch and our result is stale (#1143). Skipping the
+      // cache write is correct, but the skip was previously silent;
+      // under 401 churn that hid useful signal from operators. Emit a
+      // structured debug line carrying both the captured and current
+      // generation so log aggregators can surface the rate of dropped
+      // stale writes during invalidate storms (#1161).
+      log.debug("Dropping stale Epic token cache write after invalidate", {
+        startedAtGen,
+        currentGen: this.generation,
+      });
     }
     return parsed;
   }

--- a/services/epic-connector/src/token-client.ts
+++ b/services/epic-connector/src/token-client.ts
@@ -108,15 +108,19 @@ export class EpicTokenClient {
   ) {}
 
   /**
-   * Normalize a scope set to a stable cache key. Sorting before join
-   * means callers passing the same scopes in different orders share a
-   * single cache + in-flight slot (#1144). Empty arrays produce an
-   * empty string, which is a valid Map key distinct from any non-empty
-   * scope set — matching pre-existing behaviour that passes the empty
-   * string through as the `scope` form field.
+   * Normalize a scope set to a stable cache key. Dedupe-then-sort
+   * before join means callers passing the same scopes in different
+   * orders OR with accidental duplicates share a single cache +
+   * in-flight slot (#1144, #1164). Without the Set, ["a", "a"] would
+   * hash to "a a" and miss the cache slot occupied by ["a"] -> "a",
+   * causing a needless double fetch + double cache for two semantically
+   * identical scope requests. Empty arrays produce an empty string,
+   * which is a valid Map key distinct from any non-empty scope set —
+   * matching pre-existing behaviour that passes the empty string
+   * through as the `scope` form field.
    */
   private normalizeScopes(scopes: readonly string[]): string {
-    return [...scopes].sort().join(" ");
+    return [...new Set(scopes)].sort().join(" ");
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds Set-based dedupe in `normalizeScopes()` so duplicated-input scope arrays collapse to the same cache + in-flight slot. Latent bug — no production caller passes scope overrides — but cheap to fix.

Builds on #1161 (token-client observability).

## Test plan

- [ ] `["a", "a"]` and `["a"]` produce same key
- [ ] Concurrent calls with `["x"]` and `["x", "x"]` coalesce to one fetch
- [ ] Order + dedupe: `["b", "a", "a"]` and `["a", "b"]` produce same key

Closes #1164
Depends on #1169