### PR TITLE
feat(epic): detect Epic-id conflict on fingerprint merge (#1201)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-id-conflict.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-id-conflict.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Epic-id conflict detection on the fingerprint-merge path (#1201).
+ *
+ * Background: #1191 introduced fingerprint dedup so that a CareBridge-
+ * originated row created before Epic sync was wired doesn't get
+ * duplicated when Epic later syncs the same logical entity. #1200
+ * tightened that path so the dedup-merge UPDATE is skipped when the
+ * matched row is CareBridge-originated.
+ *
+ * But there's a *separate* failure mode: the fingerprint match lands on
+ * an internal row that ALREADY has an Epic FHIR id mapping pointing at
+ * it — and the inbound Epic FHIR id is *different*. That means either
+ * Epic has re-issued an ID for the same logical entity, or two
+ * genuinely distinct Epic entities collide on our fingerprint key. The
+ * old dedup-merge path silently wrote a SECOND `fhir_resources` row
+ * pointing at the same internal id, so two Epic FHIR ids both
+ * round-tripped to one CareBridge record with no signal to a reviewer.
+ *
+ * This suite pins the new behaviour: when the matched internal row
+ * already has a conflicting Epic mapping, the writer skips the merge,
+ * falls through to a plain INSERT (a new internal row + a new mapping
+ * for the inbound Epic id), and writes ONE audit row with
+ * action='epic_sync_dedup_conflict' carrying both Epic ids.
+ *
+ * Pipeline order, per the issue:
+ *   1. fingerprint lookup → hit?
+ *   2. (NEW) conflict check on fhir_resources → if conflict, fall
+ *      through to plain INSERT + audit `epic_sync_dedup_conflict`.
+ *   3. source_system guard (#1200).
+ *   4. dedup-merge.
+ *
+ * The conflict check is FIRST after the fingerprint hit because it's
+ * about identity ambiguity, not data ownership — once two Epic ids both
+ * point at one row we've lost the ability to safely round-trip either.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  patients: {
+    id: "id",
+    mrn_hmac: "mrn_hmac",
+    patient_id: "patient_id",
+  },
+  medications: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    started_at: "started_at",
+  },
+  vitals: {
+    id: "id",
+    patient_id: "patient_id",
+    loinc_code: "loinc_code",
+    recorded_at: "recorded_at",
+  },
+  labPanels: {},
+  labResults: {},
+  diagnoses: {
+    id: "id",
+    patient_id: "patient_id",
+    icd10_code: "icd10_code",
+    snomed_code: "snomed_code",
+    onset_date: "onset_date",
+  },
+  allergies: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    snomed_code: "snomed_code",
+  },
+  encounters: {
+    id: "id",
+    patient_id: "patient_id",
+    start_time: "start_time",
+    encounter_type: "encounter_type",
+  },
+  fhirResources: {
+    id: "id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+    internal_record_id: "internal_record_id",
+  },
+  auditLog: {},
+  hmacForIndex: (value: string) => `hmac:${value}`,
+}));
+
+const {
+  persistMedicationRequest,
+  persistCondition,
+  persistEncounter,
+} = await import("../sync/persistence.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+// ── helpers ─────────────────────────────────────────────────────
+
+function findAuditInsert(
+  action: string,
+): Record<string, unknown> | undefined {
+  const hit = db.insert.calls.find((c) => {
+    const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+    return v?.action === action;
+  });
+  return hit?.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+function findAllAuditInserts(
+  action: string,
+): Array<Record<string, unknown>> {
+  return db.insert.calls
+    .map((c) => c.chainArgs[0]?.[0] as Record<string, unknown> | undefined)
+    .filter(
+      (v): v is Record<string, unknown> => v !== undefined && v.action === action,
+    );
+}
+
+function findAllMappingInserts(): Array<Record<string, unknown>> {
+  return db.insert.calls
+    .map((c) => c.chainArgs[0]?.[0] as Record<string, unknown> | undefined)
+    .filter(
+      (v): v is Record<string, unknown> =>
+        v !== undefined &&
+        v.resource_type !== undefined &&
+        v.resource_id !== undefined &&
+        // discriminate audit_log (also has resource_type) by presence of
+        // `internal_record_id` / `imported_at`.
+        (v.internal_record_id !== undefined || v.imported_at !== undefined),
+    );
+}
+
+// ── Encounter ───────────────────────────────────────────────────
+
+describe("persistEncounter — Epic-id conflict on fingerprint match (#1201)", () => {
+  const RESOURCE = {
+    resourceType: "Encounter",
+    id: "epic-enc-B", // inbound Epic id
+    status: "finished",
+    class: { code: "AMB" },
+    subject: { reference: "Patient/p-1" },
+    period: { start: "2026-05-20T09:00:00Z", end: "2026-05-20T09:45:00Z" },
+  };
+
+  it("fingerprint hit on internal row already mapped to a DIFFERENT Epic id → fall through to INSERT + epic_sync_dedup_conflict audit", async () => {
+    const existingInternalId = "internal-enc-X";
+    const existingEpicId = "epic-enc-A";
+
+    // findMapping (Epic-id lookup for epic-enc-B) → miss
+    db.willSelect([]);
+    // fingerprint lookup → hits internal-enc-X (Epic-owned, would otherwise merge)
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]);
+    // NEW conflict-mapping lookup → returns a row mapping epic-enc-A to internal-enc-X
+    db.willSelect([
+      {
+        id: `epic:Encounter:${existingEpicId}`,
+        resource_type: "Encounter",
+        resource_id: existingEpicId,
+        internal_record_id: existingInternalId,
+        source_system: "epic",
+      },
+    ]);
+    db.willInsert(); // new encounters row (INSERT, not UPDATE)
+    db.willInsert(); // new fhir_resources mapping for epic-enc-B
+    db.willInsert(); // audit_log epic_sync_dedup_conflict
+
+    const result = await persistEncounter(RESOURCE, PATIENT_ID);
+
+    // A NEW internal row was inserted — result.inserted must be true and
+    // the returned internalId must NOT be the existing one.
+    expect(result.kind).toBe("encounter");
+    expect(result.inserted).toBe(true);
+    expect(result.internalId).not.toBe(existingInternalId);
+
+    // UPDATE must NOT have happened — the existing row is left alone.
+    expect(db.update).not.toHaveBeenCalled();
+
+    // A new fhir_resources mapping was written pointing at the NEW
+    // internal id (not the existing one). We do not silently write a
+    // second mapping pointing at the same internal row.
+    const mappings = findAllMappingInserts();
+    const inboundMapping = mappings.find(
+      (m) => m.resource_id === "epic-enc-B",
+    );
+    expect(inboundMapping).toBeDefined();
+    expect(inboundMapping?.internal_record_id).toBe(result.internalId);
+    expect(inboundMapping?.internal_record_id).not.toBe(existingInternalId);
+
+    // No mapping pointing at the existing internal row was inserted in
+    // this call (i.e. we did not write a second mapping `epic-enc-B → X`).
+    expect(
+      mappings.find(
+        (m) =>
+          m.internal_record_id === existingInternalId &&
+          m.resource_id === "epic-enc-B",
+      ),
+    ).toBeUndefined();
+
+    // Audit row uses the NEW action.
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    expect(audit?.resource_type).toBe("Encounter");
+    expect(audit?.success).toBe(false);
+    const details = JSON.parse(audit?.details as string);
+    // Both Epic ids surface for manual review.
+    expect(details.new_epic_fhir_id).toBe("epic-enc-B");
+    expect(details.existing_epic_fhir_id).toBe(existingEpicId);
+    expect(details.matched_internal_id).toBe(existingInternalId);
+    // Fingerprint fields are preserved for forensics.
+    expect(details.fingerprint).toBeDefined();
+
+    // No dedup-match row — this is a conflict, not a merge.
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeUndefined();
+    // No source-conflict row — this is identity ambiguity, not data ownership.
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeUndefined();
+  });
+
+  it("fingerprint hit + SAME Epic id (mapping already points at the matched row) → existing dedup-match path", async () => {
+    // This is the negative case: epic-enc-A already maps to internal-enc-X,
+    // and the inbound Epic id is ALSO epic-enc-A (e.g. mapping was lost
+    // due to a partial-failure and Epic is re-syncing). The conflict
+    // check must NOT trip — the existing mapping's resource_id equals
+    // the inbound FHIR id, so no ambiguity. Dedup-merge proceeds.
+    const existingInternalId = "internal-enc-same";
+    const SAME_RESOURCE = { ...RESOURCE, id: "epic-enc-A" };
+
+    db.willSelect([]); // findMapping miss (defensive — caller knows it)
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]);
+    // conflict-mapping lookup → empty (mapping with resource_id != A
+    // doesn't exist; only a row for A would, and we filter that out).
+    db.willSelect([]);
+    db.willUpdate();
+    db.willInsert(); // mapping upsert
+    db.willInsert(); // audit_log epic_sync_dedup_match
+
+    const result = await persistEncounter(SAME_RESOURCE, PATIENT_ID);
+
+    expect(result.internalId).toBe(existingInternalId);
+    expect(result.inserted).toBe(false);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+    expect(findAuditInsert("epic_sync_dedup_conflict")).toBeUndefined();
+  });
+});
+
+// ── Condition / Diagnosis ──────────────────────────────────────
+
+describe("persistCondition — Epic-id conflict on fingerprint match (#1201)", () => {
+  const RESOURCE = {
+    resourceType: "Condition",
+    id: "epic-cond-B",
+    subject: { reference: "Patient/p-1" },
+    code: {
+      text: "Pulmonary embolism",
+      coding: [
+        {
+          system: "http://hl7.org/fhir/sid/icd-10-cm",
+          code: "I26.99",
+        },
+      ],
+    },
+    onsetDateTime: "2026-04-15",
+    clinicalStatus: {
+      coding: [
+        {
+          system:
+            "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          code: "active",
+        },
+      ],
+    },
+  };
+
+  it("fingerprint hit on internal row already mapped to a DIFFERENT Epic id → INSERT + dedup_conflict audit", async () => {
+    const existingInternalId = "internal-diag-X";
+    const existingEpicId = "epic-cond-A";
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        icd10_code: "I26.99",
+        onset_date: "2026-04-15",
+        source_system: "epic",
+      },
+    ]);
+    db.willSelect([
+      {
+        id: `epic:Condition:${existingEpicId}`,
+        resource_type: "Condition",
+        resource_id: existingEpicId,
+        internal_record_id: existingInternalId,
+      },
+    ]);
+    db.willInsert(); // new diagnoses row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log
+
+    const result = await persistCondition(RESOURCE, PATIENT_ID);
+
+    expect(result.kind).toBe("diagnosis");
+    expect(result.inserted).toBe(true);
+    expect(result.internalId).not.toBe(existingInternalId);
+    expect(db.update).not.toHaveBeenCalled();
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.new_epic_fhir_id).toBe("epic-cond-B");
+    expect(details.existing_epic_fhir_id).toBe(existingEpicId);
+    expect(details.matched_internal_id).toBe(existingInternalId);
+
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeUndefined();
+  });
+});
+
+// ── MedicationRequest ──────────────────────────────────────────
+
+describe("persistMedicationRequest — Epic-id conflict on fingerprint match (#1201)", () => {
+  const RESOURCE = {
+    resourceType: "MedicationRequest",
+    id: "epic-med-B",
+    status: "active",
+    intent: "order",
+    subject: { reference: "Patient/p-1" },
+    medicationCodeableConcept: {
+      text: "Lisinopril 10 mg",
+      coding: [
+        {
+          system: "http://www.nlm.nih.gov/research/umls/rxnorm",
+          code: "314076",
+        },
+      ],
+    },
+    authoredOn: "2026-05-01T10:00:00Z",
+  };
+
+  it("fingerprint hit on internal row already mapped to a DIFFERENT Epic id → INSERT + dedup_conflict audit", async () => {
+    const existingInternalId = "internal-med-X";
+    const existingEpicId = "epic-med-A";
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        rxnorm_code: "314076",
+        started_at: "2026-05-01T10:00:00Z",
+        source_system: "epic",
+      },
+    ]);
+    db.willSelect([
+      {
+        id: `epic:MedicationRequest:${existingEpicId}`,
+        resource_type: "MedicationRequest",
+        resource_id: existingEpicId,
+        internal_record_id: existingInternalId,
+      },
+    ]);
+    db.willInsert(); // new medications row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log
+
+    const result = await persistMedicationRequest(RESOURCE, PATIENT_ID);
+
+    expect(result.kind).toBe("medication");
+    expect(result.inserted).toBe(true);
+    expect(result.internalId).not.toBe(existingInternalId);
+    expect(db.update).not.toHaveBeenCalled();
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.new_epic_fhir_id).toBe("epic-med-B");
+    expect(details.existing_epic_fhir_id).toBe(existingEpicId);
+    expect(details.matched_internal_id).toBe(existingInternalId);
+
+    // Exactly one audit row — we don't double-log conflict + match.
+    expect(findAllAuditInserts("epic_sync_dedup_conflict")).toHaveLength(1);
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeUndefined();
+  });
+
+  it("fingerprint hit + SAME Epic id → existing dedup-match path", async () => {
+    const existingInternalId = "internal-med-same";
+    const SAME_RESOURCE = { ...RESOURCE, id: "epic-med-A" };
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        rxnorm_code: "314076",
+        started_at: "2026-05-01T10:00:00Z",
+        source_system: "epic",
+      },
+    ]);
+    // conflict-mapping lookup → empty (any mapping for A would be
+    // filtered out by `resource_id != A`).
+    db.willSelect([]);
+    db.willUpdate();
+    db.willInsert(); // mapping
+    db.willInsert(); // audit_log dedup_match
+
+    const result = await persistMedicationRequest(SAME_RESOURCE, PATIENT_ID);
+
+    expect(result.internalId).toBe(existingInternalId);
+    expect(result.inserted).toBe(false);
+    expect(result.conflict).toBeUndefined();
+    expect(db.update).toHaveBeenCalledOnce();
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+    expect(findAuditInsert("epic_sync_dedup_conflict")).toBeUndefined();
+  });
+});

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -1,5 +1,5 @@
 /**
- * Persistence layer for Epic-synced FHIR resources (#391, #1191, #1200).
+ * Persistence layer for Epic-synced FHIR resources (#391, #1191, #1200, #1201).
  *
  * Each persistResource* function:
  *  1. Looks up the existing CareBridge row for the (Epic resource_type, resource_id)
@@ -25,6 +25,15 @@
  *     When the matched row IS Epic-originated (or pre-#1191 untagged),
  *     the writer merges normally and logs `epic_sync_dedup_match` so
  *     the HIPAA trail records the reconciliation explicitly.
+ *  6. Detects identity ambiguity on the fingerprint path (#1201): when
+ *     the matched internal row already has a `fhir_resources` mapping
+ *     pointing at a DIFFERENT Epic FHIR id, the writer skips the merge
+ *     entirely, falls through to a plain INSERT (a new internal row +
+ *     a new mapping for the inbound Epic id), and writes ONE audit row
+ *     with action="epic_sync_dedup_conflict" carrying both Epic ids.
+ *     The check runs BEFORE the source_system guard (#1200) — once two
+ *     Epic ids both point at one row we've lost the ability to safely
+ *     round-trip either, regardless of data ownership.
  *
  * Independent of #1190 (which adds explicit `source_system` columns to
  * encounters/diagnoses/allergies). Fingerprint matching reads only
@@ -36,7 +45,7 @@
  * the BullMQ job runner retry freely on transient errors.
  */
 import crypto from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import {
   getDb,
   patients,
@@ -73,6 +82,18 @@ const DEDUP_MATCH_ACTION = "epic_sync_dedup_match";
  * path predating fingerprint dedup). See #1200.
  */
 const SOURCE_CONFLICT_ACTION = "epic_sync_source_conflict";
+
+/**
+ * Audit action emitted when a fingerprint hit lands on an internal row
+ * that already has a `fhir_resources` mapping pointing at a DIFFERENT
+ * Epic FHIR id (#1201). Distinct from `epic_sync_dedup_match` (a clean
+ * merge) and `epic_sync_source_conflict` (#1200 — the matched row is
+ * CareBridge-originated). Identity-ambiguity case: either Epic re-issued
+ * an ID for the same logical entity or two distinct Epic entities
+ * collide on our fingerprint key. The writer falls through to a plain
+ * INSERT, refusing to silently double-map two Epic ids to one row.
+ */
+const DEDUP_CONFLICT_ACTION = "epic_sync_dedup_conflict";
 
 /**
  * Returns true when the fingerprint-matched row was originally written
@@ -241,6 +262,92 @@ async function logDedupMatch(args: {
     patient_id: args.patientId,
     success: true,
     details: JSON.stringify(details),
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/**
+ * Look up a pre-existing Epic-id mapping that already points at the
+ * given internal record id but with a DIFFERENT resource_id than the
+ * inbound FHIR id (#1201). When this returns a row, the caller must
+ * NOT merge into the fingerprint-matched internal row — two distinct
+ * Epic ids would otherwise both round-trip to the same CareBridge
+ * record with no signal to a reviewer. Caller falls through to a
+ * plain INSERT and writes an `epic_sync_dedup_conflict` audit row.
+ *
+ * Returns null when there is no such conflicting mapping. A mapping
+ * whose resource_id equals the inbound FHIR id is *not* a conflict —
+ * it's the same logical Epic resource re-syncing.
+ */
+interface ConflictingMapping {
+  existingEpicFhirId: string;
+  internalRecordId: string;
+}
+
+async function findConflictingMapping(args: {
+  resourceType: string;
+  matchedInternalId: string;
+  inboundFhirId: string;
+}): Promise<ConflictingMapping | null> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(fhirResources)
+    .where(
+      and(
+        eq(fhirResources.resource_type, args.resourceType),
+        eq(fhirResources.internal_record_id, args.matchedInternalId),
+        ne(fhirResources.resource_id, args.inboundFhirId),
+      ),
+    )
+    .limit(1);
+  // Defensive: Drizzle returns [] on no rows, but unit-test mocks that
+  // under-queue can return undefined. Treat both as "no conflict".
+  const existing = rows?.[0];
+  if (!existing) return null;
+  return {
+    existingEpicFhirId: existing.resource_id,
+    internalRecordId: existing.internal_record_id ?? args.matchedInternalId,
+  };
+}
+
+/**
+ * Log an Epic-id conflict on the fingerprint path (#1201). The matched
+ * internal row already has a different Epic FHIR id mapped to it; the
+ * caller has already fallen through to INSERT a fresh internal row and
+ * its own mapping. This audit row preserves both Epic ids and the
+ * fingerprint for manual reconciliation.
+ */
+async function logDedupConflict(args: {
+  resourceType: string;
+  newEpicFhirId: string;
+  existingEpicFhirId: string;
+  matchedInternalId: string;
+  newInternalId: string;
+  patientId: string | null;
+  fingerprint: Record<string, unknown>;
+}): Promise<void> {
+  const db = getDb();
+  await db.insert(auditLog).values({
+    id: crypto.randomUUID(),
+    user_id: EPIC_SYNC_AUDIT_USER,
+    action: DEDUP_CONFLICT_ACTION,
+    resource_type: args.resourceType,
+    // Tie the audit row to the NEWLY-inserted internal id — that's the
+    // row this Epic id now owns. The pre-existing internal id surfaces
+    // in `details.matched_internal_id` for the manual reviewer.
+    resource_id: args.newInternalId,
+    patient_id: args.patientId,
+    success: false,
+    details: JSON.stringify({
+      reason: "epic_id_conflict_on_fingerprint_match",
+      attempted_source: EPIC_SOURCE_SYSTEM_TAG,
+      new_epic_fhir_id: args.newEpicFhirId,
+      existing_epic_fhir_id: args.existingEpicFhirId,
+      matched_internal_id: args.matchedInternalId,
+      fingerprint: args.fingerprint,
+      resolution: "insert_new_internal_row",
+    }),
     timestamp: new Date().toISOString(),
   });
 }
@@ -619,7 +726,19 @@ export async function persistPatient(
   // hmac column populated by a prior write — see migration 0023).
   const mrnHmac = computeMrnHmacIfPresent(row.mrn ?? null);
   const fingerprintHit = await findPatientByFingerprint({ mrnHmac });
+  const fingerprint = { mrn_hmac: mrnHmac };
+  // #1201: identity-ambiguity check. Patient identity is a high-stakes
+  // case — two Epic patient FHIR ids resolving to the same MRN HMAC
+  // usually means an Epic-side merge / unmerge cycle. Treat as conflict.
+  let conflictMapping: ConflictingMapping | null = null;
   if (fingerprintHit) {
+    conflictMapping = await findConflictingMapping({
+      resourceType: "Patient",
+      matchedInternalId: fingerprintHit.internalId,
+      inboundFhirId: fhirId,
+    });
+  }
+  if (fingerprintHit && !conflictMapping) {
     await db
       .update(patients)
       .set({
@@ -642,7 +761,7 @@ export async function persistPatient(
       fhirId,
       internalId: fingerprintHit.internalId,
       patientId: fingerprintHit.internalId,
-      fingerprint: { mrn_hmac: mrnHmac },
+      fingerprint,
     });
     return {
       internalId: fingerprintHit.internalId,
@@ -668,6 +787,17 @@ export async function persistPatient(
     patientId: id,
     resource,
   });
+  if (conflictMapping && fingerprintHit) {
+    await logDedupConflict({
+      resourceType: "Patient",
+      newEpicFhirId: fhirId,
+      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      matchedInternalId: fingerprintHit.internalId,
+      newInternalId: id,
+      patientId: id,
+      fingerprint,
+    });
+  }
   return { internalId: id, kind: "patient", inserted: true };
 }
 
@@ -770,12 +900,21 @@ async function persistMedicationRow(
     rxnormCode: row.rxnorm_code ?? null,
     startedAt: row.started_at ?? null,
   });
+  const fingerprint = {
+    patient_id: patientId,
+    rxnorm_code: row.rxnorm_code,
+    started_at: row.started_at,
+  };
+  // #1201: identity-ambiguity check (see persistEncounter for rationale).
+  let conflictMapping: ConflictingMapping | null = null;
   if (fingerprintHit) {
-    const fingerprint = {
-      patient_id: patientId,
-      rxnorm_code: row.rxnorm_code,
-      started_at: row.started_at,
-    };
+    conflictMapping = await findConflictingMapping({
+      resourceType,
+      matchedInternalId: fingerprintHit.internalId,
+      inboundFhirId: fhirId,
+    });
+  }
+  if (fingerprintHit && !conflictMapping) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -858,6 +997,17 @@ async function persistMedicationRow(
     patientId,
     resource,
   });
+  if (conflictMapping && fingerprintHit) {
+    await logDedupConflict({
+      resourceType,
+      newEpicFhirId: fhirId,
+      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      matchedInternalId: fingerprintHit.internalId,
+      newInternalId: id,
+      patientId,
+      fingerprint,
+    });
+  }
   return { internalId: id, kind: "medication", inserted: true };
 }
 
@@ -928,12 +1078,21 @@ export async function persistObservation(
       loincCode: conversion.row.loinc_code ?? null,
       recordedAt: conversion.row.recorded_at,
     });
+    const fingerprint = {
+      patient_id: patientId,
+      loinc_code: conversion.row.loinc_code,
+      recorded_at: conversion.row.recorded_at,
+    };
+    // #1201: identity-ambiguity check (see persistEncounter).
+    let conflictMapping: ConflictingMapping | null = null;
     if (fingerprintHit) {
-      const fingerprint = {
-        patient_id: patientId,
-        loinc_code: conversion.row.loinc_code,
-        recorded_at: conversion.row.recorded_at,
-      };
+      conflictMapping = await findConflictingMapping({
+        resourceType: "Observation",
+        matchedInternalId: fingerprintHit.internalId,
+        inboundFhirId: fhirId,
+      });
+    }
+    if (fingerprintHit && !conflictMapping) {
       // #1200: source_system guard — see persistEncounter for rationale.
       if (!isEpicOwned(fingerprintHit.sourceSystem)) {
         await upsertMapping({
@@ -1010,6 +1169,17 @@ export async function persistObservation(
       patientId,
       resource,
     });
+    if (conflictMapping && fingerprintHit) {
+      await logDedupConflict({
+        resourceType: "Observation",
+        newEpicFhirId: fhirId,
+        existingEpicFhirId: conflictMapping.existingEpicFhirId,
+        matchedInternalId: fingerprintHit.internalId,
+        newInternalId: id,
+        patientId,
+        fingerprint,
+      });
+    }
     return { internalId: id, kind: "vital", inserted: true };
   }
 
@@ -1195,13 +1365,22 @@ export async function persistCondition(
     snomedCode: row.snomed_code ?? null,
     onsetDate: row.onset_date ?? null,
   });
+  const fingerprint = {
+    patient_id: patientId,
+    icd10_code: row.icd10_code,
+    snomed_code: row.snomed_code,
+    onset_date: row.onset_date,
+  };
+  // #1201: identity-ambiguity check (see persistEncounter).
+  let conflictMapping: ConflictingMapping | null = null;
   if (fingerprintHit) {
-    const fingerprint = {
-      patient_id: patientId,
-      icd10_code: row.icd10_code,
-      snomed_code: row.snomed_code,
-      onset_date: row.onset_date,
-    };
+    conflictMapping = await findConflictingMapping({
+      resourceType: "Condition",
+      matchedInternalId: fingerprintHit.internalId,
+      inboundFhirId: fhirId,
+    });
+  }
+  if (fingerprintHit && !conflictMapping) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -1278,6 +1457,17 @@ export async function persistCondition(
     patientId,
     resource,
   });
+  if (conflictMapping && fingerprintHit) {
+    await logDedupConflict({
+      resourceType: "Condition",
+      newEpicFhirId: fhirId,
+      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      matchedInternalId: fingerprintHit.internalId,
+      newInternalId: id,
+      patientId,
+      fingerprint,
+    });
+  }
   return { internalId: id, kind: "diagnosis", inserted: true };
 }
 
@@ -1345,12 +1535,21 @@ export async function persistAllergy(
     rxnormCode: row.rxnorm_code ?? null,
     snomedCode: row.snomed_code ?? null,
   });
+  const fingerprint = {
+    patient_id: patientId,
+    rxnorm_code: row.rxnorm_code,
+    snomed_code: row.snomed_code,
+  };
+  // #1201: identity-ambiguity check (see persistEncounter).
+  let conflictMapping: ConflictingMapping | null = null;
   if (fingerprintHit) {
-    const fingerprint = {
-      patient_id: patientId,
-      rxnorm_code: row.rxnorm_code,
-      snomed_code: row.snomed_code,
-    };
+    conflictMapping = await findConflictingMapping({
+      resourceType: "AllergyIntolerance",
+      matchedInternalId: fingerprintHit.internalId,
+      inboundFhirId: fhirId,
+    });
+  }
+  if (fingerprintHit && !conflictMapping) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -1433,6 +1632,17 @@ export async function persistAllergy(
     patientId,
     resource,
   });
+  if (conflictMapping && fingerprintHit) {
+    await logDedupConflict({
+      resourceType: "AllergyIntolerance",
+      newEpicFhirId: fhirId,
+      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      matchedInternalId: fingerprintHit.internalId,
+      newInternalId: id,
+      patientId,
+      fingerprint,
+    });
+  }
   return { internalId: id, kind: "allergy", inserted: true };
 }
 
@@ -1515,12 +1725,26 @@ export async function persistEncounter(
     startTime: row.start_time,
     encounterType: row.encounter_type,
   });
+  const fingerprint = {
+    patient_id: patientId,
+    start_time: row.start_time,
+    encounter_type: row.encounter_type,
+  };
+  // #1201: identity-ambiguity check. When the matched internal row
+  // already has a different Epic FHIR id mapped to it, fall through to
+  // a plain INSERT below and emit `epic_sync_dedup_conflict`. The check
+  // runs BEFORE the #1200 source_system guard because once two Epic ids
+  // both point at one row we've lost the ability to safely round-trip
+  // either, regardless of data ownership.
+  let conflictMapping: ConflictingMapping | null = null;
   if (fingerprintHit) {
-    const fingerprint = {
-      patient_id: patientId,
-      start_time: row.start_time,
-      encounter_type: row.encounter_type,
-    };
+    conflictMapping = await findConflictingMapping({
+      resourceType: "Encounter",
+      matchedInternalId: fingerprintHit.internalId,
+      inboundFhirId: fhirId,
+    });
+  }
+  if (fingerprintHit && !conflictMapping) {
     // #1200: guard the fingerprint-merge UPDATE on source_system. If the
     // matched row is CareBridge-originated, write the mapping so Epic IDs
     // still round-trip, but DO NOT overwrite the clinician's data.
@@ -1599,5 +1823,16 @@ export async function persistEncounter(
     patientId,
     resource,
   });
+  if (conflictMapping && fingerprintHit) {
+    await logDedupConflict({
+      resourceType: "Encounter",
+      newEpicFhirId: fhirId,
+      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      matchedInternalId: fingerprintHit.internalId,
+      newInternalId: id,
+      patientId,
+      fingerprint,
+    });
+  }
   return { internalId: id, kind: "encounter", inserted: true };
 }


### PR DESCRIPTION
## Summary
- Adds `findConflictingMapping(db, resourceType, internalId, fhirId)` helper in `services/epic-connector/src/sync/persistence.ts`
- Inserts a new check stage between fingerprint lookup and the source-system guard: when the matched internal row already has a `fhir_resources` mapping pointing at a different Epic FHIR id, skip the merge, fall through to INSERT, and emit `epic_sync_dedup_conflict` audit row
- New audit action constant `DEDUP_CONFLICT_ACTION = "epic_sync_dedup_conflict"` distinguishes ambiguous merges from clean dedup-matches (`epic_sync_dedup_match`) and from source-conflict skips (`epic_sync_source_conflict` from #1200)

## Stacked on #1208
This PR branches from `feat/1200-source-system-guard` and depends on the audit-action constant pattern landed there. Retarget to main after #1208 merges.

## Test plan
- [x] Pre-existing Epic-mapped encounter + same fingerprint, different Epic id -> new row inserted, conflict audit row written
- [x] Same case for diagnoses, medications
- [x] Pre-existing Epic-mapped row + same fingerprint, SAME Epic id -> unchanged dedup-match behavior

Depends on #1208
Closes #1201