### PR TITLE
fix(ai): cast reviewJobs.created_at to timestamptz in in-flight dedup probe

### DIFF
--- a/services/ai-oversight/src/__tests__/review-idempotency.test.ts
+++ b/services/ai-oversight/src/__tests__/review-idempotency.test.ts
@@ -267,4 +267,36 @@ describe("processReviewJob — idempotency probe predicate shape", () => {
 
     expect(orMock).toHaveBeenCalled();
   });
+
+  // Regression — the in-flight cutoff is `NOW() - interval` (a
+  // `timestamp with time zone`), but `review_jobs.created_at` is a
+  // `text` column. Without an explicit cast on the column side, the
+  // query errors with `operator does not exist: text >= timestamp with
+  // time zone` and silently bricks every review job. Found during the
+  // post-Wave-8 smoke test (#916). The fix wraps the column reference
+  // in a `sql` template (the cast); this asserts the column side of
+  // the in-flight gte call is no longer the bare drizzle column.
+  it("wraps the in-flight cutoff column side in a sql template (timestamptz cast)", async () => {
+    const drizzle = await import("drizzle-orm");
+    const gteMock = vi.mocked(drizzle.gte);
+
+    try {
+      await processReviewJob(makeEvent({ id: "evt-probe-cutoff-shape" }));
+    } catch {
+      // Ignore downstream errors — we only care about the probe call.
+    }
+
+    // The dedup probe calls gte(<column-or-cast>, inFlightCutoff). The
+    // pre-fix code passed `reviewJobs.created_at` directly (a string
+    // identifier under our mock). The fix passes a sql template
+    // (our mock returns `{ __sql: true }`). Assert that at least one
+    // gte call's first argument is the sql-tagged object.
+    const sqlTaggedColumnCalls = gteMock.mock.calls.filter(
+      ([col]) =>
+        typeof col === "object" &&
+        col !== null &&
+        (col as { __sql?: boolean }).__sql === true,
+    );
+    expect(sqlTaggedColumnCalls.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -150,7 +150,17 @@ export async function processReviewJob(event: ClinicalEvent): Promise<void> {
           inArray(reviewJobs.status, TERMINAL_REVIEW_STATUSES as string[]),
           and(
             eq(reviewJobs.status, "processing"),
-            gte(reviewJobs.created_at, inFlightCutoff),
+            // `reviewJobs.created_at` is a `text` column; the cutoff
+            // above is `timestamp with time zone`. Cast the column at
+            // query time so PostgreSQL has a `timestamptz >= timestamptz`
+            // operator. Without this, every probe call errors with
+            // `operator does not exist: text >= timestamp with time zone`
+            // and the dedup short-circuit silently bricks every review
+            // job. Found during the post-Wave-8 smoke test (#916). PR
+            // #608 deliberately moved to DB-clock NOW() for worker/DB
+            // clock-skew safety — we keep that property and only cast
+            // the column side.
+            gte(sql`${reviewJobs.created_at}::timestamptz`, inFlightCutoff),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

**Production-blocking regression in the AI oversight worker.** Every fresh review job currently fails on the idempotency probe with:

```
operator does not exist: text >= timestamp with time zone
```

The pipeline short-circuits before any rule evaluation or LLM call, so **no clinical flags are ever generated**. Surfaced during the post-Wave-8 smoke test (#916).

## Root cause

`services/ai-oversight/src/services/review-service.ts:137` builds the dedup cutoff as:

```ts
const inFlightCutoff = sql`NOW() - ${IN_FLIGHT_WINDOW_SEC} * interval '1 second'`;
// ...
gte(reviewJobs.created_at, inFlightCutoff),  // line 153
```

- `reviewJobs.created_at` is a **`text`** column storing ISO 8601 Z-form strings (per `CLAUDE.md` convention: "All dates as ISO 8601 strings").
- `inFlightCutoff` evaluates to a **`timestamp with time zone`** in PostgreSQL.
- PostgreSQL has no operator `text >= timestamptz` → throws on every probe call.

Why it wasn't caught earlier:
- `review-service-db-clock-idempotency.test.ts` mocks drizzle's `sql` helper, so it never executes the actual SQL.
- `review-idempotency.test.ts` mocks the entire DB layer; the `gte` mock doesn't validate the runtime types.
- No integration test exercises the dedup probe against real PostgreSQL.

## Fix

Wrap the column reference in an inline `::timestamptz` cast so PostgreSQL has a valid `timestamptz >= timestamptz` comparison:

```ts
gte(sql`${reviewJobs.created_at}::timestamptz`, inFlightCutoff),
```

This preserves the design intent of PR #608 (DB-clock NOW() for worker/DB clock-skew safety) — only the column side is cast. The cast is safe because every `created_at` value is written via `new Date().toISOString()` which always emits parseable ISO 8601 Z-form.

## Smoke-test verification

After applying the fix and letting `tsx watch` hot-reload the worker, the previously-stuck job processed cleanly:

```
[review-worker] Processing job fb6e0975-... — event: note.saved for patient 95d00e2c****
[review-worker] Job fb6e0975-... completed in 291ms
```

A `clinical_flags` row appeared for the patient (placeholder "AI review unavailable" because the smoke env has no real `ANTHROPIC_API_KEY` — the LLM path 401s and falls back to the deterministic-only path, which is the expected dev behavior).

## Regression test

`review-idempotency.test.ts` gets a new test under the existing `processReviewJob — idempotency probe predicate shape` suite:

```ts
it("wraps the in-flight cutoff column side in a sql template (timestamptz cast)", async () => {
  // ... captures gte() calls, asserts first arg is sql-tagged (cast),
  // not the bare drizzle column reference.
});
```

This catches a future regression where someone reintroduces a bare column reference on the text-vs-timestamptz comparison path.

## Test plan

- [x] `pnpm --filter @carebridge/ai-oversight test -- review-idempotency` — 11/11 (10 existing + 1 new)
- [x] `pnpm --filter @carebridge/ai-oversight test -- review-service-db-clock-idempotency` — 7/7 (unchanged; the cutoff expression itself is unchanged)
- [x] `pnpm --filter @carebridge/ai-oversight test` — 939/939
- [x] `pnpm typecheck` — 38/38 tasks clean
- [x] Live smoke verification — job that had failed 7/8 retries completed in 291ms after worker hot-reload

## Related follow-ups (separate issues, not in this PR)

1. **Seed FK violation on a clean DB** — `tooling/seed/index.ts:94` sets `patient_id: dvtPatientId` on the patient-user insert before the patient row exists, violating `users_patient_id_fkey`. The seed has a deferred linking step at line 253 that already handles this; the early set is dead code. Will file separately.
2. **DVT scenario doesn't fire** — even with the SQL fix and the seed data in place, the deterministic `ONCO-VTE-NEURO-001` rule didn't generate a flag for Margaret on `note.saved`. Needs separate investigation.
3. **Smoke-test checklist vs seed mismatch** — Phase 4.1 of #916 expects "DVT flag already firing from seed" but the seed doesn't enqueue review events. The checklist needs an update OR the seed needs to publish events.

Refs #916