### PR TITLE
fix(ai): enrich note.signed + note.amended payloads (#1259, #1260)

### DIFF
--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -1023,9 +1023,15 @@ function extractSymptoms(event: ClinicalEvent): string[] {
   if (event.type === "vital.created" && event.data.notes) {
     symptoms.push(event.data.notes as string);
   }
-  // For note events, extract from sections if available
+  // For note events, extract from sections if available. note.amended is
+  // included because amendments are the only way to change content after a
+  // note is signed — a clinician adding "new onset headache + numbness" to a
+  // previously-signed note via amendment is exactly the cross-specialty
+  // signal ONCO-VTE-NEURO-001 exists to catch (#1260).
   if (
-    (event.type === "note.saved" || event.type === "note.signed") &&
+    (event.type === "note.saved" ||
+      event.type === "note.signed" ||
+      event.type === "note.amended") &&
     event.data.subjective &&
     typeof event.data.subjective === "string"
   ) {

--- a/services/clinical-notes/src/__tests__/note-service.test.ts
+++ b/services/clinical-notes/src/__tests__/note-service.test.ts
@@ -517,6 +517,45 @@ describe("signNote", () => {
     expect(event.data.resourceId).toBe(NOTE_ID);
   });
 
+  it("enriches the note.signed payload with symptom fields from sections (#1259)", async () => {
+    // Compose-and-sign in one shot (no intervening updateNote) is the
+    // natural flow for a quick visit. Before #1259's fix, this path emitted
+    // a bare { resourceId, signedBy } payload and ai-oversight's
+    // extractSymptoms returned [] — ONCO-VTE-NEURO-001 never fired.
+    const signedDraftRow = {
+      ...existingRow,
+      sections: [
+        {
+          key: "subjective",
+          label: "Subjective",
+          fields: [
+            {
+              key: "chief_complaint",
+              label: "Chief Complaint",
+              value: "Headache with vision changes",
+              field_type: "text",
+              source: "new_entry",
+            },
+            {
+              key: "new_symptoms",
+              label: "New Symptoms",
+              value: ["headache", "vision changes"],
+              field_type: "multiselect",
+              source: "new_entry",
+            },
+          ],
+        },
+      ],
+    };
+    db.willSelect([signedDraftRow]);
+
+    await signNote(NOTE_ID, PROVIDER_ID);
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBe("Headache with vision changes");
+    expect(event.data.new_symptoms).toEqual(["headache", "vision changes"]);
+  });
+
   it("throws when note is not found", async () => {
     db.willSelect([]);
 
@@ -859,6 +898,46 @@ describe("amendNote", () => {
     expect(event.data.resourceId).toBe(NOTE_ID);
     expect(event.data.amendedBy).toBe(AMENDER_ID);
     expect(event.data.reason).toBe(AMEND_REASON);
+  });
+
+  it("enriches the note.amended payload with symptom fields from the new sections (#1260)", async () => {
+    // Amendments are the only way to change a signed note. A clinician
+    // adding "new onset headache + numbness" to a previously-signed note
+    // via amendment is exactly the cross-specialty signal
+    // ONCO-VTE-NEURO-001 exists to catch — but pre-#1260 the consumer's
+    // extractSymptoms didn't even handle note.amended.
+    db.willSelect([signedRow]);
+
+    const amendedSections: NoteSection[] = [
+      {
+        key: "subjective",
+        label: "Subjective",
+        fields: [
+          {
+            key: "chief_complaint",
+            label: "Chief Complaint",
+            value: "Now reporting numbness in left arm",
+            field_type: "text",
+            source: "new_entry",
+          },
+          {
+            key: "new_symptoms",
+            label: "New Symptoms",
+            value: ["numbness", "weakness"],
+            field_type: "multiselect",
+            source: "new_entry",
+          },
+        ],
+      },
+    ];
+
+    await amendNote(NOTE_ID, AMENDER_ID, amendedSections, AMEND_REASON);
+
+    const event = emitClinicalEvent.mock.calls[0][0];
+    expect(event.data.chief_complaint).toBe(
+      "Now reporting numbness in left arm",
+    );
+    expect(event.data.new_symptoms).toEqual(["numbness", "weakness"]);
   });
 
   it("allows amending a cosigned note", async () => {

--- a/services/clinical-notes/src/services/note-service.ts
+++ b/services/clinical-notes/src/services/note-service.ts
@@ -318,7 +318,11 @@ export async function signNote(
     patient_id: existing.patient_id,
     provider_id: existing.provider_id,
     timestamp: now,
-    data: { resourceId: noteId, signedBy },
+    data: {
+      resourceId: noteId,
+      signedBy,
+      ...extractSymptomFieldsFromSections(existing.sections as NoteSection[]),
+    },
   });
 
   return {
@@ -486,6 +490,7 @@ export async function amendNote(
       reason: reason.trim(),
       previousVersion: existing.version,
       newVersion,
+      ...extractSymptomFieldsFromSections(sections),
     },
   });
 


### PR DESCRIPTION
## Summary

PR #1249 enriched `note.saved` events emitted by `createNote` / `updateNote` so ai-oversight's `extractSymptoms()` could populate `ctx.new_symptoms` from `chief_complaint` / `subjective` / `new_symptoms`. The same publisher gap existed on two adjacent event paths:

- **`signNote` → `note.signed`** — the consumer already handled `note.signed` (see `review-service.ts:1018`), but the publisher emitted bare `{resourceId, signedBy}`. Compose-and-sign in one shot (no intervening `updateNote` — the natural quick-visit flow) produced an empty symptom set. (#1259)
- **`amendNote` → `note.amended`** — publisher emitted bare `{resourceId, amendedBy, reason, ...}` AND the consumer's `extractSymptoms` event-type guard didn't even recognise `note.amended`. Amendments adding neuro observations to a previously-signed note (the HIPAA-significant content-change path) were silently dropped. (#1260)

## What this PR does

1. **`signNote`** — spread `extractSymptomFieldsFromSections(existing.sections as NoteSection[])` onto the `note.signed` data. Reuses the row already loaded for archival — no extra DB roundtrip.
2. **`amendNote`** — spread `extractSymptomFieldsFromSections(sections)` onto the `note.amended` data. The `sections` parameter is the new amended content (correct — we want the post-amendment symptoms, not the pre-amendment archive).
3. **`extractSymptoms` in `review-service.ts`** — add `note.amended` to the event-type guard so the `subjective` field is consumed on the amendment path. (`chief_complaint` and `new_symptoms` already short-circuit on field presence and pick up the new payload automatically.)

## What this PR does NOT do

- **`cosignNote` is intentionally NOT enriched.** Cosign is a workflow signal on already-saved content — the symptoms in the cosigned note were already processed when it was originally saved or signed. Re-processing them on cosign would be duplicate work, and from a clinical-safety standpoint the cosign moment is *not* a new-content event.

## Tests

Two new regression tests:

- `enriches the note.signed payload with symptom fields from sections (#1259)` — asserts that signing a draft with realistic SOAP `subjective` content emits a `note.signed` event with `chief_complaint` + `new_symptoms` populated.
- `enriches the note.amended payload with symptom fields from the new sections (#1260)` — asserts that amending a signed note with new neuro symptoms emits a `note.amended` event with the post-amendment symptoms in the payload.

Both follow the mock-DB / mock-event pattern established by PR #1249.

**Caveat (per `feedback_mocked_sql_misses_runtime_types` memory):** these are mock-event tests — they verify the publisher payload shape but cannot prove the rule actually fires end-to-end against real PG. Smoke-verification was just completed for the `note.saved` path (#916 Phase 4.1 — Margaret's `ONCO-VTE-NEURO-001` flag fires after a note save). Equivalent live verification for `note.signed` and `note.amended` is a smoke-test follow-up.

## Verification

- `pnpm --filter=@carebridge/clinical-notes test` — 61/61 pass
- `pnpm --filter=@carebridge/ai-oversight test` — 939/939 pass
- `pnpm typecheck --filter=@carebridge/clinical-notes --filter=@carebridge/ai-oversight` — green

Closes #1259, closes #1260.

## Test plan

- [x] Unit tests for both new emit sites
- [x] Consumer-side change to `extractSymptoms` for `note.amended`
- [x] Existing 1037+ tests still pass
- [ ] CI green
- [ ] Manual smoke (post-merge): create a SOAP note for Margaret, sign without prior update — `ONCO-VTE-NEURO-001` should fire on the `note.signed` event (independent of the `note.saved` from createNote).