### PR TITLE
fix(portal): reconcile prefilled patientId with loaded list (#1274)

### DIFF
--- a/apps/clinician-portal/app/notes/new/page.tsx
+++ b/apps/clinician-portal/app/notes/new/page.tsx
@@ -155,6 +155,10 @@ function NewNoteContent() {
   const [patientId, setPatientId] = useState<string>(
     () => searchParams.get("patientId") ?? "",
   );
+  // Inline notice shown when a prefilled patientId is reconciled away
+  // because the loaded patient list doesn't contain it (deleted, no
+  // access, or malformed UUID). #1274.
+  const [patientPrefillNotice, setPatientPrefillNotice] = useState<string>("");
   const [sections, setSections] = useState<NoteSection[]>([]);
 
   const patientsQuery = trpc.patients.list.useQuery();
@@ -165,6 +169,20 @@ function NewNoteContent() {
       setSections(templateQuery.data as unknown as NoteSection[]);
     }
   }, [templateQuery.data]);
+
+  // Reconcile a prefilled patientId against the loaded patient list. If
+  // the id isn't present (deleted, not accessible, malformed), clear it
+  // and surface a small inline notice so the user picks again instead of
+  // submitting a value the server will 403. #1274.
+  useEffect(() => {
+    if (!patientsQuery.data || !patientId) return;
+    if (!patientsQuery.data.some((p) => p.id === patientId)) {
+      setPatientId("");
+      setPatientPrefillNotice(
+        "Patient not available — please pick another.",
+      );
+    }
+  }, [patientsQuery.data, patientId]);
 
   const createMutation = trpc.notes.create.useMutation({
     onSuccess: (note) => {
@@ -233,7 +251,10 @@ function NewNoteContent() {
               className="search-input"
               style={{ width: "100%" }}
               value={patientId}
-              onChange={(e) => setPatientId(e.target.value)}
+              onChange={(e) => {
+                setPatientId(e.target.value);
+                if (patientPrefillNotice) setPatientPrefillNotice("");
+              }}
               required
             >
               <option value="">Select a patient...</option>
@@ -243,6 +264,18 @@ function NewNoteContent() {
                 </option>
               ))}
             </select>
+            {patientPrefillNotice && (
+              <div
+                role="status"
+                style={{
+                  fontSize: 12,
+                  color: "var(--text-muted)",
+                  marginTop: 4,
+                }}
+              >
+                {patientPrefillNotice}
+              </div>
+            )}
           </div>
           <div className="detail-row" style={{ flexDirection: "column", gap: 4 }}>
             <label className="detail-label">Template</label>

--- a/apps/clinician-portal/src/__tests__/notes-new-patient-reconcile.test.tsx
+++ b/apps/clinician-portal/src/__tests__/notes-new-patient-reconcile.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1274 — when `/notes/new?patientId=<uuid>` lands with a patient
+ * id that is not in the loaded `patients.list` (deleted, no access, or
+ * malformed), the page should:
+ *   1. clear the prefilled `patientId` state so the user can't submit
+ *      a value the server will 403 on, and
+ *   2. surface a small inline notice next to the Patient dropdown so
+ *      the user knows why the field reset.
+ *
+ * The happy path — a prefill that *does* match a loaded patient — must
+ * be untouched.
+ */
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeEach,
+  vi,
+} from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------
+// Mutable mocks
+// ---------------------------------------------------------------------
+
+let mockPatientIdParam: string | null = null;
+let mockPatients: { id: string; name: string; mrn?: string }[] = [];
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: (key: string) => (key === "patientId" ? mockPatientIdParam : null),
+  }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+// Minimal tRPC mock: patients.list returns the configured `mockPatients`
+// array; notes.templates.get returns a stable empty template; notes.create
+// is a no-op mutation. Stable object references are crucial — React's
+// effect deps will fire on every render if `data` is a fresh ref each
+// time, which would loop forever once setSections / setPatientId run.
+const stableEmptyTemplate: never[] = [];
+const stableCreateMutation = {
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  error: null,
+};
+vi.mock("@/lib/trpc", () => {
+  const trpc = {
+    patients: {
+      list: {
+        useQuery: () => ({
+          data: mockPatients,
+          isLoading: false,
+          isError: false,
+        }),
+      },
+    },
+    notes: {
+      templates: {
+        get: {
+          useQuery: () => ({
+            data: stableEmptyTemplate,
+            isLoading: false,
+            isError: false,
+          }),
+        },
+      },
+      create: {
+        useMutation: () => stableCreateMutation,
+      },
+    },
+  };
+  return { trpc };
+});
+
+import NewNotePage from "../../app/notes/new/page";
+
+beforeEach(() => {
+  mockPatientIdParam = null;
+  mockPatients = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("/notes/new reconciles prefilled patientId (#1274)", () => {
+  it("clears the prefill and shows an inline notice when the id is not in the loaded list", async () => {
+    mockPatientIdParam = "ghost-patient-uuid";
+    mockPatients = [
+      { id: "patient-1", name: "Jane Doe", mrn: "MRN-0001" },
+      { id: "patient-2", name: "John Roe", mrn: "MRN-0002" },
+    ];
+
+    render(<NewNotePage />);
+
+    // The Patient dropdown is the first `combobox` on the page (the
+    // Template dropdown is the second). The label isn't htmlFor-tied
+    // so we select by role + position.
+    const select = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+    expect(select).toBeDefined();
+    // After the reconcile effect runs, the select should fall back to
+    // the empty "Select a patient..." option, not the ghost UUID.
+    expect(select.value).toBe("");
+
+    // Inline notice should be present.
+    expect(
+      screen.getByText(/Patient not available — please pick another\./i),
+    ).toBeDefined();
+  });
+
+  it("keeps the prefill and shows no notice when the id is in the loaded list", async () => {
+    mockPatientIdParam = "patient-2";
+    mockPatients = [
+      { id: "patient-1", name: "Jane Doe", mrn: "MRN-0001" },
+      { id: "patient-2", name: "John Roe", mrn: "MRN-0002" },
+    ];
+
+    render(<NewNotePage />);
+
+    // The Patient dropdown is the first `combobox` on the page (the
+    // Template dropdown is the second). The label isn't htmlFor-tied
+    // so we select by role + position.
+    const select = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+    expect(select.value).toBe("patient-2");
+    expect(
+      screen.queryByText(/Patient not available — please pick another\./i),
+    ).toBeNull();
+  });
+
+  it("does nothing when no patientId is prefilled at all", async () => {
+    mockPatientIdParam = null;
+    mockPatients = [{ id: "patient-1", name: "Jane Doe", mrn: "MRN-0001" }];
+
+    render(<NewNotePage />);
+
+    // The Patient dropdown is the first `combobox` on the page (the
+    // Template dropdown is the second). The label isn't htmlFor-tied
+    // so we select by role + position.
+    const select = (await screen.findAllByRole("combobox"))[0] as HTMLSelectElement;
+    expect(select.value).toBe("");
+    expect(
+      screen.queryByText(/Patient not available — please pick another\./i),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1274. After PR #1269 added the `?patientId=` query-param prefill on `/notes/new`, a clinician landing on that page with a UUID they no longer have access to (deleted, restricted, or malformed) would silently see the dropdown render with nothing selected — but the bad UUID would remain in `useState`, so clicking **Save Draft** posted it to the server and surfaced a raw 403 tRPC error instead of the friendly empty-selection path.

This PR adds a small reconciliation effect that runs when `patientsQuery.data` resolves:

- If the prefilled `patientId` is not present in the loaded list, clear it and surface a `role="status"` inline notice (`"Patient not available — please pick another."`) under the Patient dropdown.
- Clearing the notice the moment the user picks a real patient (so it doesn't linger).
- The happy path — a prefill that *does* match — is untouched.

The server-side authorization remains the real guard; this is the UX-polish change called out as non-blocking in #1274.

## Changes

- `apps/clinician-portal/app/notes/new/page.tsx` — new `patientPrefillNotice` state, reconcile effect, inline status `<div>` rendered under the patient `<select>`, and an onChange handler that dismisses the notice once the user picks again.
- `apps/clinician-portal/src/__tests__/notes-new-patient-reconcile.test.tsx` — three vitest + RTL cases covering: ghost-id is cleared and notice shown; matching id is kept and notice absent; no prefill no-ops.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/notes-new-patient-reconcile.test.tsx` in `apps/clinician-portal` — 3 tests pass.
- [x] Full `apps/clinician-portal` vitest suite — 258/258 pass (after building `@carebridge/shared-types` + `@carebridge/medical-logic` dist, which is the workspace-pkg-staleness pattern tracked separately as #1264).
- [x] `pnpm exec tsc --noEmit` in `apps/clinician-portal` — only pre-existing errors in unrelated test files (`epic-launch-banner.test.tsx`, `layout-skip-nav.test.tsx`); zero errors in the changed file or the new test.
- [x] `pnpm lint` — passes; only pre-existing warnings in unrelated files.
- [ ] Manual smoke: hit `/notes/new?patientId=<bogus-uuid>` while logged in as a clinician with no access to that patient and confirm the dropdown resets to "Select a patient..." with the inline notice shown.