### PR TITLE
fix(portal): epic-launch-banner spoofing guard (#1186)

### DIFF
--- a/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
+++ b/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
@@ -85,7 +85,12 @@ afterEach(() => {
 });
 
 describe("EpicLaunchBanner", () => {
-  it("returns null when no epic_patient param is on the URL", () => {
+  it("returns null when no URL params AND server has no launch context", () => {
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: null,
+      isLoading: false,
+      isError: false,
+    });
     const { storage } = makeStorage();
     render(<EpicLaunchBanner storage={storage} />);
     expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
@@ -95,6 +100,17 @@ describe("EpicLaunchBanner", () => {
     searchParamsMock = new URLSearchParams({
       epic_patient: "eP123",
       epic_encounter: "eE456",
+    });
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "eP123",
+        launch_encounter_fhir_id: "eE456",
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
     });
     const { storage } = makeStorage();
     render(<EpicLaunchBanner storage={storage} />);
@@ -142,5 +158,91 @@ describe("EpicLaunchBanner", () => {
 
     render(<EpicLaunchBanner storage={storage} />);
     expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
+  });
+
+  // Issue #1186 — banner must NOT trust URL params alone. The server-confirmed
+  // launch context (epicAuth.getLaunchContext) is the source of truth; URL
+  // params are only used as a hint to enable the query.
+
+  it("renders null when server returns null but URL has epic_patient (anti-spoof)", () => {
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "spoofed-fhir-id",
+    });
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: null,
+      isLoading: false,
+      isError: false,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { storage } = makeStorage();
+    render(<EpicLaunchBanner storage={storage} />);
+    expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  it("renders banner from server values when URL params absent (post-callback genuine launch)", () => {
+    // No URL params at all — but server has a valid launch context.
+    searchParamsMock = new URLSearchParams();
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const { storage } = makeStorage();
+    render(<EpicLaunchBanner storage={storage} />);
+    const banner = screen.getByTestId("epic-launch-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toMatch(/abc/);
+  });
+
+  it("renders null + warns when URL epic_patient mismatches server epic_patient_fhir_id", () => {
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "spoof",
+    });
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { storage } = makeStorage();
+    render(<EpicLaunchBanner storage={storage} />);
+    expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("renders banner from server values when URL epic_patient matches server (uses server values)", () => {
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "abc",
+    });
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+    const { storage } = makeStorage();
+    render(<EpicLaunchBanner storage={storage} />);
+    const banner = screen.getByTestId("epic-launch-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toMatch(/abc/);
   });
 });

--- a/apps/clinician-portal/src/components/epic-launch-banner.tsx
+++ b/apps/clinician-portal/src/components/epic-launch-banner.tsx
@@ -1,16 +1,32 @@
 "use client";
 
 /**
- * Epic launch-context banner (#1182).
+ * Epic launch-context banner (#1182, hardened in #1186).
  *
  * Shown at the top of the clinician portal when the user has arrived
  * via the SMART App Launch callback. The callback in
  * services/api-gateway/src/routes/epic-auth.ts appends
  * `?epic_patient=<fhir-id>&epic_encounter=<fhir-id>` to the configured
- * post-launch redirect, so the SPA detects launch-mode by looking for
- * those query params and cross-checks against `epicAuth.getLaunchContext`
- * (which only returns a non-null payload when the most-recent connection
- * is still within its access-token TTL).
+ * post-launch redirect.
+ *
+ * SECURITY (#1186): The banner does NOT trust URL params on their own —
+ * server-confirmed launch context (`epicAuth.getLaunchContext`) is the
+ * sole source of truth for the rendered patient/org/encounter values.
+ * URL params can be spoofed by anyone with a clinician-facing link
+ * (e.g. `?epic_patient=fake-id`), so we:
+ *
+ *   1. Always issue the `getLaunchContext` query (regardless of URL).
+ *   2. Render null while the query is in flight, on error, or when the
+ *      server returns null (no valid Epic connection).
+ *   3. When server context is present AND URL params are present, they
+ *      MUST match — otherwise we hide the banner and emit a console.warn
+ *      (a tamper signal worth surfacing in browser logs).
+ *   4. When server context is present AND no URL params are present,
+ *      we still render — this preserves the original clinical-safety
+ *      intent for the "session-store row outlived the URL" case (e.g.
+ *      a deep-link navigation that dropped the search params).
+ *   5. The displayed FHIR ids/org are taken from the SERVER payload,
+ *      never the URL.
  *
  * The banner offers a "Switch to portal mode" action that strips the
  * launch markers from the URL and sets a sessionStorage suppression flag
@@ -35,45 +51,76 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const epicPatient = searchParams?.get("epic_patient") ?? null;
-  const epicEncounter = searchParams?.get("epic_encounter") ?? null;
-  const inLaunchContext = Boolean(epicPatient);
+  const urlEpicPatient = searchParams?.get("epic_patient") ?? null;
+  const urlEpicEncounter = searchParams?.get("epic_encounter") ?? null;
+
+  // Always query the server. URL params are a hint at best — the server
+  // is the source of truth for whether a launch context is real and what
+  // the actual patient/org/encounter ids are.
+  const contextQuery = trpc.epicAuth.getLaunchContext.useQuery(undefined, {
+    staleTime: 60_000,
+  });
 
   // Sessionstorage suppression — only access on the client after mount.
+  // Keyed on the server-confirmed patient id so spoofed URLs can't
+  // pre-suppress a future genuine launch.
+  const ctx = contextQuery.data ?? null;
+  const serverPatient = ctx?.epic_patient_fhir_id ?? null;
+
   const [suppressed, setSuppressed] = useState(false);
   useEffect(() => {
-    if (!inLaunchContext) return;
+    if (!serverPatient) return;
     try {
       const ss = storage ?? globalThis.sessionStorage;
-      if (ss?.getItem(SUPPRESS_KEY) === epicPatient) {
+      if (ss?.getItem(SUPPRESS_KEY) === serverPatient) {
         setSuppressed(true);
       }
     } catch {
       // sessionStorage unavailable (SSR, blocked) — leave un-suppressed.
     }
-  }, [inLaunchContext, epicPatient, storage]);
+  }, [serverPatient, storage]);
 
-  // Pull the full launch context (org iss, expiry) only when the URL
-  // claims we just launched — avoids an unnecessary network round-trip
-  // for every page view.
-  const contextQuery = trpc.epicAuth.getLaunchContext.useQuery(undefined, {
-    enabled: inLaunchContext && !suppressed,
-    staleTime: 60_000,
-  });
+  // Hide while loading or on error — better to flash nothing than to
+  // flash an unverified URL-derived banner.
+  if (contextQuery.isLoading || contextQuery.isError) return null;
 
-  if (!inLaunchContext || suppressed) return null;
+  // Server says no valid Epic connection → render nothing, even if the
+  // URL claims otherwise. This is the anti-spoofing gate.
+  if (!ctx) return null;
 
-  // Optional: when the URL says we launched but the server says no valid
-  // connection, still show the banner using URL data (the connection
-  // may have just expired between the redirect and now — clinically it's
-  // safer to surface the patient context than to silently drop it).
-  const ctx = contextQuery.data ?? null;
-  const orgLabel = ctx?.epic_org_iss ?? "Epic";
+  if (suppressed) return null;
+
+  // If the URL has params, they MUST agree with the server. If they
+  // don't, someone tampered — hide the banner and log a warning so it
+  // surfaces in browser dev tools / error-reporting pipelines.
+  if (urlEpicPatient && urlEpicPatient !== ctx.epic_patient_fhir_id) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[epic-launch-banner] URL epic_patient does not match server launch context; hiding banner.",
+    );
+    return null;
+  }
+  if (
+    urlEpicEncounter &&
+    ctx.launch_encounter_fhir_id &&
+    urlEpicEncounter !== ctx.launch_encounter_fhir_id
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[epic-launch-banner] URL epic_encounter does not match server launch context; hiding banner.",
+    );
+    return null;
+  }
+
+  // From here on, render exclusively from server values.
+  const orgLabel = ctx.epic_org_iss ?? "Epic";
+  const patientId = ctx.epic_patient_fhir_id;
+  const encounterId = ctx.launch_encounter_fhir_id;
 
   function handleSwitchToPortal() {
     try {
       const ss = storage ?? globalThis.sessionStorage;
-      if (epicPatient) ss?.setItem(SUPPRESS_KEY, epicPatient);
+      if (patientId) ss?.setItem(SUPPRESS_KEY, patientId);
     } catch {
       // Best-effort.
     }
@@ -111,11 +158,11 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
           Launched from {orgLabel}
         </div>
         <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
-          Viewing Epic patient FHIR id <code>{epicPatient}</code>
-          {epicEncounter && (
+          Viewing Epic patient FHIR id <code>{patientId}</code>
+          {encounterId && (
             <>
               {" "}
-              · Encounter <code>{epicEncounter}</code>
+              · Encounter <code>{encounterId}</code>
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

The banner no longer renders Epic context from URL params alone — it requires `epicAuth.getLaunchContext` to return a non-null server-confirmed context. If the server says no context and the URL says yes, the banner stays hidden (and emits a console.warn for mismatch).

Preserves the clinical-safety intent for genuine launches: when server context is present, the banner uses server values exclusively.

## Test plan

- [ ] Server null + URL set → renders null
- [ ] Server set + URL absent → banner renders (genuine post-callback)
- [ ] Server set + URL mismatch → renders null + warn
- [ ] Server set + URL match → banner renders, uses server values

Closes #1186