### PR TITLE
fix(portal): epic-launch-banner flash on suppressed re-renders (#1187)

### DIFF
--- a/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
+++ b/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
@@ -245,4 +245,64 @@ describe("EpicLaunchBanner", () => {
     expect(banner).toBeInTheDocument();
     expect(banner.textContent).toMatch(/abc/);
   });
+
+  // Issue #1187 — suppression flag must be read synchronously during render
+  // (lazy useState initializer), not in a post-mount useEffect. Reading it
+  // post-mount causes the banner to paint once before the effect hides it,
+  // producing a visible flash on deep-link re-visits with launch params still
+  // present in the URL.
+
+  it("reads sessionStorage suppress flag during initial render (lazy init, not via effect)", () => {
+    // Contract: with the lazy useState initializer, getItem must be called
+    // as part of the synchronous render path. Without the fix, getItem is
+    // only called inside useEffect — which fires AFTER the first paint.
+    //
+    // The probe below renders AFTER the banner in tree order. React calls
+    // function components top-down during render, so by the time Probe's
+    // render function executes, the banner's render function has already
+    // run to completion (including any lazy useState initializer). If
+    // getItem was called by then, the lazy-init path was exercised; if not,
+    // the read is deferred to an effect and the banner has already painted.
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "eP123",
+    });
+    getLaunchContextQuery.mockReturnValueOnce({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "eP123",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { store, storage } = makeStorage();
+    store.set("carebridge_epic_launch_suppressed", "eP123");
+
+    const getItemSpy = vi.fn((k: string) => storage.getItem(k));
+    const spyStorage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = {
+      getItem: getItemSpy,
+      setItem: (k, v) => storage.setItem(k, v),
+      removeItem: (k) => storage.removeItem(k),
+    };
+
+    let getItemCallsSeenByProbe = 0;
+    function Probe() {
+      getItemCallsSeenByProbe = getItemSpy.mock.calls.length;
+      return null;
+    }
+
+    render(
+      <div>
+        <EpicLaunchBanner storage={spyStorage} />
+        <Probe />
+      </div>,
+    );
+
+    expect(getItemCallsSeenByProbe).toBeGreaterThan(0);
+    // And the steady-state DOM has no banner either.
+    expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
+  });
 });

--- a/apps/clinician-portal/src/components/epic-launch-banner.tsx
+++ b/apps/clinician-portal/src/components/epic-launch-banner.tsx
@@ -61,13 +61,33 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
     staleTime: 60_000,
   });
 
-  // Sessionstorage suppression — only access on the client after mount.
-  // Keyed on the server-confirmed patient id so spoofed URLs can't
-  // pre-suppress a future genuine launch.
+  // Sessionstorage suppression — keyed on the server-confirmed patient id
+  // so spoofed URLs can't pre-suppress a future genuine launch.
   const ctx = contextQuery.data ?? null;
   const serverPatient = ctx?.epic_patient_fhir_id ?? null;
 
-  const [suppressed, setSuppressed] = useState(false);
+  // Issue #1187: Read the suppression flag SYNCHRONOUSLY during the first
+  // render via a useState lazy initializer. If we read it inside useEffect
+  // instead, the banner paints once on first render (with suppressed=false),
+  // then re-renders to null after the effect — producing a visible flash on
+  // deep-link re-visits where the launch params are still in the URL.
+  //
+  // The follow-up useEffect below still runs to catch the rare cross-tab
+  // edge case: user lands without the flag, then another tab sets it
+  // (storage events would be needed for true cross-tab sync, but at minimum
+  // the effect handles the case where serverPatient resolves after first
+  // render, e.g. cold tRPC query mount).
+  const [suppressed, setSuppressed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false; // SSR-safe
+    if (!serverPatient) return false;
+    try {
+      const ss = storage ?? globalThis.sessionStorage;
+      return ss?.getItem(SUPPRESS_KEY) === serverPatient;
+    } catch {
+      // sessionStorage unavailable (Safari private mode, sandboxed iframe).
+      return false;
+    }
+  });
   useEffect(() => {
     if (!serverPatient) return;
     try {


### PR DESCRIPTION
## Summary

Replaces the post-mount `useEffect` sessionStorage read in `epic-launch-banner.tsx` with a `useState` lazy initializer so the banner doesn't paint between Suspense/query resolution and the effect run. Builds on #1186's server-context restructuring.

- Lazy `useState` initializer reads sessionStorage during the first render, before paint
- `typeof window === "undefined"` guard keeps SSR-safe
- `try/catch` covers Safari private mode and sandboxed-iframe blocked-storage
- Suppress key uses the server-confirmed `epic_patient_fhir_id` (matches #1186)
- The follow-up `useEffect` stays in place for the cold-mount case (server data resolves after first render) and the cross-tab edge case

## Test plan

- [x] Existing 8 banner tests still pass (no regressions)
- [x] New TDD test asserts sessionStorage `getItem` is consulted during the synchronous render path (via a render-order probe), not deferred to a post-mount effect
- [x] With suppress flag set, banner never renders (no flash)
- [x] Without suppress flag, banner renders normally
- [x] SSR-safe (`typeof window` guard)

Closes #1187
Depends on #1192