### PR TITLE
feat(infra): incremental TS compilation (#1278)

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "incremental": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary
- Enable `incremental: true` in `tsconfig.base.json` so every workspace `tsc`/`tsc --watch` writes a `.tsbuildinfo` cache next to `dist/`.
- After PR #1267, `pnpm dev` spawns 15+ `tsc --watch` processes. Without incremental compilation, each cold-start does a full program parse — the tax compounds across watchers. With `.tsbuildinfo`, subsequent cold-starts reuse the cached program graph and only re-check what changed.
- `*.tsbuildinfo` is already covered by `.gitignore` (line 7), so no gitignore change required.

## Why
Closes #1278. Reduces `pnpm dev` initial startup cost; steady-state edit latency unchanged (already fast via in-memory program). `incremental` only affects compiler caching — emitted output is identical.

## Test plan
- [x] `pnpm build` — clean rebuild succeeds (56s, 21/21 tasks)
- [x] Verified 17 `.tsbuildinfo` files produced (one per workspace package with `tsc` build)
- [x] `git status` confirms `.tsbuildinfo` files are gitignored
- [x] `pnpm typecheck` — 38/38 cache hit
- [x] `pnpm lint` — 21/21 cache hit

Refs #1264, #1267.