### PR TITLE
feat(portal): forward epic_patient URL param to EpicSyncCard (#1188)

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/lab-display";
 import { PrescriptionForm } from "./PrescriptionForm";
 import { EpicSyncCard } from "@/components/epic-sync-card";
+import { parseEpicPatientParam } from "@/lib/epic-launch";
 import type { Medication } from "@carebridge/shared-types";
 
 const tabs = [
@@ -85,7 +86,13 @@ function stalenessStyles(tier: StalenessTier): {
   }
 }
 
-function OverviewTab({ patientId }: { patientId: string }) {
+function OverviewTab({
+  patientId,
+  epicPatientFhirId,
+}: {
+  patientId: string;
+  epicPatientFhirId?: string;
+}) {
   const patientQuery = trpc.patients.getById.useQuery({ id: patientId });
   const diagnosesQuery = trpc.patients.diagnoses.getByPatient.useQuery({ patientId });
   const allergiesQuery = trpc.patients.allergies.getByPatient.useQuery({ patientId });
@@ -249,8 +256,14 @@ function OverviewTab({ patientId }: { patientId: string }) {
         )}
       </div>
 
-      {/* Epic sync status + admin-only Sync Now action (#1182). */}
-      <EpicSyncCard patientId={patientId} />
+      {/* Epic sync status + admin-only Sync Now action (#1182).
+          When the user arrived via the Epic SMART launch flow the URL
+          carries `?epic_patient=<fhir-id>` (#1188) — forward it so the
+          backend can skip the stored-mapping lookup. */}
+      <EpicSyncCard
+        patientId={patientId}
+        epicPatientFhirId={epicPatientFhirId}
+      />
     </div>
   );
 }
@@ -952,6 +965,12 @@ function PatientChartContent() {
 
   const patientId = params.id as string;
   const activeTab = searchParams.get("tab") || "overview";
+  // Epic SMART-launch flow surfaces the patient FHIR id on the URL
+  // (#1188). Validate before forwarding so a hostile / typo'd value
+  // never reaches the triggerSync payload.
+  const epicPatientFhirId = parseEpicPatientParam(
+    searchParams.get("epic_patient"),
+  );
 
   const patientQuery = trpc.patients.getById.useQuery({ id: patientId });
   const patient = patientQuery.data;
@@ -1011,7 +1030,12 @@ function PatientChartContent() {
             ))}
           </div>
 
-          {activeTab === "overview" && <OverviewTab patientId={patientId} />}
+          {activeTab === "overview" && (
+            <OverviewTab
+              patientId={patientId}
+              epicPatientFhirId={epicPatientFhirId}
+            />
+          )}
           {activeTab === "vitals" && <VitalsTab patientId={patientId} />}
           {activeTab === "labs" && <LabsTab patientId={patientId} />}
           {activeTab === "medications" && (

--- a/apps/clinician-portal/src/__tests__/epic-launch-helper.test.ts
+++ b/apps/clinician-portal/src/__tests__/epic-launch-helper.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for `parseEpicPatientParam` (#1188).
+ *
+ * The helper is the single source of truth for the FHIR-id grammar
+ * applied to the `?epic_patient` query param before it leaves the
+ * clinician portal. The acceptance bar mirrors FHIR R4 §2.36.1.4 plus
+ * the additional defence-in-depth requirements called out in the
+ * issue: reject empty input, reject anything outside `[A-Za-z0-9.-]`,
+ * cap at 64 characters.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseEpicPatientParam,
+  FHIR_ID_MAX_LENGTH,
+} from "../lib/epic-launch";
+
+describe("parseEpicPatientParam (#1188)", () => {
+  it("returns undefined for null", () => {
+    expect(parseEpicPatientParam(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(parseEpicPatientParam(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(parseEpicPatientParam("")).toBeUndefined();
+  });
+
+  it("accepts a plain alphanumeric FHIR id", () => {
+    expect(parseEpicPatientParam("ePatient123")).toBe("ePatient123");
+  });
+
+  it("accepts hyphens and dots (FHIR-allowed separators)", () => {
+    expect(parseEpicPatientParam("a-b.c-1")).toBe("a-b.c-1");
+  });
+
+  it("rejects whitespace", () => {
+    expect(parseEpicPatientParam("eP 1")).toBeUndefined();
+  });
+
+  it("rejects HTML/script-injection characters", () => {
+    expect(parseEpicPatientParam("<script>")).toBeUndefined();
+    expect(parseEpicPatientParam("a&b")).toBeUndefined();
+    expect(parseEpicPatientParam("a/b")).toBeUndefined();
+  });
+
+  it("rejects underscore and other non-FHIR punctuation", () => {
+    expect(parseEpicPatientParam("a_b")).toBeUndefined();
+    expect(parseEpicPatientParam("a:b")).toBeUndefined();
+  });
+
+  it("accepts a 64-character id (boundary)", () => {
+    const id = "a".repeat(FHIR_ID_MAX_LENGTH);
+    expect(parseEpicPatientParam(id)).toBe(id);
+  });
+
+  it("rejects a 65-character id (just over the boundary)", () => {
+    const id = "a".repeat(FHIR_ID_MAX_LENGTH + 1);
+    expect(parseEpicPatientParam(id)).toBeUndefined();
+  });
+});

--- a/apps/clinician-portal/src/__tests__/patient-chart-epic-param.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patient-chart-epic-param.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1188 — forward the `?epic_patient` URL param from the Epic SMART
+ * launch flow into `<EpicSyncCard>` so the "Sync from Epic now" action
+ * skips the stored-mapping round-trip.
+ *
+ * Three behaviours are exercised:
+ *   1. URL param present and well-formed → forwarded as
+ *      `epicPatientFhirId` prop and ends up in the `triggerSync` payload
+ *      as `epic_patient_fhir_id`.
+ *   2. URL param absent → not forwarded; the mutation is called without
+ *      `epic_patient_fhir_id` (effectively `undefined`).
+ *   3. URL param malformed (e.g. `<script>` injection, oversize) → not
+ *      forwarded. The card behaves identically to the no-param case so
+ *      a hostile URL cannot poison the downstream tRPC call.
+ */
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeEach,
+  vi,
+} from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+
+// ---------------------------------------------------------------------
+// Mutable mocks
+// ---------------------------------------------------------------------
+
+let mockEpicPatientParam: string | null = null;
+let mockTabParam: string | null = null;
+
+const triggerMutate = vi.fn();
+const invalidate = vi.fn().mockResolvedValue(undefined);
+
+const { patient } = vi.hoisted(() => ({
+  patient: {
+    id: "patient-1",
+    name: "Jane Doe",
+    mrn: "MRN-0001",
+    date_of_birth: "1970-01-01",
+    biological_sex: "F",
+    allergy_status: "nkda",
+  },
+}));
+
+// AuthGuard pass-through.
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Admin so the Sync Now button is rendered and we can click it.
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "admin", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "patient-1" }),
+  useSearchParams: () => ({
+    get: (key: string) => {
+      if (key === "tab") return mockTabParam;
+      if (key === "epic_patient") return mockEpicPatientParam;
+      return null;
+    },
+  }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/components/vitals-trend-chart", () => ({
+  VitalsTrendChart: () => null,
+}));
+
+vi.mock("@/components/stale-data-banner", () => ({
+  StaleDataBanner: () => null,
+}));
+
+// Permissive tRPC mock; we override the handful of procs the Overview
+// tab + EpicSyncCard actually exercise. triggerSync is wired to a real
+// vi.fn so we can assert on its payload.
+vi.mock("@/lib/trpc", () => {
+  const stubQuery = <T,>(data: T) => ({
+    useQuery: () => ({ data, isLoading: false, isError: false }),
+  });
+
+  const proxyFor = (path: string): unknown => {
+    if (path === "patients.getById") {
+      return stubQuery(patient);
+    }
+    if (path === "patients.diagnoses.getByPatient") return stubQuery([]);
+    if (path === "patients.allergies.getByPatient") return stubQuery([]);
+    if (path === "patients.careTeam.getByPatient") return stubQuery([]);
+    if (path === "epicSync.getSyncStatus") return stubQuery([]);
+
+    // Default: loading-but-quiet.
+    return {
+      useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
+      useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+    };
+  };
+
+  const proxy = (path: string[]): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === "then") return undefined;
+          if (prop === "useUtils") {
+            return () => ({
+              epicSync: {
+                getSyncStatus: { invalidate },
+              },
+              // Deep proxy for any other utils chain.
+              get: () => ({}),
+            });
+          }
+          if (prop === "useQuery" || prop === "useMutation") {
+            const target = proxyFor(path.join(".")) as Record<string, unknown>;
+            if (prop === "useMutation" && path.join(".") === "epicSync.triggerSync") {
+              return ({ onSuccess }: { onSuccess?: () => void } = {}) => ({
+                mutate: (input: unknown) => {
+                  triggerMutate(input);
+                  onSuccess?.();
+                },
+                isPending: false,
+              });
+            }
+            const fn = target[prop];
+            if (typeof fn === "function") return fn;
+            if (prop === "useMutation") {
+              return () => ({ mutate: vi.fn(), isPending: false });
+            }
+            return () => ({ data: undefined, isLoading: true, isError: false });
+          }
+          return proxy([...path, prop]);
+        },
+      },
+    );
+
+  return { trpc: proxy([]) };
+});
+
+import PatientChartPage from "../../app/patients/[id]/page";
+
+beforeEach(() => {
+  triggerMutate.mockClear();
+  invalidate.mockClear();
+  mockEpicPatientParam = null;
+  mockTabParam = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("patient chart forwards ?epic_patient to EpicSyncCard (#1188)", () => {
+  it("forwards a well-formed epic_patient param into triggerSync", () => {
+    mockEpicPatientParam = "eP1";
+
+    render(<PatientChartPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sync from Epic now/i }),
+    );
+
+    expect(triggerMutate).toHaveBeenCalledTimes(1);
+    expect(triggerMutate).toHaveBeenCalledWith({
+      mode: "incremental",
+      patient_id: "patient-1",
+      epic_patient_fhir_id: "eP1",
+    });
+  });
+
+  it("does not forward epic_patient_fhir_id when the param is absent", () => {
+    mockEpicPatientParam = null;
+
+    render(<PatientChartPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sync from Epic now/i }),
+    );
+
+    expect(triggerMutate).toHaveBeenCalledTimes(1);
+    const payload = triggerMutate.mock.calls[0]?.[0] as {
+      epic_patient_fhir_id?: string;
+    };
+    expect(payload.epic_patient_fhir_id).toBeUndefined();
+  });
+
+  it("rejects a malformed epic_patient param (script injection)", () => {
+    mockEpicPatientParam = "<script>alert(1)</script>";
+
+    render(<PatientChartPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sync from Epic now/i }),
+    );
+
+    expect(triggerMutate).toHaveBeenCalledTimes(1);
+    const payload = triggerMutate.mock.calls[0]?.[0] as {
+      epic_patient_fhir_id?: string;
+    };
+    expect(payload.epic_patient_fhir_id).toBeUndefined();
+  });
+
+  it("rejects an over-length epic_patient param (>64 chars per FHIR spec)", () => {
+    // 65 a's — one more than the FHIR id max length.
+    mockEpicPatientParam = "a".repeat(65);
+
+    render(<PatientChartPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sync from Epic now/i }),
+    );
+
+    expect(triggerMutate).toHaveBeenCalledTimes(1);
+    const payload = triggerMutate.mock.calls[0]?.[0] as {
+      epic_patient_fhir_id?: string;
+    };
+    expect(payload.epic_patient_fhir_id).toBeUndefined();
+  });
+
+  it("accepts a FHIR id at the 64-char boundary with allowed separators", () => {
+    // Mix of alphanumerics, hyphens and dots — full FHIR id grammar,
+    // exactly 64 chars.
+    const id = "ePatient-001.with.dots-and-dashes-".padEnd(64, "X");
+    expect(id).toHaveLength(64);
+    mockEpicPatientParam = id;
+
+    render(<PatientChartPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sync from Epic now/i }),
+    );
+
+    expect(triggerMutate).toHaveBeenCalledTimes(1);
+    expect(triggerMutate).toHaveBeenCalledWith({
+      mode: "incremental",
+      patient_id: "patient-1",
+      epic_patient_fhir_id: id,
+    });
+  });
+});

--- a/apps/clinician-portal/src/lib/epic-launch.ts
+++ b/apps/clinician-portal/src/lib/epic-launch.ts
@@ -1,0 +1,39 @@
+/**
+ * Helpers for handling Epic SMART-launch URL parameters (#1188).
+ *
+ * The SMART App Launch callback in
+ * services/api-gateway/src/routes/epic-auth.ts appends
+ * `?epic_patient=<fhir-id>` to the post-launch redirect. Components that
+ * consume the launch context — currently `<EpicSyncCard>` — accept the
+ * value as a prop, so we read it from `useSearchParams()` on the page
+ * and forward it after validation.
+ *
+ * The validator enforces FHIR `id` grammar (R4 §2.36.1.4): up to 64
+ * characters of `[A-Za-z0-9.-]`. We intentionally do NOT call
+ * `decodeURIComponent` — `URLSearchParams.get()` already returns the
+ * decoded string, and double-decoding would let a malicious URL smuggle
+ * reserved characters past the regex.
+ */
+
+/** Maximum FHIR id length per R4 spec. */
+export const FHIR_ID_MAX_LENGTH = 64;
+
+/** FHIR id grammar: alphanumerics, hyphen, period. */
+const FHIR_ID_PATTERN = /^[A-Za-z0-9.\-]+$/;
+
+/**
+ * Returns the input if it is a well-formed FHIR id (non-empty, within
+ * the 64-char limit, only alphanumerics + `-` + `.`); otherwise
+ * `undefined`. Callers should forward the returned value as-is — a
+ * `null` or invalid input becomes `undefined`, which downstream
+ * mutations treat as "no override" and fall back to the stored
+ * patient-FHIR mapping.
+ */
+export function parseEpicPatientParam(
+  raw: string | null | undefined,
+): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  if (raw.length === 0 || raw.length > FHIR_ID_MAX_LENGTH) return undefined;
+  if (!FHIR_ID_PATTERN.test(raw)) return undefined;
+  return raw;
+}


### PR DESCRIPTION
## Summary

`/patients/[id]` now reads `?epic_patient` from `useSearchParams` and passes it to `EpicSyncCard` as `epicPatientFhirId`. The card already knew how to consume the prop — this just wires the URL→prop path so clinicians arriving via the Epic launch flow get a faster Sync-Now (no round-trip to the stored mapping).

Input is validated to FHIR-id shape (`[A-Za-z0-9.-]{1,64}`) before forwarding.

## Test plan

- [ ] URL param present → forwarded
- [ ] URL param absent → not forwarded
- [ ] URL param malformed → not forwarded

Closes #1188