### PR TITLE
fix(gateway): /auth/epic/authorize open-redirect (#1185)

### DIFF
--- a/services/api-gateway/src/__tests__/epic-auth-redirect-validation.test.ts
+++ b/services/api-gateway/src/__tests__/epic-auth-redirect-validation.test.ts
@@ -244,4 +244,33 @@ describe("GET /auth/epic/authorize — redirect validation (#1185)", () => {
     expect(beginLaunchMock).toHaveBeenCalledTimes(1);
     expect(capturedBeginLaunchArgs[0]?.postLaunchRedirect).toBe("/");
   });
+
+  // Exercises the explicit `/\` prefix guard. Some URL parsers normalise
+  // `/\foo` into the same-origin path `/\foo`, others promote the
+  // backslash to a path separator. We reject up-front so neither shape
+  // can slip through if the parser ever changes behaviour.
+  it("rejects mixed-slash ?redirect=/\\attacker.example with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("/\\attacker.example")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
+
+  // Whitespace-prefixed candidate — fails the `startsWith("/")` guard.
+  // Important because raw spaces survive `decodeURIComponent` and could
+  // hide downstream parser quirks if we accepted them.
+  it("rejects whitespace-prefixed ?redirect=%20/legit with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent(" /legit")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
 });

--- a/services/api-gateway/src/__tests__/epic-auth-redirect-validation.test.ts
+++ b/services/api-gateway/src/__tests__/epic-auth-redirect-validation.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Open-redirect hardening on GET /auth/epic/authorize (issue #1185).
+ *
+ * The handler previously stored `request.query.redirect` verbatim in launch
+ * state; the callback later did `reply.redirect(finalUrl)` on whatever came
+ * back. Anyone crafting the URL by hand could land a logged-in clinician on
+ * an attacker-controlled origin after the OAuth dance.
+ *
+ * We now validate the redirect on entry: it must parse as a same-origin
+ * path (starts with `/`, no scheme, no protocol-relative `//`, no Windows
+ * `\\` trick). Reject with 400 otherwise.
+ *
+ * These tests boot a minimal Fastify server with a stub user preHandler
+ * and stub the epic-connector orchestrator so beginLaunch doesn't try to
+ * fetch SMART configuration over the network.
+ */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted above the route-module import
+// ---------------------------------------------------------------------------
+
+interface CapturedBeginLaunchArgs {
+  iss: string;
+  launch?: string;
+  userId: string;
+  redirectUri: string;
+  clientId: string;
+  postLaunchRedirect: string;
+}
+
+const capturedBeginLaunchArgs: CapturedBeginLaunchArgs[] = [];
+const beginLaunchMock = vi.fn(async (args: CapturedBeginLaunchArgs) => {
+  capturedBeginLaunchArgs.push(args);
+  return {
+    authorizeUrl:
+      "https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize?state=test-state",
+    state: "test-state",
+  };
+});
+
+vi.mock("@carebridge/epic-connector", () => {
+  class InMemoryLaunchStateStore {
+    async set() {}
+    async get() {
+      return null;
+    }
+    async delete() {}
+  }
+  class RedisLaunchStateStore {
+    async set() {}
+    async get() {
+      return null;
+    }
+    async delete() {}
+  }
+  return {
+    beginLaunch: beginLaunchMock,
+    completeLaunch: vi.fn(),
+    InMemoryLaunchStateStore,
+    RedisLaunchStateStore,
+  };
+});
+
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Env must be set before the route module imports `process.env`.
+process.env.EPIC_CLIENT_ID = "test-client-id";
+process.env.EPIC_APP_LAUNCH_REDIRECT_URI =
+  "https://app.carebridge.test/auth/epic/callback";
+
+const { registerEpicAuthRoutes } = await import("../routes/epic-auth.js");
+
+// ---------------------------------------------------------------------------
+// Server builder
+// ---------------------------------------------------------------------------
+
+const TEST_USER = {
+  id: "user-1185-test",
+  email: "redirect-test@carebridge.dev",
+  name: "Redirect Test",
+  role: "physician" as const,
+  is_active: true,
+};
+
+function buildServer(): FastifyInstance {
+  const server = Fastify({ logger: false });
+
+  // Stub-auth preHandler — mimics what authMiddleware does for real
+  // sessions, but driven by a header so each test can opt in.
+  server.addHook("preHandler", async (req) => {
+    if (req.headers["x-test-auth"] === "1") {
+      (req as unknown as Record<string, unknown>).user = TEST_USER;
+    }
+  });
+
+  registerEpicAuthRoutes(server);
+  return server;
+}
+
+const ISS = "https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /auth/epic/authorize — redirect validation (#1185)", () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = buildServer();
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    capturedBeginLaunchArgs.length = 0;
+    beginLaunchMock.mockClear();
+  });
+
+  it("accepts same-origin path '/settings/integrations' and forwards it to launch state", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=/settings/integrations`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(beginLaunchMock).toHaveBeenCalledTimes(1);
+    expect(capturedBeginLaunchArgs[0]?.postLaunchRedirect).toBe(
+      "/settings/integrations",
+    );
+  });
+
+  it("rejects absolute URL ?redirect=https://attacker.example with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=https://attacker.example`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+    const body = response.json() as { error: string };
+    expect(body.error).toBe("invalid_redirect");
+  });
+
+  it("rejects protocol-relative ?redirect=//attacker.example with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("//attacker.example")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects javascript: scheme injection ?redirect=javascript:alert(1) with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("javascript:alert(1)")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Windows-style backslash ?redirect=\\\\attacker.example with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("\\\\attacker.example")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects data: URI ?redirect=data:text/html,<script>alert(1)</script> with 400", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("data:text/html,<script>alert(1)</script>")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(beginLaunchMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts paths with traversal segments (path traversal is the receiver's problem)", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=${encodeURIComponent("/../../../etc/passwd")}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    // The redirect validator's job is to keep the user on our origin, not
+    // to second-guess what their app does with the path.
+    expect(response.statusCode).toBe(302);
+    expect(beginLaunchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to '/' when ?redirect is absent", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(beginLaunchMock).toHaveBeenCalledTimes(1);
+    expect(capturedBeginLaunchArgs[0]?.postLaunchRedirect).toBe("/");
+  });
+
+  it("treats empty ?redirect= as absent and defaults to '/'", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: `/auth/epic/authorize?iss=${encodeURIComponent(ISS)}&redirect=`,
+      headers: { "x-test-auth": "1" },
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(beginLaunchMock).toHaveBeenCalledTimes(1);
+    expect(capturedBeginLaunchArgs[0]?.postLaunchRedirect).toBe("/");
+  });
+});

--- a/services/api-gateway/src/routes/epic-auth.ts
+++ b/services/api-gateway/src/routes/epic-auth.ts
@@ -36,6 +36,64 @@ import { createLogger } from "@carebridge/logger";
 
 const log = createLogger("epic-auth-routes");
 
+/**
+ * Sentinel origin used to parse a candidate redirect as a URL relative to
+ * a known-bad base. If the resulting `URL.origin` differs, the input
+ * declared its own origin (i.e. it's absolute or protocol-relative) and
+ * we must reject — otherwise we'd hand attackers an open-redirect via
+ * `?redirect=https://evil.example` etc.
+ */
+const REDIRECT_BASE = "http://placeholder.invalid";
+
+/**
+ * Validate that `redirect` is a same-origin path we can safely hand to
+ * `reply.redirect()` on the callback. Returns the normalised redirect
+ * string on success, or `null` to signal "reject as 400".
+ *
+ * Accepts:
+ *   - missing / empty → `/`
+ *   - any string that starts with `/` and parses as a path relative to
+ *     the placeholder origin (i.e. URL parsing does not promote it to
+ *     a different origin)
+ *
+ * Rejects:
+ *   - absolute URLs (`https://attacker.example/…`)
+ *   - protocol-relative (`//attacker.example`)
+ *   - Windows-path tricks (`\\attacker.example`)
+ *   - any `scheme:` form (`javascript:`, `data:`, etc.) — caught by the
+ *     same-origin check after URL parsing.
+ *
+ * Path-traversal like `/../../etc/passwd` is NOT rejected here — it's
+ * still a same-origin path, so it can't take the user off our origin.
+ * Defending against traversal is the receiving handler's job.
+ */
+export function validateRedirect(redirect: string | undefined): string | null {
+  if (redirect === undefined || redirect === "") {
+    return "/";
+  }
+
+  // Must start with a single forward slash. Reject `//…` (protocol-
+  // relative) and `\\…` (Windows-style) up-front so a malformed URL
+  // parser quirk can't slip them through.
+  if (!redirect.startsWith("/")) return null;
+  if (redirect.startsWith("//")) return null;
+  if (redirect.startsWith("/\\")) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(redirect, REDIRECT_BASE);
+  } catch {
+    return null;
+  }
+
+  // If URL parsing produced a different origin, the input declared one
+  // of its own — that's the open-redirect vector we're closing.
+  if (parsed.origin !== REDIRECT_BASE) return null;
+  if (!parsed.pathname.startsWith("/")) return null;
+
+  return redirect;
+}
+
 interface EpicAuthRouteOptions {
   redis?: Redis;
   /**
@@ -103,6 +161,21 @@ export function registerEpicAuthRoutes(
         });
       }
 
+      // #1185 — Validate `redirect` BEFORE we persist anything to launch
+      // state. The callback later does `reply.redirect(postLaunchRedirect)`
+      // verbatim, so an unchecked value here is a classic open-redirect
+      // surface. The validator accepts only same-origin paths.
+      const safeRedirect = validateRedirect(request.query.redirect);
+      if (safeRedirect === null) {
+        return reply.code(400).send({
+          error: "invalid_redirect",
+          message:
+            "?redirect must be a same-origin path starting with '/'. " +
+            "Absolute URLs, protocol-relative '//', and 'scheme:' forms " +
+            "are rejected.",
+        });
+      }
+
       try {
         const { authorizeUrl } = await beginLaunch(
           {
@@ -111,7 +184,7 @@ export function registerEpicAuthRoutes(
             userId: request.user.id,
             redirectUri,
             clientId,
-            postLaunchRedirect: request.query.redirect ?? "/",
+            postLaunchRedirect: safeRedirect,
           },
           store,
         );

--- a/services/api-gateway/vitest.config.ts
+++ b/services/api-gateway/vitest.config.ts
@@ -49,6 +49,18 @@ export default defineConfig({
         __dirname,
         "../../services/ai-oversight/src/index.ts",
       ),
+      // Aliased so the route module can import the package in tests
+      // without the dist build. Every test that uses the gateway's epic
+      // routes mocks `@carebridge/epic-connector` directly, so the alias
+      // only needs to resolve to *something* in the module graph.
+      "@carebridge/epic-connector": path.resolve(
+        __dirname,
+        "../../services/epic-connector/src/index.ts",
+      ),
+      "@carebridge/logger": path.resolve(
+        __dirname,
+        "../../packages/logger/src/index.ts",
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary

Validates the optional `redirect` query parameter on `GET /auth/epic/authorize` to be a same-origin path. Rejects `https://*`, `//`, `javascript:`, `data:`, and other absolute or protocol-relative forms with 400.

UI today hardcodes `redirect=/settings/integrations` so users hitting the OAuth flow via the portal are unaffected. This closes the route-level open-redirect surface for hand-crafted phishing URLs.

## Test plan

- [ ] Same-origin paths preserved through the flow
- [ ] Absolute / protocol-relative / scheme-injection rejected with 400
- [ ] Missing redirect defaults to "/"

Closes #1185