### PR TITLE
fix(notes): stable version sort in getNoteById (#1272)

### DIFF
--- a/services/clinical-notes/src/__tests__/note-service.test.ts
+++ b/services/clinical-notes/src/__tests__/note-service.test.ts
@@ -705,6 +705,28 @@ describe("getNoteById", () => {
     expect(result!.note.signed_at).toBeUndefined();
     expect(result!.note.signed_by).toBeUndefined();
   });
+
+  // ─── Regression for #1272 ────────────────────────────────────
+  // signNote and cosignNote both archive at `existing.version` without
+  // bumping it — disambiguated only by lifecycle_event — so a single note
+  // can yield multiple note_versions rows sharing the same `version`.
+  // A version-only ORDER BY is non-deterministic for those tied rows, so
+  // getNoteById must add saved_at as a tiebreaker (mirroring the
+  // saved_at-based ordering documented on getVersionHistory).
+  it("orders the versions query by saved_at as a tiebreaker for same-version rows (#1272)", async () => {
+    db.willSelect([existingRow]).willSelect([]);
+
+    await getNoteById(NOTE_ID);
+
+    // Second select is the versions query.
+    const versionsSelect = db.select.calls[1];
+    const orderByIndex = versionsSelect?.chain.indexOf("orderBy") ?? -1;
+    expect(orderByIndex).toBeGreaterThanOrEqual(0);
+    const orderByArgs = versionsSelect?.chainArgs[orderByIndex] ?? [];
+    // version-only ordering is unstable; the fix passes two ordering
+    // expressions (version desc, saved_at desc).
+    expect(orderByArgs.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────

--- a/services/clinical-notes/src/services/note-service.ts
+++ b/services/clinical-notes/src/services/note-service.ts
@@ -575,6 +575,12 @@ export async function getNotesByPatient(patientId: string): Promise<ClinicalNote
 
 /**
  * Retrieves a single note by ID along with its version history.
+ *
+ * Versions are returned newest-first for UI consumers. Because signNote and
+ * cosignNote archive at the same `existing.version` (disambiguated only by
+ * lifecycle_event), `desc(version)` alone is non-deterministic for tied
+ * rows — `saved_at` is the monotonic tiebreaker that mirrors the canonical
+ * chronological ordering used by `getVersionHistory` (#1272).
  */
 export async function getNoteById(
   noteId: string,
@@ -593,7 +599,7 @@ export async function getNoteById(
     .select()
     .from(noteVersions)
     .where(eq(noteVersions.note_id, noteId))
-    .orderBy(desc(noteVersions.version));
+    .orderBy(desc(noteVersions.version), desc(noteVersions.saved_at));
 
   return {
     note: {


### PR DESCRIPTION
## Summary

`getNoteById` returns the `versions` array ordered by `desc(noteVersions.version)` alone. Because `signNote` and `cosignNote` both archive at `existing.version` without bumping it (disambiguated only by `lifecycle_event`), a single note can produce multiple `note_versions` rows that tie on `version` — and Postgres is free to return tied rows in any order. The detail page rendered by `app/notes/[id]/page.tsx` therefore shuffles across reloads.

This PR adds `desc(noteVersions.saved_at)` as the tiebreaker so the sort is stable. `saved_at` is already documented on the sibling `getVersionHistory` helper as the monotonic source of truth for transition order. The UI keeps its newest-first contract; only the relative order of same-version rows is now deterministic.

Closes #1272

## Test plan

- [x] New regression test in `services/clinical-notes/src/__tests__/note-service.test.ts` asserts the versions query is ordered by at least two expressions (version + saved_at) — fails before the fix, passes after.
- [x] `pnpm --filter @carebridge/clinical-notes test` — 55 / 55 pass
- [x] `pnpm typecheck`
- [x] `pnpm lint`