### PR TITLE
feat(medical-logic): age-aware getVitalSeverity (#1253)

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -987,6 +987,48 @@ describe("getVitalSeverity", () => {
   it("returns critical for critically low heart rate", () => {
     expect(getVitalSeverity("heart_rate", 30)).toBe("critical");
   });
+
+  // Age-aware severity (#1253) — parity with isCriticalVital/validateVital.
+  // Without the age argument the function preserves the existing adult-only
+  // behaviour; passing ageYears routes through the same age-stratified
+  // threshold table used by getVitalRangeForAge.
+
+  it("uses adult thresholds when no age is provided (HR 150 → null)", () => {
+    expect(getVitalSeverity("heart_rate", 150)).toBeNull();
+  });
+
+  it("flags HR 150 as critical for a toddler (age 2)", () => {
+    expect(getVitalSeverity("heart_rate", 150, 2)).toBe("critical");
+  });
+
+  it("does not flag HR 120 as critical for a toddler (age 2)", () => {
+    expect(getVitalSeverity("heart_rate", 120, 2)).toBeNull();
+  });
+
+  it("flags HR 165 as critical for a neonate (age 0.01)", () => {
+    expect(getVitalSeverity("heart_rate", 165, 0.01)).toBe("critical");
+  });
+
+  it("flags low SBP for a school-age child where the same value is only a warning for adults", () => {
+    // Adult: SBP 80 → warning (warningLow 90, criticalLow 55)
+    // School-age (age 8): SBP 80 → critical (criticalLow 85)
+    expect(getVitalSeverity("blood_pressure", 80)).toBe("warning");
+    expect(getVitalSeverity("blood_pressure", 80, 8)).toBe("critical");
+  });
+
+  it("returns null for an adolescent HR that is normal for age (HR 70, age 15)", () => {
+    // Adolescent criticalLow 60, criticalHigh 100 — 70 is normal.
+    expect(getVitalSeverity("heart_rate", 70, 15)).toBeNull();
+  });
+
+  it("falls back to adult range for vitals with no pediatric band", () => {
+    // blood_glucose has no pediatric override → adult criticalLow 54 applies.
+    expect(getVitalSeverity("blood_glucose", 45, 3)).toBe("critical");
+  });
+
+  it("uses adult thresholds for age 25 (HR 150 → null)", () => {
+    expect(getVitalSeverity("heart_rate", 150, 25)).toBeNull();
+  });
 });
 
 // ─── classifyAgeGroup ──────────────────────────────────────────

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -538,12 +538,26 @@ export function isCriticalVital(
   return false;
 }
 
-/** Return severity level for a vital value: "critical", "warning", or null if normal */
+/**
+ * Return severity level for a vital value: "critical", "warning", or null if normal.
+ *
+ * When `ageYears` is provided, age-appropriate pediatric thresholds are used
+ * (same age-stratified table as {@link isCriticalVital} and
+ * {@link validateVital}). When omitted, adult thresholds apply — preserving
+ * backwards compatibility with callers that have no age context.
+ *
+ * Issue #1253: the three severity entrypoints (`isCriticalVital`,
+ * `validateVital`, `getVitalSeverity`) now share the same age-stratified
+ * threshold lookup so a pediatric patient with a value that is normal for
+ * their age cannot be flagged "high severity" by one entrypoint while the
+ * others correctly classify it as normal.
+ */
 export function getVitalSeverity(
   type: VitalType,
-  value: number
+  value: number,
+  ageYears?: number | undefined,
 ): "critical" | "warning" | null {
-  const range = VITAL_DANGER_ZONES[type];
+  const range = getVitalRangeForAge(type, ageYears);
   if (!range) return null;
 
   if (range.criticalLow !== undefined && value <= range.criticalLow) return "critical";


### PR DESCRIPTION
## Summary

`getVitalSeverity()` previously read `VITAL_DANGER_ZONES[type]` directly with no `ageYears` parameter, so after PR #1242 made `isCriticalVital`/`validateVital` age-aware it was the only severity entrypoint silently using adult thresholds. This PR routes it through `getVitalRangeForAge` so all three severity entrypoints share the same age-stratified threshold table.

## Changes

- `getVitalSeverity(type, value, ageYears?)` — new optional 3rd arg; omitted preserves the existing adult-default behaviour (backwards compatible)
- Internally delegates to `getVitalRangeForAge(type, ageYears)`, the same lookup `isCriticalVital` and `validateVital` already use
- 8 new pediatric/age-aware test cases parallel to the existing `isCriticalVital` pediatric coverage, including the canonical foot-gun: SBP 80 returns `"warning"` for an adult but `"critical"` for a school-age child

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 513/513 pass (181 in medical-validation, 8 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only pre-existing portal warnings, unrelated)
- [x] `pnpm --filter @carebridge/ai-oversight test` — 939/939 pass (mock signature in `rules.test.ts` remains compatible)

Closes #1253