### PR TITLE
refactor(epic): drop defensive source_system casts (post-migration 0054) (#1216)

### DIFF
--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -450,13 +450,9 @@ async function findEncounterByFingerprint(args: {
     .limit(1);
   const hit = rows[0];
   if (!hit) return null;
-  // encounters has no source_system column today (#1190 may add one);
-  // treat absence as "internal" — anything not tagged epic-via-mapping
-  // is CareBridge-originated by definition.
   return {
     internalId: hit.id,
-    sourceSystem:
-      (hit as { source_system?: string | null }).source_system ?? null,
+    sourceSystem: hit.source_system ?? null,
   };
 }
 
@@ -487,8 +483,7 @@ async function findDiagnosisByFingerprint(args: {
   if (!hit) return null;
   return {
     internalId: hit.id,
-    sourceSystem:
-      (hit as { source_system?: string | null }).source_system ?? null,
+    sourceSystem: hit.source_system ?? null,
   };
 }
 
@@ -509,21 +504,14 @@ async function findAllergyByFingerprint(args: {
     .limit(1);
   const hit = rows[0];
   if (!hit) return null;
-  const raw = hit as {
-    id: string;
-    source_system?: string | null;
-    allergen?: string | null;
-    severity?: string | null;
-    reaction?: string | null;
-  };
   return {
-    internalId: raw.id,
-    sourceSystem: raw.source_system ?? null,
+    internalId: hit.id,
+    sourceSystem: hit.source_system ?? null,
     // #1203: snapshot the columns persistAllergy's UPDATE will rewrite.
     priorAllergyRow: {
-      allergen: raw.allergen ?? null,
-      severity: raw.severity ?? null,
-      reaction: raw.reaction ?? null,
+      allergen: hit.allergen ?? null,
+      severity: hit.severity ?? null,
+      reaction: hit.reaction ?? null,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Drops three defensive type-casts (`(hit as { source_system?: string | null }).source_system ?? null`) in `services/epic-connector/src/sync/persistence.ts` fingerprint helpers for Encounter, Condition/Diagnosis, and Allergy
- Direct property access now, matching the medications/vitals helpers
- Removes the stale "#1190 may add one" comment

## Test plan
- [x] Existing tests still pass (no behaviour change)
- [x] Typecheck confirms the direct access compiles after migration 0054

Closes #1216