### PR TITLE
feat(medical-logic): anthropometric staleness thresholds (#1176)

### DIFF
--- a/packages/medical-logic/src/__tests__/vital-staleness-thresholds.test.ts
+++ b/packages/medical-logic/src/__tests__/vital-staleness-thresholds.test.ts
@@ -57,6 +57,28 @@ describe("getStalenessThreshold", () => {
     expect(t.overdueMs).toBe(4 * HOUR);
     expect(t.staleMs).toBe(24 * HOUR);
   });
+
+  // Anthropometric vitals (#1176) — measured on a monthly (pediatric
+  // well-child) or annual (adult) cadence, NOT the acute-care 4h/24h
+  // default. Flagging a 5-hour-old body_height as overdue is clinical
+  // noise, mirroring the existing `weight` precedent.
+  it("returns 30d/365d for body_height", () => {
+    const t = getStalenessThreshold("body_height");
+    expect(t.overdueMs).toBe(30 * DAY);
+    expect(t.staleMs).toBe(365 * DAY);
+  });
+
+  it("returns 30d/365d for bmi", () => {
+    const t = getStalenessThreshold("bmi");
+    expect(t.overdueMs).toBe(30 * DAY);
+    expect(t.staleMs).toBe(365 * DAY);
+  });
+
+  it("returns 30d/180d for head_circumference", () => {
+    const t = getStalenessThreshold("head_circumference");
+    expect(t.overdueMs).toBe(30 * DAY);
+    expect(t.staleMs).toBe(6 * 30 * DAY);
+  });
 });
 
 describe("VITAL_STALENESS_THRESHOLDS", () => {

--- a/packages/medical-logic/src/vital-staleness-thresholds.ts
+++ b/packages/medical-logic/src/vital-staleness-thresholds.ts
@@ -46,6 +46,13 @@ export const VITAL_STALENESS_THRESHOLDS: Partial<
   weight: { overdueMs: 24 * HOUR, staleMs: 7 * DAY },
   o2_sat: { overdueMs: 4 * HOUR, staleMs: 24 * HOUR },
   respiratory_rate: { overdueMs: 4 * HOUR, staleMs: 24 * HOUR },
+  // Anthropometric vitals (#1176). Acute-care 4h/24h is wrong: these
+  // refresh on a monthly (pediatric well-child) or annual (adult)
+  // cadence, mirroring the `weight` precedent above. Without explicit
+  // entries a 5h-old body_height would flag overdue — clinical noise.
+  body_height: { overdueMs: 30 * DAY, staleMs: 365 * DAY },
+  bmi: { overdueMs: 30 * DAY, staleMs: 365 * DAY },
+  head_circumference: { overdueMs: 30 * DAY, staleMs: 6 * 30 * DAY },
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds explicit `VITAL_STALENESS_THRESHOLDS` entries for the three new anthropometric vital types added by #1165 (`body_height`, `bmi`, `head_circumference`). The acute-care 4h/24h default was wrong for these — clinically they refresh on a monthly (pediatric well-child) or annual (adult) cadence, matching the existing `weight` precedent.

Proposed cadences:
- `body_height`: 30 days overdue / 365 days stale (pediatric monthly, adult annual)
- `bmi`: 30 days overdue / 365 days stale (derived from weight + height)
- `head_circumference`: 30 days overdue / 180 days stale (monthly pediatric well-child up to age 2-3)

**Clinical confirmation pending** — these match well-child schedule conventions but a nurse / pediatrics reviewer should sanity-check before merge. PR is otherwise mechanically complete.

Closes #1176