### PR TITLE
feat(ai): summarize note.amended in buildEventSummary (#1270)

### DIFF
--- a/services/ai-oversight/src/__tests__/context-builder.test.ts
+++ b/services/ai-oversight/src/__tests__/context-builder.test.ts
@@ -554,6 +554,56 @@ describe("buildPatientContext — event-time snapshot (LLM path)", () => {
   });
 
   // ─── #515 — exclude logical retractions ────────────────────────────
+  // ─── #1270 — note.amended must produce a humanised event summary ───
+  it("summarises note.amended events with the amendment reason when present", async () => {
+    const amendedEvent: ClinicalEvent = {
+      id: "evt-amended-1",
+      type: "note.amended",
+      patient_id: "p-1",
+      timestamp: EVENT_AT,
+      data: {
+        resourceId: "note-1",
+        amendedBy: "u-1",
+        reason: "Added new onset headache + numbness",
+        previousVersion: 1,
+        newVersion: 2,
+      },
+    };
+
+    const ctx = await buildPatientContext("p-1", amendedEvent);
+
+    // Must NOT fall through to the generic "Clinical event: <type>" branch.
+    expect(ctx.triggering_event.summary).not.toBe(
+      "Clinical event: note.amended",
+    );
+    expect(ctx.triggering_event.summary).toContain("amended");
+    expect(ctx.triggering_event.summary).toContain(
+      "Added new onset headache + numbness",
+    );
+  });
+
+  it("summarises note.amended events without a reason as a bare humanised string", async () => {
+    const amendedEvent: ClinicalEvent = {
+      id: "evt-amended-2",
+      type: "note.amended",
+      patient_id: "p-1",
+      timestamp: EVENT_AT,
+      data: {
+        resourceId: "note-1",
+        amendedBy: "u-1",
+        previousVersion: 1,
+        newVersion: 2,
+      },
+    };
+
+    const ctx = await buildPatientContext("p-1", amendedEvent);
+
+    expect(ctx.triggering_event.summary).not.toBe(
+      "Clinical event: note.amended",
+    );
+    expect(ctx.triggering_event.summary).toBe("Clinical note amended");
+  });
+
   it("excludes a diagnosis with status=entered_in_error even when timestamps say active", async () => {
     diagnosesSelect.mockResolvedValue([
       {

--- a/services/ai-oversight/src/workers/context-builder.ts
+++ b/services/ai-oversight/src/workers/context-builder.ts
@@ -378,6 +378,20 @@ function buildEventSummary(event: ClinicalEvent): string {
     case "note.saved":
     case "note.signed":
       return `Clinical note ${event.type === "note.signed" ? "signed" : "saved"}`;
+    case "note.amended": {
+      // Amendments carry a free-text `reason` (#1266); surface it when present
+      // so the LLM-context line distinguishes a routine save from a clinically
+      // significant after-the-fact edit. Falls back to the bare verb if absent
+      // so we never propagate the placeholder "Clinical event: note.amended"
+      // (#1270).
+      const reason =
+        typeof event.data.reason === "string" && event.data.reason.trim().length > 0
+          ? event.data.reason.trim()
+          : null;
+      return reason
+        ? `Clinical note amended: ${reason}`
+        : `Clinical note amended`;
+    }
     case "diagnosis.added":
       return `New diagnosis added: ${event.data.description ?? "unknown"}`;
     case "procedure.completed":


### PR DESCRIPTION
## Summary

`buildEventSummary` in `services/ai-oversight/src/workers/context-builder.ts` had cases for every event type the worker emits except `note.amended`, which fell through to the generic `default:` branch and produced the unhelpful LLM-context line `Clinical event: note.amended`. PR #1266 added `note.amended` to `extractSymptoms` for the deterministic path; this PR closes the matching gap on the LLM event-summary side.

- Adds a `case "note.amended":` that returns `Clinical note amended: <reason>` when the amendment carries a non-empty `event.data.reason` (which the publisher in `clinical-notes/note-service.ts` always sets), and falls back to `Clinical note amended` when it does not.
- Vocabulary-consistent with the existing `note.saved` / `note.signed` casing.

## Test plan

- [x] Added two vitest cases in `services/ai-oversight/src/__tests__/context-builder.test.ts`:
  - asserts a `note.amended` event with a `reason` produces a summary containing both `amended` and the reason text, and is NOT the placeholder `Clinical event: note.amended`.
  - asserts a `note.amended` event without a `reason` produces the bare humanised string `Clinical note amended`.
- [x] `pnpm --filter @carebridge/ai-oversight test -- --run src/__tests__/context-builder.test.ts` — 17 / 17 pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (pre-existing warnings unchanged).

Closes #1270