### PR TITLE
feat(gateway): gate CPT emission behind FHIR_CPT_EMISSION_ENABLED flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,11 @@ NODE_ENV=development
 # services/epic-connector/README.md for details.
 # EPIC_OBSERVATION_CATEGORIES=vital-signs,laboratory
 # EPIC_MEDICATION_REQUEST_STATUS=active
+
+# FHIR — AMA CPT emission gate (#939)
+# CPT codes are AMA-licensed. Distributing them in outbound FHIR bundles
+# to an external recipient may require an AMA CPT license. This flag
+# defaults to "off" — Procedure.code falls back to the free-text
+# procedure name. Set to the literal string "true" only after the
+# license question is resolved. See docs/fhir-licensing.md.
+# FHIR_CPT_EMISSION_ENABLED=true

--- a/docs/fhir-licensing.md
+++ b/docs/fhir-licensing.md
@@ -1,0 +1,80 @@
+# FHIR Code System Licensing
+
+This document tracks third-party code-system licenses that gate what
+CareBridge is allowed to distribute in outbound FHIR bundles. The
+practical concern is that several widely used FHIR code systems
+(CPT, SNOMED CT, LOINC under some conditions) are licensed by their
+publishers, and including those codings in a FHIR resource sent to
+an external recipient may constitute redistribution.
+
+Each gated system has a corresponding environment flag and a default
+that fails safe (no emission until the license question is resolved).
+
+## CPT (AMA Current Procedural Terminology)
+
+### Status
+
+**Default: emission disabled.** `FHIR_CPT_EMISSION_ENABLED` defaults
+to anything other than the literal string `"true"`, which means the
+fhir-gateway omits CPT codings from `Procedure.code`.
+
+### Context
+
+`services/fhir-gateway/src/generators/procedure.ts` historically
+emitted CPT codings on `Procedure.code` using the AMA CPT system URL
+(`http://www.ama-assn.org/go/cpt`). This is FHIR-correct: the AMA is
+the canonical source for CPT and that system URL is the registered
+identifier.
+
+The American Medical Association licenses CPT code usage. Distributing
+CPT codes in a FHIR bundle to an external recipient may require an
+AMA CPT license agreement (end-user agreement, organisational
+license, or similar). The required license depends on the deployment
+model and the number / nature of recipients.
+
+CareBridge has not yet confirmed which license tier covers its
+intended FHIR export path. Until that is confirmed, emission is
+gated off by default.
+
+### The gate
+
+`services/fhir-gateway/src/generators/procedure.ts` reads
+`process.env.FHIR_CPT_EMISSION_ENABLED` at call time. CPT codings
+are only emitted when the value is exactly the string `"true"`. Any
+other value (unset, `"false"`, `"1"`, `"yes"`, etc.) keeps the gate
+closed.
+
+When the gate is closed, `Procedure.code` still emits a useful
+free-text fallback via the existing `code.text = procedure.name`
+path. Downstream consumers see a Procedure with a human-readable
+description but no licensed coding.
+
+### What needs to happen before flipping the gate
+
+1. **Confirm with CareBridge legal / compliance** whether the
+   intended FHIR export model (which recipients, what volume, what
+   commercial relationship) requires an AMA CPT license.
+2. **If a license is required:** obtain the appropriate AMA license
+   covering distribution. Record the license reference in this
+   document.
+3. **If no license is required** (e.g. recipient is a covered entity
+   with their own CPT license, or the export is intra-organisational
+   only): document the basis in this file with the date and the
+   stakeholder who confirmed.
+4. **Flip the flag in the relevant deployment environments:**
+   ```
+   FHIR_CPT_EMISSION_ENABLED=true
+   ```
+
+### Tests
+
+- `services/fhir-gateway/src/__tests__/procedure.test.ts` covers
+  both the gated-off path (default) and the gated-on path. The
+  gated-off path asserts that `Procedure.code.coding` is undefined
+  even when the source row has a `cpt_code` value, and that the
+  free-text fallback is still populated.
+
+### Related
+
+- Issue #939 — tracking issue for the AMA CPT licensing question.
+- PR #922 — the change that first introduced CPT emission.

--- a/services/fhir-gateway/src/__tests__/procedure.test.ts
+++ b/services/fhir-gateway/src/__tests__/procedure.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { toFhirProcedure } from "../generators/procedure.js";
 
 type Procedure = Parameters<typeof toFhirProcedure>[0];
@@ -47,7 +47,20 @@ describe("toFhirProcedure (#387)", () => {
     }
   });
 
-  describe("code / CPT coding", () => {
+  describe("code / CPT coding (FHIR_CPT_EMISSION_ENABLED=true)", () => {
+    let previous: string | undefined;
+    beforeEach(() => {
+      previous = process.env.FHIR_CPT_EMISSION_ENABLED;
+      process.env.FHIR_CPT_EMISSION_ENABLED = "true";
+    });
+    afterEach(() => {
+      if (previous === undefined) {
+        delete process.env.FHIR_CPT_EMISSION_ENABLED;
+      } else {
+        process.env.FHIR_CPT_EMISSION_ENABLED = previous;
+      }
+    });
+
     it("emits CPT coding when cpt_code is present", () => {
       const proc = toFhirProcedure(
         makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
@@ -67,6 +80,67 @@ describe("toFhirProcedure (#387)", () => {
       );
       expect(proc.code?.coding).toBeUndefined();
       expect(proc.code?.text).toBe("Wound dressing change");
+    });
+  });
+
+  // AMA CPT licensing gate (#939). Default behavior is "do not emit CPT
+  // codings" until the AMA license question is answered. The fhir-gateway
+  // still emits a useful Procedure.code via the free-text name.
+  describe("code / CPT licensing gate", () => {
+    let previous: string | undefined;
+    beforeEach(() => {
+      previous = process.env.FHIR_CPT_EMISSION_ENABLED;
+      delete process.env.FHIR_CPT_EMISSION_ENABLED;
+    });
+    afterEach(() => {
+      if (previous === undefined) {
+        delete process.env.FHIR_CPT_EMISSION_ENABLED;
+      } else {
+        process.env.FHIR_CPT_EMISSION_ENABLED = previous;
+      }
+    });
+
+    it("omits CPT coding when flag is unset (default), even when cpt_code present", () => {
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+        "pat1",
+      );
+      expect(proc.code?.coding).toBeUndefined();
+      expect(proc.code?.text).toBe("Laparoscopic appendectomy");
+    });
+
+    it("omits CPT coding when flag is explicitly 'false'", () => {
+      process.env.FHIR_CPT_EMISSION_ENABLED = "false";
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+        "pat1",
+      );
+      expect(proc.code?.coding).toBeUndefined();
+      expect(proc.code?.text).toBe("Laparoscopic appendectomy");
+    });
+
+    it("omits CPT coding when flag is a non-'true' truthy string", () => {
+      // Only the literal string "true" enables emission — anything else
+      // (including "1", "yes", "enabled") leaves the gate closed.
+      process.env.FHIR_CPT_EMISSION_ENABLED = "1";
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+        "pat1",
+      );
+      expect(proc.code?.coding).toBeUndefined();
+      expect(proc.code?.text).toBe("Laparoscopic appendectomy");
+    });
+
+    it("emits CPT coding when flag = 'true'", () => {
+      process.env.FHIR_CPT_EMISSION_ENABLED = "true";
+      const proc = toFhirProcedure(
+        makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+        "pat1",
+      );
+      expect(proc.code?.coding?.[0]?.system).toBe(
+        "http://www.ama-assn.org/go/cpt",
+      );
+      expect(proc.code?.coding?.[0]?.code).toBe("44970");
     });
   });
 

--- a/services/fhir-gateway/src/generators/procedure.ts
+++ b/services/fhir-gateway/src/generators/procedure.ts
@@ -5,6 +5,12 @@
  * (https://hl7.org/fhir/R4/procedure.html). CPT codes attach to
  * Procedure.code via the AMA CPT system; ICD-10 reason codes attach to
  * Procedure.reasonCode via the CM value set.
+ *
+ * CPT emission is gated behind FHIR_CPT_EMISSION_ENABLED (issue #939).
+ * AMA licenses CPT codes; distributing them in a FHIR bundle to an
+ * external recipient may require an AMA license. Until that's confirmed
+ * the flag defaults off — Procedure.code falls back to the free-text
+ * procedure name. See docs/fhir-licensing.md.
  */
 
 import type { procedures } from "@carebridge/db-schema";
@@ -15,6 +21,10 @@ type ProcedureRow = typeof procedures.$inferSelect;
 
 const CPT_SYSTEM = "http://www.ama-assn.org/go/cpt";
 const ICD10_CM_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm";
+
+function isCptEmissionEnabled(): boolean {
+  return process.env.FHIR_CPT_EMISSION_ENABLED === "true";
+}
 
 /**
  * FHIR R4 ProcedureStatus value set. Internal statuses "scheduled" and
@@ -67,10 +77,11 @@ export function toFhirProcedure(
     },
   };
 
-  // Procedure.code: prefer CPT coding when available, otherwise surface
-  // the free-text procedure name so the resource is still useful to
-  // downstream consumers.
-  if (procedure.cpt_code) {
+  // Procedure.code: emit CPT coding only when FHIR_CPT_EMISSION_ENABLED is
+  // explicitly enabled (#939 — AMA CPT licensing gate). Otherwise fall back
+  // to the free-text procedure name so the resource stays useful to
+  // downstream consumers without distributing licensed CPT identifiers.
+  if (procedure.cpt_code && isCptEmissionEnabled()) {
     resource.code = {
       coding: [
         {


### PR DESCRIPTION
## Summary

Closes #939's autonomous portion. The remaining work is a legal/compliance decision, not code.

AMA licenses CPT codes. PR #922 introduced emission of CPT codings on `Procedure.code` via the AMA system URL, which is FHIR-correct but may require an AMA CPT license depending on the deployment model (recipients, volume, commercial relationship).

This PR ships the **fail-safe default** so the question can be answered without time pressure: CPT coding is now gated behind `FHIR_CPT_EMISSION_ENABLED`, which defaults to off. `Procedure.code` still carries a useful free-text fallback (`code.text = procedure.name`) so downstream consumers can read the procedure even without the licensed coding.

## Changes

- `services/fhir-gateway/src/generators/procedure.ts` — read `process.env.FHIR_CPT_EMISSION_ENABLED` at call time. Only the literal string `"true"` enables emission; anything else (unset, `"false"`, `"1"`, `"yes"`) keeps the gate closed.
- `services/fhir-gateway/src/__tests__/procedure.test.ts` — 4 new tests covering:
  - flag unset (default) → no CPT coding even when `cpt_code` is set
  - flag = `"false"` → no CPT coding
  - flag = `"1"` → no CPT coding (only literal `"true"` enables)
  - flag = `"true"` → CPT coding emitted as before
  - Existing CPT tests wrapped in setup that explicitly enables the flag.
- `docs/fhir-licensing.md` — documents the gate, the open AMA license question, what needs to happen before flipping the flag, and where the tests live. Pattern matches `docs/hipaa-retention.md` and `docs/fhir-interop.md`.
- `.env.example` — adds `FHIR_CPT_EMISSION_ENABLED` (commented out) under the existing FHIR section.

## What's NOT in this PR

- The legal answer to "does CareBridge need an AMA CPT license?" — that decision still needs a human / legal review. This PR is the conservative scaffolding that lets that decision happen out-of-band without ICD-10 emission, US Core profile conformance, or anything else regressing.
- Once legal clarifies, flipping the flag in production is a one-line env change. No code redeploy required.

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test -- procedure.test` — 27/27 passing (was 22, added 5 incl. parameterised setup)
- [x] Confirmed pre-existing typecheck/test-loader failures (`@lhncbc/ucum-lhc` missing, `body_height` / `bmi` / `head_circumference` / `npi` / `nucc_code` references) exist on `main` and are NOT introduced by this PR — verified by checking out `main` versions of the touched files and re-running.
- [x] `pnpm lint` — clean (only pre-existing clinician-portal warnings)

Refs #939