### PR TITLE
refactor(epic): drop stale source_system cast in findLabPanelByFingerprint (#1235)

### DIFF
--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -685,8 +685,7 @@ async function findLabPanelByFingerprint(args: {
   if (!hit) return null;
   return {
     internalId: hit.id,
-    sourceSystem:
-      (hit as { source_system?: string | null }).source_system ?? null,
+    sourceSystem: hit.source_system ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Drops the defensive `(hit as { source_system?: string | null })` cast in `findLabPanelByFingerprint` (services/epic-connector/src/sync/persistence.ts)
- Direct property access now — matches the pattern landed in #1226 for the other fingerprint helpers
- Keeps `?? null` since `lab_panels.source_system` is still nullable in the Drizzle schema (unlike migration-0054's NOT NULL tables)

## Test plan
- [x] Typecheck confirms direct access compiles
- [x] Existing epic-connector tests still pass

Closes #1235