### PR TITLE
feat(epic): emit existing_epic_fhir_id_count in dedup_conflict audit (#1232)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-multi-conflict.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-multi-conflict.test.ts
@@ -507,3 +507,88 @@ describe.each(CASES)(
     });
   },
 );
+// ── existing_epic_fhir_id_count audit field (#1232) ───────────────────
+//
+// #1232 adds a derived `existing_epic_fhir_id_count` field to the
+// dedup_conflict audit details: it's `existingEpicFhirIds.length` and
+// gives audit consumers a cheap numeric signal without re-counting the
+// array client-side. These two cases lock in the single-row (count===1)
+// and multi-row (count===3) shapes against the Encounter persister.
+
+describe("dedup_conflict audit surfaces existing_epic_fhir_id_count (#1232)", () => {
+  it("single conflicting mapping → existing_epic_fhir_id_count === 1", async () => {
+    const existingInternalId = "internal-enc-count-single";
+    const existingEpicId = "epic-enc-A";
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]); // fingerprint hit
+    db.willSelect([
+      {
+        id: `epic:Encounter:${existingEpicId}`,
+        resource_type: "Encounter",
+        resource_id: existingEpicId,
+        internal_record_id: existingInternalId,
+      },
+    ]); // conflict-mapping lookup → 1 row
+    db.willInsert(); // new encounters row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log dedup_conflict
+
+    await persistEncounter(ENCOUNTER_RESOURCE, PATIENT_ID);
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+
+    expect(details.existing_epic_fhir_id_count).toBe(1);
+    expect(details.existing_epic_fhir_id_count).toBe(
+      details.existing_epic_fhir_ids.length,
+    );
+  });
+
+  it("multiple conflicting mappings (3 rows) → existing_epic_fhir_id_count === 3", async () => {
+    const existingInternalId = "internal-enc-count-multi";
+    const existingEpicIds = ["epic-enc-A", "epic-enc-B", "epic-enc-C"];
+
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingInternalId,
+        patient_id: PATIENT_ID,
+        start_time: "2026-05-20T09:00:00Z",
+        encounter_type: "AMB",
+        source_system: "epic",
+      },
+    ]); // fingerprint hit
+    db.willSelect(
+      existingEpicIds.map((rid) => ({
+        id: `epic:Encounter:${rid}`,
+        resource_type: "Encounter",
+        resource_id: rid,
+        internal_record_id: existingInternalId,
+      })),
+    );
+    db.willInsert(); // new encounters row
+    db.willInsert(); // new mapping
+    db.willInsert(); // audit_log dedup_conflict
+
+    await persistEncounter(ENCOUNTER_RESOURCE, PATIENT_ID);
+
+    const audit = findAuditInsert("epic_sync_dedup_conflict");
+    expect(audit).toBeDefined();
+    const details = JSON.parse(audit?.details as string);
+
+    expect(details.existing_epic_fhir_id_count).toBe(3);
+    expect(details.existing_epic_fhir_id_count).toBe(
+      details.existing_epic_fhir_ids.length,
+    );
+  });
+});

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -360,6 +360,11 @@ async function findConflictingMappings(args: {
  * back-compat with consumers wired against the original scalar field.
  * The caller must pass a non-empty array; the function's contract is
  * that `existing_epic_fhir_id` always reflects `existing_epic_fhir_ids[0]`.
+ *
+ * #1232: also emit `existing_epic_fhir_id_count: number` (always equal
+ * to `existing_epic_fhir_ids.length`) so downstream filters (alert
+ * rules, dashboards, jq pipelines) can grep the multi-mapping case
+ * without parsing the array. Schema-additive only.
  */
 async function logDedupConflict(args: {
   resourceType: string;
@@ -392,6 +397,10 @@ async function logDedupConflict(args: {
       // below for back-compat with consumers wired against #1201.
       existing_epic_fhir_ids: args.existingEpicFhirIds,
       existing_epic_fhir_id: args.existingEpicFhirIds[0],
+      // #1232: explicit count so downstream alert rules / dashboards /
+      // jq filters can match the multi-mapping case (count > 1) without
+      // parsing the array.
+      existing_epic_fhir_id_count: args.existingEpicFhirIds.length,
       matched_internal_id: args.matchedInternalId,
       fingerprint: args.fingerprint,
       resolution: "insert_new_internal_row",


### PR DESCRIPTION
## Summary
- Adds `existing_epic_fhir_id_count: number` to `logDedupConflict`'s audit details payload in `services/epic-connector/src/sync/persistence.ts`
- Single-conflict assertion: count === 1
- Multi-conflict assertion: count === length of `existing_epic_fhir_ids`

## Test plan
- [x] Single-conflict test asserts count === 1
- [x] Multi-conflict test asserts count === array length
- [x] Existing audit/dedup tests still pass

Closes #1232