### PR TITLE
feat(portal): + New Note button on patient chart (#1263)

### DIFF
--- a/apps/clinician-portal/app/notes/new/page.tsx
+++ b/apps/clinician-portal/app/notes/new/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc";
 import { AuthGuard } from "@/lib/auth-guard";
 import { useAuth } from "@/lib/auth";
@@ -147,9 +147,14 @@ function FieldInput({
 
 function NewNoteContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user } = useAuth();
   const [templateType, setTemplateType] = useState<TemplateType>("soap");
-  const [patientId, setPatientId] = useState<string>("");
+  // Pre-fill the patient when arriving from a patient-chart "+ New Note"
+  // affordance (`/notes/new?patientId=...`). #1263.
+  const [patientId, setPatientId] = useState<string>(
+    () => searchParams.get("patientId") ?? "",
+  );
   const [sections, setSections] = useState<NoteSection[]>([]);
 
   const patientsQuery = trpc.patients.list.useQuery();

--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -1015,6 +1015,14 @@ function PatientChartContent() {
                 <span>{patient.biological_sex}</span>
               </div>
             </div>
+            <div style={{ marginLeft: "auto" }}>
+              <Link
+                href={`/notes/new?patientId=${patientId}`}
+                className="btn btn-primary btn-sm"
+              >
+                + New Note
+              </Link>
+            </div>
           </div>
 
           <div className="tabs">


### PR DESCRIPTION
## Summary

The patient chart header had no affordance for creating a clinical note. To create a note for a patient, a clinician had to know to navigate to \`/notes/new\` directly and pick the patient from the dropdown — discoverable to the engineer who wrote it, not to a real user.

The post-Wave-8 smoke-test checklist (#916 Phase 4.1, updated per #1247) asks the tester to *"navigate to Margaret Chen → click + New Note"* — but the button didn't exist. This PR adds it.

## What changed

**Two coordinated edits:**

1. **\`apps/clinician-portal/app/patients/[id]/page.tsx\`** — Add a \`+ New Note\` Link as the rightmost element in \`chart-header\`. \`marginLeft: auto\` pushes it to the right edge of the header row. Styling uses the existing \`btn btn-primary btn-sm\` classes (consistent with the "Sign Note" button on the note detail page).
2. **\`apps/clinician-portal/app/notes/new/page.tsx\`** — Read \`patientId\` from \`useSearchParams()\` and use it as the \`useState\` initializer for the patient-select. The dropdown remains editable so a clinician can re-pick if they navigated wrong.

## No UI role gating (intentional)

The existing \`canSign\` pattern on the note detail page doesn't gate by role at the UI level either — server-side \`createNote\` authorization is the source of truth. Adding a UI role check here would duplicate the rule and risk drift. If a patient-role user somehow lands on this page (they shouldn't — clinician-portal is gated by \`AuthGuard\`), the server will reject the eventual create call.

## Verification

- \`pnpm typecheck --filter=@carebridge/clinician-portal\` — green
- Manually verified in a running dev environment: clicking the button on Margaret's chart navigates to \`/notes/new?patientId={uuid}\` with Margaret pre-selected in the dropdown.

## Test plan

- [x] Typecheck green
- [x] Manual smoke: + New Note button visible on patient chart
- [x] Click → \`/notes/new?patientId=...\` with patient pre-filled
- [ ] CI green
- [ ] Mobile-viewport spot check (per AC) — header should still wrap cleanly at 375px width

Closes #1263.