### PR TITLE
fix(db): drop premature patient_id on demo user (#1245)

### DIFF
--- a/tooling/seed/index.ts
+++ b/tooling/seed/index.ts
@@ -91,7 +91,9 @@ async function seed() {
       password_hash: devPasswordHash,
       name: "Demo Patient",
       role: "patient",
-      patient_id: dvtPatientId,
+      // patient_id is set by the deferred update below, after the patients
+      // row exists. Setting it here violates users_patient_id_fkey on a
+      // clean DB (#1245).
       is_active: true,
       created_at: now(),
       updated_at: now(),


### PR DESCRIPTION
## Summary

`tooling/seed/index.ts` set `patient_id: dvtPatientId` on the `patient@carebridge.dev` user row before the corresponding `patients` row was inserted. On a clean DB this violated `users_patient_id_fkey` and the seed aborted; on a re-seed, `.onConflictDoNothing()` silently swallowed the row and masked the bug — discovered during the post-Wave-8 smoke test (#916) when the smoke-test workflow ran against a freshly-truncated DB.

The deferred update further down in the seed script (around line 253) already sets `patient_id` once the `patients` row exists, so dropping the early set is the complete fix.

## Why no test

The seed package has no test infrastructure — it's a one-off TypeScript script. Adding a real-PG integration test for a single seed run is out of scope for a 1-line fix. The added comment guards against re-introduction (a future contributor would otherwise look at a "Demo Patient" user with no `patient_id` and assume it was an oversight).

## Repro (before fix)

```bash
docker exec carebridge-postgres-1 psql -U carebridge -d carebridge \
  -c "TRUNCATE users, patients CASCADE"
pnpm db:seed   # fails: users_patient_id_fkey
```

After this fix, the same sequence succeeds.

Closes #1245.

## Test plan

- [x] Verified `pnpm typecheck --filter=@carebridge/seed` passes
- [ ] CI green
- [ ] Manual verification: `TRUNCATE users, patients CASCADE; pnpm db:seed` succeeds (already done during smoke test pre-merge)