### PR TITLE
fix(ai): enrich note.saved payload with chief_complaint/HPI/new_symptoms (#1246)

### DIFF
--- a/services/clinical-notes/src/__tests__/note-service.test.ts
+++ b/services/clinical-notes/src/__tests__/note-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createMockDb, type MockDb } from "@carebridge/test-utils";
+import type { NoteSection } from "@carebridge/shared-types";
 
 // ── Mock DB ──────────────────────────────────────────────────────
 // A single MockDb instance is recreated per test so queued results and call
@@ -168,6 +169,166 @@ describe("createNote", () => {
     expect(event.data.resourceId).toBe(result.id);
   });
 
+  it("enriches the note.saved payload with chief_complaint, HPI, and new_symptoms (#1246)", async () => {
+    // Realistic SOAP shape — the seed/DVT scenario writes sections like
+    // this. Before #1246's fix the publisher only sent resourceId, so
+    // ai-oversight's extractSymptoms() returned [] and ONCO-VTE-NEURO-001
+    // never fired.
+    const soapWithSymptoms: NoteSection[] = [
+      {
+        key: "subjective",
+        label: "Subjective",
+        fields: [
+          {
+            key: "chief_complaint",
+            label: "Chief Complaint",
+            value: "New onset headache x 3 days",
+            field_type: "text",
+            source: "new_entry",
+          },
+          {
+            key: "history_of_present_illness",
+            label: "History of Present Illness",
+            value: "Severe headache with left-arm weakness since this morning",
+            field_type: "textarea",
+            source: "new_entry",
+          },
+          {
+            key: "new_symptoms",
+            label: "New Symptoms",
+            value: ["headache", "numbness", "vision changes"],
+            field_type: "multiselect",
+            source: "new_entry",
+          },
+        ],
+      },
+    ];
+
+    await createNote({
+      patient_id: PATIENT_ID,
+      provider_id: PROVIDER_ID,
+      template_type: "soap",
+      sections: soapWithSymptoms,
+    });
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBe("New onset headache x 3 days");
+    expect(event.data.subjective).toBe(
+      "Severe headache with left-arm weakness since this morning",
+    );
+    expect(event.data.new_symptoms).toEqual([
+      "headache",
+      "numbness",
+      "vision changes",
+    ]);
+  });
+
+  it("omits symptom keys when the SOAP subjective section is empty", async () => {
+    // The publisher must NOT serialize `undefined` keys onto the event —
+    // downstream `extractSymptoms` does `if (event.data.new_symptoms &&
+    // Array.isArray(...))` and a stray undefined would not break it, but
+    // keeping the payload sparse mirrors the pre-#1246 shape for notes
+    // that genuinely have no symptom content.
+    const emptySoap: NoteSection[] = [
+      {
+        key: "subjective",
+        label: "Subjective",
+        fields: [
+          {
+            key: "chief_complaint",
+            label: "Chief Complaint",
+            value: null,
+            field_type: "text",
+            source: "new_entry",
+          },
+          {
+            key: "new_symptoms",
+            label: "New Symptoms",
+            value: [],
+            field_type: "multiselect",
+            source: "new_entry",
+          },
+        ],
+      },
+    ];
+
+    await createNote({
+      patient_id: PATIENT_ID,
+      provider_id: PROVIDER_ID,
+      template_type: "soap",
+      sections: emptySoap,
+    });
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBeUndefined();
+    expect(event.data.subjective).toBeUndefined();
+    expect(event.data.new_symptoms).toBeUndefined();
+  });
+
+  it("picks up H&P template fields (chief_complaint section + hpi key)", async () => {
+    // H&P puts chief_complaint and hpi at the top level (no enclosing
+    // 'subjective' section). Field-key matching must be section-agnostic
+    // so both templates emit the same payload shape.
+    const handpSections: NoteSection[] = [
+      {
+        key: "chief_complaint",
+        label: "Chief Complaint",
+        fields: [
+          {
+            key: "chief_complaint",
+            label: "Chief Complaint",
+            value: "Chest pain",
+            field_type: "text",
+            source: "new_entry",
+          },
+        ],
+      },
+      {
+        key: "hpi",
+        label: "History of Present Illness",
+        fields: [
+          {
+            key: "hpi",
+            label: "History of Present Illness",
+            value: "Substernal pressure for 2 hours, radiating to left arm",
+            field_type: "textarea",
+            source: "new_entry",
+          },
+        ],
+      },
+      {
+        key: "review_of_systems",
+        label: "Review of Systems",
+        fields: [
+          {
+            key: "ros",
+            label: "Review of Systems",
+            value: ["cardiovascular: chest pain", "neurological: numbness"],
+            field_type: "multiselect",
+            source: "new_entry",
+          },
+        ],
+      },
+    ];
+
+    await createNote({
+      patient_id: PATIENT_ID,
+      provider_id: PROVIDER_ID,
+      template_type: "h_and_p",
+      sections: handpSections,
+    });
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBe("Chest pain");
+    expect(event.data.subjective).toBe(
+      "Substernal pressure for 2 hours, radiating to left arm",
+    );
+    expect(event.data.new_symptoms).toEqual([
+      "cardiovascular: chest pain",
+      "neurological: numbness",
+    ]);
+  });
+
   it("sets encounter_id when provided", async () => {
     const result = await createNote({
       patient_id: PATIENT_ID,
@@ -236,6 +397,42 @@ describe("updateNote", () => {
     expect(event.type).toBe("note.saved");
     expect(event.data.version).toBe(4);
     expect(event.data.resourceId).toBe(NOTE_ID);
+  });
+
+  it("enriches the note.saved payload with symptom fields from the new sections (#1246)", async () => {
+    // Re-saving a draft with newly-added neurological symptoms should
+    // propagate them onto the event so ai-oversight can re-evaluate
+    // cross-specialty rules.
+    db.willSelect([existingRow]).willInsert().willUpdate([{ id: NOTE_ID }]);
+
+    const sectionsWithSymptoms: NoteSection[] = [
+      {
+        key: "subjective",
+        label: "Subjective",
+        fields: [
+          {
+            key: "chief_complaint",
+            label: "Chief Complaint",
+            value: "Sudden onset confusion",
+            field_type: "text",
+            source: "new_entry",
+          },
+          {
+            key: "new_symptoms",
+            label: "New Symptoms",
+            value: ["confusion", "speech difficulty"],
+            field_type: "multiselect",
+            source: "new_entry",
+          },
+        ],
+      },
+    ];
+
+    await updateNote(NOTE_ID, { sections: sectionsWithSymptoms });
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBe("Sudden onset confusion");
+    expect(event.data.new_symptoms).toEqual(["confusion", "speech difficulty"]);
   });
 
   it("succeeds when expectedVersion matches the current version", async () => {

--- a/services/clinical-notes/src/services/note-service.ts
+++ b/services/clinical-notes/src/services/note-service.ts
@@ -66,6 +66,65 @@ async function archiveVersion(params: {
 }
 
 /**
+ * Pull symptom-relevant fields out of a structured note for inclusion in
+ * the emitted clinical event. The ai-oversight worker's extractSymptoms()
+ * reads `chief_complaint`, `subjective`, and `new_symptoms` off the event
+ * payload to populate `ctx.new_symptoms` for cross-specialty rules like
+ * ONCO-VTE-NEURO-001. Without enrichment the payload is just `{resourceId}`
+ * and every note-triggered rule sees an empty symptom set (#1246).
+ *
+ * Field-key matching is template-agnostic — SOAP nests these inside a
+ * `subjective` section; H&P uses top-level `chief_complaint` / `hpi`
+ * sections. The first non-empty value wins for the string fields; ROS and
+ * `new_symptoms` arrays are concatenated.
+ */
+function extractSymptomFieldsFromSections(sections: NoteSection[]): {
+  chief_complaint?: string;
+  subjective?: string;
+  new_symptoms?: string[];
+} {
+  const out: {
+    chief_complaint?: string;
+    subjective?: string;
+    new_symptoms?: string[];
+  } = {};
+  const collectedSymptoms: string[] = [];
+
+  for (const section of sections) {
+    for (const field of section.fields ?? []) {
+      const value = field.value;
+      if (
+        field.key === "chief_complaint" &&
+        typeof value === "string" &&
+        value.trim().length > 0 &&
+        out.chief_complaint === undefined
+      ) {
+        out.chief_complaint = value;
+      } else if (
+        (field.key === "history_of_present_illness" || field.key === "hpi") &&
+        typeof value === "string" &&
+        value.trim().length > 0 &&
+        out.subjective === undefined
+      ) {
+        out.subjective = value;
+      } else if (
+        (field.key === "new_symptoms" || field.key === "ros") &&
+        Array.isArray(value)
+      ) {
+        for (const entry of value) {
+          if (typeof entry === "string" && entry.trim().length > 0) {
+            collectedSymptoms.push(entry);
+          }
+        }
+      }
+    }
+  }
+
+  if (collectedSymptoms.length > 0) out.new_symptoms = collectedSymptoms;
+  return out;
+}
+
+/**
  * Creates a new clinical note, persists it, and emits a "note.saved" event.
  */
 export async function createNote(input: CreateNoteInput): Promise<ClinicalNote> {
@@ -109,7 +168,10 @@ export async function createNote(input: CreateNoteInput): Promise<ClinicalNote> 
     patient_id: input.patient_id,
     provider_id: input.provider_id,
     timestamp: now,
-    data: { resourceId: id },
+    data: {
+      resourceId: id,
+      ...extractSymptomFieldsFromSections(input.sections),
+    },
   });
 
   return {
@@ -188,7 +250,11 @@ export async function updateNote(
     patient_id: existing.patient_id,
     provider_id: existing.provider_id,
     timestamp: now,
-    data: { resourceId: noteId, version: newVersion },
+    data: {
+      resourceId: noteId,
+      version: newVersion,
+      ...extractSymptomFieldsFromSections(input.sections),
+    },
   });
 
   return {


### PR DESCRIPTION
## Summary

`ai-oversight`'s `extractSymptoms()` populates `ctx.new_symptoms` from `event.data.chief_complaint`, `event.data.subjective`, and `event.data.new_symptoms`. The note-service publishers (`createNote`, `updateNote`) were only emitting `{ resourceId, [version] }`, so `ctx.new_symptoms` always came back empty. The `ONCO-VTE-NEURO-001` rule's `hasNeuroSymptom` check then returned `false` — even on a SOAP draft that explicitly listed `headache` + `numbness` + `vision changes` in the New Symptoms checklist for a cancer+VTE patient.

This was found in the post-Wave-8 smoke test (#916), reported as #1246. The SQL regression that previously bricked every review job (#1244) was masking the symptom-extraction gap; once the worker started running cleanly, the empty-symptoms problem became visible.

## Fix

Add a publisher-side helper `extractSymptomFieldsFromSections` in `services/clinical-notes/src/services/note-service.ts` that walks the structured `NoteSection[]` and pulls:

- `chief_complaint` — the first non-empty `chief_complaint` field across all sections (SOAP nests it inside `subjective`; H&P puts it at the top level).
- `subjective` — first non-empty `history_of_present_illness` or `hpi` field.
- `new_symptoms` — concatenation of any `new_symptoms` or `ros` array values.

The result is spread onto `event.data` alongside `resourceId` for both the `createNote` and `updateNote` publish points. Empty / null fields are omitted so the event stays sparse for notes that genuinely lack symptom content.

## Why publisher-side, not consumer-side

Alternatives considered:
- **Worker fetches the note row by `resourceId`.** Cleaner separation (event stays minimal), but pulls more shape responsibility into `ai-oversight` and adds a DB roundtrip per event. Worth considering once we have integration test coverage to validate the SQL.
- **Spread `sections` whole onto `event.data`.** Includes objective/assessment/plan content unnecessarily and grows queue payload size — most fields are PHI that have no rule consumers.

The narrow field-key extractor keeps the payload small and avoids broadcasting non-symptom PHI through BullMQ.

## Tests

Added 4 regression tests in `services/clinical-notes/src/__tests__/note-service.test.ts`:
- `enriches the note.saved payload with chief_complaint, HPI, and new_symptoms (#1246)` — primary regression coverage with realistic SOAP fixture.
- `omits symptom keys when the SOAP subjective section is empty` — verifies sparse-payload behavior.
- `picks up H&P template fields (chief_complaint section + hpi key)` — validates template-agnostic field matching.
- `enriches the note.saved payload with symptom fields from the new sections (#1246)` — `updateNote` parity check.

All 59 clinical-notes tests pass, all 938 ai-oversight tests still pass, typecheck + lint green.

## Known limitation

Per the auto-memory note from #1244 — these are all mock-DB tests. They verify the event payload shape but cannot prove the rule actually fires end-to-end. A real-PG smoke check is the durable verification (smoke-test Phase 4.1 per #1247 updates).

Closes #1246.

## Test plan

- [x] `pnpm --filter=@carebridge/clinical-notes test` — 59/59 pass
- [x] `pnpm --filter=@carebridge/ai-oversight test` — 938/938 pass (consumer still happy)
- [x] `pnpm typecheck --filter=@carebridge/clinical-notes` — green
- [x] `pnpm lint --filter=@carebridge/clinical-notes` — green
- [ ] CI green on the PR
- [ ] Manual smoke (post-merge): save a SOAP note on Margaret with `headache`+`numbness` checked → `ONCO-VTE-NEURO-001` flag appears