### PR TITLE
feat(medical-logic): age-stratified anthropometric bounds — height/bmi/head_circ (#1175)

### DIFF
--- a/packages/medical-logic/src/__tests__/medical-validation.test.ts
+++ b/packages/medical-logic/src/__tests__/medical-validation.test.ts
@@ -1428,3 +1428,209 @@ describe("isFentanylTransdermal (#1020)", () => {
     expect(isFentanylTransdermal("Fentanyl patch", "")).toBe(false);
   });
 });
+
+// ─── Age-stratified anthropometric bounds (#1175) ──────────────
+//
+// VITAL_DANGER_ZONES.body_height (20–280 cm), bmi (5–150 kg/m²),
+// and head_circumference (20–80 cm) are deliberate adult/global
+// ceilings. They miss the "globally plausible but age-impossible"
+// case identified in #1175 — e.g. a 4yo with 60 cm OFC (probable
+// hydrocephalus), a 5yo with 25 cm OFC (severe microcephaly), or a
+// 120 cm "height" in an adult (kg/cm data-entry error).
+//
+// PEDIATRIC_VITAL_RANGES now ships age-banded plausibility + critical
+// thresholds for these three measurements. The tests below pin both
+// directions: age-appropriate values must NOT be flagged, and
+// age-implausible values MUST be flagged.
+
+describe("anthropometric age-stratified bounds (#1175)", () => {
+  // body_height ────────────────────────────────────────────────
+  describe("body_height", () => {
+    it("does not flag 60 cm height for a 3-month-old infant", () => {
+      // Infant band: 50–80 cm. 60 cm is normal at ~3 months.
+      const result = validateVital("body_height", 60, undefined, 0.25);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("does not error on 60 cm height for an adult (within global plausibility ceiling)", () => {
+      // Adult band: 20–280 cm with no critical thresholds, so 60 cm
+      // sits inside adult plausibility. This documents the deliberately
+      // loose adult bands — they prevent false positives in legitimate
+      // adult cases (achondroplasia, etc.). The pediatric bands are
+      // where the age-aware check earns its keep. Issue #1175 calls out
+      // 120 cm in an adult as a known gap; the fix here is the pediatric
+      // direction, not tightening the adult lower bound.
+      const result = validateVital("body_height", 60);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects 30 cm height for a 4-year-old child as below plausible range", () => {
+      // Child band: 70–130 cm, criticalLow 65. A 30 cm "height" for
+      // a 4yo is almost certainly a unit-conversion error.
+      const result = validateVital("body_height", 30, undefined, 4);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toMatch(/outside plausible range/);
+    });
+
+    it("flags 175 cm height for a 3-year-old child as above plausible range", () => {
+      // Child band: 70–130 cm. 175 cm in a 3yo is implausible.
+      const result = validateVital("body_height", 175, undefined, 3);
+      expect(result.valid).toBe(false);
+    });
+
+    it("does not flag 175 cm height for an adult", () => {
+      const result = validateVital("body_height", 175);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("flags 90 cm height for a 9-year-old school-age child as critically low", () => {
+      // School-age band: min 100, criticalLow 95. 90 < min 100 → out of
+      // plausible (error) AND 90 < criticalLow 95 → critically low warning.
+      const result = validateVital("body_height", 90, undefined, 9);
+      expect(result.warnings.some((w) => w.includes("Critically low"))).toBe(true);
+    });
+
+    it("flags 42 cm height for a neonate (age 0.01) as critically low", () => {
+      // Neonate band: 45–58 cm, criticalLow 40. 42 < 45 → out of plausible.
+      const result = validateVital("body_height", 42, undefined, 0.01);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // head_circumference ────────────────────────────────────────
+  describe("head_circumference", () => {
+    it("does not flag 40 cm OFC for a 3-month-old infant", () => {
+      // Infant band: 33–50 cm. 40 cm is normal at ~3 months.
+      const result = validateVital("head_circumference", 40, undefined, 0.25);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("flags 60 cm OFC for a 4-year-old as critically high (hydrocephalus signal)", () => {
+      // Child band: 42–55 cm, criticalHigh 57. 60 ≥ 57 → critically high.
+      const result = validateVital("head_circumference", 60, undefined, 4);
+      expect(result.warnings.some((w) => w.includes("Critically high"))).toBe(true);
+    });
+
+    it("flags 25 cm OFC for a 5-year-old as below plausible range (severe microcephaly signal)", () => {
+      // Child band: 42–55 cm. 25 cm is far below plausible.
+      const result = validateVital("head_circumference", 25, undefined, 5);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toMatch(/outside plausible range/);
+    });
+
+    it("does not flag 60 cm OFC for an adult", () => {
+      // Adult band: 20–80 cm, no critical thresholds.
+      const result = validateVital("head_circumference", 60);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("flags 29 cm OFC for a neonate as critically low", () => {
+      // Neonate band: 30–39 cm, criticalLow 28. 29 ≤ criticalLow? No:
+      // 29 > 28 but 29 < min 30 → out of plausible range.
+      const result = validateVital("head_circumference", 29, undefined, 0.01);
+      expect(result.valid).toBe(false);
+    });
+
+    it("flags 42 cm OFC for a neonate as critically high", () => {
+      // Neonate band: 30–39 cm, criticalHigh 41. 42 > criticalHigh 41 → critical.
+      // Also 42 > max 39 → out of plausible range (error).
+      const result = validateVital("head_circumference", 42, undefined, 0.01);
+      expect(result.warnings.some((w) => w.includes("Critically high"))).toBe(true);
+    });
+  });
+
+  // bmi ────────────────────────────────────────────────────────
+  describe("bmi", () => {
+    it("does not flag BMI 16 for a 6-month-old infant", () => {
+      // Infant band: 13–20.
+      const result = validateVital("bmi", 16, undefined, 0.5);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("flags BMI 25 for a 6-month-old infant as critically high", () => {
+      // Infant band: criticalHigh 22 → 25 ≥ 22 → critical, and 25 > max 20
+      // → also out of plausible range.
+      const result = validateVital("bmi", 25, undefined, 0.5);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some((w) => w.includes("Critically high"))).toBe(true);
+    });
+
+    it("flags BMI 10 for a 3-year-old child as below plausible range", () => {
+      // Child band: 13–22, criticalLow 11. 10 < min 13 → out of plausible.
+      const result = validateVital("bmi", 10, undefined, 3);
+      expect(result.valid).toBe(false);
+    });
+
+    it("does not flag BMI 22 for an adult", () => {
+      const result = validateVital("bmi", 22);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("flags BMI 36 for an 8-year-old school-age child as critically high", () => {
+      // School-age band: criticalHigh 35 → 36 > 35 → critical.
+      const result = validateVital("bmi", 36, undefined, 8);
+      expect(result.warnings.some((w) => w.includes("Critically high"))).toBe(true);
+    });
+  });
+
+  // getVitalRangeForAge wiring — confirm the new bands resolve. ─
+  describe("getVitalRangeForAge wires anthropometrics by age", () => {
+    it("returns infant body_height band for age 0.5", () => {
+      const range = getVitalRangeForAge("body_height", 0.5);
+      expect(range).toEqual(PEDIATRIC_VITAL_RANGES.infant.body_height);
+    });
+
+    it("returns child head_circumference band for age 4", () => {
+      const range = getVitalRangeForAge("head_circumference", 4);
+      expect(range).toEqual(PEDIATRIC_VITAL_RANGES.child.head_circumference);
+    });
+
+    it("returns school_age bmi band for age 9", () => {
+      const range = getVitalRangeForAge("bmi", 9);
+      expect(range).toEqual(PEDIATRIC_VITAL_RANGES.school_age.bmi);
+    });
+
+    it("falls back to adult body_height band for adolescents (no pediatric band defined)", () => {
+      // Adolescents intentionally have no anthropometric override — by
+      // age 13+ the bands approach adult ranges.
+      const range = getVitalRangeForAge("body_height", 15);
+      expect(range).toEqual(VITAL_DANGER_ZONES.body_height);
+    });
+
+    it("falls back to adult bmi band when age is unknown", () => {
+      const range = getVitalRangeForAge("bmi");
+      expect(range).toEqual(VITAL_DANGER_ZONES.bmi);
+    });
+  });
+
+  // isCriticalVital + getVitalSeverity parity for the new bands. ─
+  describe("severity entrypoints share the age-stratified anthropometric lookup", () => {
+    it("isCriticalVital flags 60 cm OFC for a 4-year-old", () => {
+      expect(isCriticalVital("head_circumference", 60, 4)).toBe(true);
+    });
+
+    it("getVitalSeverity reports critical for 60 cm OFC, age 4", () => {
+      expect(getVitalSeverity("head_circumference", 60, 4)).toBe("critical");
+    });
+
+    it("isCriticalVital does NOT flag 60 cm OFC for an adult", () => {
+      // Adult band has no critical thresholds for OFC.
+      expect(isCriticalVital("head_circumference", 60)).toBe(false);
+    });
+
+    it("getVitalSeverity returns null for 60 cm OFC adult", () => {
+      expect(getVitalSeverity("head_circumference", 60)).toBeNull();
+    });
+
+    it("getVitalSeverity flags BMI 9 as critical for a neonate", () => {
+      expect(getVitalSeverity("bmi", 9, 0.01)).toBe("critical");
+    });
+  });
+});

--- a/packages/medical-logic/src/medical-validation.ts
+++ b/packages/medical-logic/src/medical-validation.ts
@@ -66,7 +66,25 @@ export type AgeGroup =
   | "adolescent" // 13–17 years
   | "adult";     // 18+ years
 
-/** Age-stratified vital sign ranges keyed by age group, then by vital type. */
+/**
+ * Age-stratified vital sign ranges keyed by age group, then by vital type.
+ *
+ * Anthropometric bands (body_height, bmi, head_circumference) added in
+ * #1175 close the "globally plausible but age-impossible" gap left by
+ * the adult-only ceilings in {@link VITAL_DANGER_ZONES}. Adult height
+ * ceilings (20–280 cm) wouldn't flag a 60 cm head circumference in a
+ * 4yo (probable hydrocephalus) or a 120 cm height in an adult
+ * (achondroplasia or — more often — a kg-vs-cm data-entry error).
+ *
+ * Threshold sources (approximate, aligned to WHO Child Growth Standards
+ * and CDC growth charts):
+ *  - WHO Child Growth Standards (0–60 months): https://www.who.int/tools/child-growth-standards
+ *  - CDC growth charts (2–20 years): https://www.cdc.gov/growthcharts/clinical_charts.htm
+ *
+ * NOTE: These values are conservative WHO/CDC-aligned approximations.
+ * Clinical sign-off is recommended before relying on the exact band edges
+ * for high-stakes decisions — see #1175 acceptance criteria.
+ */
 export const PEDIATRIC_VITAL_RANGES: Record<
   Exclude<AgeGroup, "adult">,
   Partial<Record<VitalType, VitalRange>>
@@ -75,26 +93,43 @@ export const PEDIATRIC_VITAL_RANGES: Record<
     heart_rate: { min: 70, max: 220, criticalLow: 100, criticalHigh: 160 },
     respiratory_rate: { min: 20, max: 80, criticalLow: 30, criticalHigh: 60 },
     blood_pressure: { min: 40, max: 120, criticalLow: 60, criticalHigh: 90 },
+    body_height: { min: 45, max: 58, criticalLow: 40, criticalHigh: 62 },
+    bmi: { min: 11, max: 18, criticalLow: 9, criticalHigh: 20 },
+    head_circumference: { min: 30, max: 39, criticalLow: 28, criticalHigh: 41 },
   },
   infant: {
     heart_rate: { min: 70, max: 200, criticalLow: 100, criticalHigh: 150 },
     respiratory_rate: { min: 15, max: 70, criticalLow: 25, criticalHigh: 50 },
     blood_pressure: { min: 50, max: 130, criticalLow: 70, criticalHigh: 100 },
+    body_height: { min: 50, max: 80, criticalLow: 45, criticalHigh: 85 },
+    bmi: { min: 13, max: 20, criticalLow: 11, criticalHigh: 22 },
+    head_circumference: { min: 33, max: 50, criticalLow: 30, criticalHigh: 52 },
   },
   child: {
     heart_rate: { min: 50, max: 200, criticalLow: 80, criticalHigh: 130 },
     respiratory_rate: { min: 12, max: 40, criticalLow: 20, criticalHigh: 30 },
     blood_pressure: { min: 60, max: 140, criticalLow: 80, criticalHigh: 110 },
+    body_height: { min: 70, max: 130, criticalLow: 65, criticalHigh: 135 },
+    bmi: { min: 13, max: 22, criticalLow: 11, criticalHigh: 25 },
+    head_circumference: { min: 42, max: 55, criticalLow: 40, criticalHigh: 57 },
   },
   school_age: {
     heart_rate: { min: 40, max: 200, criticalLow: 70, criticalHigh: 110 },
     respiratory_rate: { min: 10, max: 35, criticalLow: 16, criticalHigh: 22 },
     blood_pressure: { min: 60, max: 160, criticalLow: 85, criticalHigh: 120 },
+    body_height: { min: 100, max: 175, criticalLow: 95, criticalHigh: 180 },
+    bmi: { min: 14, max: 30, criticalLow: 12, criticalHigh: 35 },
+    head_circumference: { min: 48, max: 58, criticalLow: 46, criticalHigh: 60 },
   },
   adolescent: {
     heart_rate: { min: 30, max: 250, criticalLow: 60, criticalHigh: 100 },
     respiratory_rate: { min: 6, max: 40, criticalLow: 12, criticalHigh: 20 },
     blood_pressure: { min: 60, max: 200, criticalLow: 95, criticalHigh: 140 },
+    // Anthropometric bands deliberately omitted for adolescents —
+    // by age 13+ height/BMI/head-circumference approach adult ranges,
+    // and getVitalRangeForAge falls back to VITAL_DANGER_ZONES when a
+    // pediatric band is undefined. Add age-13–17 bands here once
+    // clinically reviewed if tighter checks are needed (#1175 follow-up).
   },
 };
 


### PR DESCRIPTION
## Summary

Extends `PEDIATRIC_VITAL_RANGES` in `packages/medical-logic/src/medical-validation.ts` with age-banded plausibility and critical thresholds for the three US Core anthropometric vital types added in #1165 / #1171:

- `body_height`
- `bmi`
- `head_circumference`

Bands cover **neonate** (0–28d), **infant** (1–12mo), **child** (1–5y), and **school_age** (5–12y). Adolescents (13+) deliberately fall back to the adult `VITAL_DANGER_ZONES` because anthropometric values approach adult-typical by that age — adding a tighter band there is a possible #1175 follow-up if clinically required.

Closes the "globally plausible but age-impossible" gap called out in the issue:
- 60 cm OFC in a 4yo (probable hydrocephalus) — now critical
- 25 cm OFC in a 5yo (severe microcephaly) — now outside plausibility
- 175 cm "height" in a 3yo (likely data-entry error) — now outside plausibility

All three severity entrypoints (`validateVital`, `isCriticalVital`, `getVitalSeverity`) inherit the new bands via the existing `getVitalRangeForAge` lookup — same pattern established in #1290 and #1301.

## Threshold sources (approximate)

- WHO Child Growth Standards (0–60 months) — https://www.who.int/tools/child-growth-standards
- CDC growth charts (2–20 years) — https://www.cdc.gov/growthcharts/clinical_charts.htm

| Vital | neonate | infant | child (1–5y) | school_age (5–12y) |
|---|---|---|---|---|
| body_height (cm) | 45–58 (crit 40/62) | 50–80 (crit 45/85) | 70–130 (crit 65/135) | 100–175 (crit 95/180) |
| head_circumference (cm) | 30–39 (crit 28/41) | 33–50 (crit 30/52) | 42–55 (crit 40/57) | 48–58 (crit 46/60) |
| bmi (kg/m²) | 11–18 (crit 9/20) | 13–20 (crit 11/22) | 13–22 (crit 11/25) | 14–30 (crit 12/35) |

**Clinical sign-off recommended** — these numbers are WHO/CDC-aligned approximations rather than peer-reviewed cut-points. A clinician (the issue suggests nurse / pediatrics) should validate the exact band edges before relying on them for sentinel-event routing. The bands are deliberately wide where uncertainty exists; a tightening pass post-review is the next step.

## Test plan

- [x] `pnpm --filter=@carebridge/medical-logic test` — 570/570 pass (28 new tests in the `anthropometric age-stratified bounds (#1175)` block)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Clinical sign-off on threshold values (issue AC requirement)

## Coverage of the issue's concrete cases

- [x] `head_circumference = 60` in a 4yo → flagged critical (criticalHigh 57)
- [x] `head_circumference = 25` in a 5yo → outside plausible range (child min 42)
- [x] `bmi = 9` in a neonate → flagged critical (criticalLow 9)
- [x] Age-implausible height — `body_height = 175` in a 3yo → outside plausible range

The "120 cm in a healthy adult" case from the issue is deliberately **not** addressed — adult lower bounds are intentionally loose to avoid false positives in legitimate cases (achondroplasia). A regression test pins the current adult behaviour so a future tightening pass has to make that call explicitly.

Refs #1175