### PR TITLE
refactor(ai): reuse in-flight constants from review-service in int test (#1297)

### DIFF
--- a/services/ai-oversight/src/__tests__/review-service-in-flight-probe.int.test.ts
+++ b/services/ai-oversight/src/__tests__/review-service-in-flight-probe.int.test.ts
@@ -35,6 +35,10 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import crypto from "node:crypto";
 import { and, eq, gte, inArray, or, sql } from "drizzle-orm";
+import {
+  IN_FLIGHT_WINDOW_SEC,
+  TERMINAL_REVIEW_STATUSES,
+} from "../services/review-service.js";
 
 // Safety invariant identical to the other *.int.test.ts harnesses: force
 // DATABASE_URL to TEST_DATABASE_URL so a developer with DATABASE_URL pointing
@@ -62,12 +66,6 @@ if (TEST_URL && !process.env.PHI_ENCRYPTION_KEY) {
 
 const { getDb, patients, reviewJobs } = await import("@carebridge/db-schema");
 
-// Constants pulled from review-service.ts so the probe shape stays in sync
-// with the production query. If review-service.ts changes its window or
-// terminal-status set, update these together.
-const IN_FLIGHT_WINDOW_SEC = 150; // matches IN_FLIGHT_WINDOW_MS / 1000
-const TERMINAL_REVIEW_STATUSES = ["completed", "llm_timeout", "llm_error"];
-
 /**
  * Reconstruct the exact dedup probe query from
  * services/ai-oversight/src/services/review-service.ts lines 137-168.
@@ -92,7 +90,7 @@ async function runInFlightProbe(triggerEventId: string) {
       and(
         eq(reviewJobs.trigger_event_id, triggerEventId),
         or(
-          inArray(reviewJobs.status, TERMINAL_REVIEW_STATUSES),
+          inArray(reviewJobs.status, TERMINAL_REVIEW_STATUSES as string[]),
           and(
             eq(reviewJobs.status, "processing"),
             // The cast under test. Without `::timestamptz` on the column side

--- a/services/ai-oversight/src/services/review-service.ts
+++ b/services/ai-oversight/src/services/review-service.ts
@@ -80,7 +80,7 @@ import { createFlag } from "./flag-service.js";
  *     freshness window below (see IN_FLIGHT_WINDOW_MS).
  *   - `failed`: the pipeline threw before flag writes; a retry IS desired.
  */
-const TERMINAL_REVIEW_STATUSES: readonly string[] = [
+export const TERMINAL_REVIEW_STATUSES: readonly string[] = [
   "completed",
   "llm_timeout",
   "llm_error",


### PR DESCRIPTION
## Summary
- Import `IN_FLIGHT_WINDOW_SEC` and `TERMINAL_REVIEW_STATUSES` from `review-service.ts` in the in-flight probe int test instead of re-declaring local copies that could silently drift from production.
- Add `export` to `TERMINAL_REVIEW_STATUSES` in `review-service.ts` (it was already used internally; `IN_FLIGHT_WINDOW_SEC` was already exported).

## Why
PR #1293 (the first PG integration test for the ai-oversight in-flight dedup probe) copied two constants as local literals. If a future PR widens the in-flight window or adds a new terminal status (e.g. `llm_circuit_breaker`), the production query and the test query would diverge silently and the int test would keep passing on a probe shape that no longer matches production — defeating the structural-guard purpose of the test.

## Test plan
- [x] `pnpm --filter @carebridge/ai-oversight test` — 942 passed / 4 skipped (int test gated on `TEST_DATABASE_URL`, runs in CI)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

Closes #1297