### PR TITLE
feat(clinical): age-stratified anthropometric bounds + age-aware validateVital

### DIFF
--- a/LAUNCH-CHECKLIST.md
+++ b/LAUNCH-CHECKLIST.md
@@ -32,7 +32,21 @@ to reconstruct them.
 
 <!-- Newest first. Add at the top when you merge a clinical-safety PR. -->
 
-<!-- Entries seeded with the inaugural pre-launch merges go here. -->
+### PR #1242 — age-stratified anthropometric bounds + age-aware validateVital (merge SHA pending)
+
+**Subsystem:** Clinical validators — `packages/medical-logic/src/medical-validation.ts`
+
+**Citations:**
+
+- WHO Child Growth Standards (MGRS), head_circumference + body_height, 0–60 months. https://www.who.int/tools/child-growth-standards
+- CDC growth charts, body_height + BMI, 2–20 years. https://www.cdc.gov/growthcharts/clinical_charts.htm
+- AAP Bright Futures / CDC pediatric OFC guidance, WHO→CDC handoff at 24 months.
+
+**What needs attestation:** Numeric band edges in `PEDIATRIC_VITAL_RANGES` (neonate / infant / child / school_age / adolescent) for `body_height`, `head_circumference`, and `bmi`, plus the adult `body_height.criticalLow = 140 cm` and `bmi.criticalLow = 12 / warningLow = 16` additions to `VITAL_DANGER_ZONES`.
+
+- [ ] Clinician (pref. peds) reviews the band table head-to-toe and concurs with critical / plausibility thresholds
+- [ ] Specifically reviews OFC bands per #1175 AC ("Nurse sign-off on age-stratified thresholds, especially OFC bands")
+- [ ] Signed by: __________________  Date: __________
 
 ## Completed Attestations
 

--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -375,6 +375,138 @@ describe("validateVital", () => {
       expect(result.warnings.some((w) => w.toLowerCase().includes("critically"))).toBe(false);
     });
   });
+
+  // ─── Anthropometric age-stratified bounds (issue #1175) ─────────
+  //
+  // Closes the "globally plausible but age-impossible" gap for
+  // body_height, head_circumference, and BMI. Each case below
+  // mirrors a sentinel example called out in the issue body.
+
+  describe("anthropometric age-stratified bounds (#1175)", () => {
+    describe("head_circumference", () => {
+      it("flags 60 cm OFC in a 4-year-old (sentinel hydrocephalus)", () => {
+        // child band: criticalHigh = 56. 60 cm is globally plausible
+        // (< 80 cm adult ceiling) but well above the 95th %ile for age.
+        const result = validateVital("head_circumference", 60, undefined, 4);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically high"))).toBe(true);
+      });
+
+      it("flags 25 cm OFC in a 5-year-old (sentinel microcephaly)", () => {
+        // child band: min = 40. 25 cm trips the plausibility floor
+        // even though it would pass the global 20 cm adult floor.
+        const result = validateVital("head_circumference", 25, undefined, 5);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.toLowerCase().includes("outside plausible range"))).toBe(true);
+      });
+
+      it("accepts normal OFC 50 cm in a 4-year-old", () => {
+        const result = validateVital("head_circumference", 50, undefined, 4);
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it("flags 30 cm OFC in a 12-month-old (sentinel microcephaly)", () => {
+        // infant band: criticalLow = 36. 30 cm is well below.
+        const result = validateVital("head_circumference", 30, undefined, 1);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.toLowerCase().includes("outside plausible range"))).toBe(true);
+      });
+
+      it("flags 55 cm OFC in a term newborn (sentinel hydrocephalus)", () => {
+        // neonate band: max = 42. 55 cm trips the plausibility ceiling.
+        const result = validateVital("head_circumference", 55, undefined, 0.01);
+        expect(result.valid).toBe(false);
+        expect(result.errors.some((e) => e.toLowerCase().includes("outside plausible range"))).toBe(true);
+      });
+    });
+
+    describe("body_height", () => {
+      it("flags 120 cm height in a healthy adult (unit confusion sentinel)", () => {
+        // adult VITAL_DANGER_ZONES.body_height.criticalLow = 140 cm.
+        // 120 cm is globally plausible but indicates either
+        // achondroplasia or — much more commonly — a weight-in-kg
+        // entered as height-in-cm.
+        const result = validateVital("body_height", 120, undefined, 30);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically low"))).toBe(true);
+      });
+
+      it("flags 120 cm height when age is not provided (adult default)", () => {
+        const result = validateVital("body_height", 120);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically low"))).toBe(true);
+      });
+
+      it("accepts 75 cm height in a 12-month-old", () => {
+        // infant band: 45–90 cm plausible, 50–85 critical band.
+        const result = validateVital("body_height", 75, undefined, 1);
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it("flags 145 cm height in a healthy adult as normal (above critical floor)", () => {
+        // 145 > criticalLow=140 — should NOT fire.
+        const result = validateVital("body_height", 145, undefined, 30);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically low"))).toBe(false);
+      });
+    });
+
+    describe("bmi", () => {
+      it("flags BMI = 5 in an adult as critically low (severe wasting)", () => {
+        // adult criticalLow = 12. BMI = 5 is at the plausibility floor
+        // (min = 5), so '<' check doesn't error — the criticalLow fires.
+        const result = validateVital("bmi", 5, undefined, 30);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically low"))).toBe(true);
+      });
+
+      it("flags BMI = 14 in an adult as low (underweight warning)", () => {
+        // adult warningLow = 16, criticalLow = 12. BMI = 14 is between
+        // the two — should fire the regular (non-critical) low warning.
+        const result = validateVital("bmi", 14, undefined, 30);
+        // The "Critically low" check uses strict less-than vs criticalLow,
+        // so 14 doesn't trip critical (14 > 12). It does trip warningLow.
+        expect(result.warnings.some((w) =>
+          w.toLowerCase().startsWith("low ")
+        )).toBe(true);
+        expect(result.warnings.some((w) =>
+          w.toLowerCase().includes("critically low")
+        )).toBe(false);
+      });
+
+      it("flags BMI = 5 with no age provided as critically low", () => {
+        const result = validateVital("bmi", 5);
+        expect(result.warnings.some((w) => w.toLowerCase().includes("critically low"))).toBe(true);
+      });
+
+      it("accepts BMI = 22 in an adult (normal range)", () => {
+        const result = validateVital("bmi", 22, undefined, 30);
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toHaveLength(0);
+      });
+    });
+
+    describe("getVitalRangeForAge for anthropometrics", () => {
+      it("returns child band for head_circumference at age 4", () => {
+        const range = getVitalRangeForAge("head_circumference", 4);
+        expect(range).toEqual(PEDIATRIC_VITAL_RANGES.child.head_circumference);
+      });
+
+      it("returns infant band for body_height at age 0.5", () => {
+        const range = getVitalRangeForAge("body_height", 0.5);
+        expect(range).toEqual(PEDIATRIC_VITAL_RANGES.infant.body_height);
+      });
+
+      it("returns adult band for body_height at age 30", () => {
+        const range = getVitalRangeForAge("body_height", 30);
+        expect(range).toEqual(VITAL_DANGER_ZONES.body_height);
+      });
+
+      it("returns adult band for bmi when no pediatric entry (neonate / infant)", () => {
+        // neonate + infant intentionally have no bmi entry — falls back
+        // to adult plausibility per getVitalRangeForAge contract.
+        const range = getVitalRangeForAge("bmi", 0.5);
+        expect(range).toEqual(VITAL_DANGER_ZONES.bmi);
+      });
+    });
+  });
 });
 
 // ─── validateMedicationDose ─────────────────────────────────────

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -42,17 +42,30 @@ export const VITAL_DANGER_ZONES: Record<VitalType, VitalRange> = {
   respiratory_rate: { min: 4, max: 60, criticalLow: 8, criticalHigh: 30 },
   pain_level: { min: 0, max: 10 },
   blood_glucose: { min: 10, max: 800, criticalLow: 54, criticalHigh: 350, warningLow: 70, warningHigh: 250 },
-  // US Core 5+ vital types (#1165). Bounds are plausibility checks only —
-  // no critical/warning thresholds because a single anthropometric
-  // measurement isn't a critical-value signal on its own. The min/max
-  // exist to reject sensor / unit-conversion noise.
+  // US Core 5+ anthropometric vital types (#1165, #1175). The min/max
+  // bounds are global plausibility (sensor / unit-conversion noise);
+  // critical/warning bands are tuned for the adult population. See
+  // PEDIATRIC_VITAL_RANGES below for age-banded thresholds — those
+  // catch readings that are globally plausible but age-impossible
+  // (e.g. body_height = 120 cm in a healthy adult, OFC = 25 cm in a
+  // 5yo).
+  //
   // body_height: 20 cm (extreme preemie at ~22 wks ≈ 28 cm; pad down)
-  //              to 280 cm (tallest documented human, Robert Wadlow, 272 cm).
-  body_height: { min: 20, max: 280 },
-  // bmi: 5 kg/m² (extreme cachexia) to 150 kg/m² (super-morbid obesity).
-  bmi: { min: 5, max: 150 },
+  //              to 280 cm (tallest documented human, Robert Wadlow,
+  //              272 cm). criticalLow = 140 cm catches achondroplasia
+  //              and the very common unit-confusion case (weight kg
+  //              entered as height cm).
+  body_height: { min: 20, max: 280, criticalLow: 140 },
+  // bmi: 5 kg/m² (extreme cachexia) to 150 kg/m² (super-morbid
+  //      obesity). warningLow = 16 (WHO underweight class I), and
+  //      criticalLow = 12 catches severe wasting / calculation error
+  //      per #1175 acceptance criteria.
+  bmi: { min: 5, max: 150, criticalLow: 12, warningLow: 16 },
   // head_circumference: 20 cm (extreme microcephaly preemie) to 80 cm
   //                     (extreme macrocephaly; covers hydrocephalus).
+  //                     Adult OFC is rarely measured; pediatric bands
+  //                     in PEDIATRIC_VITAL_RANGES below carry the
+  //                     clinical work.
   head_circumference: { min: 20, max: 80 },
 };
 
@@ -66,7 +79,36 @@ export type AgeGroup =
   | "adolescent" // 13–17 years
   | "adult";     // 18+ years
 
-/** Age-stratified vital sign ranges keyed by age group, then by vital type. */
+/**
+ * Age-stratified vital sign ranges keyed by age group, then by vital type.
+ *
+ * Anthropometric bands (body_height, head_circumference, bmi) close the
+ * gap called out in #1175: the global plausibility ceilings in
+ * VITAL_DANGER_ZONES are appropriate for sensor noise but allow
+ * globally-plausible-but-age-impossible readings to slip through (e.g.
+ * head_circumference = 60 cm in a 4-year-old, body_height = 120 cm in
+ * a healthy adult).
+ *
+ * The bands below are conservative envelopes derived from:
+ *   - WHO Child Growth Standards (MGRS), head_circumference + body_height,
+ *     0–60 months. https://www.who.int/tools/child-growth-standards
+ *   - CDC growth charts, body_height + BMI, 2–20 years.
+ *     https://www.cdc.gov/growthcharts/clinical_charts.htm
+ *   - AAP Bright Futures / CDC pediatric OFC guidance for the WHO→CDC
+ *     handoff at 24 months.
+ *
+ * `min`/`max` are wide plausibility envelopes (errors); `criticalLow`/
+ * `criticalHigh` are clinical-alert thresholds (warnings) — set near the
+ * 5th and 95th percentile of the age band so single sentinel readings
+ * (concerning microcephaly, hydrocephalus, severe stunting) get flagged
+ * without flooding clinicians with normal-percentile-tail noise.
+ *
+ * NOTE: BMI in growing children is normally expressed as an age-and-sex
+ * specific percentile, not a fixed numeric range. The pediatric BMI
+ * entries here are intentionally permissive plausibility guards only,
+ * intended to catch unit errors and gross calculation mistakes — not
+ * to replace percentile-based assessment.
+ */
 export const PEDIATRIC_VITAL_RANGES: Record<
   Exclude<AgeGroup, "adult">,
   Partial<Record<VitalType, VitalRange>>
@@ -75,26 +117,60 @@ export const PEDIATRIC_VITAL_RANGES: Record<
     heart_rate: { min: 70, max: 220, criticalLow: 100, criticalHigh: 160 },
     respiratory_rate: { min: 20, max: 80, criticalLow: 30, criticalHigh: 60 },
     blood_pressure: { min: 40, max: 120, criticalLow: 60, criticalHigh: 90 },
+    // head_circumference: extreme preemie (~22 wk ≈ 19–22 cm) through
+    // term-newborn 99th %ile (~38 cm). Critical bands flag concerning
+    // micro- or macrocephaly at birth.
+    head_circumference: { min: 22, max: 42, criticalLow: 30, criticalHigh: 39 },
+    // body_height: extreme preemie (~30 cm) through term-newborn 99th
+    // %ile (~56 cm).
+    body_height: { min: 28, max: 60, criticalLow: 40, criticalHigh: 56 },
   },
   infant: {
     heart_rate: { min: 70, max: 200, criticalLow: 100, criticalHigh: 150 },
     respiratory_rate: { min: 15, max: 70, criticalLow: 25, criticalHigh: 50 },
     blood_pressure: { min: 50, max: 130, criticalLow: 70, criticalHigh: 100 },
+    // head_circumference 1–12 mo: ~36 cm (1mo 5th %ile) to ~48 cm
+    // (12mo 95th %ile). criticalLow at 35 catches sentinel microcephaly.
+    head_circumference: { min: 32, max: 52, criticalLow: 36, criticalHigh: 50 },
+    // body_height 1–12 mo: ~50 cm (1mo 5th) to ~80 cm (12mo 95th).
+    body_height: { min: 45, max: 90, criticalLow: 50, criticalHigh: 85 },
   },
   child: {
     heart_rate: { min: 50, max: 200, criticalLow: 80, criticalHigh: 130 },
     respiratory_rate: { min: 12, max: 40, criticalLow: 20, criticalHigh: 30 },
     blood_pressure: { min: 60, max: 140, criticalLow: 80, criticalHigh: 110 },
+    // head_circumference 1–5 yr: ~43 cm (1yr 5th) to ~54 cm (5yr 95th).
+    // criticalHigh = 56 catches sentinel hydrocephalus per #1175 example:
+    // "60 cm OFC in 4-year-old". criticalLow = 44 catches severe
+    // microcephaly per #1175 example: "25 cm OFC in 5-year-old" trips
+    // the plausibility error (min = 40).
+    head_circumference: { min: 40, max: 58, criticalLow: 44, criticalHigh: 56 },
+    // body_height 1–5 yr: ~70 cm (1yr 5th) to ~120 cm (5yr 95th).
+    body_height: { min: 65, max: 130, criticalLow: 72, criticalHigh: 125 },
+    // bmi 1–5 yr: percentile-based clinically; numeric guard only.
+    bmi: { min: 10, max: 30, criticalLow: 11, criticalHigh: 25 },
   },
   school_age: {
     heart_rate: { min: 40, max: 200, criticalLow: 70, criticalHigh: 110 },
     respiratory_rate: { min: 10, max: 35, criticalLow: 16, criticalHigh: 22 },
     blood_pressure: { min: 60, max: 160, criticalLow: 85, criticalHigh: 120 },
+    // head_circumference 6–12 yr: converging toward adult ~51–57 cm.
+    head_circumference: { min: 45, max: 62, criticalLow: 48, criticalHigh: 60 },
+    // body_height 6–12 yr: ~108 cm (6yr 5th) to ~160 cm (12yr 95th).
+    body_height: { min: 100, max: 175, criticalLow: 108, criticalHigh: 165 },
+    // bmi 6–12 yr: percentile-based clinically; numeric guard only.
+    bmi: { min: 10, max: 40, criticalLow: 12, criticalHigh: 30 },
   },
   adolescent: {
     heart_rate: { min: 30, max: 250, criticalLow: 60, criticalHigh: 100 },
     respiratory_rate: { min: 6, max: 40, criticalLow: 12, criticalHigh: 20 },
     blood_pressure: { min: 60, max: 200, criticalLow: 95, criticalHigh: 140 },
+    // head_circumference 13–17 yr: adult-like, ~52–60 cm.
+    head_circumference: { min: 48, max: 64, criticalLow: 50, criticalHigh: 62 },
+    // body_height 13–17 yr: ~140 cm (13yr 5th) to ~195 cm (17yr 95th).
+    body_height: { min: 130, max: 205, criticalLow: 140, criticalHigh: 198 },
+    // bmi 13–17 yr.
+    bmi: { min: 12, max: 50, criticalLow: 14, criticalHigh: 35 },
   },
 };
 


### PR DESCRIPTION
## Summary

Closes the anthropometric-bounds gap called out in #1175.

> **Note on rebase (2026-05-28):** While this PR was parked, PR #1301 landed
> the `validateVital` → `getVitalRangeForAge` wiring that was originally part
> of this branch. After rebase onto current `main`, this PR contains only
> the unique value-add it always had on its own: the **anthropometric band
> data** (and the matching tests + adult `body_height` / `bmi` criticals).
> No functional overlap remains with #1290 / #1301.

The original problem: `PEDIATRIC_VITAL_RANGES` had no entries for
`body_height`, `head_circumference`, or `bmi` — so the age-banded path
silently fell back to adult plausibility (the wide global ceilings).

With this PR, the sentinel examples from the issue body now flag:

| Reading | Patient | Before | Now |
|---|---|---|---|
| `head_circumference = 60 cm` | 4-year-old | no flag | **warning** (`criticalHigh = 56` for child band) |
| `head_circumference = 25 cm` | 5-year-old | no flag | **error** (`min = 40` for child band) |
| `body_height = 120 cm` | healthy adult | no flag | **warning** (`criticalLow = 140` on adult body_height) |
| `bmi = 5` | any patient | no flag | **warning** (`criticalLow = 12` on adult bmi; same threshold via age-fallback for neonate/infant) |

## Data sources

- **WHO MGRS** (Multicentre Growth Reference Study), 0–60 months, head_circumference + body_height. https://www.who.int/tools/child-growth-standards
- **CDC growth charts**, 2–20 years, body_height + BMI. https://www.cdc.gov/growthcharts/clinical_charts.htm
- **AAP Bright Futures / CDC** guidance for the WHO→CDC handoff at 24 months.

The bands are conservative envelopes — `min`/`max` are wide plausibility (reject sensor / unit noise), `criticalLow`/`criticalHigh` are clinical-alert thresholds tuned near the 5th and 95th percentile of the band.

**BMI in growing children** is intentionally a permissive guard only — clinical assessment of pediatric BMI uses age-and-sex percentiles, not fixed numbers. The pediatric BMI entries exist to catch unit errors and gross calculation mistakes, not to replace percentile-based interpretation.

## Behaviour change in downstream consumers

`services/ai-oversight/src/rules/critical-values.ts` already consumes `getVitalRangeForAge` to generate clinical flags. With the new bands, AI oversight will now emit `CRITICAL-VITAL-BODY_HEIGHT` / `CRITICAL-VITAL-HEAD_CIRCUMFERENCE` / `CRITICAL-VITAL-BMI` flags when an age-stratified threshold is crossed. All 61 critical-values tests still pass — no existing assertion regresses.

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 583/583 passing post-rebase
- [x] `pnpm --filter @carebridge/medical-logic typecheck` — clean
- [x] `pnpm typecheck` — 38/38 tasks pass repo-wide

The 4 sentinel cases from the issue body are codified as named tests:

- `flags 60 cm OFC in a 4-year-old (sentinel hydrocephalus)`
- `flags 25 cm OFC in a 5-year-old (sentinel microcephaly)`
- `flags 120 cm height in a healthy adult (unit confusion sentinel)`
- `flags BMI = 5 in an adult as critically low (severe wasting)`

## Clinical review path (merge gate vs launch gate — per #1317)

Per the updated `docs/ai-prompt-editing.md` § 5, `clinical-safety` PRs split into:

- **Merge gate** — engineering review + primary-source citations. Both satisfied.
- **Launch gate** — credentialed clinician walks through the cited content before live patient use. Tracked in `LAUNCH-CHECKLIST.md` (entry added in this PR).

This PR also seeds the corresponding `LAUNCH-CHECKLIST.md` entry for pediatric-clinician walk-through (OFC bands especially, per the original #1175 AC).

Closes #1175.