### PR TITLE
docs(epic): note lab_panels provenance preserved on fingerprint reuse (#1213)

### DIFF
--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -1223,6 +1223,10 @@ export async function persistObservation(
     collectedAt: conversion.row.recorded_at,
   });
   if (panelFingerprintHit) {
+    // #1213 — intentionally NO update to lab_panels.source_system or
+    // reported_at on reuse: a CareBridge-originated panel keeps its
+    // provenance, and the Epic-side merge fact is captured in the
+    // logDedupMatch audit row below.
     // #1207 — store the newly-inserted lab_results.id (the leaf the
     // Epic Observation id round-trips to) in the fhir_resources
     // mapping, NOT the reused lab_panels.id. The round-2 update path


### PR DESCRIPTION
## Summary
- Adds a one-liner comment in `persistObservation` (services/epic-connector/src/sync/persistence.ts) lab fingerprint-hit branch noting that `lab_panels.source_system` and `reported_at` are intentionally preserved on merge

## Test plan
- [x] Comment-only change; no logic delta
- [x] Existing tests still pass

Closes #1213