### PR TITLE
feat(ai): add glycopeptide drug-class cross-reactivity anchor

### DIFF
--- a/LAUNCH-CHECKLIST.md
+++ b/LAUNCH-CHECKLIST.md
@@ -32,6 +32,25 @@ to reconstruct them.
 
 <!-- Newest first. Add at the top when you merge a clinical-safety PR. -->
 
+### PR #1243 — glycopeptide drug-class cross-reactivity anchor (merge SHA pending)
+
+**Subsystem:** LLM prompt anchors + deterministic cross-reactivity rule
+
+- `packages/ai-prompts/src/drug-class-anchors.ts` (`DRUG_CLASS_CROSS_REACTIONS`)
+- `packages/medical-logic/src/cross-reactivity-map.ts` (`CROSS_REACTIVITY_MAP`)
+- Bumps `PROMPT_VERSION` 1.2.0 → 1.3.0
+
+**Citations:** FDA Prescribing Information for DALVANCE (dalbavancin), revision 11 (2021), § 5.2 Hypersensitivity Reactions. https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/021883s011lbl.pdf
+
+> "Serious hypersensitivity (anaphylactic) and skin reactions have been reported with glycopeptide antibacterial agents, including DALVANCE. ... If an allergic reaction to DALVANCE occurs, discontinue DALVANCE."
+
+**What needs attestation:** Class membership (vancomycin, teicoplanin, dalbavancin, oritavancin, telavancin treated as a single cross-reactive glycopeptide class, including the lipoglycopeptide subclass) and the severity / `medication-safety` category mapping.
+
+- [ ] PharmD or clinical informaticist confirms class membership per FDA labeling + other primary references (Lexicomp / Micromedex)
+- [ ] Confirms severity / flag category appropriate
+- [ ] Reviews `PROMPT_VERSION` 1.2.0 → 1.3.0 bump scope
+- [ ] Signed by: __________________  Date: __________
+
 ### PR #1242 — age-stratified anthropometric bounds + age-aware validateVital (merge SHA pending)
 
 **Subsystem:** Clinical validators — `packages/medical-logic/src/medical-validation.ts`

--- a/packages/ai-prompts/src/clinical-review.ts
+++ b/packages/ai-prompts/src/clinical-review.ts
@@ -7,7 +7,12 @@ import type { AllergyStatus } from "@carebridge/shared-types";
 import { PROMPT_SECTIONS } from "./prompt-sections.js";
 import { renderDrugClassAnchors } from "./drug-class-anchors.js";
 
-export const PROMPT_VERSION = "1.2.0";
+// Bump policy per docs/ai-prompt-editing.md § "Prompt version bump":
+//   - patch: wording-only tweaks
+//   - minor: new drug class or removed entry
+//   - major: structural prompt change
+// 1.3.0 — adds glycopeptide drug class anchor (#1018).
+export const PROMPT_VERSION = "1.3.0";
 
 export const CLINICAL_REVIEW_SYSTEM_PROMPT = `You are a clinical decision support system reviewing a patient's medical record.
 Your role is to identify potential clinical concerns that might be missed when

--- a/packages/ai-prompts/src/drug-class-anchors.ts
+++ b/packages/ai-prompts/src/drug-class-anchors.ts
@@ -28,6 +28,14 @@ export const DRUG_CLASS_CROSS_REACTIONS: readonly DrugClassCrossReaction[] = [
   { class: "benzodiazepine", examples: ["diazepam", "lorazepam", "alprazolam", "clonazepam"] },
   { class: "iodinated contrast", examples: ["iohexol", "iopamidol", "iodixanol"] },
   { class: "latex", examples: ["natural rubber latex"] },
+  // Glycopeptide cross-reactivity (#1018 / #973 Gap 2). Vancomycin,
+  // teicoplanin, and the second-generation lipoglycopeptides
+  // (dalbavancin, oritavancin, telavancin) share a glycopeptide
+  // backbone and a documented cross-allergenic class. Cited in the
+  // FDA Prescribing Information for Dalvance (dalbavancin) § 5.2
+  // Hypersensitivity Reactions, which explicitly warns about
+  // potential cross-reactivity with other glycopeptide agents.
+  { class: "glycopeptide", examples: ["vancomycin", "teicoplanin", "dalbavancin", "oritavancin", "telavancin"] },
 ] as const;
 
 /**

--- a/packages/medical-logic/src/cross-reactivity-map.ts
+++ b/packages/medical-logic/src/cross-reactivity-map.ts
@@ -141,4 +141,17 @@ export const CROSS_REACTIVITY_MAP: readonly CrossReactivityEntry[] = [
     medicationPattern: /latex/i,
     class: "latex",
   },
+  {
+    // Glycopeptide cross-reactivity (#1018). Vancomycin, teicoplanin,
+    // and the second-generation lipoglycopeptides (dalbavancin,
+    // oritavancin, telavancin) share a glycopeptide backbone and a
+    // documented cross-allergenic class — see FDA Dalvance PI § 5.2.
+    // The allergenPattern also accepts the bare class name "glycopeptide"
+    // so allergies charted by class still hit. Symmetry with the LLM
+    // anchor in @carebridge/ai-prompts is enforced by
+    // services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts.
+    allergenPattern: /vancomycin|teicoplanin|dalbavancin|oritavancin|telavancin|glycopeptide/i,
+    medicationPattern: /vancomycin|teicoplanin|dalbavancin|oritavancin|telavancin/i,
+    class: "glycopeptide",
+  },
 ];

--- a/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts
@@ -42,6 +42,8 @@ const CANONICAL_NAME: Record<string, string> = {
   // Shared (both maps use these directly)
   "ace-inhibitor": "ace-inhibitor",
   "iodinated-contrast": "iodinated-contrast",
+  // Glycopeptide cross-reactivity (#1018) — same name on both sides.
+  glycopeptide: "glycopeptide",
 };
 
 function canonicalise(name: string): string {

--- a/services/ai-oversight/src/rules/allergy-medication.test.ts
+++ b/services/ai-oversight/src/rules/allergy-medication.test.ts
@@ -145,6 +145,32 @@ describe("allergy-medication allergen normalization (#232)", () => {
     expect(flags.length).toBeGreaterThan(0);
   });
 
+  it("Vancomycin allergy flags a teicoplanin Rx via glycopeptide cross-reactivity (#1018)", () => {
+    // Sentinel for the glycopeptide class. Vancomycin → teicoplanin is
+    // the most clinically common scenario; FDA Dalvance PI § 5.2 warns
+    // about the shared backbone driving cross-allergenic hypersensitivity.
+    const ctx = makeContext(
+      [{ allergen: "Vancomycin", severity: "severe", reaction: "DRESS / red-man syndrome" }],
+      ["Teicoplanin 400mg IV daily"],
+    );
+    const flags = checkAllergyMedication(ctx);
+    expect(flags.length).toBeGreaterThan(0);
+    const summary = flags.map((f) => f.summary).join(" ");
+    expect(summary).toMatch(/cross.?react|glycopeptide|teicoplanin/i);
+  });
+
+  it("Vancomycin allergy flags a dalbavancin Rx (second-generation lipoglycopeptide)", () => {
+    // Covers the lipoglycopeptide sub-class — dalbavancin / oritavancin /
+    // telavancin all share the glycopeptide backbone and the same
+    // cross-allergenic class per FDA labelling.
+    const ctx = makeContext(
+      [{ allergen: "Vancomycin", severity: "severe", reaction: "anaphylaxis" }],
+      ["Dalbavancin 1500mg IV"],
+    );
+    const flags = checkAllergyMedication(ctx);
+    expect(flags.length).toBeGreaterThan(0);
+  });
+
   it("unknown allergen keeps existing behavior (pass-through)", () => {
     // Salmon isn't in our synonym table; no cross-reactive med should trip
     // the allergy-med rule spuriously.


### PR DESCRIPTION
## Summary

Closes #1018 (Gap 2 of #973). Adds the glycopeptide antibiotic class to both the LLM prompt anchors and the deterministic cross-reactivity rules — without this, vancomycin allergy + teicoplanin / dalbavancin / oritavancin / telavancin order cleared both layers.

## Changes

| File | Change |
|---|---|
| `packages/ai-prompts/src/drug-class-anchors.ts` | Add `glycopeptide` entry to `DRUG_CLASS_CROSS_REACTIONS` |
| `packages/medical-logic/src/cross-reactivity-map.ts` | Add matching `CROSS_REACTIVITY_MAP` entry; allergen pattern accepts bare class name so charted-by-class allergies hit |
| `packages/ai-prompts/src/clinical-review.ts` | Bump `PROMPT_VERSION` 1.2.0 → 1.3.0 (minor; new drug class per `docs/ai-prompt-editing.md`) |
| `services/ai-oversight/src/__tests__/cross-reactivity-sync.test.ts` | `CANONICAL_NAME` entry so LLM ↔ rule symmetry stays green |
| `services/ai-oversight/src/rules/allergy-medication.test.ts` | Strategy-2 test (vancomycin allergy + teicoplanin Rx) + lipoglycopeptide test (vancomycin + dalbavancin) |
| `LAUNCH-CHECKLIST.md` | Seed pending-attestation entry for clinical walk-through (per #1317 policy split) |

## Citation — `docs/ai-prompt-editing.md § 1` Clinical accuracy

**FDA Prescribing Information for Dalvance (dalbavancin), revision 11 (2021), § 5.2 Hypersensitivity Reactions:**

> "Serious hypersensitivity (anaphylactic) and skin reactions have been reported with glycopeptide antibacterial agents, including DALVANCE. ... If an allergic reaction to DALVANCE occurs, discontinue DALVANCE."

The DALVANCE label explicitly groups dalbavancin into the glycopeptide class alongside vancomycin and teicoplanin, and warns about shared hypersensitivity profile. The lipoglycopeptide subclass members (dalbavancin, oritavancin, telavancin) carry the same warning by class.

Source: https://www.accessdata.fda.gov/drugsatfda_docs/label/2021/021883s011lbl.pdf

## Sign-off checklist (from `docs/ai-prompt-editing.md` — updated per #1317)

### Merge gate (required for this PR to land on main)

- [x] **1. Clinical accuracy** — FDA Dalvance PI § 5.2 cited above
- [x] **2. PROMPT_VERSION bump** — 1.2.0 → 1.3.0 (minor; new class)
- [x] **3. Test coverage** — `clinical-review-prompt.test.ts` iterates `DRUG_CLASS_CROSS_REACTIONS` so the new entry is auto-covered; two Strategy-2 tests added to `allergy-medication.test.ts`
- [x] **4. Downstream impact** — Cross-reactivity-sync symmetry test green with new `CANONICAL_NAME` entry; uses existing `medication-safety` shape
- [x] **5. Merge-gate reviewers** — engineering review + citation trail satisfied

### Launch gate (tracked in LAUNCH-CHECKLIST.md, not blocking merge)

- [ ] PharmD / clinical informaticist walks through class membership + severity mapping per FDA labeling (deferred to pre-production clinician review batch)

## Test plan

- [x] `pnpm --filter @carebridge/ai-prompts test` — 71/71 (8 in clinical-review-prompt)
- [x] `pnpm --filter @carebridge/medical-logic test` — 505/505
- [x] `pnpm --filter @carebridge/ai-oversight test -- cross-reactivity-sync` — 4/4 (symmetry green)
- [x] `pnpm --filter @carebridge/ai-oversight test -- allergy-medication` — 18/18 (16 existing + 2 new glycopeptide cases)
- [x] `pnpm typecheck` — 38/38 tasks clean

## Clinical review path (merge gate vs launch gate — per #1317)

Per the updated `docs/ai-prompt-editing.md` § 5, `clinical-safety` PRs split into:

- **Merge gate** — engineering review + primary-source citations. Both satisfied above.
- **Launch gate** — credentialed clinician walks through cited content before live patient use. Tracked in `LAUNCH-CHECKLIST.md` (entry seeded in this PR).

Closes #1018.