### PR TITLE
feat(portal): dedupe epic-launch-banner mismatch console.warn (#1199)

### DIFF
--- a/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
+++ b/apps/clinician-portal/src/__tests__/epic-launch-banner.test.tsx
@@ -305,4 +305,102 @@ describe("EpicLaunchBanner", () => {
     // And the steady-state DOM has no banner either.
     expect(screen.queryByTestId("epic-launch-banner")).toBeNull();
   });
+
+  // Issue #1199 — the mismatch console.warn runs inline in render, so React
+  // strict-mode double-renders and parent re-renders fired the same tamper
+  // warning repeatedly in dev. Dedup by tracking the last warned
+  // (urlEpicPatient, serverPatient) pair in a useRef and only re-warning
+  // when the pair changes.
+
+  it("warns only once when re-rendered repeatedly with the same patient mismatch", () => {
+    searchParamsMock = new URLSearchParams({ epic_patient: "spoof" });
+    getLaunchContextQuery.mockReturnValue({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { storage } = makeStorage();
+    const { rerender } = render(<EpicLaunchBanner storage={storage} />);
+    for (let i = 0; i < 10; i++) {
+      rerender(<EpicLaunchBanner storage={storage} />);
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it("emits a fresh warn when the mismatch pair changes between renders", () => {
+    searchParamsMock = new URLSearchParams({ epic_patient: "spoof-1" });
+    getLaunchContextQuery.mockReturnValue({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        launch_encounter_fhir_id: null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { storage } = makeStorage();
+    const { rerender } = render(<EpicLaunchBanner storage={storage} />);
+    rerender(<EpicLaunchBanner storage={storage} />);
+    // Same pair so far: only one warn.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Switch the URL to a different spoofed value: pair changes, warn again.
+    searchParamsMock = new URLSearchParams({ epic_patient: "spoof-2" });
+    rerender(<EpicLaunchBanner storage={storage} />);
+    rerender(<EpicLaunchBanner storage={storage} />);
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it("warns only once on repeat encounter-mismatch re-renders, fires again on new pair", () => {
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "abc",
+      epic_encounter: "spoof-enc-1",
+    });
+    getLaunchContextQuery.mockReturnValue({
+      data: {
+        epic_org_iss: "https://fhir.epic.example/api/FHIR/R4",
+        epic_practitioner_fhir_id: "prac-1",
+        epic_patient_fhir_id: "abc",
+        // Cast through unknown because the vi.fn's inferred return type
+        // pins this property to `null` from the module-level default;
+        // tests need a concrete encounter id to exercise the mismatch path.
+        launch_encounter_fhir_id: "real-enc" as unknown as null,
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { storage } = makeStorage();
+    const { rerender } = render(<EpicLaunchBanner storage={storage} />);
+    for (let i = 0; i < 10; i++) {
+      rerender(<EpicLaunchBanner storage={storage} />);
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    searchParamsMock = new URLSearchParams({
+      epic_patient: "abc",
+      epic_encounter: "spoof-enc-2",
+    });
+    rerender(<EpicLaunchBanner storage={storage} />);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
 });

--- a/apps/clinician-portal/src/components/epic-launch-banner.tsx
+++ b/apps/clinician-portal/src/components/epic-launch-banner.tsx
@@ -35,7 +35,7 @@
  * re-show it.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc";
 
@@ -100,6 +100,15 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
     }
   }, [serverPatient, storage]);
 
+  // Issue #1199: the mismatch warns below run inline in the render body,
+  // so React strict-mode double-renders and parent re-renders previously
+  // caused the same tamper warning to spam the dev console. Track the
+  // last warned (urlValue, serverValue) pair in a ref and only warn when
+  // the pair changes. Refs persist across re-renders but reset on remount,
+  // so a fresh launch attempt will still log once.
+  const warnedPatientPairRef = useRef<string | null>(null);
+  const warnedEncounterPairRef = useRef<string | null>(null);
+
   // Hide while loading or on error — better to flash nothing than to
   // flash an unverified URL-derived banner.
   if (contextQuery.isLoading || contextQuery.isError) return null;
@@ -114,10 +123,14 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
   // don't, someone tampered — hide the banner and log a warning so it
   // surfaces in browser dev tools / error-reporting pipelines.
   if (urlEpicPatient && urlEpicPatient !== ctx.epic_patient_fhir_id) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[epic-launch-banner] URL epic_patient does not match server launch context; hiding banner.",
-    );
+    const pairKey = `${urlEpicPatient}|${ctx.epic_patient_fhir_id}`;
+    if (warnedPatientPairRef.current !== pairKey) {
+      warnedPatientPairRef.current = pairKey;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[epic-launch-banner] URL epic_patient does not match server launch context; hiding banner.",
+      );
+    }
     return null;
   }
   if (
@@ -125,10 +138,14 @@ export function EpicLaunchBanner({ storage }: EpicLaunchBannerProps = {}) {
     ctx.launch_encounter_fhir_id &&
     urlEpicEncounter !== ctx.launch_encounter_fhir_id
   ) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[epic-launch-banner] URL epic_encounter does not match server launch context; hiding banner.",
-    );
+    const pairKey = `${urlEpicEncounter}|${ctx.launch_encounter_fhir_id}`;
+    if (warnedEncounterPairRef.current !== pairKey) {
+      warnedEncounterPairRef.current = pairKey;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[epic-launch-banner] URL epic_encounter does not match server launch context; hiding banner.",
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Adds a useRef-based dedup so the URL-vs-server mismatch console.warn fires at most once per unique (urlEpicPatient, serverPatient) pair per mount
- Applies same dedup to the encounter mismatch warn path

## Test plan
- [x] Re-rendering with same mismatch pair → exactly 1 warn
- [x] Switching to a different mismatch pair → second warn fires
- [x] No regression on the suppression / matching-context paths

Closes #1199