### PR TITLE
chore(infra): ignore local-only state (epic-connector probes + .claude lock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ dist/
 .env.local
 *.tsbuildinfo
 .claude/worktrees/
+
+# Local-only Epic-sandbox probe scripts (hit live Epic creds and reference
+# test-patient IDs — keep out of git).
+services/epic-connector/scripts/
+
+# Claude Code runtime state — local-only.
+.claude/*.lock


### PR DESCRIPTION
## Summary

Adds two `.gitignore` rules for local-only state that has been surfacing in `git status` every session:

- `services/epic-connector/scripts/` — hand-run Epic-sandbox probe scripts (token / search-param / full-sync) created during the epic-connector PRs (#1089, #1114, #1132). They hit live Epic creds and reference test-patient IDs, so they're explicitly **not** safe to commit.
- `.claude/*.lock` — Claude Code's runtime scheduled-task lock file. Per-session local state.

Both already exist on developer machines but have never been part of the tracked tree. Codifying the rule keeps future probe scripts / lock files quietly out of `git add .` and serves as a soft safety net against accidentally staging anything with PHI-adjacent identifiers.

## Test plan

- [ ] `git status` clean after the rules apply
- [ ] No existing tracked files match either pattern (verified — neither path was ever committed)