### PR TITLE
feat(epic): surface epic_id_conflict discriminator on writer return (#1217)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-id-conflict.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-id-conflict.test.ts
@@ -186,6 +186,11 @@ describe("persistEncounter — Epic-id conflict on fingerprint match (#1201)", (
     expect(result.kind).toBe("encounter");
     expect(result.inserted).toBe(true);
     expect(result.internalId).not.toBe(existingInternalId);
+    // #1217: caller-visible discriminator mirrors source_system_conflict
+    // so the sync orchestrator can distinguish a forked-insert (fingerprint
+    // collided on a different Epic id) from a clean import without
+    // re-reading the audit_log row.
+    expect(result.conflict).toBe("epic_id_conflict");
 
     // UPDATE must NOT have happened — the existing row is left alone.
     expect(db.update).not.toHaveBeenCalled();
@@ -326,6 +331,8 @@ describe("persistCondition — Epic-id conflict on fingerprint match (#1201)", (
     expect(result.kind).toBe("diagnosis");
     expect(result.inserted).toBe(true);
     expect(result.internalId).not.toBe(existingInternalId);
+    // #1217: discriminator surfaces the forked-insert reason to callers.
+    expect(result.conflict).toBe("epic_id_conflict");
     expect(db.update).not.toHaveBeenCalled();
 
     const audit = findAuditInsert("epic_sync_dedup_conflict");
@@ -391,6 +398,8 @@ describe("persistMedicationRequest — Epic-id conflict on fingerprint match (#1
     expect(result.kind).toBe("medication");
     expect(result.inserted).toBe(true);
     expect(result.internalId).not.toBe(existingInternalId);
+    // #1217: discriminator surfaces the forked-insert reason to callers.
+    expect(result.conflict).toBe("epic_id_conflict");
     expect(db.update).not.toHaveBeenCalled();
 
     const audit = findAuditInsert("epic_sync_dedup_conflict");

--- a/services/epic-connector/src/__tests__/sync-jobs.test.ts
+++ b/services/epic-connector/src/__tests__/sync-jobs.test.ts
@@ -194,6 +194,41 @@ describe("Epic sync-jobs (#391)", () => {
     expect(result.imported).toBe(0);
   });
 
+  // #1217 — epic_id_conflict is the fingerprint-collision-on-different-
+  // Epic-id forked-insert path. Persistence inserts a NEW internal row
+  // (so `inserted: true`) but the operator still needs the conflict
+  // signal: a row pair needs manual reconciliation. Treated identically
+  // to source_system_conflict by the orchestrator — counted as a
+  // conflict (NOT imported), event emit suppressed.
+  it("counts epic_id_conflict as a conflict and suppresses the clinical event", async () => {
+    persistMedicationRequest.mockResolvedValueOnce({
+      internalId: "internal-med-forked",
+      kind: "medication",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    });
+    const client = makeFakeClient({
+      MedicationRequest: [
+        { resourceType: "MedicationRequest", id: "med-B" },
+      ],
+    });
+
+    const result = await runSingleResourceSync(
+      {
+        patientId: PATIENT_ID,
+        epicPatientFhirId: EPIC_PATIENT_FHIR_ID,
+        resourceType: "MedicationRequest",
+        watermark: null,
+      },
+      { client, emit },
+    );
+
+    expect(emit).not.toHaveBeenCalled();
+    expect(result.conflicts).toBe(1);
+    expect(result.imported).toBe(0);
+    expect(result.updated).toBe(0);
+  });
+
   it("skips unmapped resources without crashing the loop", async () => {
     persistObservation
       .mockResolvedValueOnce({

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -121,8 +121,27 @@ export interface PersistResult {
     | "unmapped";
   /** True when the call inserted a new row; false when it updated. */
   inserted: boolean;
-  /** Set when the call rejected an Epic update due to source_system mismatch. */
-  conflict?: string;
+  /**
+   * Caller-visible conflict discriminator (#1200, #1217). Distinguishes
+   * the two skip / fork paths that otherwise look identical from a
+   * `{ inserted, internalId }` reading:
+   *
+   *   - `source_system_conflict` (#1200) — the matched row is
+   *     CareBridge-originated. The writer skipped the UPDATE, wrote the
+   *     fhir_resources mapping anyway so future re-syncs round-trip to
+   *     the same row, and logged `epic_sync_source_conflict`. Combined
+   *     with `inserted: false`.
+   *
+   *   - `epic_id_conflict` (#1201, surfaced #1217) — the fingerprint hit
+   *     landed on an internal row that already has a different Epic FHIR
+   *     id mapped to it. The writer fell through to a plain INSERT (a
+   *     new internal row + a new mapping) rather than silently double-
+   *     map two Epic ids to one row, and logged `epic_sync_dedup_conflict`.
+   *     Combined with `inserted: true` and a fresh `internalId`.
+   *
+   * Absent on clean inserts and clean dedup-merges.
+   */
+  conflict?: "source_system_conflict" | "epic_id_conflict";
 }
 
 interface MappingLookup {
@@ -797,6 +816,12 @@ export async function persistPatient(
       patientId: id,
       fingerprint,
     });
+    return {
+      internalId: id,
+      kind: "patient",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    };
   }
   return { internalId: id, kind: "patient", inserted: true };
 }
@@ -1007,6 +1032,12 @@ async function persistMedicationRow(
       patientId,
       fingerprint,
     });
+    return {
+      internalId: id,
+      kind: "medication",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    };
   }
   return { internalId: id, kind: "medication", inserted: true };
 }
@@ -1179,6 +1210,12 @@ export async function persistObservation(
         patientId,
         fingerprint,
       });
+      return {
+        internalId: id,
+        kind: "vital",
+        inserted: true,
+        conflict: "epic_id_conflict",
+      };
     }
     return { internalId: id, kind: "vital", inserted: true };
   }
@@ -1467,6 +1504,12 @@ export async function persistCondition(
       patientId,
       fingerprint,
     });
+    return {
+      internalId: id,
+      kind: "diagnosis",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    };
   }
   return { internalId: id, kind: "diagnosis", inserted: true };
 }
@@ -1642,6 +1685,12 @@ export async function persistAllergy(
       patientId,
       fingerprint,
     });
+    return {
+      internalId: id,
+      kind: "allergy",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    };
   }
   return { internalId: id, kind: "allergy", inserted: true };
 }
@@ -1833,6 +1882,12 @@ export async function persistEncounter(
       patientId,
       fingerprint,
     });
+    return {
+      internalId: id,
+      kind: "encounter",
+      inserted: true,
+      conflict: "epic_id_conflict",
+    };
   }
   return { internalId: id, kind: "encounter", inserted: true };
 }


### PR DESCRIPTION
## Summary
- Adds `conflict: "epic_id_conflict"` discriminator to writer return values on the dedup-conflict path in `services/epic-connector/src/sync/persistence.ts`
- Widens the writer result type union to a literal union `"source_system_conflict" | "epic_id_conflict"` so call-sites get exhaustive narrowing
- Applies the discriminator across every persist* function with a fingerprint-conflict path (Patient, MedicationRequest/Statement, Observation/vital, Condition, Allergy, Encounter)

## Background
The #1200 source_system guard path returns `conflict: "source_system_conflict"` on the writer result so the orchestrator can distinguish ambiguity from a clean insert. The #1201 Epic-id conflict path (landed in #1210) returned a bare `{ inserted: true }` with no caller-side signal — the conflict was only visible by reading the freshly-written audit_log row. This PR mirrors the #1200 pattern.

## sync-worker / sync-jobs counter
The existing counter in `syncResourceType` is already discriminator-agnostic:

```
if (persisted.conflict) result.conflicts++;
else if (persisted.inserted) result.imported++;
else result.updated++;
```

So a `conflict: "epic_id_conflict"` return automatically counts toward `result.conflicts` (mirroring source-conflicts) and suppresses the clinical-event emit (`!persisted.conflict && persisted.internalId` gate). No structural code change to `sync-jobs.ts` was needed; a new explicit test in `sync-jobs.test.ts` pins the behaviour so a future counter refactor can't regress the wiring.

## Test plan
- [x] Conflict path returns `{ inserted: true, conflict: "epic_id_conflict" }` (asserted for Encounter, Condition, MedicationRequest in `persistence-id-conflict.test.ts`)
- [x] Clean merge / same-Epic-id path returns no `conflict` field (existing `toBeUndefined()` assertions preserved)
- [x] sync-jobs orchestrator counts `epic_id_conflict` toward `result.conflicts` and suppresses the clinical-event emit (new test)
- [x] Full epic-connector test suite (311 pass)
- [x] `pnpm typecheck` + `pnpm lint` clean

Closes #1217