### PR TITLE
feat(epic): extend source_system guard to lab_panels persister (#1234)

### DIFF
--- a/services/epic-connector/src/__tests__/persistence-source-guard.test.ts
+++ b/services/epic-connector/src/__tests__/persistence-source-guard.test.ts
@@ -48,8 +48,16 @@ vi.mock("@carebridge/db-schema", () => ({
     loinc_code: "loinc_code",
     recorded_at: "recorded_at",
   },
-  labPanels: {},
-  labResults: {},
+  labPanels: {
+    id: "id",
+    patient_id: "patient_id",
+    panel_name: "panel_name",
+    collected_at: "collected_at",
+  },
+  labResults: {
+    id: "id",
+    panel_id: "panel_id",
+  },
   diagnoses: {
     id: "id",
     patient_id: "patient_id",
@@ -516,6 +524,161 @@ describe("persistObservation (vital) — source_system guard on fingerprint path
     expect(result.conflict).toBeUndefined();
     expect(db.update).toHaveBeenCalledOnce();
     expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+  });
+});
+
+// ── Labs (Observation, panel-level fingerprint) ───────────────
+
+describe("persistObservation (lab) — source_system guard on panel fingerprint path (#1234)", () => {
+  const RESOURCE = {
+    resourceType: "Observation",
+    id: "epic-lab-1",
+    status: "final",
+    category: [
+      {
+        coding: [
+          {
+            system:
+              "http://terminology.hl7.org/CodeSystem/observation-category",
+            code: "laboratory",
+          },
+        ],
+      },
+    ],
+    code: {
+      text: "Hemoglobin",
+      coding: [
+        {
+          system: "http://loinc.org",
+          code: "718-7",
+          display: "Hemoglobin",
+        },
+      ],
+    },
+    subject: { reference: "Patient/p-1" },
+    effectiveDateTime: "2026-05-20T07:30:00Z",
+    valueQuantity: { value: 13.2, unit: "g/dL" },
+  };
+
+  it("CareBridge-originated lab_panels (source_system='internal') → skip lab_results attach, write mapping, audit epic_sync_source_conflict", async () => {
+    const existingPanelId = "internal-panel-cb-1";
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingPanelId,
+        patient_id: PATIENT_ID,
+        panel_name: "Hemoglobin",
+        collected_at: "2026-05-20T07:30:00Z",
+        source_system: "internal",
+      },
+    ]);
+    db.willInsert(); // fhir_resources mapping
+    db.willInsert(); // audit_log epic_sync_source_conflict
+
+    const result = await persistObservation(RESOURCE, PATIENT_ID);
+
+    expect(result.internalId).toBe(existingPanelId);
+    expect(result.kind).toBe("lab");
+    expect(result.inserted).toBe(false);
+    expect(result.conflict).toBe("source_system_conflict");
+
+    // No lab_results row attached — Epic must not silently grow a leaf
+    // on a CareBridge-originated panel.
+    const labResultInsert = db.insert.calls.find((c) => {
+      const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+      return v?.panel_id !== undefined;
+    });
+    expect(labResultInsert).toBeUndefined();
+
+    // fhir_resources mapping IS written so the Epic FHIR id still
+    // round-trips to the same panel on the next sync (and trips the
+    // same guard).
+    const mapping = findMappingInsert();
+    expect(mapping).toBeDefined();
+    expect(mapping?.resource_type).toBe("Observation");
+    expect(mapping?.resource_id).toBe("epic-lab-1");
+    expect(mapping?.internal_record_id).toBe(existingPanelId);
+
+    // Audit row uses the source-conflict action and carries provenance.
+    const audit = findAuditInsert("epic_sync_source_conflict");
+    expect(audit).toBeDefined();
+    expect(audit?.resource_type).toBe("Observation");
+    expect(audit?.resource_id).toBe(existingPanelId);
+    const details = JSON.parse(audit?.details as string);
+    expect(details.epic_fhir_id).toBe("epic-lab-1");
+    expect(details.existing_source).toBe("internal");
+    expect(details.resolution).toBe("keep_carebridge_value");
+
+    // No dedup-match row — this is a conflict, not a merge.
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeUndefined();
+  });
+
+  it("Epic-originated lab_panels (source_system='epic') → attach lab_result + epic_sync_dedup_match (negative)", async () => {
+    const existingPanelId = "internal-panel-epic-1";
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingPanelId,
+        patient_id: PATIENT_ID,
+        panel_name: "Hemoglobin",
+        collected_at: "2026-05-20T07:30:00Z",
+        source_system: "epic",
+      },
+    ]);
+    db.willInsert(); // lab_results row attached to existing Epic panel
+    db.willInsert(); // fhir_resources mapping
+    db.willInsert(); // audit_log epic_sync_dedup_match
+
+    const result = await persistObservation(RESOURCE, PATIENT_ID);
+
+    expect(result.kind).toBe("lab");
+    expect(result.inserted).toBe(false);
+    expect(result.conflict).toBeUndefined();
+
+    // A new lab_results leaf WAS attached to the Epic panel — the
+    // existing dedup behaviour stands when both sides are Epic-owned.
+    const labResultInsert = db.insert.calls.find((c) => {
+      const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+      return v?.panel_id === existingPanelId;
+    });
+    expect(labResultInsert).toBeDefined();
+    const newResultId = (
+      labResultInsert!.chainArgs[0]![0] as Record<string, unknown>
+    ).id as string;
+    expect(result.internalId).toBe(newResultId);
+
+    // Dedup audit, NOT source-conflict.
+    expect(findAuditInsert("epic_sync_dedup_match")).toBeDefined();
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeUndefined();
+  });
+
+  it("Matched lab_panels with source_system=null → treated as non-epic, skip attach", async () => {
+    const existingPanelId = "internal-panel-null-1";
+    db.willSelect([]); // findMapping miss
+    db.willSelect([
+      {
+        id: existingPanelId,
+        patient_id: PATIENT_ID,
+        panel_name: "Hemoglobin",
+        collected_at: "2026-05-20T07:30:00Z",
+        source_system: null,
+      },
+    ]);
+    db.willInsert(); // mapping
+    db.willInsert(); // audit
+
+    const result = await persistObservation(RESOURCE, PATIENT_ID);
+
+    expect(result.conflict).toBe("source_system_conflict");
+    expect(result.internalId).toBe(existingPanelId);
+
+    const labResultInsert = db.insert.calls.find((c) => {
+      const v = c.chainArgs[0]?.[0] as Record<string, unknown> | undefined;
+      return v?.panel_id !== undefined;
+    });
+    expect(labResultInsert).toBeUndefined();
+
+    expect(findAuditInsert("epic_sync_source_conflict")).toBeDefined();
   });
 });
 

--- a/services/epic-connector/src/__tests__/persistence.test.ts
+++ b/services/epic-connector/src/__tests__/persistence.test.ts
@@ -518,7 +518,10 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
     valueQuantity: { value: 13.2, unit: "g/dL" },
   };
 
-  it("dedups against existing CareBridge lab_panels row by patient_id+panel_name+collected_at and attaches the result to it", async () => {
+  it("dedups against an existing Epic-owned lab_panels row by patient_id+panel_name+collected_at and attaches the result to it", async () => {
+    // #1234 — the panel must be source_system='epic' to follow the
+    // attach-leaf branch. CareBridge-originated panels now trip the
+    // source_system guard (covered in persistence-source-guard.test.ts).
     const existingPanelId = "internal-panel-1";
     db.willSelect([]); // findMapping miss
     db.willSelect([
@@ -527,6 +530,7 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
         patient_id: PATIENT_ID,
         panel_name: "Hemoglobin",
         collected_at: "2026-05-20T07:30:00Z",
+        source_system: "epic",
       },
     ]);
     db.willInsert(); // lab_results row attached to existing panel
@@ -615,6 +619,8 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
     // test so regressions on either side fail loudly.
 
     // ── Path A: same test_name (Hemoglobin) → fingerprint HIT, reuse panel ──
+    // #1234 — Epic-sourced panel so the attach-leaf branch runs (the
+    // source_system guard is exercised in persistence-source-guard.test.ts).
     const existingPanelId = "internal-panel-hemoglobin-1";
     db.willSelect([]); // mapping miss
     db.willSelect([
@@ -623,6 +629,7 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
         patient_id: PATIENT_ID,
         panel_name: "Hemoglobin",
         collected_at: "2026-05-20T07:30:00Z",
+        source_system: "epic",
       },
     ]);
     db.willInsert(); // lab_results row attached
@@ -727,6 +734,7 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
     const existingPanelId = "internal-panel-1207";
 
     // ── Round 1: fingerprint hit on the existing panel ──
+    // #1234 — Epic-sourced panel so the attach-leaf branch runs.
     db.willSelect([]); // findMapping miss
     db.willSelect([
       {
@@ -734,6 +742,7 @@ describe("persistObservation (lab) — panel-level dedup (#1202)", () => {
         patient_id: PATIENT_ID,
         panel_name: "Hemoglobin",
         collected_at: "2026-05-20T07:30:00Z",
+        source_system: "epic",
       },
     ]);
     db.willInsert(); // lab_results insert hanging off existing panel

--- a/services/epic-connector/src/sync/persistence.ts
+++ b/services/epic-connector/src/sync/persistence.ts
@@ -14,9 +14,11 @@
  *     find the same internal row.
  *  5. Refuses to overwrite CareBridge-originated data on BOTH the
  *     Epic-id path (step 1) AND the fingerprint path (step 2) for the
- *     five resource tables that carry `source_system` (encounters,
- *     diagnoses, allergies, medications, vitals/observations). Patient
- *     identity is treated as Epic-owned at first import — the `patients`
+ *     six resource tables that carry `source_system` (encounters,
+ *     diagnoses, allergies, medications, vitals/observations, and
+ *     lab_panels — the lab branch of persistObservation guards the
+ *     panel a new Epic lab_results leaf would attach to per #1234).
+ *     Patient identity is treated as Epic-owned at first import — the `patients`
  *     table has no `source_system` column and the fingerprint hit in
  *     `persistPatient` merges unconditionally; see
  *     `findPatientByFingerprint` for the rationale. When the existing
@@ -1296,6 +1298,50 @@ export async function persistObservation(
     collectedAt: conversion.row.recorded_at,
   });
   if (panelFingerprintHit) {
+    // #1234: source_system guard on the panel fingerprint-hit branch.
+    // When the matched lab_panels row was originally written by
+    // CareBridge (source_system != 'epic', or null which we defensively
+    // treat as non-epic), an Epic Observation MUST NOT silently attach
+    // a new lab_results leaf — that would let an Epic-sourced result
+    // grow underneath a CareBridge-owned panel, defeating the data-
+    // ownership boundary #1200 established for the parent-row writers
+    // (encounters/diagnoses/allergies/medications/vitals). Skip the
+    // leaf attach, still upsert the fhir_resources mapping so the Epic
+    // FHIR id round-trips to the same panel on the next sync (and trips
+    // the same guard), and emit epic_sync_source_conflict carrying the
+    // matched panel id + its existing source_system value. The mapping
+    // intentionally points at the panel id here (not a leaf, because no
+    // leaf was inserted) — round-2 syncs land in the `mapping.internalId`
+    // branch above; that branch looks the id up in lab_results and finds
+    // zero rows, so the UPDATE is a no-op and the guard holds without
+    // further plumbing.
+    if (!isEpicOwned(panelFingerprintHit.sourceSystem)) {
+      await upsertMapping({
+        resourceType: "Observation",
+        fhirId,
+        internalId: panelFingerprintHit.internalId,
+        patientId,
+        resource,
+      });
+      await logFingerprintSourceConflict({
+        resourceType: "Observation",
+        fhirId,
+        internalId: panelFingerprintHit.internalId,
+        patientId,
+        existingSourceSystem: panelFingerprintHit.sourceSystem,
+        fingerprint: {
+          patient_id: patientId,
+          panel_name: conversion.row.test_name,
+          collected_at: conversion.row.recorded_at,
+        },
+      });
+      return {
+        internalId: panelFingerprintHit.internalId,
+        kind: "lab",
+        inserted: false,
+        conflict: "source_system_conflict",
+      };
+    }
     // #1213 — intentionally NO update to lab_panels.source_system or
     // reported_at on reuse: a CareBridge-originated panel keeps its
     // provenance, and the Epic-side merge fact is captured in the


### PR DESCRIPTION
## Summary
- Adds source_system guard to `persistObservation`'s lab fingerprint-hit branch in `services/epic-connector/src/sync/persistence.ts`
- When matched `lab_panels` row has `source_system != 'epic'` (CareBridge-originated): skip lab_results attach, upsert fhir_resources mapping, emit `epic_sync_source_conflict` audit row
- When matched panel is Epic-sourced: existing dedup behavior preserved (lab_result attached)
- Procedures persister does not exist yet; out of scope per #1234

## Test plan
- [x] CareBridge panel + Epic Observation fingerprint match → no leaf attach + audit row
- [x] Epic panel + Epic Observation fingerprint match → leaf attached + dedup audit
- [x] Existing lab fingerprint dedup + source_system tests still pass

Closes #1234
Refs: #1200, #1183, #1190