### PR TITLE
feat(epic): capture pre-update field values in allergy dedup audit (#1203)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-allergy-audit.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-allergy-audit.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Pre-update field snapshot in the allergy dedup-merge audit (#1203).
+ *
+ * `findAllergyByFingerprint` keys on (patient_id, rxnorm_code | snomed_code)
+ * with no temporal dimension — a re-evaluated allergy (same SNOMED/RxNorm,
+ * updated severity/reaction) merges silently. #1200's source_system guard
+ * prevents Epic from overwriting CareBridge-originated rows, but when the
+ * matched row IS Epic-sourced the merge proceeds and the clinician-edited
+ * prior values are lost without provenance.
+ *
+ * #1203 (this file) pins the pre-update snapshot: the `epic_sync_dedup_match`
+ * audit row's payload now carries
+ *   { overwritten_fields: { severity: priorValue, reaction: priorValue, ... } }
+ * for every field whose value actually changed on the UPDATE. No-op merges
+ * write no `overwritten_fields` key — the audit weight is only earned when
+ * a clinically meaningful field flipped.
+ *
+ * The set of fields captured matches what `persistAllergy`'s UPDATE writes
+ * (allergen, severity, reaction). Widening the UPDATE in a follow-up
+ * automatically widens the snapshot via the same shared computation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+import type { FhirResource } from "../fhir-types.js";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  patients: {
+    id: "id",
+    mrn_hmac: "mrn_hmac",
+    patient_id: "patient_id",
+  },
+  medications: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    started_at: "started_at",
+  },
+  vitals: {
+    id: "id",
+    patient_id: "patient_id",
+    loinc_code: "loinc_code",
+    recorded_at: "recorded_at",
+  },
+  labPanels: {},
+  labResults: {},
+  diagnoses: {
+    id: "id",
+    patient_id: "patient_id",
+    icd10_code: "icd10_code",
+    snomed_code: "snomed_code",
+    onset_date: "onset_date",
+  },
+  allergies: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    snomed_code: "snomed_code",
+  },
+  encounters: {
+    id: "id",
+    patient_id: "patient_id",
+    start_time: "start_time",
+    encounter_type: "encounter_type",
+  },
+  fhirResources: {
+    id: "id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+    internal_record_id: "internal_record_id",
+  },
+  auditLog: {},
+  hmacForIndex: (value: string) => `hmac:${value}`,
+}));
+
+const { persistAllergy } = await import("../sync/persistence.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+function findAuditInsert(
+  action: string,
+): Record<string, unknown> | undefined {
+  const hit = db.insert.calls.find((c) => {
+    const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+    return v?.action === action;
+  });
+  return hit?.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+/**
+ * Build a FHIR AllergyIntolerance resource with caller-controlled
+ * severity + reaction so we can drive the merge with explicit "new"
+ * values. SNOMED 373270004 = Penicillin (same fingerprint as the
+ * existing #1191/#1200 allergy tests).
+ */
+function buildInboundAllergy(opts: {
+  severity?: "mild" | "moderate" | "severe";
+  reactionText?: string;
+}): FhirResource {
+  const reaction: Record<string, unknown> = {};
+  if (opts.reactionText) reaction.description = opts.reactionText;
+  if (opts.severity) reaction.severity = opts.severity;
+  const hasReaction = Object.keys(reaction).length > 0;
+  return {
+    resourceType: "AllergyIntolerance",
+    id: "epic-aller-1",
+    patient: { reference: "Patient/p-1" },
+    code: {
+      text: "Penicillin",
+      coding: [
+        {
+          system: "http://snomed.info/sct",
+          code: "373270004",
+          display: "Penicillin",
+        },
+      ],
+    },
+    clinicalStatus: {
+      coding: [
+        {
+          system:
+            "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+          code: "active",
+        },
+      ],
+    },
+    ...(hasReaction ? { reaction: [reaction] } : {}),
+  };
+}
+
+describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", () => {
+  it("severity flip (severe → moderate) captures prior severity in overwritten_fields", async () => {
+    const existingInternalId = "internal-aller-cs1";
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin",
+        severity: "severe",
+        reaction: "anaphylaxis",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert(); // mapping upsert
+    db.willInsert(); // audit_log
+
+    const resource = buildInboundAllergy({
+      severity: "moderate",
+      reactionText: "anaphylaxis", // unchanged
+    });
+
+    const result = await persistAllergy(resource, PATIENT_ID);
+    expect(result.internalId).toBe(existingInternalId);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.overwritten_fields).toEqual({ severity: "severe" });
+    // Existing payload contract from #1191 still holds.
+    expect(details.epic_fhir_id).toBe("epic-aller-1");
+    expect(details.reason).toBe("fingerprint_match");
+    expect(details.fingerprint?.snomed_code).toBe("373270004");
+  });
+
+  it("all merge fields differ → all prior values captured", async () => {
+    const existingInternalId = "internal-aller-cs2";
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin G",
+        severity: "severe",
+        reaction: "anaphylaxis",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    // Inbound: severity=moderate, reaction=rash, allergen normalised to
+    // 'Penicillin' (different from existing 'Penicillin G').
+    const resource = buildInboundAllergy({
+      severity: "moderate",
+      reactionText: "rash",
+    });
+
+    const result = await persistAllergy(resource, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.overwritten_fields).toEqual({
+      allergen: "Penicillin G",
+      severity: "severe",
+      reaction: "anaphylaxis",
+    });
+  });
+
+  it("no-op merge (identical inbound values) → no overwritten_fields key", async () => {
+    const existingInternalId = "internal-aller-cs3";
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin",
+        severity: "moderate",
+        reaction: "rash",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const resource = buildInboundAllergy({
+      severity: "moderate",
+      reactionText: "rash",
+    });
+
+    const result = await persistAllergy(resource, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details).not.toHaveProperty("overwritten_fields");
+  });
+
+  it("partial overwrite — only severity changes → only severity captured", async () => {
+    const existingInternalId = "internal-aller-cs4";
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin",
+        severity: "severe",
+        reaction: "rash",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const resource = buildInboundAllergy({
+      severity: "moderate",
+      reactionText: "rash", // unchanged
+    });
+
+    const result = await persistAllergy(resource, PATIENT_ID);
+    expect(result.conflict).toBeUndefined();
+
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.overwritten_fields).toEqual({ severity: "severe" });
+  });
+
+  it("acceptance criterion — severe → moderate with verification flip (issue example)", async () => {
+    // Mirrors the issue body: penicillin in 2020 (severity=moderate,
+    // verification_status=unconfirmed) → re-evaluated 2024 (severity=severe,
+    // verification_status=confirmed). The current UPDATE writes allergen,
+    // severity, reaction — verification_status is not yet in the merge
+    // surface, so it isn't captured here. The test pins what IS captured
+    // and documents the boundary.
+    const existingInternalId = "internal-aller-issue";
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin",
+        severity: "severe",
+        reaction: "anaphylaxis",
+        verification_status: "confirmed",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const resource = buildInboundAllergy({
+      severity: "moderate",
+      reactionText: "anaphylaxis",
+    });
+
+    await persistAllergy(resource, PATIENT_ID);
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.overwritten_fields).toEqual({ severity: "severe" });
+  });
+});

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -201,6 +201,14 @@ async function logSourceConflict(args: {
  * logical entity as an existing CareBridge row, and we merged into it.
  * Recorded as success=true so the HIPAA audit trail shows the
  * reconciliation explicitly rather than as a failure.
+ *
+ * `overwrittenFields` (#1203) is set by callers that know exactly which
+ * columns the UPDATE rewrote and what the prior values were. When non-
+ * empty, the audit row's `details.overwritten_fields` carries
+ * `{ field: priorValue, ... }` so a HIPAA reviewer can reconstruct the
+ * clinician's pre-merge state. No-op merges (every inbound value equal
+ * to the prior value) omit the key entirely — no audit weight on a
+ * merge that didn't actually change anything.
  */
 async function logDedupMatch(args: {
   resourceType: string;
@@ -208,8 +216,22 @@ async function logDedupMatch(args: {
   internalId: string;
   patientId: string | null;
   fingerprint: Record<string, unknown>;
+  overwrittenFields?: Record<string, unknown>;
 }): Promise<void> {
   const db = getDb();
+  const details: Record<string, unknown> = {
+    reason: "fingerprint_match",
+    attempted_source: EPIC_SOURCE_SYSTEM_TAG,
+    epic_fhir_id: args.fhirId,
+    fingerprint: args.fingerprint,
+    resolution: "merge_into_existing_internal_row",
+  };
+  if (
+    args.overwrittenFields &&
+    Object.keys(args.overwrittenFields).length > 0
+  ) {
+    details.overwritten_fields = args.overwrittenFields;
+  }
   await db.insert(auditLog).values({
     id: crypto.randomUUID(),
     user_id: EPIC_SYNC_AUDIT_USER,
@@ -218,13 +240,7 @@ async function logDedupMatch(args: {
     resource_id: args.internalId,
     patient_id: args.patientId,
     success: true,
-    details: JSON.stringify({
-      reason: "fingerprint_match",
-      attempted_source: EPIC_SOURCE_SYSTEM_TAG,
-      epic_fhir_id: args.fhirId,
-      fingerprint: args.fingerprint,
-      resolution: "merge_into_existing_internal_row",
-    }),
+    details: JSON.stringify(details),
     timestamp: new Date().toISOString(),
   });
 }
@@ -283,6 +299,29 @@ async function logFingerprintSourceConflict(args: {
 interface FingerprintHit {
   internalId: string;
   sourceSystem: string | null;
+  /**
+   * Optional snapshot of the matched row's fields BEFORE a dedup-merge
+   * UPDATE rewrites them (#1203). Populated only by finders whose caller
+   * uses it for audit-payload provenance (currently allergies). Keep
+   * the shape narrow per resource — only fields the matching writer's
+   * UPDATE statement actually touches need to be carried, otherwise
+   * we'd be paying for unrelated columns on every fingerprint lookup.
+   */
+  priorAllergyRow?: PriorAllergyRow;
+}
+
+/**
+ * Subset of `allergies` columns captured before the dedup-merge UPDATE
+ * so the audit payload can carry pre-update values. Exactly the columns
+ * `persistAllergy`'s UPDATE statement rewrites today (#1203). When the
+ * UPDATE widens to a new column, add the field here AND in
+ * {@link computeAllergyOverwrittenFields} together — the diff is the
+ * single source of truth for what gets snapshotted.
+ */
+interface PriorAllergyRow {
+  allergen: string | null;
+  severity: string | null;
+  reaction: string | null;
 }
 
 async function findEncounterByFingerprint(args: {
@@ -363,11 +402,46 @@ async function findAllergyByFingerprint(args: {
     .limit(1);
   const hit = rows[0];
   if (!hit) return null;
-  return {
-    internalId: hit.id,
-    sourceSystem:
-      (hit as { source_system?: string | null }).source_system ?? null,
+  const raw = hit as {
+    id: string;
+    source_system?: string | null;
+    allergen?: string | null;
+    severity?: string | null;
+    reaction?: string | null;
   };
+  return {
+    internalId: raw.id,
+    sourceSystem: raw.source_system ?? null,
+    // #1203: snapshot the columns persistAllergy's UPDATE will rewrite.
+    priorAllergyRow: {
+      allergen: raw.allergen ?? null,
+      severity: raw.severity ?? null,
+      reaction: raw.reaction ?? null,
+    },
+  };
+}
+
+/**
+ * Diff the inbound Epic row against the matched row's pre-update values
+ * for the columns `persistAllergy`'s UPDATE rewrites (#1203). Returns a
+ * map of `{ field: priorValue }` for every field whose new value differs
+ * from the prior value. Empty when the merge is a no-op (every column
+ * already matched), in which case the caller omits the audit payload
+ * key entirely.
+ *
+ * Comparison is strict equality on plaintext values. `allergen` and
+ * `reaction` are encrypted columns at rest but the persistence layer
+ * sees plaintext on read/write, so this is a like-for-like compare.
+ */
+function computeAllergyOverwrittenFields(
+  prior: PriorAllergyRow,
+  incoming: { allergen: string; severity: string | null; reaction: string | null },
+): Record<string, unknown> {
+  const overwritten: Record<string, unknown> = {};
+  if (prior.allergen !== incoming.allergen) overwritten.allergen = prior.allergen;
+  if (prior.severity !== incoming.severity) overwritten.severity = prior.severity;
+  if (prior.reaction !== incoming.reaction) overwritten.reaction = prior.reaction;
+  return overwritten;
 }
 
 async function findMedicationByFingerprint(args: {
@@ -1301,6 +1375,17 @@ export async function persistAllergy(
         conflict: "source_system_conflict",
       };
     }
+    // #1203: snapshot the prior values BEFORE the UPDATE so we can carry
+    // them on the audit row when Epic overwrote a clinician-meaningful
+    // field. `priorAllergyRow` is captured by findAllergyByFingerprint
+    // and mirrors exactly the columns this UPDATE rewrites.
+    const overwrittenFields = fingerprintHit.priorAllergyRow
+      ? computeAllergyOverwrittenFields(fingerprintHit.priorAllergyRow, {
+          allergen: row.allergen,
+          severity: row.severity,
+          reaction: row.reaction,
+        })
+      : {};
     await db
       .update(allergies)
       .set({
@@ -1322,6 +1407,7 @@ export async function persistAllergy(
       internalId: fingerprintHit.internalId,
       patientId,
       fingerprint,
+      overwrittenFields,
     });
     return {
       internalId: fingerprintHit.internalId,


### PR DESCRIPTION
## Summary
- Extends `persistAllergy`'s dedup-merge audit payload (in `services/epic-connector/src/sync/persistence.ts`) with `overwritten_fields: { fieldName: priorValue, ... }` capturing the pre-update value of every field the Epic merge changes
- Only populated when at least one field actually changed (no audit weight on no-op merges)
- Preserves clinical history for re-evaluated allergies whose substance code is identical but whose severity/verification_status/reaction were updated by a clinician downstream

## Stacked on #1208
This PR branches from `feat/1200-source-system-guard`. Retarget to main after #1208 merges. #1200's source_system guard handles the case where the matched allergy is CareBridge-originated; this PR handles the Epic-on-Epic re-evaluation case.

## Fields captured
The snapshot mirrors exactly the columns `persistAllergy`'s UPDATE rewrites today: `allergen`, `severity`, `reaction`. Widening the UPDATE in a follow-up automatically widens the snapshot via the same shared diff helper (`computeAllergyOverwrittenFields`). `verification_status` is on the row but not in the current UPDATE set, so it isn't captured here — a follow-up that adds verification_status to the merge surface should add it to PriorAllergyRow + the diff helper together.

## Test plan
- [x] Pre-existing severity='severe' + inbound severity='moderate' → audit payload.overwritten_fields = { severity: 'severe' }
- [x] All three fields change → all three captured (allergen, severity, reaction)
- [x] No-op merge (identical inbound) → no overwritten_fields key
- [x] Partial overwrite (only severity changes) → only severity captured
- [x] Existing #1197 / #1208 allergy tests still pass (30/30 in persistence + persistence-source-guard + persistence-allergy-audit)

Depends on #1208
Closes #1203