### PR TITLE
feat(epic): widen allergy dedup-merge to include verification_status (#1220)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-allergy-audit.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-allergy-audit.test.ts
@@ -103,12 +103,13 @@ function findAuditInsert(
 function buildInboundAllergy(opts: {
   severity?: "mild" | "moderate" | "severe";
   reactionText?: string;
+  verificationStatus?: "unconfirmed" | "confirmed" | "refuted";
 }): FhirResource {
   const reaction: Record<string, unknown> = {};
   if (opts.reactionText) reaction.description = opts.reactionText;
   if (opts.severity) reaction.severity = opts.severity;
   const hasReaction = Object.keys(reaction).length > 0;
-  return {
+  const resource: FhirResource = {
     resourceType: "AllergyIntolerance",
     id: "epic-aller-1",
     patient: { reference: "Patient/p-1" },
@@ -133,6 +134,18 @@ function buildInboundAllergy(opts: {
     },
     ...(hasReaction ? { reaction: [reaction] } : {}),
   };
+  if (opts.verificationStatus) {
+    (resource as Record<string, unknown>).verificationStatus = {
+      coding: [
+        {
+          system:
+            "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
+          code: opts.verificationStatus,
+        },
+      ],
+    };
+  }
+  return resource;
 }
 
 describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", () => {
@@ -147,6 +160,7 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
         allergen: "Penicillin",
         severity: "severe",
         reaction: "anaphylaxis",
+        verification_status: "unconfirmed",
         source_system: "epic",
       },
     ]);
@@ -185,6 +199,7 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
         allergen: "Penicillin G",
         severity: "severe",
         reaction: "anaphylaxis",
+        verification_status: "unconfirmed",
         source_system: "epic",
       },
     ]);
@@ -223,6 +238,7 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
         allergen: "Penicillin",
         severity: "moderate",
         reaction: "rash",
+        verification_status: "unconfirmed",
         source_system: "epic",
       },
     ]);
@@ -255,6 +271,7 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
         allergen: "Penicillin",
         severity: "severe",
         reaction: "rash",
+        verification_status: "unconfirmed",
         source_system: "epic",
       },
     ]);
@@ -276,13 +293,12 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
     expect(details.overwritten_fields).toEqual({ severity: "severe" });
   });
 
-  it("acceptance criterion — severe → moderate with verification flip (issue example)", async () => {
+  it("acceptance criterion — severity flip with verification flip both captured (#1220)", async () => {
     // Mirrors the issue body: penicillin in 2020 (severity=moderate,
     // verification_status=unconfirmed) → re-evaluated 2024 (severity=severe,
-    // verification_status=confirmed). The current UPDATE writes allergen,
-    // severity, reaction — verification_status is not yet in the merge
-    // surface, so it isn't captured here. The test pins what IS captured
-    // and documents the boundary.
+    // verification_status=confirmed). Post-#1220 the UPDATE now writes
+    // verification_status alongside allergen/severity/reaction, so the
+    // diff helper captures both flips.
     const existingInternalId = "internal-aller-issue";
     db.willSelect([]);
     db.willSelect([
@@ -291,9 +307,49 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
         patient_id: PATIENT_ID,
         snomed_code: "373270004",
         allergen: "Penicillin",
-        severity: "severe",
+        severity: "moderate",
         reaction: "anaphylaxis",
-        verification_status: "confirmed",
+        verification_status: "unconfirmed",
+        source_system: "epic",
+      },
+    ]);
+    db.willUpdate();
+    db.willInsert();
+    db.willInsert();
+
+    const resource = buildInboundAllergy({
+      severity: "severe",
+      reactionText: "anaphylaxis",
+      verificationStatus: "confirmed",
+    });
+
+    await persistAllergy(resource, PATIENT_ID);
+    const audit = findAuditInsert("epic_sync_dedup_match");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+    expect(details.overwritten_fields).toEqual({
+      severity: "moderate",
+      verification_status: "unconfirmed",
+    });
+  });
+
+  it("verification_status flip only (unconfirmed → confirmed) captured in overwritten_fields (#1220)", async () => {
+    // Pure verification_status flip: every other clinically meaningful
+    // column on the merge surface matches the inbound row. The diff
+    // helper still records the verification flip — re-evaluation of an
+    // unconfirmed allergy to confirmed is clinically meaningful even
+    // when allergen/severity/reaction are unchanged.
+    const existingInternalId = "internal-aller-vs1";
+    db.willSelect([]);
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        snomed_code: "373270004",
+        allergen: "Penicillin",
+        severity: "moderate",
+        reaction: "rash",
+        verification_status: "unconfirmed",
         source_system: "epic",
       },
     ]);
@@ -303,13 +359,16 @@ describe("persistAllergy — dedup-merge audit snapshots prior values (#1203)", 
 
     const resource = buildInboundAllergy({
       severity: "moderate",
-      reactionText: "anaphylaxis",
+      reactionText: "rash",
+      verificationStatus: "confirmed",
     });
 
     await persistAllergy(resource, PATIENT_ID);
     const audit = findAuditInsert("epic_sync_dedup_match");
     expect(audit).toBeDefined();
     const details = JSON.parse(audit?.details as string);
-    expect(details.overwritten_fields).toEqual({ severity: "severe" });
+    expect(details.overwritten_fields).toEqual({
+      verification_status: "unconfirmed",
+    });
   });
 });

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -454,6 +454,7 @@ interface PriorAllergyRow {
   allergen: string | null;
   severity: string | null;
   reaction: string | null;
+  verification_status: string | null;
 }
 
 async function findEncounterByFingerprint(args: {
@@ -529,14 +530,25 @@ async function findAllergyByFingerprint(args: {
     .limit(1);
   const hit = rows[0];
   if (!hit) return null;
+  const raw = hit as {
+    id: string;
+    source_system?: string | null;
+    allergen?: string | null;
+    severity?: string | null;
+    reaction?: string | null;
+    verification_status?: string | null;
+  };
   return {
     internalId: hit.id,
     sourceSystem: hit.source_system ?? null,
     // #1203: snapshot the columns persistAllergy's UPDATE will rewrite.
+    // #1220 widens the snapshot + UPDATE to include verification_status
+    // so an unconfirmed → confirmed flip is captured in the audit row.
     priorAllergyRow: {
-      allergen: hit.allergen ?? null,
-      severity: hit.severity ?? null,
-      reaction: hit.reaction ?? null,
+      allergen: raw.allergen ?? null,
+      severity: raw.severity ?? null,
+      reaction: raw.reaction ?? null,
+      verification_status: raw.verification_status ?? null,
     },
   };
 }
@@ -555,12 +567,20 @@ async function findAllergyByFingerprint(args: {
  */
 function computeAllergyOverwrittenFields(
   prior: PriorAllergyRow,
-  incoming: { allergen: string; severity: string | null; reaction: string | null },
+  incoming: {
+    allergen: string;
+    severity: string | null;
+    reaction: string | null;
+    verification_status: string | null;
+  },
 ): Record<string, unknown> {
   const overwritten: Record<string, unknown> = {};
   if (prior.allergen !== incoming.allergen) overwritten.allergen = prior.allergen;
   if (prior.severity !== incoming.severity) overwritten.severity = prior.severity;
   if (prior.reaction !== incoming.reaction) overwritten.reaction = prior.reaction;
+  if (prior.verification_status !== incoming.verification_status) {
+    overwritten.verification_status = prior.verification_status;
+  }
   return overwritten;
 }
 
@@ -1555,6 +1575,7 @@ export async function persistAllergy(
         allergen: row.allergen,
         severity: row.severity,
         reaction: row.reaction,
+        verification_status: row.verification_status,
       })
       .where(eq(allergies.id, mapping.internalId));
     await upsertMapping({
@@ -1628,6 +1649,7 @@ export async function persistAllergy(
           allergen: row.allergen,
           severity: row.severity,
           reaction: row.reaction,
+          verification_status: row.verification_status,
         })
       : {};
     await db
@@ -1636,6 +1658,7 @@ export async function persistAllergy(
         allergen: row.allergen,
         severity: row.severity,
         reaction: row.reaction,
+        verification_status: row.verification_status,
       })
       .where(eq(allergies.id, fingerprintHit.internalId));
     await upsertMapping({


### PR DESCRIPTION
## Summary
- `persistAllergy`'s UPDATE now writes `verification_status` from the inbound Epic row
- `PriorAllergyRow` interface widened to include `verification_status: string | null`
- `findAllergyByFingerprint` reads the prior verification_status into priorAllergyRow
- `computeAllergyOverwrittenFields` diffs verification_status alongside allergen/severity/reaction
- New test: pre-existing `unconfirmed` + Epic sync `confirmed` → `overwritten_fields.verification_status = "unconfirmed"`

## Test plan
- [x] verification_status flip captured in audit payload
- [x] Existing 5 audit + 12 source-guard tests still pass

Closes #1220