### PR TITLE
feat(fhir): log CPT suppression by licensing gate (#1251)

### DIFF
--- a/services/fhir-gateway/src/__tests__/procedure-cpt-suppression-log.test.ts
+++ b/services/fhir-gateway/src/__tests__/procedure-cpt-suppression-log.test.ts
@@ -1,0 +1,143 @@
+/**
+ * #1251 — fhir-gateway: operator-visible log when CPT coding is suppressed
+ * by the AMA licensing gate.
+ *
+ * When `procedure.cpt_code` is present but `FHIR_CPT_EMISSION_ENABLED` is
+ * not the literal string "true", the gateway silently falls back to a
+ * free-text Procedure.code. That silent drop is the conservative default
+ * (#939), but without a log line operators can't tell apart "no rows have
+ * cpt_code" from "env var is misconfigured ('True' / '1' / 'yes' instead
+ * of 'true')". This test pins the one-shot operator breadcrumb in place.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const infoSpy = vi.fn();
+
+vi.mock("@carebridge/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: infoSpy,
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const {
+  toFhirProcedure,
+  __resetCptSuppressionLogForTests,
+} = await import("../generators/procedure.js");
+
+type Procedure = Parameters<typeof toFhirProcedure>[0];
+
+function makeProcedure(overrides: Partial<Procedure> = {}): Procedure {
+  return {
+    id: "p1",
+    patient_id: "pat1",
+    name: "Appendectomy",
+    cpt_code: "44970",
+    icd10_codes: ["K35.80"],
+    status: "completed",
+    performed_at: "2026-04-10T14:00:00.000Z",
+    performed_by: "surg1",
+    provider_id: null,
+    encounter_id: null,
+    notes: null,
+    source_system: "internal",
+    created_at: "2026-04-10T14:00:00.000Z",
+    ...overrides,
+  } as Procedure;
+}
+
+describe("CPT suppression operator log (#1251)", () => {
+  let previous: string | undefined;
+  beforeEach(() => {
+    infoSpy.mockClear();
+    __resetCptSuppressionLogForTests();
+    previous = process.env.FHIR_CPT_EMISSION_ENABLED;
+    delete process.env.FHIR_CPT_EMISSION_ENABLED;
+  });
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.FHIR_CPT_EMISSION_ENABLED;
+    } else {
+      process.env.FHIR_CPT_EMISSION_ENABLED = previous;
+    }
+  });
+
+  it("emits logger.info breadcrumb when gate suppresses a cpt_code", () => {
+    toFhirProcedure(
+      makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+      "pat1",
+    );
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [msg, meta] = infoSpy.mock.calls[0]!;
+    expect(msg).toBe("CPT coding suppressed by licensing gate");
+    expect(meta).toMatchObject({ flag: "FHIR_CPT_EMISSION_ENABLED" });
+  });
+
+  it("does NOT include the suppressed cpt_code value in the log meta", () => {
+    toFhirProcedure(
+      makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+      "pat1",
+    );
+
+    // The log stream may have a different licensing posture than the
+    // FHIR bundle itself — never leak the code through logs (#1251 AC).
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const serialized = JSON.stringify(infoSpy.mock.calls);
+    expect(serialized).not.toContain("44970");
+  });
+
+  it("logs at most once per process across many suppressed rows", () => {
+    for (let i = 0; i < 5; i++) {
+      toFhirProcedure(
+        makeProcedure({
+          id: `p${i}`,
+          cpt_code: "44970",
+          name: "Laparoscopic appendectomy",
+        }),
+        "pat1",
+      );
+    }
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT log when the gate is open (flag = 'true')", () => {
+    process.env.FHIR_CPT_EMISSION_ENABLED = "true";
+
+    toFhirProcedure(
+      makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+      "pat1",
+    );
+
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT log when there is no cpt_code to suppress", () => {
+    // The breadcrumb is "we silently dropped a code you might be looking
+    // for" — if no code was present, there's nothing to communicate.
+    toFhirProcedure(
+      makeProcedure({ cpt_code: null, name: "Wound dressing change" }),
+      "pat1",
+    );
+
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs once when flag is a non-'true' truthy string ('1', 'yes', 'True')", () => {
+    // Mirrors the #1241 misconfig case the issue explicitly calls out.
+    process.env.FHIR_CPT_EMISSION_ENABLED = "True";
+
+    toFhirProcedure(
+      makeProcedure({ cpt_code: "44970", name: "Laparoscopic appendectomy" }),
+      "pat1",
+    );
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0]![0]).toBe(
+      "CPT coding suppressed by licensing gate",
+    );
+  });
+});

--- a/services/fhir-gateway/src/generators/procedure.ts
+++ b/services/fhir-gateway/src/generators/procedure.ts
@@ -13,6 +13,7 @@
  * procedure name. See docs/fhir-licensing.md.
  */
 
+import { createLogger } from "@carebridge/logger";
 import type { procedures } from "@carebridge/db-schema";
 import type { FhirProcedure } from "../types/fhir-r4.js";
 import { US_CORE_PROCEDURE } from "./us-core-profiles.js";
@@ -22,8 +23,39 @@ type ProcedureRow = typeof procedures.$inferSelect;
 const CPT_SYSTEM = "http://www.ama-assn.org/go/cpt";
 const ICD10_CM_SYSTEM = "http://hl7.org/fhir/sid/icd-10-cm";
 
+const logger = createLogger("fhir-gateway");
+
 function isCptEmissionEnabled(): boolean {
   return process.env.FHIR_CPT_EMISSION_ENABLED === "true";
+}
+
+/**
+ * One-time-per-process operator breadcrumb for the AMA CPT licensing gate
+ * (#1251). When a procedure row carries a `cpt_code` but the gate is closed,
+ * the gateway silently falls back to the free-text procedure name. Without a
+ * log line this misconfig is undiagnosable in prod — operators can't tell
+ * whether their downstream consumer "doesn't see CPT codes" because no rows
+ * have one or because the env flag was set to "True" / "1" / "yes" instead
+ * of the literal "true" the gate requires.
+ *
+ * Intentionally:
+ *   - logged at most once per process (suppressionLoggedOnce latch)
+ *   - does NOT include the suppressed cpt_code value itself — the log
+ *     stream may have a different licensing posture than the FHIR bundle
+ *   - includes the env flag name so operators can connect log → env var
+ */
+let suppressionLoggedOnce = false;
+function noteCptSuppression(): void {
+  if (suppressionLoggedOnce) return;
+  suppressionLoggedOnce = true;
+  logger.info("CPT coding suppressed by licensing gate", {
+    flag: "FHIR_CPT_EMISSION_ENABLED",
+  });
+}
+
+/** Test-only: reset the one-shot latch so unit tests can re-trigger the log. */
+export function __resetCptSuppressionLogForTests(): void {
+  suppressionLoggedOnce = false;
 }
 
 /**
@@ -93,6 +125,11 @@ export function toFhirProcedure(
       text: procedure.name,
     };
   } else if (procedure.name) {
+    if (procedure.cpt_code) {
+      // cpt_code was present but the gate is closed — leave a one-shot
+      // breadcrumb for operators (#1251).
+      noteCptSuppression();
+    }
     resource.code = {
       text: procedure.name,
     };


### PR DESCRIPTION
## Summary

When a `procedure` row carries a `cpt_code` but `FHIR_CPT_EMISSION_ENABLED` is not the literal string `"true"`, the fhir-gateway silently falls back to a free-text `Procedure.code`. That silent drop is the conservative default (#939, PR #1241) but leaves operators unable to distinguish "no rows have a cpt_code" from "the env flag was set to `True` / `1` / `yes` instead of `true`".

This change adds a one-time-per-process `logger.info` breadcrumb the first time the licensing gate suppresses a CPT coding in a given process. The breadcrumb:

- Includes the env flag name (`FHIR_CPT_EMISSION_ENABLED`) so operators can connect log to env var
- Does NOT include the suppressed `cpt_code` value (log streams may have a different licensing posture than the FHIR bundle)
- Fires only when there was actually a code to suppress — no log noise when `cpt_code` is null

A test-only `__resetCptSuppressionLogForTests` export lets vitest re-trigger the one-shot latch across cases.

Closes #1251

## Test plan

- [x] `pnpm --filter @carebridge/fhir-gateway test` — 6 new tests pass, all 27 existing `procedure.test.ts` cases still green
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] CI: typecheck / lint / unit on push