### PR TITLE
chore(db): source_system columns for encounters/diagnoses/allergies (#1190)

### DIFF
--- a/packages/db-schema/drizzle/0054_source_system_columns.sql
+++ b/packages/db-schema/drizzle/0054_source_system_columns.sql
@@ -1,0 +1,23 @@
+-- #1190: source_system provenance columns for encounters/diagnoses/allergies.
+--
+-- The medications, vitals, lab_panels, and procedures tables already carry
+-- a source_system text column (DEFAULT 'internal') so callers can answer
+-- "where did this row come from?" without joining through fhir_resources.
+-- These three tables were the only remaining gaps; Epic-sourced rows here
+-- are currently indistinguishable from CareBridge-originated rows at the
+-- row level, which blocks WHERE source_system = 'epic' reporting and
+-- cross-source dedup.
+--
+-- Pattern A from docs/migration-patterns.md, special case: the DEFAULT
+-- 'internal' populates every existing row in the same ADD COLUMN
+-- statement, so the pre-clean step is unnecessary — the default IS the
+-- cleanup. No CHECK constraint needed today; downstream code already
+-- treats source_system as an open-set tag ("internal", "epic",
+-- "fhir_import").
+--
+-- Pure additive — no NOT VALID + VALIDATE dance required. Safe on a
+-- populated DB: PostgreSQL records the default in pg_attribute and
+-- existing rows are filled in-place.
+ALTER TABLE encounters ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';
+ALTER TABLE diagnoses  ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';
+ALTER TABLE allergies  ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1747930200000,
       "tag": "0053_npi_nucc_check",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1747930260000,
+      "tag": "0054_source_system_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db-schema/src/__tests__/migration-0054-source-system.test.ts
+++ b/packages/db-schema/src/__tests__/migration-0054-source-system.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getTableColumns } from "drizzle-orm";
+import { encounters, diagnoses, allergies } from "../schema/index.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const MIGRATION_PATH = join(
+  __dirname,
+  "..",
+  "..",
+  "drizzle",
+  "0054_source_system_columns.sql",
+);
+
+describe("migration 0054_source_system_columns (#1190)", () => {
+  const sql = readFileSync(MIGRATION_PATH, "utf8");
+
+  it("adds source_system NOT NULL DEFAULT 'internal' to encounters", () => {
+    // Pure additive ADD COLUMN — the DEFAULT 'internal' populates every
+    // existing row in the same statement, so no NOT VALID + VALIDATE
+    // dance is required (Pattern A from docs/migration-patterns.md
+    // without the pre-clean step because the default IS the cleanup).
+    assert.match(
+      sql,
+      /ALTER\s+TABLE\s+encounters\s+ADD\s+COLUMN\s+source_system\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'internal'/i,
+      "migration must add source_system NOT NULL DEFAULT 'internal' to encounters",
+    );
+  });
+
+  it("adds source_system NOT NULL DEFAULT 'internal' to diagnoses", () => {
+    assert.match(
+      sql,
+      /ALTER\s+TABLE\s+diagnoses\s+ADD\s+COLUMN\s+source_system\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'internal'/i,
+      "migration must add source_system NOT NULL DEFAULT 'internal' to diagnoses",
+    );
+  });
+
+  it("adds source_system NOT NULL DEFAULT 'internal' to allergies", () => {
+    assert.match(
+      sql,
+      /ALTER\s+TABLE\s+allergies\s+ADD\s+COLUMN\s+source_system\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'internal'/i,
+      "migration must add source_system NOT NULL DEFAULT 'internal' to allergies",
+    );
+  });
+
+  it("does not touch any other tables (single-purpose migration)", () => {
+    // Defends against accidental scope creep — the migration must only
+    // alter the three tables documented in the PR. ALTER TABLE statements
+    // for any other table should fail this check.
+    const alterMatches = Array.from(
+      sql.matchAll(/ALTER\s+TABLE\s+(\w+)/gi),
+      (m) => m[1].toLowerCase(),
+    );
+    const allowed = new Set(["encounters", "diagnoses", "allergies"]);
+    const unexpected = alterMatches.filter((t) => !allowed.has(t));
+    assert.deepEqual(
+      unexpected,
+      [],
+      `migration must only ALTER encounters/diagnoses/allergies; got ${unexpected.join(", ")}`,
+    );
+  });
+});
+
+describe("drizzle schema source_system columns (#1190)", () => {
+  // The Drizzle column descriptor exposes `default` and `notNull` so we
+  // can verify the schema definition matches the migration SQL without
+  // spinning up Postgres. Catches drift where the SQL adds the column
+  // but the TS schema forgets it (or vice versa).
+
+  it("encounters.source_system is NOT NULL with default 'internal'", () => {
+    const cols = getTableColumns(encounters);
+    const col = cols.source_system;
+    assert.ok(col, "encounters schema must define source_system column");
+    assert.equal(col.notNull, true, "encounters.source_system must be NOT NULL");
+    assert.equal(
+      col.default,
+      "internal",
+      "encounters.source_system must default to 'internal'",
+    );
+  });
+
+  it("diagnoses.source_system is NOT NULL with default 'internal'", () => {
+    const cols = getTableColumns(diagnoses);
+    const col = cols.source_system;
+    assert.ok(col, "diagnoses schema must define source_system column");
+    assert.equal(col.notNull, true, "diagnoses.source_system must be NOT NULL");
+    assert.equal(
+      col.default,
+      "internal",
+      "diagnoses.source_system must default to 'internal'",
+    );
+  });
+
+  it("allergies.source_system is NOT NULL with default 'internal'", () => {
+    const cols = getTableColumns(allergies);
+    const col = cols.source_system;
+    assert.ok(col, "allergies schema must define source_system column");
+    assert.equal(col.notNull, true, "allergies.source_system must be NOT NULL");
+    assert.equal(
+      col.default,
+      "internal",
+      "allergies.source_system must default to 'internal'",
+    );
+  });
+
+  it("encounters.source_system preserves explicit 'epic' overrides at the type level", () => {
+    // Drizzle text() with .default() still allows the caller to pass an
+    // explicit value on insert — the default only applies when the field
+    // is absent. This isn't an exhaustive runtime check (no DB connection
+    // here) but verifies the column is a plain text column, not an enum
+    // that would reject 'epic'.
+    const cols = getTableColumns(encounters);
+    const col = cols.source_system;
+    assert.equal(col.dataType, "string");
+    assert.equal(col.columnType, "PgText");
+  });
+});

--- a/packages/db-schema/src/schema/encounters.ts
+++ b/packages/db-schema/src/schema/encounters.ts
@@ -14,6 +14,10 @@ export const encounters = pgTable("encounters", {
   location: text("location"),
   reason: text("reason"),
   notes: encryptedText("notes"),
+  // Provenance tag — distinguishes Epic-imported encounters from
+  // CareBridge-originated ones without joining through fhir_resources
+  // (#1190). Mirrors medications/vitals/lab_panels/procedures convention.
+  source_system: text("source_system").notNull().default("internal"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_encounters_patient").on(table.patient_id),

--- a/packages/db-schema/src/schema/patients.ts
+++ b/packages/db-schema/src/schema/patients.ts
@@ -39,6 +39,10 @@ export const diagnoses = pgTable("diagnoses", {
   onset_date: text("onset_date"),
   resolved_date: text("resolved_date"),
   diagnosed_by: text("diagnosed_by"),
+  // Provenance tag — distinguishes Epic-imported diagnoses from
+  // CareBridge-originated ones without joining through fhir_resources
+  // (#1190). Mirrors medications/vitals/lab_panels/procedures convention.
+  source_system: text("source_system").notNull().default("internal"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_diagnoses_patient").on(table.patient_id, table.status),
@@ -55,6 +59,10 @@ export const allergies = pgTable("allergies", {
   // Tracks clinical verification of this allergy record: confirmed (verified reaction),
   // unconfirmed (reported but not verified), entered_in_error, or refuted (tested negative).
   verification_status: text("verification_status").notNull().default("unconfirmed"), // confirmed, unconfirmed, entered_in_error, refuted
+  // Provenance tag — distinguishes Epic-imported allergies from
+  // CareBridge-originated ones without joining through fhir_resources
+  // (#1190). Mirrors medications/vitals/lab_panels/procedures convention.
+  source_system: text("source_system").notNull().default("internal"),
   created_at: text("created_at").notNull(),
 }, (table) => [
   index("idx_allergies_patient").on(table.patient_id),

--- a/services/epic-connector/src/__tests__/persistence-source-system.int.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-source-system.int.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Integration test for #1190 — persistEncounter / persistCondition /
+ * persistAllergy must stamp source_system='epic' on the inserted row.
+ *
+ * Closes the gap surfaced during #1183 review: the Epic converters always
+ * returned `source_system: "epic"` on the row shape, but for encounters,
+ * diagnoses, and allergies the value was being silently dropped on insert
+ * because the column didn't exist. Migration 0054 adds the column; the
+ * persistence layer was updated to thread row.source_system through.
+ *
+ * Gated on TEST_DATABASE_URL — no-op locally without docker-compose up.
+ * CI's `test` job (.github/workflows/ci.yml) supplies it after running
+ * migrations.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import crypto from "node:crypto";
+import { sql, eq } from "drizzle-orm";
+
+// Safety invariant identical to packages/outbox/src/__tests__/batch-disjointness.int.test.ts:
+// force DATABASE_URL to TEST_DATABASE_URL so we never mutate a dev/prod DB.
+const TEST_URL = process.env.TEST_DATABASE_URL;
+if (TEST_URL) {
+  if (process.env.DATABASE_URL && process.env.DATABASE_URL !== TEST_URL) {
+    console.warn(
+      `[persistence-source-system.int] Overriding DATABASE_URL (${process.env.DATABASE_URL}) ` +
+        `with TEST_DATABASE_URL for test safety.`,
+    );
+  }
+  process.env.DATABASE_URL = TEST_URL;
+}
+
+const {
+  getDb,
+  patients,
+  encounters,
+  diagnoses,
+  allergies,
+  fhirResources,
+} = await import("@carebridge/db-schema");
+const { persistEncounter, persistCondition, persistAllergy } = await import(
+  "../sync/persistence.js"
+);
+
+async function seedPatient(): Promise<string> {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  await getDb().insert(patients).values({
+    id,
+    name: "Source Sys Test",
+    created_at: now,
+    updated_at: now,
+  });
+  return id;
+}
+
+describe.skipIf(!TEST_URL)(
+  "Epic persistence writes source_system='epic' (#1190)",
+  () => {
+    beforeAll(async () => {
+      // Fail fast if migration 0054 hasn't run.
+      await getDb().execute(
+        sql`SELECT source_system FROM encounters LIMIT 1`,
+      );
+      await getDb().execute(
+        sql`SELECT source_system FROM diagnoses LIMIT 1`,
+      );
+      await getDb().execute(
+        sql`SELECT source_system FROM allergies LIMIT 1`,
+      );
+    });
+
+    afterAll(async () => {
+      const db = getDb() as unknown as {
+        $client?: { end?: () => Promise<void> };
+      };
+      await db.$client?.end?.();
+    });
+
+    beforeEach(async () => {
+      // Targeted cleanup — leaves other tables alone so parallel int tests
+      // don't trample each other. fhir_resources references encounters /
+      // diagnoses / allergies indirectly via internal_record_id (no FK),
+      // so order matters only for the patient FK.
+      await getDb().execute(sql`DELETE FROM fhir_resources WHERE resource_type IN ('Encounter', 'Condition', 'AllergyIntolerance')`);
+      await getDb().execute(sql`DELETE FROM encounters WHERE patient_id LIKE '%'`);
+      await getDb().execute(sql`DELETE FROM diagnoses WHERE patient_id LIKE '%'`);
+      await getDb().execute(sql`DELETE FROM allergies WHERE patient_id LIKE '%'`);
+    });
+
+    it("persistEncounter writes source_system='epic' on insert", async () => {
+      const patientId = await seedPatient();
+      const result = await persistEncounter(
+        {
+          resourceType: "Encounter",
+          id: "epic-enc-1",
+          status: "finished",
+          class: { code: "AMB" },
+          subject: { reference: `Patient/epic-pat-1` },
+          period: { start: "2026-05-22T10:00:00Z", end: "2026-05-22T11:00:00Z" },
+        },
+        patientId,
+      );
+
+      expect(result.inserted).toBe(true);
+      expect(result.internalId).toBeTruthy();
+
+      const rows = await getDb()
+        .select({ source_system: encounters.source_system })
+        .from(encounters)
+        .where(eq(encounters.id, result.internalId!));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].source_system).toBe("epic");
+    });
+
+    it("persistCondition writes source_system='epic' on insert", async () => {
+      const patientId = await seedPatient();
+      const result = await persistCondition(
+        {
+          resourceType: "Condition",
+          id: "epic-cond-1",
+          clinicalStatus: {
+            coding: [
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                code: "active",
+              },
+            ],
+          },
+          code: {
+            text: "Test condition",
+            coding: [
+              { system: "http://hl7.org/fhir/sid/icd-10-cm", code: "Z00.0" },
+            ],
+          },
+          subject: { reference: `Patient/epic-pat-1` },
+        },
+        patientId,
+      );
+
+      expect(result.inserted).toBe(true);
+      expect(result.internalId).toBeTruthy();
+
+      const rows = await getDb()
+        .select({ source_system: diagnoses.source_system })
+        .from(diagnoses)
+        .where(eq(diagnoses.id, result.internalId!));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].source_system).toBe("epic");
+    });
+
+    it("persistAllergy writes source_system='epic' on insert", async () => {
+      const patientId = await seedPatient();
+      const result = await persistAllergy(
+        {
+          resourceType: "AllergyIntolerance",
+          id: "epic-allergy-1",
+          clinicalStatus: {
+            coding: [
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                code: "active",
+              },
+            ],
+          },
+          code: {
+            text: "Peanut",
+          },
+          patient: { reference: `Patient/epic-pat-1` },
+        },
+        patientId,
+      );
+
+      expect(result.inserted).toBe(true);
+      expect(result.internalId).toBeTruthy();
+
+      const rows = await getDb()
+        .select({ source_system: allergies.source_system })
+        .from(allergies)
+        .where(eq(allergies.id, result.internalId!));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].source_system).toBe("epic");
+    });
+
+    it("default 'internal' applies when no source_system is supplied (existing row migration semantics)", async () => {
+      // Verifies the migration default — a direct insert without
+      // source_system populates 'internal'. This is the safety net for
+      // rows that existed before migration 0054 ran.
+      const patientId = await seedPatient();
+      const id = crypto.randomUUID();
+      await getDb().insert(encounters).values({
+        id,
+        patient_id: patientId,
+        encounter_type: "AMB",
+        status: "finished",
+        start_time: "2026-05-22T10:00:00Z",
+        created_at: new Date().toISOString(),
+      });
+      const rows = await getDb()
+        .select({ source_system: encounters.source_system })
+        .from(encounters)
+        .where(eq(encounters.id, id));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].source_system).toBe("internal");
+    });
+  },
+);

--- a/services/epic-connector/src/__tests__/persistence-source-system.int.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-source-system.int.test.ts
@@ -29,6 +29,16 @@ if (TEST_URL) {
   process.env.DATABASE_URL = TEST_URL;
 }
 
+// `patients.name` is an encryptedText column, so seedPatient() needs a
+// PHI_ENCRYPTION_KEY to write any row. CI's test job (.github/workflows/ci.yml)
+// doesn't set one — and we don't want it to, because that's a real production
+// secret. Generate a per-process throwaway key here so the test is self-
+// contained. Must be set BEFORE the dynamic import of @carebridge/db-schema
+// below: getKey() memoises the parsed key on first read.
+if (TEST_URL && !process.env.PHI_ENCRYPTION_KEY) {
+  process.env.PHI_ENCRYPTION_KEY = crypto.randomBytes(32).toString("hex");
+}
+
 const {
   getDb,
   patients,

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -554,6 +554,7 @@ export async function persistCondition(
     status: row.status,
     onset_date: row.onset_date,
     resolved_date: row.resolved_date,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
     created_at: now,
   });
   await upsertMapping({
@@ -628,6 +629,7 @@ export async function persistAllergy(
     allergen: row.allergen,
     severity: row.severity,
     reaction: row.reaction,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
     created_at: now,
   });
   await upsertMapping({
@@ -645,11 +647,11 @@ export async function persistAllergy(
  *
  * Closes the last gap of #390 — the FHIR client has searchEncounters and
  * #1181 adds the converter + this writer + sync-worker fan-out. The
- * `encounters` table doesn't carry a dedicated `epic_encounter_id` or
- * `source_system` column today; the FHIR resource.id round-trips through
- * the `fhir_resources` mapping row, and source provenance is recoverable
- * via the same mapping table. A future migration can lift those fields
- * onto the table without changing this writer.
+ * `encounters` table now carries a `source_system` column (#1190) which
+ * this writer stamps with EPIC_SOURCE_SYSTEM_TAG on insert so Epic-
+ * imported rows are distinguishable at the row level without a JOIN to
+ * `fhir_resources`. The Epic CSN still round-trips through `fhir_resources`
+ * (a dedicated `epic_encounter_id` column is out of scope here).
  */
 export async function persistEncounter(
   resource: FhirResource,
@@ -719,6 +721,7 @@ export async function persistEncounter(
     end_time: row.end_time,
     location: row.location,
     reason: row.reason,
+    source_system: EPIC_SOURCE_SYSTEM_TAG,
     created_at: now,
   });
   await upsertMapping({

--- a/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
+++ b/services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts
@@ -66,6 +66,7 @@ function makeDiagnosis(): Diagnosis {
     resolved_date: null,
     diagnosed_by: null,
     notes: null,
+    source_system: "internal",
     created_at: "2024-01-01T00:00:00.000Z",
     updated_at: "2024-01-01T00:00:00.000Z",
   } as Diagnosis;
@@ -105,6 +106,7 @@ function makeAllergy(): Allergy {
     rxnorm_code: null,
     reaction: null,
     severity: null,
+    source_system: "internal",
     created_at: "2026-01-01T00:00:00.000Z",
   } as Allergy;
 }
@@ -148,6 +150,7 @@ function makeEncounter(): EncounterRow {
     location: null,
     reason: null,
     notes: null,
+    source_system: "internal",
     created_at: "2026-04-10T10:00:00.000Z",
   } as EncounterRow;
 }


### PR DESCRIPTION
## Summary

Adds `source_system TEXT NOT NULL DEFAULT 'internal'` to `encounters`, `diagnoses`, and `allergies` tables. Brings the schema in line with `medications` / `vitals` / `lab_panels` / `procedures` which already carry the column.

Closes the gap surfaced during #1183 review — Epic converters were always returning `source_system: "epic"` on the row shape, but for these three tables the value was being silently dropped on insert because the column did not exist. The persistence layer now threads `row.source_system` through to the insert.

## Migration

Single additive migration (`drizzle/0054_source_system_columns.sql`, journal idx 58). The `DEFAULT 'internal'` populates every existing row in the same statement — Pattern A from `docs/migration-patterns.md`, special case where pre-clean is unnecessary because the default IS the cleanup. No `NOT VALID + VALIDATE` required.

```sql
ALTER TABLE encounters ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';
ALTER TABLE diagnoses  ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';
ALTER TABLE allergies  ADD COLUMN source_system TEXT NOT NULL DEFAULT 'internal';
```

## Files touched

- `packages/db-schema/drizzle/0054_source_system_columns.sql` — new migration
- `packages/db-schema/drizzle/meta/_journal.json` — idx 58 entry
- `packages/db-schema/src/schema/encounters.ts` — add column
- `packages/db-schema/src/schema/patients.ts` — add column to `diagnoses` + `allergies`
- `packages/db-schema/src/__tests__/migration-0054-source-system.test.ts` — SQL + Drizzle column shape tests
- `services/epic-connector/src/sync/persistence.ts` — pass `source_system: EPIC_SOURCE_SYSTEM_TAG` on insert for the three tables (the converters already returned it; the writer was dropping it)
- `services/epic-connector/src/__tests__/persistence-source-system.int.test.ts` — gated integration test (TEST_DATABASE_URL) asserting end-to-end that `persistEncounter` / `persistCondition` / `persistAllergy` write `source_system: "epic"` and the migration default is `'internal'`
- `services/fhir-gateway/src/__tests__/us-core-meta-profile.test.ts` — fixture rows updated to include `source_system: "internal"` (context-field drift, per CLAUDE.md memory)

## Unlocks

- `WHERE source_system = 'epic'` reporting on encounters/diagnoses/allergies
- Cleaner cross-source dedup (see #1191, in flight)
- Row-level provenance without a JOIN through `fhir_resources`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm --filter @carebridge/db-schema test` — 50/50 pass (new SQL + Drizzle column tests green)
- [x] `pnpm --filter @carebridge/epic-connector test` — 271 pass / 4 skipped (integration tests gated on TEST_DATABASE_URL)
- [x] `pnpm --filter @carebridge/fhir-gateway test` — 500/500 pass (fixture drift fixed)
- [x] `pnpm test` — all 41 workspaces green
- [ ] CI runs migration against fresh DB and the new int test in `persistence-source-system.int.test.ts` verifies `persistEncounter`/`persistCondition`/`persistAllergy` write `source_system: "epic"` against real Postgres

Closes #1190