### PR TITLE
fix(portal): unique React keys for note version history (#1265)

### DIFF
--- a/apps/clinician-portal/app/notes/[id]/page.tsx
+++ b/apps/clinician-portal/app/notes/[id]/page.tsx
@@ -201,7 +201,10 @@ function NoteDetailContent() {
         <div className="detail-card">
           <div className="detail-card-title">Version History</div>
           {versions.map((v) => (
-            <div key={v.version} className="detail-row">
+            <div
+              key={`${v.version}-${v.lifecycle_event}-${v.saved_at}`}
+              className="detail-row"
+            >
               <span className="detail-label">v{v.version}</span>
               <span className="detail-value">
                 {formatDate(v.saved_at)} — {v.saved_by}


### PR DESCRIPTION
## Summary

The note detail page (\`apps/clinician-portal/app/notes/[id]/page.tsx:204\`) was rendering the version history list with \`<div key={v.version}>\`. \`note_versions\` rows share the same numeric \`version\` because \`signNote\` and \`cosignNote\` both archive at \`existing.version\` without bumping it — disambiguated only by \`lifecycle_event\`. A single note progressing draft → signed produces two rows keyed \`"1"\`, and React warns:

\`\`\`
Encountered two children with the same key, \`1\`. Keys should be unique...
\`\`\`

## Fix

Combine \`version\`, \`lifecycle_event\`, and \`saved_at\` into the key. \`saved_at\` is the ultimate tie-breaker — even if a future bug emitted two rows with the same version+lifecycle_event (retroactive correction, etc.) the ISO timestamp keeps keys unique.

## Verification

- \`pnpm typecheck --filter=@carebridge/clinician-portal\` — green
- Reproduced the warning before the fix by signing any draft note as \`dr.smith\` (caught during the post-Wave-8 smoke-test re-run yesterday)

Closes #1265.

## Test plan

- [x] Typecheck green
- [ ] Manual: sign a draft note → React DevTools should no longer warn about duplicate keys
- [ ] CI green