### PR TITLE
feat(epic): source_system guard on fingerprint-merge path (#1200)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-source-guard.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-source-guard.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Source-system guard on the fingerprint-merge path (#1200).
+ *
+ * #1197 added cross-source fingerprint dedup that UPDATEs the matched
+ * row with the Epic payload regardless of who originally created it.
+ * The Epic-id mapping path has guarded against this since #1183 ("Epic
+ * does not get to overwrite CareBridge-originated data"). This test
+ * suite pins the equivalent guard for the fingerprint path:
+ *
+ *  - When findByFingerprint hits a row whose source_system != 'epic'
+ *    (or null on a table that has the column — treated as non-epic):
+ *      • SKIP the UPDATE of clinical fields
+ *      • Still write the fhir_resources mapping (Epic id round-trips
+ *        to the same internal row)
+ *      • Write an audit_log row with action='epic_sync_source_conflict'
+ *        carrying the matched row id, the Epic FHIR id, and the
+ *        source_system value of the matched row.
+ *  - When the matched row has source_system='epic' (or table lacks the
+ *    column and we treat absence as 'epic-equivalent' per resource —
+ *    medications/vitals where the column was added long ago and pre-
+ *    column rows are effectively internal — we still treat null as
+ *    non-epic to be safe): existing dedup-match behaviour preserved.
+ *
+ * Uses the shared createMockDb harness — same pattern as the cycle-5
+ * tests in persistence.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  patients: {
+    id: "id",
+    mrn_hmac: "mrn_hmac",
+    patient_id: "patient_id",
+  },
+  medications: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    started_at: "started_at",
+  },
+  vitals: {
+    id: "id",
+    patient_id: "patient_id",
+    loinc_code: "loinc_code",
+    recorded_at: "recorded_at",
+  },
+  labPanels: {},
+  labResults: {},
+  diagnoses: {
+    id: "id",
+    patient_id: "patient_id",
+    icd10_code: "icd10_code",
+    snomed_code: "snomed_code",
+    onset_date: "onset_date",
+  },
+  allergies: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    snomed_code: "snomed_code",
+  },
+  encounters: {
+    id: "id",
+    patient_id: "patient_id",
+    start_time: "start_time",
+    encounter_type: "encounter_type",
+  },
+  fhirResources: {
+    id: "id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+    internal_record_id: "internal_record_id",
+  },
+  auditLog: {},
+  hmacForIndex: (value: string) => `hmac:${value}`,
+}));
+
+const {
+  persistMedicationRequest,
+  persistObservation,
+  persistCondition,
+  persistAllergy,
+  persistEncounter,
+} = await import("../sync/persistence.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+// ── helpers ─────────────────────────────────────────────────────
+
+function findAuditInsert(
+  action: string,
+): Record<string, unknown> | undefined {
+  const hit = db.insert.calls.find((c) => {
+    const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+    return v?.action === action;
+  });
+  return hit?.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+function findMappingInsert(): Record<string, unknown> | undefined {
+  const hit = db.insert.calls.find((c) => {
+    const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+    return v?.resource_type !== undefined && v?.resource_id !== undefined;
+  });
+  return hit?.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+// ── Encounter ───────────────────────────────────────────────────
+
+describe("persistEncounter — source_system guard on fingerprint path (#1200)", () => {
+  const RESOURCE = {
+    resourceType: "Encounter",
+    id: "epic-enc-1",
+    status: "finished",
+    class: { code: "AMB" },
+    subject: { reference: "Patient/p-1" },
+    period: { start: "2026-05-20T09:00:00Z", end: "2026-05-20T11:00:00Z" },
+    location: [{ location: { display: "ICU" } }],
+    reasonCode: [{ text: "unstable" }],
+  };
+
+  it("matched fingerprint row with source_system='internal' → skip UPDATE, write mapping, audit epic_sync_source_conflict", async () => {
+    const existingInternalId = "internal-enc-1";
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "internal",
+        location: "ER Bay 4",
+        reason: "chest pain",
+      },
+    ]);
+    // No willUpdate() — the guard MUST short-circuit before db.update is called.
+    db.willInsert(); // mapping upsert
+    db.willInsert(); // audit_log epic_sync_source_conflict
+
+    const result = await persistEncounter(RESOURCE, PATIENT_ID);
+
+    expect(result.internalId).toBe(existingInternalId);
+    expect(result.kind).toBe("encounter");
+    expect(result.inserted).toBe(false);
+    expect(result.conflict).toBe("source_system_conflict");
+
+    // UPDATE must NOT have been called — clinician's data is protected.
+    expect(db.update).not.toHaveBeenCalled();
+
+    // Mapping row IS written so the Epic FHIR id still round-trips to
+    // the same internal row on the next sync.
+    const mapping = findMappingInsert();
+    expect(mapping).toBeDefined();
+    expect(mapping?.resource_type).toBe("Encounter");
+    expect(mapping?.resource_id).toBe("epic-enc-1");
+    expect(mapping?.internal_record_id).toBe(existingInternalId);
+
+    // Audit row uses the NEW action — distinct from epic_sync_dedup_match.
+    const audit = findAuditInsert("epic_sync_source_conflict");
+    expect(audit).toBeDefined();
+    expect(audit?.resource_type).toBe("Encounter");
+    expect(audit?.resource_id).toBe(existingInternalId);
+    const details = JSON.parse(audit?.details as string);
+    expect(details.epic_fhir_id).toBe("epic-enc-1");
+    expect(details.existing_source).toBe("internal");
+    expect(details.resolution).toBe("keep_carebridge_value");
+
+    // No epic_sync_dedup_match row — this is a conflict, not a merge.
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeUndefined();
+  });
+
+  it("matched fingerprint row with source_system='epic' → UPDATE + epic_sync_dedup_match (negative)", async () => {
+    const existingInternalId = "internal-enc-epic";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert(); // mapping
+    db.willInsert(); // audit_log epic_sync_dedup_match
+
+    const result = await persistEncounter(RESOURCE, PATIENT_ID);
+
+    expect(result.internalId).toBe(existingInternalId);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeUndefined();
+  });
+
+  it("matched fingerprint row with source_system=null → treated as non-epic, skip UPDATE", async () => {
+    // Defensive: even though encounters.source_system is NOT NULL with
+    // default 'internal' today, pre-#1190 rows that bypassed the default
+    // (or any future schema regression) should still be protected.
+    const existingInternalId = "internal-enc-null";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: null,
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistEncounter(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(db.update).not.toHaveBeenCalled();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeDefined();
+  });
+});
+
+// ── Condition / Diagnosis ──────────────────────────────────────
+
+describe("persistCondition — source_system guard on fingerprint path (#1200)", () => {
+  const RESOURCE = {
+    resourceType: "Condition",
+    id: "epic-cond-1",
+    subject: { reference: "Patient/p-1" },
+    code: {
+      text: "Pulmonary embolism",
+      coding: [
+        {
+          system: "http://hl7.org/fhir/sid/icd-10-cm",
+          code: "I26.99",
+        },
+      ],
+    },
+    onsetDateTime: "2026-04-15",
+    clinicalStatus: {
+      coding: [
+        {
+          system:
+            "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          code: "active",
+        },
+      ],
+    },
+  };
+
+  it("CareBridge-originated diagnosis (source_system='internal') is preserved", async () => {
+    const existingInternalId = "internal-diag-1";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        icd10_code: "I26.99",
+        onset_date: "2026-04-15",
+        source_system: "internal",
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistCondition(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(result.kind).toBe("diagnosis");
+    expect(db.update).not.toHaveBeenCalled();
+
+    const audit = findAuditInsert("epic_sync_source_conflict");
+    expect(audit).toBeDefined();
+    expect(audit?.resource_type).toBe("Condition");
+    const details = JSON.parse(audit?.details as string);
+    expect(details.existing_source).toBe("internal");
+
+    const mapping = findMappingInsert();
+    expect(mapping?.internal_record_id).toBe(existingInternalId);
+  });
+
+  it("Epic-originated diagnosis still gets merged + epic_sync_dedup_match", async () => {
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: "diag-epic-1",
+        patient_id: PATIENT_ID,
+        icd10_code: "I26.99",
+        onset_date: "2026-04-15",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const result = await persistCondition(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+  });
+});
+
+// ── Allergy ────────────────────────────────────────────────────
+
+describe("persistAllergy — source_system guard on fingerprint path (#1200)", () => {
+  const RESOURCE = {
+    resourceType: "AllergyIntolerance",
+    id: "epic-aller-1",
+    patient: { reference: "Patient/p-1" },
+    code: {
+      text: "Penicillin",
+      coding: [
+        {
+          system: "http://snomed.info/sct",
+          code: "373270004",
+        },
+      ],
+    },
+    clinicalStatus: {
+      coding: [
+        {
+          system:
+            "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          code: "active",
+        },
+      ],
+    },
+  };
+
+  it("CareBridge-originated allergy is preserved", async () => {
+    const existingInternalId = "internal-aller-1";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        source_system: "internal",
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistAllergy(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(db.update).not.toHaveBeenCalled();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeDefined();
+    const mapping = findMappingInsert();
+    expect(mapping?.internal_record_id).toBe(existingInternalId);
+  });
+
+  it("Epic-originated allergy follows the existing dedup-match path", async () => {
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: "aller-epic-1",
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const result = await persistAllergy(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+  });
+});
+
+// ── MedicationRequest ──────────────────────────────────────────
+
+describe("persistMedicationRequest — source_system guard on fingerprint path (#1200)", () => {
+  const RESOURCE = {
+    resourceType: "MedicationRequest",
+    id: "epic-med-1",
+    status: "active",
+    intent: "order",
+    subject: { reference: "Patient/p-1" },
+    medicationCodeableConcept: {
+      text: "Lisinopril 10 mg",
+      coding: [
+        {
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+          code: "314076",
+        },
+      ],
+    },
+    authoredOn: "2026-05-01T10:00:00Z",
+  };
+
+  it("CareBridge-originated medication is preserved", async () => {
+    const existingInternalId = "internal-med-1";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        rxnorm_code: "314076",
+        started_at: "2026-05-01T10:00:00Z",
+        source_system: "internal",
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistMedicationRequest(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(result.kind).toBe("medication");
+    expect(db.update).not.toHaveBeenCalled();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeDefined();
+  });
+
+  it("Epic-originated medication still merges + epic_sync_dedup_match", async () => {
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: "med-epic-1",
+        patient_id: PATIENT_ID,
+        rxnorm_code: "314076",
+        started_at: "2026-05-01T10:00:00Z",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const result = await persistMedicationRequest(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+  });
+});
+
+// ── Vitals (Observation) ───────────────────────────────────────
+
+describe("persistObservation (vital) — source_system guard on fingerprint path (#1200)", () => {
+  const RESOURCE = {
+    resourceType: "Observation",
+    id: "epic-obs-1",
+    status: "final",
+    category: [
+      {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/observation-category",
+            code: "vital-signs",
+          },
+        ],
+      },
+    ],
+    code: {
+      coding: [
+        {
+          system: "http://loinc.org",
+          code: "8867-4",
+          display: "Heart rate",
+        },
+      ],
+    },
+    subject: { reference: "Patient/p-1" },
+    effectiveDateTime: "2026-05-20T08:00:00Z",
+    valueQuantity: { value: 72, unit: "/min" },
+  };
+
+  it("CareBridge-originated vital is preserved", async () => {
+    const existingInternalId = "internal-vital-1";
+    db.willSelect([]); // mapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        loinc_code: "8867-4",
+        recorded_at: "2026-05-20T08:00:00Z",
+        source_system: "internal",
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistObservation(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(result.kind).toBe("vital");
+    expect(db.update).not.toHaveBeenCalled();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeDefined();
+  });
+
+  it("Epic-originated vital still merges + epic_sync_dedup_match", async () => {
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: "vital-epic-1",
+        patient_id: PATIENT_ID,
+        loinc_code: "8867-4",
+        recorded_at: "2026-05-20T08:00:00Z",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const result = await persistObservation(RESOURCE, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+  });
+});
+
+// ── Clinical-safety scenario from issue #1200 ─────────────────
+
+describe("Clinical-safety scenario — clinician edits survive Epic sync (#1200)", () => {
+  it("Pre-existing CareBridge encounter location='ER Bay 4', reason='chest pain' → Epic sync with location='ICU', reason='unstable' → row unchanged + audit row", async () => {
+    // Pre-existing CareBridge-originated encounter.
+    const carebridgeEncounter = {
+      id: "internal-enc-cs",
+      patient_id: PATIENT_ID,
+      start_time: "2026-05-25T08:00:00Z",
+      encounter_type: "AMB",
+      status: "in-progress",
+      end_time: null,
+      location: "ER Bay 4",
+      reason: "chest pain",
+      source_system: "internal",
+      created_at: "2026-05-25T08:00:00Z",
+    };
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([carebridgeEncounter]); // fingerprint hit
+    db.willInsert(); // fhir_resources mapping
+    db.willInsert(); // audit_log
+
+    const epicPayload = {
+      resourceType: "Encounter",
+      id: "epic-enc-cs",
+      status: "in-progress",
+      class: { code: "AMB" },
+      subject: { reference: "Patient/p-cs" },
+      period: { start: "2026-05-25T08:00:00Z" },
+      location: [{ location: { display: "ICU" } }],
+      reasonCode: [{ text: "unstable" }],
+    };
+
+    const result = await persistEncounter(epicPayload, PATIENT_ID);
+
+    expect(result.internalId).toBe(carebridgeEncounter.id);
+    expect(result.conflict).toBe("source_system_conflict");
+    // CRITICAL: db.update was NEVER called → location stays 'ER Bay 4',
+    // reason stays 'chest pain'. The clinician's work is intact.
+    expect(db.update).not.toHaveBeenCalled();
+    // Mapping written so the next Epic sync of the same FHIR id finds
+    // this same internal row (and still hits the source-system guard).
+    expect(findMappingInsert()?.internal_record_id).toBe(carebridgeEncounter.id);
+    // Audit row carries enough provenance for manual review.
+    const audit = findAuditInsert("epic_sync_source_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.epic_fhir_id).toBe("epic-enc-cs");
+    expect(details.existing_source).toBe("internal");
+  });
+});

--- a/services/epic-connector/src/__tests__/persistence.test.ts
+++ b/services/epic-connector/src/__tests__/persistence.test.ts
@@ -126,7 +126,10 @@ describe("persistEncounter — cross-source dedup (#1191)", () => {
     period: { start: "2026-05-20T09:00:00Z", end: "2026-05-20T09:45:00Z" },
   };
 
-  it("dedups against an existing CareBridge-originated encounter by patient_id+start_time+encounter_type and inserts a mapping row", async () => {
+  it("dedups against an existing Epic-originated encounter by patient_id+start_time+encounter_type and inserts a mapping row", async () => {
+    // NOTE (#1200): existing row is tagged source_system='epic' so this
+    // test exercises the dedup-MERGE path. The protection-of-CareBridge-
+    // data variant lives in persistence-source-guard.test.ts.
     const existingInternalId = "internal-enc-1";
     // findMapping → no Epic mapping yet
     db.willSelect([]);
@@ -137,6 +140,7 @@ describe("persistEncounter — cross-source dedup (#1191)", () => {
         patient_id: PATIENT_ID,
         start_time: "2026-05-20T09:00:00Z",
         encounter_type: "AMB",
+        source_system: "epic",
       },
     ]);
     // UPDATE the matched encounters row
@@ -223,7 +227,10 @@ describe("persistCondition — cross-source dedup (#1191)", () => {
     },
   };
 
-  it("dedups against existing CareBridge diagnosis by patient_id+icd10_code+onset_date", async () => {
+  it("dedups against existing Epic-originated diagnosis by patient_id+icd10_code+onset_date", async () => {
+    // NOTE (#1200): tagged source_system='epic' to exercise the merge
+    // path; CareBridge-protection variant lives in
+    // persistence-source-guard.test.ts.
     const existingInternalId = "internal-diag-1";
     db.willSelect([]); // findMapping miss
     db.willSelect([
@@ -232,6 +239,7 @@ describe("persistCondition — cross-source dedup (#1191)", () => {
         patient_id: PATIENT_ID,
         icd10_code: "I26.99",
         onset_date: "2026-04-15",
+        source_system: "epic",
       },
     ]);
     db.willUpdate();
@@ -290,7 +298,10 @@ describe("persistAllergy — cross-source dedup (#1191)", () => {
     },
   };
 
-  it("dedups against existing CareBridge allergy by patient_id+snomed_code", async () => {
+  it("dedups against existing Epic-originated allergy by patient_id+snomed_code", async () => {
+    // NOTE (#1200): tagged source_system='epic' to exercise the merge
+    // path; CareBridge-protection variant lives in
+    // persistence-source-guard.test.ts.
     const existingInternalId = "internal-aller-1";
     db.willSelect([]); // mapping miss
     db.willSelect([
@@ -298,6 +309,7 @@ describe("persistAllergy — cross-source dedup (#1191)", () => {
         id: existingInternalId,
         patient_id: PATIENT_ID,
         snomed_code: "373270004",
+        source_system: "epic",
       },
     ]);
     db.willUpdate();
@@ -349,7 +361,10 @@ describe("persistMedicationRequest — cross-source dedup (#1191)", () => {
     authoredOn: "2026-05-01T10:00:00Z",
   };
 
-  it("dedups against existing CareBridge medication by patient_id+rxnorm_code+started_at", async () => {
+  it("dedups against existing Epic-originated medication by patient_id+rxnorm_code+started_at", async () => {
+    // NOTE (#1200): tagged source_system='epic' to exercise the merge
+    // path; CareBridge-protection variant lives in
+    // persistence-source-guard.test.ts.
     const existingInternalId = "internal-med-1";
     db.willSelect([]); // mapping miss
     db.willSelect([
@@ -358,6 +373,7 @@ describe("persistMedicationRequest — cross-source dedup (#1191)", () => {
         patient_id: PATIENT_ID,
         rxnorm_code: "314076",
         started_at: "2026-05-01T10:00:00Z",
+        source_system: "epic",
       },
     ]);
     db.willUpdate();
@@ -419,7 +435,10 @@ describe("persistObservation (vital) — cross-source dedup (#1191)", () => {
     valueQuantity: { value: 72, unit: "/min" },
   };
 
-  it("dedups against existing CareBridge vital by patient_id+loinc_code+recorded_at", async () => {
+  it("dedups against existing Epic-originated vital by patient_id+loinc_code+recorded_at", async () => {
+    // NOTE (#1200): tagged source_system='epic' to exercise the merge
+    // path; CareBridge-protection variant lives in
+    // persistence-source-guard.test.ts.
     const existingInternalId = "internal-vital-1";
     db.willSelect([]); // mapping miss
     db.willSelect([
@@ -428,6 +447,7 @@ describe("persistObservation (vital) — cross-source dedup (#1191)", () => {
         patient_id: PATIENT_ID,
         loinc_code: "8867-4",
         recorded_at: "2026-05-20T08:00:00Z",
+        source_system: "epic",
       },
     ]);
     db.willUpdate();

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -1,5 +1,5 @@
 /**
- * Persistence layer for Epic-synced FHIR resources (#391, #1191).
+ * Persistence layer for Epic-synced FHIR resources (#391, #1191, #1200).
  *
  * Each persistResource* function:
  *  1. Looks up the existing CareBridge row for the (Epic resource_type, resource_id)
@@ -7,22 +7,24 @@
  *  2. If the mapping miss, does a *clinical fingerprint* fallback lookup
  *     (#1191) — patient_id + a small handful of stable plaintext columns
  *     per resource type (MRN, start_time + encounter_type, ICD-10 +
- *     onset_date, RxNorm + started_at, LOINC + recorded_at, etc.). When
- *     a fingerprint hit is found on a CareBridge-originated row, the Epic
- *     sync updates that row in place AND creates a `fhir_resources` row
- *     so future Epic re-syncs land on the same record. The match is
- *     logged to audit_log (action="epic_sync_dedup_match") for HIPAA
- *     traceability — clinicians need to see when a manually-entered row
- *     was reconciled with an Epic record.
+ *     onset_date, RxNorm + started_at, LOINC + recorded_at, etc.).
  *  3. UPSERTs the target row (insert when no mapping or fingerprint
  *     exists; update when one does).
  *  4. UPSERTs the `fhir_resources` mapping row so the next sync pull can
  *     find the same internal row.
- *  5. Records a source-system conflict to `audit_log` if the existing
- *     target row has `source_system != "epic"` — Epic does not get to
- *     overwrite CareBridge-originated data through the Epic-id path; we
- *     keep CareBridge's row and log the attempted overwrite for manual
- *     review.
+ *  5. Refuses to overwrite CareBridge-originated data on BOTH the
+ *     Epic-id path (step 1) AND the fingerprint path (step 2). When the
+ *     existing target row has `source_system != "epic"` (or null on a
+ *     table that has the column — defensively treated as non-epic), the
+ *     writer skips the UPDATE, still writes the `fhir_resources`
+ *     mapping (so Epic and CareBridge IDs round-trip to the same row),
+ *     and logs the attempt to `audit_log`:
+ *       • Epic-id path     → action="update", success=false,
+ *                            reason="source_system_conflict" (#1183)
+ *       • Fingerprint path → action="epic_sync_source_conflict" (#1200)
+ *     When the matched row IS Epic-originated (or pre-#1191 untagged),
+ *     the writer merges normally and logs `epic_sync_dedup_match` so
+ *     the HIPAA trail records the reconciliation explicitly.
  *
  * Independent of #1190 (which adds explicit `source_system` columns to
  * encounters/diagnoses/allergies). Fingerprint matching reads only
@@ -63,6 +65,25 @@ import type { FhirResource } from "../fhir-types.js";
 
 const EPIC_SYNC_AUDIT_USER = "system:epic-sync";
 const DEDUP_MATCH_ACTION = "epic_sync_dedup_match";
+/**
+ * Audit action emitted when the fingerprint-merge path (#1191) hits a
+ * row whose `source_system` is anything other than "epic". Distinct
+ * from `epic_sync_dedup_match` (a successful merge) and from the
+ * Epic-id-path `action="update", success=false` row (a different code
+ * path predating fingerprint dedup). See #1200.
+ */
+const SOURCE_CONFLICT_ACTION = "epic_sync_source_conflict";
+
+/**
+ * Returns true when the fingerprint-matched row was originally written
+ * by Epic and is therefore safe to overwrite with the latest Epic
+ * payload. Null is treated as "not Epic": pre-#1190 rows on tables that
+ * lacked the column default to null at read time, and the safer policy
+ * is to skip the UPDATE and let manual reconciliation decide.
+ */
+function isEpicOwned(sourceSystem: string | null | undefined): boolean {
+  return sourceSystem === EPIC_SOURCE_SYSTEM_TAG;
+}
 
 export interface PersistResult {
   /** Internal CareBridge row id, or null when the resource was unmappable. */
@@ -203,6 +224,43 @@ async function logDedupMatch(args: {
       epic_fhir_id: args.fhirId,
       fingerprint: args.fingerprint,
       resolution: "merge_into_existing_internal_row",
+    }),
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Log a fingerprint-merge attempt that hit a CareBridge-originated row
+ * (#1200). Recorded as success=false to flag the attempted overwrite,
+ * but the `fhir_resources` mapping IS still written by the caller — the
+ * Epic FHIR id and the CareBridge internal id refer to the same logical
+ * entity, so future re-syncs need to land on this row (and trip the
+ * same guard).
+ */
+async function logFingerprintSourceConflict(args: {
+  resourceType: string;
+  fhirId: string;
+  internalId: string;
+  patientId: string | null;
+  existingSourceSystem: string | null | undefined;
+  fingerprint: Record<string, unknown>;
+}): Promise<void> {
+  const db = getDb();
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: EPIC_SYNC_AUDIT_USER,
+    action: SOURCE_CONFLICT_ACTION,
+    resource_type: args.resourceType,
+    resource_id: args.internalId,
+    patient_id: args.patientId,
+    success: false,
+    details: JSON.stringify({
+      reason: "fingerprint_source_system_conflict",
+      attempted_source: EPIC_SOURCE_SYSTEM_TAG,
+      existing_source: args.existingSourceSystem ?? null,
+      epic_fhir_id: args.fhirId,
+      fingerprint: args.fingerprint,
+      resolution: "keep_carebridge_value",
     }),
     timestamp: new Date().toISOString(),
   });
@@ -611,6 +669,35 @@ async function persistMedicationRow(
     startedAt: row.started_at ?? null,
   });
   if (fingerprintHit) {
+    const fingerprint = {
+      patient_id: patientId,
+      rxnorm_code: row.rxnorm_code,
+      started_at: row.started_at,
+    };
+    // #1200: source_system guard — see persistEncounter for rationale.
+    if (!isEpicOwned(fingerprintHit.sourceSystem)) {
+      await upsertMapping({
+        resourceType,
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        resource,
+      });
+      await logFingerprintSourceConflict({
+        resourceType,
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        existingSourceSystem: fingerprintHit.sourceSystem,
+        fingerprint,
+      });
+      return {
+        internalId: fingerprintHit.internalId,
+        kind: "medication",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
     await db
       .update(medications)
       .set({
@@ -637,11 +724,7 @@ async function persistMedicationRow(
       fhirId,
       internalId: fingerprintHit.internalId,
       patientId,
-      fingerprint: {
-        patient_id: patientId,
-        rxnorm_code: row.rxnorm_code,
-        started_at: row.started_at,
-      },
+      fingerprint,
     });
     return {
       internalId: fingerprintHit.internalId,
@@ -744,6 +827,35 @@ export async function persistObservation(
       recordedAt: conversion.row.recorded_at,
     });
     if (fingerprintHit) {
+      const fingerprint = {
+        patient_id: patientId,
+        loinc_code: conversion.row.loinc_code,
+        recorded_at: conversion.row.recorded_at,
+      };
+      // #1200: source_system guard — see persistEncounter for rationale.
+      if (!isEpicOwned(fingerprintHit.sourceSystem)) {
+        await upsertMapping({
+          resourceType: "Observation",
+          fhirId,
+          internalId: fingerprintHit.internalId,
+          patientId,
+          resource,
+        });
+        await logFingerprintSourceConflict({
+          resourceType: "Observation",
+          fhirId,
+          internalId: fingerprintHit.internalId,
+          patientId,
+          existingSourceSystem: fingerprintHit.sourceSystem,
+          fingerprint,
+        });
+        return {
+          internalId: fingerprintHit.internalId,
+          kind: "vital",
+          inserted: false,
+          conflict: "source_system_conflict",
+        };
+      }
       await db
         .update(vitals)
         .set({
@@ -767,11 +879,7 @@ export async function persistObservation(
         fhirId,
         internalId: fingerprintHit.internalId,
         patientId,
-        fingerprint: {
-          patient_id: patientId,
-          loinc_code: conversion.row.loinc_code,
-          recorded_at: conversion.row.recorded_at,
-        },
+        fingerprint,
       });
       return {
         internalId: fingerprintHit.internalId,
@@ -936,6 +1044,36 @@ export async function persistCondition(
     onsetDate: row.onset_date ?? null,
   });
   if (fingerprintHit) {
+    const fingerprint = {
+      patient_id: patientId,
+      icd10_code: row.icd10_code,
+      snomed_code: row.snomed_code,
+      onset_date: row.onset_date,
+    };
+    // #1200: source_system guard — see persistEncounter for rationale.
+    if (!isEpicOwned(fingerprintHit.sourceSystem)) {
+      await upsertMapping({
+        resourceType: "Condition",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        resource,
+      });
+      await logFingerprintSourceConflict({
+        resourceType: "Condition",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        existingSourceSystem: fingerprintHit.sourceSystem,
+        fingerprint,
+      });
+      return {
+        internalId: fingerprintHit.internalId,
+        kind: "diagnosis",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
     await db
       .update(diagnoses)
       .set({
@@ -959,12 +1097,7 @@ export async function persistCondition(
       fhirId,
       internalId: fingerprintHit.internalId,
       patientId,
-      fingerprint: {
-        patient_id: patientId,
-        icd10_code: row.icd10_code,
-        snomed_code: row.snomed_code,
-        onset_date: row.onset_date,
-      },
+      fingerprint,
     });
     return {
       internalId: fingerprintHit.internalId,
@@ -1061,6 +1194,35 @@ export async function persistAllergy(
     snomedCode: row.snomed_code ?? null,
   });
   if (fingerprintHit) {
+    const fingerprint = {
+      patient_id: patientId,
+      rxnorm_code: row.rxnorm_code,
+      snomed_code: row.snomed_code,
+    };
+    // #1200: source_system guard — see persistEncounter for rationale.
+    if (!isEpicOwned(fingerprintHit.sourceSystem)) {
+      await upsertMapping({
+        resourceType: "AllergyIntolerance",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        resource,
+      });
+      await logFingerprintSourceConflict({
+        resourceType: "AllergyIntolerance",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        existingSourceSystem: fingerprintHit.sourceSystem,
+        fingerprint,
+      });
+      return {
+        internalId: fingerprintHit.internalId,
+        kind: "allergy",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
     await db
       .update(allergies)
       .set({
@@ -1081,11 +1243,7 @@ export async function persistAllergy(
       fhirId,
       internalId: fingerprintHit.internalId,
       patientId,
-      fingerprint: {
-        patient_id: patientId,
-        rxnorm_code: row.rxnorm_code,
-        snomed_code: row.snomed_code,
-      },
+      fingerprint,
     });
     return {
       internalId: fingerprintHit.internalId,
@@ -1194,6 +1352,37 @@ export async function persistEncounter(
     encounterType: row.encounter_type,
   });
   if (fingerprintHit) {
+    const fingerprint = {
+      patient_id: patientId,
+      start_time: row.start_time,
+      encounter_type: row.encounter_type,
+    };
+    // #1200: guard the fingerprint-merge UPDATE on source_system. If the
+    // matched row is CareBridge-originated, write the mapping so Epic IDs
+    // still round-trip, but DO NOT overwrite the clinician's data.
+    if (!isEpicOwned(fingerprintHit.sourceSystem)) {
+      await upsertMapping({
+        resourceType: "Encounter",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        resource,
+      });
+      await logFingerprintSourceConflict({
+        resourceType: "Encounter",
+        fhirId,
+        internalId: fingerprintHit.internalId,
+        patientId,
+        existingSourceSystem: fingerprintHit.sourceSystem,
+        fingerprint,
+      });
+      return {
+        internalId: fingerprintHit.internalId,
+        kind: "encounter",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
     await db
       .update(encounters)
       .set({
@@ -1217,11 +1406,7 @@ export async function persistEncounter(
       fhirId,
       internalId: fingerprintHit.internalId,
       patientId,
-      fingerprint: {
-        patient_id: patientId,
-        start_time: row.start_time,
-        encounter_type: row.encounter_type,
-      },
+      fingerprint,
     });
     return {
       internalId: fingerprintHit.internalId,


### PR DESCRIPTION
## Summary
- Adds a `source_system != 'epic'` guard on the fingerprint-merge path in `services/epic-connector/src/sync/persistence.ts`
- When the fingerprint hit is a CareBridge-originated row, the writer skips the UPDATE, writes the fhir_resources mapping, and emits an `epic_sync_source_conflict` audit entry
- Closes the gap between the Epic-id mapping path (already guarded) and the fingerprint path (added in #1197 without an equivalent guard)
- Updates the persistence.ts header doc to cover both paths

## Why this matters (clinical safety)
A clinician edits a CareBridge encounter (location, reason, end_time) -> Epic later syncs the same logical encounter -> fingerprint would match and overwrite the clinician's edits. This PR prevents that.

## Test plan
- [x] Pre-existing internal encounter + Epic fingerprint match -> fields preserved, audit row written
- [x] Pre-existing internal diagnosis + Epic fingerprint match -> fields preserved
- [x] Pre-existing internal allergy + Epic fingerprint match -> fields preserved
- [x] Pre-existing internal medication + Epic fingerprint match -> fields preserved
- [x] Pre-existing internal vital + Epic fingerprint match -> fields preserved
- [x] Pre-existing epic-sourced row + Epic fingerprint match -> existing dedup-match behavior intact
- [x] source_system=null treated as non-epic (defensive) -> fields preserved
- [x] Clinical-safety scenario from issue: location='ER Bay 4', reason='chest pain' survives Epic sync with location='ICU', reason='unstable'

Closes #1200
Follows: #1197