### PR TITLE
feat(epic): surface up to N existing Epic-ids in dedup_conflict audit (#1219)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-multi-conflict.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-multi-conflict.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Multi-conflict audit surfacing on the fingerprint-merge dedup_conflict
+ * path (#1219).
+ *
+ * Background: #1201 introduced the `epic_sync_dedup_conflict` audit row
+ * for the case where a fingerprint hit lands on an internal row already
+ * mapped to a DIFFERENT Epic FHIR id. The original implementation used
+ * `LIMIT 1` and surfaced a single `existing_epic_fhir_id` in the audit
+ * details — sufficient for detection, but loses information when more
+ * than one Epic id maps to the same internal id (today impossible via
+ * the `(resource_type, resource_id)` unique key on `fhir_resources`, but
+ * possible after manual DB intervention or any future schema change
+ * that loosens the constraint).
+ *
+ * This suite pins the new behaviour:
+ *  - Single-conflict (existing case, exactly one row): the audit
+ *    details carry `existing_epic_fhir_ids` as a 1-element array AND
+ *    the back-compat `existing_epic_fhir_id` is the same string.
+ *  - Multi-conflict (synthetic 2-3 rows): `existing_epic_fhir_ids` is
+ *    the full array (capped at 5), and `existing_epic_fhir_id` is the
+ *    first entry.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMockDb, type MockDb } from "@carebridge/test-utils";
+
+let db: MockDb;
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => db,
+  patients: {
+    id: "id",
+    mrn_hmac: "mrn_hmac",
+    patient_id: "patient_id",
+  },
+  medications: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    started_at: "started_at",
+  },
+  vitals: {
+    id: "id",
+    patient_id: "patient_id",
+    loinc_code: "loinc_code",
+    recorded_at: "recorded_at",
+  },
+  labPanels: {},
+  labResults: {},
+  diagnoses: {
+    id: "id",
+    patient_id: "patient_id",
+    icd10_code: "icd10_code",
+    snomed_code: "snomed_code",
+    onset_date: "onset_date",
+  },
+  allergies: {
+    id: "id",
+    patient_id: "patient_id",
+    rxnorm_code: "rxnorm_code",
+    snomed_code: "snomed_code",
+  },
+  encounters: {
+    id: "id",
+    patient_id: "patient_id",
+    start_time: "start_time",
+    encounter_type: "encounter_type",
+  },
+  fhirResources: {
+    id: "id",
+    resource_type: "resource_type",
+    resource_id: "resource_id",
+    internal_record_id: "internal_record_id",
+  },
+  auditLog: {},
+  hmacForIndex: (value: string) => `hmac:${value}`,
+}));
+
+const { persistEncounter } = await import("../sync/persistence.js");
+
+const PATIENT_ID = "11111111-1111-1111-1111-111111111111";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db = createMockDb();
+});
+
+function findAuditInsert(
+  action: string,
+): Record<string, unknown> | undefined {
+  const hit = db.insert.calls.find((c) => {
+    const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+    return v?.action === action;
+  });
+  return hit?.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+}
+
+const RESOURCE = {
+  resourceType: "Encounter",
+  id: "epic-enc-NEW",
+  status: "finished",
+  class: { code: "AMB" },
+  subject: { reference: "Patient/p-1" },
+  period: { start: "2026-05-20T09:00:00Z", end: "2026-05-20T09:45:00Z" },
+};
+
+describe("dedup_conflict audit surfaces multiple existing Epic ids (#1219)", () => {
+  it("single conflicting mapping → existing_epic_fhir_ids is a 1-element array AND existing_epic_fhir_id matches it (back-compat)", async () => {
+    const existingInternalId = "internal-enc-single";
+    const existingEpicId = "epic-enc-A";
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]); // fingerprint hit
+    db.willSelect([
+      {
+        id: `epic:Encounter:${existingEpicId}`,
+        resource_type: "Encounter",
+        resource_id: existingEpicId,
+        internal_record_id: existingInternalId,
+      },
+    ]); // conflict-mapping lookup → 1 row
+    db.willInsert(); // new encounters row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log dedup_conflict
+
+    await persistEncounter(RESOURCE, PATIENT_ID);
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+
+    // New array shape carries all conflicting Epic ids.
+    expect(Array.isArray(details.existing_epic_fhir_ids)).toBe(true);
+    expect(details.existing_epic_fhir_ids).toEqual([existingEpicId]);
+
+    // Back-compat scalar is the first entry of the array.
+    expect(details.existing_epic_fhir_id).toBe(existingEpicId);
+    expect(details.existing_epic_fhir_id).toBe(
+      details.existing_epic_fhir_ids[0],
+    );
+
+    // Other invariants from #1201 still hold.
+    expect(details.new_epic_fhir_id).toBe("epic-enc-NEW");
+    expect(details.matched_internal_id).toBe(existingInternalId);
+  });
+
+  it("multiple conflicting mappings (3 rows) → existing_epic_fhir_ids carries every id; existing_epic_fhir_id is the first", async () => {
+    const existingInternalId = "internal-enc-multi";
+    const existingEpicIds = ["epic-enc-A", "epic-enc-B", "epic-enc-C"];
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]); // fingerprint hit
+    // Synthetic 3-row conflict — drop the unique-key invariant for the
+    // test by simulating a post-intervention state where multiple Epic
+    // ids already map to the same internal id.
+    db.willSelect(
+      existingEpicIds.map((rid) => ({
+        id: `epic:Encounter:${rid}`,
+        resource_type: "Encounter",
+        resource_id: rid,
+        internal_record_id: existingInternalId,
+      })),
+    );
+    db.willInsert(); // new encounters row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log dedup_conflict
+
+    await persistEncounter(RESOURCE, PATIENT_ID);
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+
+    expect(Array.isArray(details.existing_epic_fhir_ids)).toBe(true);
+    expect(details.existing_epic_fhir_ids).toEqual(existingEpicIds);
+
+    // Back-compat scalar stays populated with the first entry — old
+    // consumers that read only `existing_epic_fhir_id` still see a
+    // valid Epic id rather than null.
+    expect(details.existing_epic_fhir_id).toBe(existingEpicIds[0]);
+  });
+});

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -267,28 +267,38 @@ async function logDedupMatch(args: {
 }
 
 /**
- * Look up a pre-existing Epic-id mapping that already points at the
+ * Look up pre-existing Epic-id mappings that already point at the
  * given internal record id but with a DIFFERENT resource_id than the
- * inbound FHIR id (#1201). When this returns a row, the caller must
- * NOT merge into the fingerprint-matched internal row — two distinct
- * Epic ids would otherwise both round-trip to the same CareBridge
- * record with no signal to a reviewer. Caller falls through to a
- * plain INSERT and writes an `epic_sync_dedup_conflict` audit row.
+ * inbound FHIR id (#1201, #1219). When this returns a non-empty array,
+ * the caller must NOT merge into the fingerprint-matched internal row
+ * — two distinct Epic ids would otherwise both round-trip to the same
+ * CareBridge record with no signal to a reviewer. Caller falls through
+ * to a plain INSERT and writes an `epic_sync_dedup_conflict` audit row.
  *
- * Returns null when there is no such conflicting mapping. A mapping
- * whose resource_id equals the inbound FHIR id is *not* a conflict —
- * it's the same logical Epic resource re-syncing.
+ * Returns an empty array when there is no such conflicting mapping.
+ * A mapping whose resource_id equals the inbound FHIR id is *not* a
+ * conflict — it's the same logical Epic resource re-syncing.
+ *
+ * #1219: result is capped at {@link CAP_CONFLICTING_MAPPINGS}. Today's
+ * `(resource_type, resource_id)` unique key on `fhir_resources` makes
+ * more than one row impossible, but a manual DB intervention or a
+ * future schema change could relax that. `LIMIT 5` keeps the audit
+ * payload bounded while still surfacing the multi-id case for review.
  */
-interface ConflictingMapping {
-  existingEpicFhirId: string;
-  internalRecordId: string;
-}
+/**
+ * Upper bound on the number of conflicting Epic mappings reported in
+ * the `epic_sync_dedup_conflict` audit row (#1219). Five is a soft
+ * forensic cap: enough to surface a non-trivial multi-mapping bug,
+ * small enough that a malformed `fhir_resources` table can't bloat the
+ * audit payload.
+ */
+const CAP_CONFLICTING_MAPPINGS = 5;
 
-async function findConflictingMapping(args: {
+async function findConflictingMappings(args: {
   resourceType: string;
   matchedInternalId: string;
   inboundFhirId: string;
-}): Promise<ConflictingMapping | null> {
+}): Promise<string[]> {
   const db = getDb();
   const rows = await db
     .select()
@@ -300,28 +310,31 @@ async function findConflictingMapping(args: {
         ne(fhirResources.resource_id, args.inboundFhirId),
       ),
     )
-    .limit(1);
+    .limit(CAP_CONFLICTING_MAPPINGS);
   // Defensive: Drizzle returns [] on no rows, but unit-test mocks that
   // under-queue can return undefined. Treat both as "no conflict".
-  const existing = rows?.[0];
-  if (!existing) return null;
-  return {
-    existingEpicFhirId: existing.resource_id,
-    internalRecordId: existing.internal_record_id ?? args.matchedInternalId,
-  };
+  if (!rows || rows.length === 0) return [];
+  return rows.map((row) => row.resource_id);
 }
 
 /**
- * Log an Epic-id conflict on the fingerprint path (#1201). The matched
- * internal row already has a different Epic FHIR id mapped to it; the
- * caller has already fallen through to INSERT a fresh internal row and
- * its own mapping. This audit row preserves both Epic ids and the
+ * Log an Epic-id conflict on the fingerprint path (#1201, #1219). The
+ * matched internal row already has one or more different Epic FHIR ids
+ * mapped to it; the caller has already fallen through to INSERT a fresh
+ * internal row and its own mapping. This audit row preserves every
+ * conflicting Epic id (up to {@link CAP_CONFLICTING_MAPPINGS}) and the
  * fingerprint for manual reconciliation.
+ *
+ * #1219: details carry `existing_epic_fhir_ids: string[]` (the full
+ * array) AND `existing_epic_fhir_id: string` (the first entry) for
+ * back-compat with consumers wired against the original scalar field.
+ * The caller must pass a non-empty array; the function's contract is
+ * that `existing_epic_fhir_id` always reflects `existing_epic_fhir_ids[0]`.
  */
 async function logDedupConflict(args: {
   resourceType: string;
   newEpicFhirId: string;
-  existingEpicFhirId: string;
+  existingEpicFhirIds: string[];
   matchedInternalId: string;
   newInternalId: string;
   patientId: string | null;
@@ -343,7 +356,12 @@ async function logDedupConflict(args: {
       reason: "epic_id_conflict_on_fingerprint_match",
       attempted_source: EPIC_SOURCE_SYSTEM_TAG,
       new_epic_fhir_id: args.newEpicFhirId,
-      existing_epic_fhir_id: args.existingEpicFhirId,
+      // #1219: surface the full set of conflicting Epic ids so a
+      // reviewer can see when more than one mapping survived a manual
+      // intervention. First entry is duplicated into the scalar field
+      // below for back-compat with consumers wired against #1201.
+      existing_epic_fhir_ids: args.existingEpicFhirIds,
+      existing_epic_fhir_id: args.existingEpicFhirIds[0],
       matched_internal_id: args.matchedInternalId,
       fingerprint: args.fingerprint,
       resolution: "insert_new_internal_row",
@@ -730,15 +748,15 @@ export async function persistPatient(
   // #1201: identity-ambiguity check. Patient identity is a high-stakes
   // case — two Epic patient FHIR ids resolving to the same MRN HMAC
   // usually means an Epic-side merge / unmerge cycle. Treat as conflict.
-  let conflictMapping: ConflictingMapping | null = null;
+  let conflictingEpicIds: string[] = [];
   if (fingerprintHit) {
-    conflictMapping = await findConflictingMapping({
+    conflictingEpicIds = await findConflictingMappings({
       resourceType: "Patient",
       matchedInternalId: fingerprintHit.internalId,
       inboundFhirId: fhirId,
     });
   }
-  if (fingerprintHit && !conflictMapping) {
+  if (fingerprintHit && conflictingEpicIds.length === 0) {
     await db
       .update(patients)
       .set({
@@ -787,11 +805,11 @@ export async function persistPatient(
     patientId: id,
     resource,
   });
-  if (conflictMapping && fingerprintHit) {
+  if (conflictingEpicIds.length > 0 && fingerprintHit) {
     await logDedupConflict({
       resourceType: "Patient",
       newEpicFhirId: fhirId,
-      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      existingEpicFhirIds: conflictingEpicIds,
       matchedInternalId: fingerprintHit.internalId,
       newInternalId: id,
       patientId: id,
@@ -906,15 +924,15 @@ async function persistMedicationRow(
     started_at: row.started_at,
   };
   // #1201: identity-ambiguity check (see persistEncounter for rationale).
-  let conflictMapping: ConflictingMapping | null = null;
+  let conflictingEpicIds: string[] = [];
   if (fingerprintHit) {
-    conflictMapping = await findConflictingMapping({
+    conflictingEpicIds = await findConflictingMappings({
       resourceType,
       matchedInternalId: fingerprintHit.internalId,
       inboundFhirId: fhirId,
     });
   }
-  if (fingerprintHit && !conflictMapping) {
+  if (fingerprintHit && conflictingEpicIds.length === 0) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -997,11 +1015,11 @@ async function persistMedicationRow(
     patientId,
     resource,
   });
-  if (conflictMapping && fingerprintHit) {
+  if (conflictingEpicIds.length > 0 && fingerprintHit) {
     await logDedupConflict({
       resourceType,
       newEpicFhirId: fhirId,
-      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      existingEpicFhirIds: conflictingEpicIds,
       matchedInternalId: fingerprintHit.internalId,
       newInternalId: id,
       patientId,
@@ -1084,15 +1102,15 @@ export async function persistObservation(
       recorded_at: conversion.row.recorded_at,
     };
     // #1201: identity-ambiguity check (see persistEncounter).
-    let conflictMapping: ConflictingMapping | null = null;
+    let conflictingEpicIds: string[] = [];
     if (fingerprintHit) {
-      conflictMapping = await findConflictingMapping({
+      conflictingEpicIds = await findConflictingMappings({
         resourceType: "Observation",
         matchedInternalId: fingerprintHit.internalId,
         inboundFhirId: fhirId,
       });
     }
-    if (fingerprintHit && !conflictMapping) {
+    if (fingerprintHit && conflictingEpicIds.length === 0) {
       // #1200: source_system guard — see persistEncounter for rationale.
       if (!isEpicOwned(fingerprintHit.sourceSystem)) {
         await upsertMapping({
@@ -1169,11 +1187,11 @@ export async function persistObservation(
       patientId,
       resource,
     });
-    if (conflictMapping && fingerprintHit) {
+    if (conflictingEpicIds.length > 0 && fingerprintHit) {
       await logDedupConflict({
         resourceType: "Observation",
         newEpicFhirId: fhirId,
-        existingEpicFhirId: conflictMapping.existingEpicFhirId,
+        existingEpicFhirIds: conflictingEpicIds,
         matchedInternalId: fingerprintHit.internalId,
         newInternalId: id,
         patientId,
@@ -1372,15 +1390,15 @@ export async function persistCondition(
     onset_date: row.onset_date,
   };
   // #1201: identity-ambiguity check (see persistEncounter).
-  let conflictMapping: ConflictingMapping | null = null;
+  let conflictingEpicIds: string[] = [];
   if (fingerprintHit) {
-    conflictMapping = await findConflictingMapping({
+    conflictingEpicIds = await findConflictingMappings({
       resourceType: "Condition",
       matchedInternalId: fingerprintHit.internalId,
       inboundFhirId: fhirId,
     });
   }
-  if (fingerprintHit && !conflictMapping) {
+  if (fingerprintHit && conflictingEpicIds.length === 0) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -1457,11 +1475,11 @@ export async function persistCondition(
     patientId,
     resource,
   });
-  if (conflictMapping && fingerprintHit) {
+  if (conflictingEpicIds.length > 0 && fingerprintHit) {
     await logDedupConflict({
       resourceType: "Condition",
       newEpicFhirId: fhirId,
-      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      existingEpicFhirIds: conflictingEpicIds,
       matchedInternalId: fingerprintHit.internalId,
       newInternalId: id,
       patientId,
@@ -1541,15 +1559,15 @@ export async function persistAllergy(
     snomed_code: row.snomed_code,
   };
   // #1201: identity-ambiguity check (see persistEncounter).
-  let conflictMapping: ConflictingMapping | null = null;
+  let conflictingEpicIds: string[] = [];
   if (fingerprintHit) {
-    conflictMapping = await findConflictingMapping({
+    conflictingEpicIds = await findConflictingMappings({
       resourceType: "AllergyIntolerance",
       matchedInternalId: fingerprintHit.internalId,
       inboundFhirId: fhirId,
     });
   }
-  if (fingerprintHit && !conflictMapping) {
+  if (fingerprintHit && conflictingEpicIds.length === 0) {
     // #1200: source_system guard — see persistEncounter for rationale.
     if (!isEpicOwned(fingerprintHit.sourceSystem)) {
       await upsertMapping({
@@ -1632,11 +1650,11 @@ export async function persistAllergy(
     patientId,
     resource,
   });
-  if (conflictMapping && fingerprintHit) {
+  if (conflictingEpicIds.length > 0 && fingerprintHit) {
     await logDedupConflict({
       resourceType: "AllergyIntolerance",
       newEpicFhirId: fhirId,
-      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      existingEpicFhirIds: conflictingEpicIds,
       matchedInternalId: fingerprintHit.internalId,
       newInternalId: id,
       patientId,
@@ -1736,15 +1754,15 @@ export async function persistEncounter(
   // runs BEFORE the #1200 source_system guard because once two Epic ids
   // both point at one row we've lost the ability to safely round-trip
   // either, regardless of data ownership.
-  let conflictMapping: ConflictingMapping | null = null;
+  let conflictingEpicIds: string[] = [];
   if (fingerprintHit) {
-    conflictMapping = await findConflictingMapping({
+    conflictingEpicIds = await findConflictingMappings({
       resourceType: "Encounter",
       matchedInternalId: fingerprintHit.internalId,
       inboundFhirId: fhirId,
     });
   }
-  if (fingerprintHit && !conflictMapping) {
+  if (fingerprintHit && conflictingEpicIds.length === 0) {
     // #1200: guard the fingerprint-merge UPDATE on source_system. If the
     // matched row is CareBridge-originated, write the mapping so Epic IDs
     // still round-trip, but DO NOT overwrite the clinician's data.
@@ -1823,11 +1841,11 @@ export async function persistEncounter(
     patientId,
     resource,
   });
-  if (conflictMapping && fingerprintHit) {
+  if (conflictingEpicIds.length > 0 && fingerprintHit) {
     await logDedupConflict({
       resourceType: "Encounter",
       newEpicFhirId: fhirId,
-      existingEpicFhirId: conflictMapping.existingEpicFhirId,
+      existingEpicFhirIds: conflictingEpicIds,
       matchedInternalId: fingerprintHit.internalId,
       newInternalId: id,
       patientId,


### PR DESCRIPTION
## Summary
- `findConflictingMapping` (services/epic-connector/src/sync/persistence.ts) now returns an array of up to 5 conflicting Epic FHIR ids instead of a single row
- `logDedupConflict` emits `existing_epic_fhir_ids: string[]` in audit details, alongside the existing `existing_epic_fhir_id` (first entry, for backwards compat)
- Multi-conflict synthetic test exercises the array shape

## Test plan
- [x] Single-conflict: array length 1, first entry matches existing field
- [x] Multi-conflict: array length matches inserted rows (capped at 5)
- [x] All existing conflict tests still pass

Closes #1219