### PR TITLE
feat(portal): provider names + specialty in care team panel (#1304)

### DIFF
--- a/apps/clinician-portal/app/patients/[id]/page.tsx
+++ b/apps/clinician-portal/app/patients/[id]/page.tsx
@@ -243,12 +243,24 @@ function OverviewTab({
         {careTeamQuery.isLoading ? (
           <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>
         ) : careTeam.length > 0 ? (
-          careTeam.map((member, i) => (
-            <div key={i} className="detail-row">
-              <span className="detail-label">{member.role}</span>
-              <span className="detail-value">{member.provider_id}</span>
-            </div>
-          ))
+          careTeam.map((member, i) => {
+            // Issue #1304: render provider name + specialty rather than
+            // the raw UUID. The gateway's careTeam.getByPatient now
+            // LEFT JOINs `users`, so `provider_name` + `provider_specialty`
+            // may be null when the linked user row is missing (stale
+            // roster entry, deleted user). Fall back to "Unknown provider"
+            // so clinicians get an explicit signal instead of an empty cell.
+            const name = member.provider_name ?? "Unknown provider";
+            const specialty = member.provider_specialty;
+            return (
+              <div key={i} className="detail-row">
+                <span className="detail-label">{member.role}</span>
+                <span className="detail-value">
+                  {specialty ? `${name} — ${specialty}` : name}
+                </span>
+              </div>
+            );
+          })
         ) : (
           <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
             No care team members assigned

--- a/apps/clinician-portal/src/__tests__/patient-chart-care-team-names.test.tsx
+++ b/apps/clinician-portal/src/__tests__/patient-chart-care-team-names.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1304 — the patient chart's Care Team panel was rendering raw
+ * `provider_id` UUIDs instead of the provider's name + specialty.
+ *
+ * The gateway's `patients.careTeam.getByPatient` now LEFT JOINs `users`
+ * and surfaces `provider_name` + `provider_specialty`. The Overview tab
+ * must render those fields, and must fall back to "Unknown provider"
+ * when the join returns null (stale roster entry / deleted user).
+ */
+import React from "react";
+import {
+  describe,
+  it,
+  expect,
+  afterEach,
+  beforeEach,
+  vi,
+} from "vitest";
+import { render, cleanup, screen, within } from "@testing-library/react";
+
+let mockCareTeam: Array<{
+  id: string;
+  patient_id: string;
+  provider_id: string;
+  role: string;
+  specialty: string | null;
+  is_active: boolean;
+  started_at: string;
+  ended_at: string | null;
+  created_at: string;
+  provider_name: string | null;
+  provider_specialty: string | null;
+}> = [];
+
+const { patient } = vi.hoisted(() => ({
+  patient: {
+    id: "patient-1",
+    name: "Margaret Chen",
+    mrn: "MRN-0001",
+    date_of_birth: "1970-01-01",
+    biological_sex: "F",
+    allergy_status: "nkda",
+  },
+}));
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "patient-1" }),
+  useSearchParams: () => ({
+    get: () => null,
+  }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/components/vitals-trend-chart", () => ({
+  VitalsTrendChart: () => null,
+}));
+
+vi.mock("@/components/stale-data-banner", () => ({
+  StaleDataBanner: () => null,
+}));
+
+vi.mock("@/components/epic-sync-card", () => ({
+  EpicSyncCard: () => null,
+}));
+
+vi.mock("@/lib/trpc", () => {
+  const stubQuery = <T,>(data: T) => ({
+    useQuery: () => ({ data, isLoading: false, isError: false }),
+  });
+
+  const proxyFor = (path: string): unknown => {
+    if (path === "patients.getById") return stubQuery(patient);
+    if (path === "patients.diagnoses.getByPatient") return stubQuery([]);
+    if (path === "patients.allergies.getByPatient") return stubQuery([]);
+    if (path === "patients.careTeam.getByPatient") return stubQuery(mockCareTeam);
+    return {
+      useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
+      useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+    };
+  };
+
+  const proxy = (path: string[]): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === "then") return undefined;
+          if (prop === "useUtils") {
+            return () => ({});
+          }
+          if (prop === "useQuery" || prop === "useMutation") {
+            const target = proxyFor(path.join(".")) as Record<string, unknown>;
+            const fn = target[prop];
+            if (typeof fn === "function") return fn;
+            if (prop === "useMutation") {
+              return () => ({ mutate: vi.fn(), isPending: false });
+            }
+            return () => ({ data: undefined, isLoading: true, isError: false });
+          }
+          return proxy([...path, prop]);
+        },
+      },
+    );
+
+  return { trpc: proxy([]) };
+});
+
+import PatientChartPage from "../../app/patients/[id]/page";
+
+beforeEach(() => {
+  mockCareTeam = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeMember(overrides: Partial<(typeof mockCareTeam)[number]>) {
+  return {
+    id: "ctm-1",
+    patient_id: "patient-1",
+    provider_id: "4fbb067d-bfca-4e24-84cf-0e04cf88b4db",
+    role: "primary",
+    specialty: null,
+    is_active: true,
+    started_at: "2025-01-01T00:00:00Z",
+    ended_at: null,
+    created_at: "2025-01-01T00:00:00Z",
+    provider_name: null,
+    provider_specialty: null,
+    ...overrides,
+  };
+}
+
+describe("patient chart care-team renders provider names + specialty (#1304)", () => {
+  it("renders name and specialty for each care-team row", () => {
+    mockCareTeam = [
+      makeMember({
+        id: "ctm-1",
+        role: "primary",
+        provider_name: "Dr. Sarah Smith",
+        provider_specialty: "Hematology/Oncology",
+      }),
+      makeMember({
+        id: "ctm-2",
+        role: "specialist",
+        provider_id: "4521c6bf-e6bd-45e8-80c4-1319f67fc7a2",
+        provider_name: "Dr. Michael Jones",
+        provider_specialty: "Interventional Radiology",
+      }),
+      makeMember({
+        id: "ctm-3",
+        role: "nurse",
+        provider_id: "b2fa0be2-c448-49ec-8588-7fdfd5679260",
+        provider_name: "Rachel Torres, RN",
+        provider_specialty: "Oncology",
+      }),
+    ];
+
+    render(<PatientChartPage />);
+
+    // Heading still present.
+    expect(screen.getByText("Care Team")).toBeTruthy();
+
+    // Names + specialties rendered for all three rows.
+    expect(
+      screen.getByText("Dr. Sarah Smith — Hematology/Oncology"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Dr. Michael Jones — Interventional Radiology"),
+    ).toBeTruthy();
+    expect(screen.getByText("Rachel Torres, RN — Oncology")).toBeTruthy();
+
+    // Raw UUIDs MUST NOT leak into the rendered chart.
+    expect(
+      screen.queryByText("4fbb067d-bfca-4e24-84cf-0e04cf88b4db"),
+    ).toBeNull();
+    expect(
+      screen.queryByText("4521c6bf-e6bd-45e8-80c4-1319f67fc7a2"),
+    ).toBeNull();
+    expect(
+      screen.queryByText("b2fa0be2-c448-49ec-8588-7fdfd5679260"),
+    ).toBeNull();
+  });
+
+  it("falls back to 'Unknown provider' when the joined user row is missing", () => {
+    mockCareTeam = [
+      makeMember({
+        role: "specialist",
+        provider_name: null,
+        provider_specialty: null,
+      }),
+    ];
+
+    render(<PatientChartPage />);
+
+    expect(screen.getByText("Unknown provider")).toBeTruthy();
+    // Even the fallback row must not leak the UUID.
+    expect(
+      screen.queryByText("4fbb067d-bfca-4e24-84cf-0e04cf88b4db"),
+    ).toBeNull();
+  });
+
+  it("renders name only when specialty is null but the user record exists", () => {
+    mockCareTeam = [
+      makeMember({
+        role: "nurse",
+        provider_name: "Casey Coordinator",
+        provider_specialty: null,
+      }),
+    ];
+
+    render(<PatientChartPage />);
+
+    // No "— specialty" suffix when specialty is null.
+    const careCard = screen.getByText("Care Team").parentElement!;
+    expect(within(careCard).getByText("Casey Coordinator")).toBeTruthy();
+    expect(within(careCard).queryByText(/—/)).toBeNull();
+  });
+});

--- a/services/api-gateway/src/__tests__/care-team-get-by-patient.test.ts
+++ b/services/api-gateway/src/__tests__/care-team-get-by-patient.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Issue #1304 — the gateway's `patients.careTeam.getByPatient` procedure
+ * was returning bare `care_team_members` rows so the clinician portal
+ * rendered raw `provider_id` UUIDs as the only identifier.
+ *
+ * The procedure now LEFT JOINs the `users` table and projects
+ * `provider_name` + `provider_specialty` (roster-level specialty wins,
+ * falling back to the user's profile specialty). The LEFT join is
+ * intentional: a stale roster entry pointing at a deleted user must still
+ * appear on the chart so reviewers can spot the orphan.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { User } from "@carebridge/shared-types";
+
+const PATIENT_ID = "22222222-2222-4222-8222-222222222222";
+const PHYSICIAN_ID = "44444444-4444-4444-8444-444444444444";
+
+const mocks = vi.hoisted(() => {
+  const fn = vi.fn;
+
+  // Captures the most recent select() column-map argument, the joined
+  // table reference, and the rows we want the awaited chain to resolve to.
+  const state: {
+    selectColumns: Record<string, unknown> | undefined;
+    leftJoinArgs: unknown[] | undefined;
+    rows: unknown[];
+  } = {
+    selectColumns: undefined,
+    leftJoinArgs: undefined,
+    rows: [],
+  };
+
+  function makeSelectChain() {
+    const chain: Record<string, unknown> = {};
+    chain.from = fn(() => chain);
+    chain.leftJoin = fn((...args: unknown[]) => {
+      state.leftJoinArgs = args;
+      return chain;
+    });
+    chain.where = fn(() => Promise.resolve(state.rows));
+    chain.limit = fn(async () => state.rows);
+    return chain;
+  }
+
+  return {
+    state,
+    mockDb: {
+      select: fn((cols?: Record<string, unknown>) => {
+        state.selectColumns = cols;
+        return makeSelectChain();
+      }),
+      insert: fn(() => ({ values: fn() })),
+    },
+    assertCareTeamAccess: fn(async () => true),
+  };
+});
+
+vi.mock("@carebridge/db-schema", () => ({
+  getDb: () => mocks.mockDb,
+  hmacForIndex: (v: string) => `hmac:${v}`,
+  patients: { id: "patients.id" },
+  diagnoses: { id: "diagnoses.id", patient_id: "diagnoses.patient_id" },
+  allergies: { id: "allergies.id", patient_id: "allergies.patient_id" },
+  allergyOverrides: { id: "allergy_overrides.id" },
+  auditLog: {},
+  clinicalFlags: { id: "clinical_flags.id" },
+  familyRelationships: { id: "family_relationships.id" },
+  careTeamMembers: {
+    id: "care_team_members.id",
+    patient_id: "care_team_members.patient_id",
+    provider_id: "care_team_members.provider_id",
+    role: "care_team_members.role",
+    specialty: "care_team_members.specialty",
+    is_active: "care_team_members.is_active",
+    started_at: "care_team_members.started_at",
+    ended_at: "care_team_members.ended_at",
+    created_at: "care_team_members.created_at",
+  },
+  careTeamAssignments: {
+    id: "care_team_assignments.id",
+    user_id: "care_team_assignments.user_id",
+    patient_id: "care_team_assignments.patient_id",
+    removed_at: "care_team_assignments.removed_at",
+  },
+  users: {
+    id: "users.id",
+    name: "users.name",
+    specialty: "users.specialty",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: (col: unknown, val: unknown) => ({ op: "eq", col, val }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  isNull: (col: unknown) => ({ op: "isNull", col }),
+  isNotNull: (col: unknown) => ({ op: "isNotNull", col }),
+  inArray: (col: unknown, vals: unknown[]) => ({ op: "inArray", col, vals }),
+  desc: (col: unknown) => ({ op: "desc", col }),
+}));
+
+vi.mock("../middleware/rbac.js", () => ({
+  assertCareTeamAccess: mocks.assertCareTeamAccess,
+}));
+
+vi.mock("@carebridge/patient-records", () => ({
+  listObservationsByPatient: vi.fn(),
+  createObservation: vi.fn(),
+  createDiagnosis: vi.fn(),
+  updateDiagnosis: vi.fn(),
+  createAllergy: vi.fn(),
+  updateAllergy: vi.fn(),
+}));
+
+vi.mock("@carebridge/shared-types", async () => {
+  const actual = await vi.importActual<typeof import("@carebridge/shared-types")>(
+    "@carebridge/shared-types",
+  );
+  const { z } = await import("zod");
+  return {
+    ...actual,
+    createPatientSchema: z.object({ mrn: z.string().optional() }),
+    updatePatientSchema: z.object({}),
+    createDiagnosisSchema: z.object({}),
+    updateDiagnosisSchema: z.object({}),
+    createAllergySchema: z.object({}),
+    updateAllergySchema: z.object({}),
+    overrideAllergyFlagSchema: z.object({}),
+  };
+});
+
+import { patientRecordsRbacRouter } from "../routers/patient-records.js";
+import type { Context } from "../context.js";
+
+function makeUser(role: User["role"], id: string): User {
+  return {
+    id,
+    email: `${role}@carebridge.dev`,
+    name: `Test ${role}`,
+    role,
+    is_active: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function makeContext(user: User | null): Context {
+  return {
+    db: mocks.mockDb as unknown as Context["db"],
+    user,
+    sessionId: "session-1",
+    requestId: "req-1",
+    clientIp: null,
+  };
+}
+
+function callerFor(user: User | null) {
+  return patientRecordsRbacRouter.createCaller(makeContext(user));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.state.selectColumns = undefined;
+  mocks.state.leftJoinArgs = undefined;
+  mocks.state.rows = [];
+});
+
+describe("patients.careTeam.getByPatient — joins users for name + specialty (#1304)", () => {
+  it("selects provider_name + provider_specialty via LEFT JOIN on users", async () => {
+    mocks.state.rows = [];
+
+    const physician = makeUser("physician", PHYSICIAN_ID);
+    await callerFor(physician).careTeam.getByPatient({ patientId: PATIENT_ID });
+
+    expect(mocks.mockDb.select).toHaveBeenCalledTimes(1);
+    const cols = mocks.state.selectColumns!;
+    expect(cols).toBeDefined();
+
+    // The projection must surface the new joined columns alongside the
+    // existing roster columns the patient-portal already consumes.
+    expect(cols).toHaveProperty("provider_name");
+    expect(cols).toHaveProperty("provider_user_specialty");
+    expect(cols).toHaveProperty("provider_id");
+    expect(cols).toHaveProperty("role");
+    expect(cols).toHaveProperty("specialty");
+
+    // LEFT (not INNER) join — orphaned roster rows must still surface.
+    expect(mocks.state.leftJoinArgs).toBeDefined();
+    expect(mocks.state.leftJoinArgs![0]).toEqual({
+      id: "users.id",
+      name: "users.name",
+      specialty: "users.specialty",
+    });
+  });
+
+  it("returns provider_name + provider_specialty when the users row exists", async () => {
+    mocks.state.rows = [
+      {
+        id: "ctm-1",
+        patient_id: PATIENT_ID,
+        provider_id: "provider-1",
+        role: "primary",
+        specialty: null,
+        is_active: true,
+        started_at: "2025-01-01T00:00:00Z",
+        ended_at: null,
+        created_at: "2025-01-01T00:00:00Z",
+        provider_name: "Dr. Sarah Smith",
+        provider_user_specialty: "Hematology/Oncology",
+      },
+    ];
+
+    const physician = makeUser("physician", PHYSICIAN_ID);
+    const result = await callerFor(physician).careTeam.getByPatient({
+      patientId: PATIENT_ID,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      provider_id: "provider-1",
+      role: "primary",
+      provider_name: "Dr. Sarah Smith",
+      provider_specialty: "Hematology/Oncology",
+    });
+    // The intermediate alias is stripped from the response payload.
+    expect(result[0]).not.toHaveProperty("provider_user_specialty");
+  });
+
+  it("prefers roster-level specialty over the user profile specialty", async () => {
+    mocks.state.rows = [
+      {
+        id: "ctm-2",
+        patient_id: PATIENT_ID,
+        provider_id: "provider-2",
+        role: "specialist",
+        // Roster overrides the user's general specialty for this patient.
+        specialty: "Interventional Radiology — Stroke",
+        is_active: true,
+        started_at: "2025-01-01T00:00:00Z",
+        ended_at: null,
+        created_at: "2025-01-01T00:00:00Z",
+        provider_name: "Dr. Michael Jones",
+        provider_user_specialty: "Interventional Radiology",
+      },
+    ];
+
+    const physician = makeUser("physician", PHYSICIAN_ID);
+    const result = await callerFor(physician).careTeam.getByPatient({
+      patientId: PATIENT_ID,
+    });
+
+    expect(result[0]?.provider_specialty).toBe(
+      "Interventional Radiology — Stroke",
+    );
+  });
+
+  it("returns null name/specialty when the joined user row is missing", async () => {
+    // Stale roster entry — provider_id points at a deleted user. LEFT JOIN
+    // yields nulls for the user columns; the response surfaces null so
+    // the UI can render an explicit "Unknown provider" fallback.
+    mocks.state.rows = [
+      {
+        id: "ctm-3",
+        patient_id: PATIENT_ID,
+        provider_id: "deleted-provider",
+        role: "nurse",
+        specialty: null,
+        is_active: true,
+        started_at: "2025-01-01T00:00:00Z",
+        ended_at: null,
+        created_at: "2025-01-01T00:00:00Z",
+        provider_name: null,
+        provider_user_specialty: null,
+      },
+    ];
+
+    const physician = makeUser("physician", PHYSICIAN_ID);
+    const result = await callerFor(physician).careTeam.getByPatient({
+      patientId: PATIENT_ID,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provider_name).toBeNull();
+    expect(result[0]?.provider_specialty).toBeNull();
+  });
+});

--- a/services/api-gateway/src/routers/patient-records.ts
+++ b/services/api-gateway/src/routers/patient-records.ts
@@ -781,10 +781,42 @@ export const patientRecordsRbacRouter = t.router({
         // who can see demographics can see who the patient's providers are.
         await enforcePatientAccess(ctx.user, input.patientId, "view_summary", ctx.clientIp);
         const db = getDb();
-        return db
-          .select()
+        // Issue #1304: the portal renders this list as "Care Team" and was
+        // showing raw `provider_id` UUIDs because the roster row carries no
+        // human-readable identity. LEFT JOIN users so we surface
+        // `provider_name` + a `provider_specialty` that prefers the
+        // roster-level specialty (per-patient role context) and falls back
+        // to the user's profile specialty. LEFT (not INNER) so a stale
+        // roster entry for a deleted user still renders ("Unknown
+        // provider") rather than silently vanishing — important for chart
+        // continuity audits.
+        const rows = await db
+          .select({
+            id: careTeamMembers.id,
+            patient_id: careTeamMembers.patient_id,
+            provider_id: careTeamMembers.provider_id,
+            role: careTeamMembers.role,
+            specialty: careTeamMembers.specialty,
+            is_active: careTeamMembers.is_active,
+            started_at: careTeamMembers.started_at,
+            ended_at: careTeamMembers.ended_at,
+            created_at: careTeamMembers.created_at,
+            provider_name: users.name,
+            provider_user_specialty: users.specialty,
+          })
           .from(careTeamMembers)
+          .leftJoin(users, eq(users.id, careTeamMembers.provider_id))
           .where(eq(careTeamMembers.patient_id, input.patientId));
+
+        return rows.map((row) => {
+          const { provider_user_specialty, ...rest } = row;
+          return {
+            ...rest,
+            // Roster-level specialty wins; fall back to the provider's
+            // profile specialty when the roster row left it null.
+            provider_specialty: rest.specialty ?? provider_user_specialty ?? null,
+          };
+        });
       }),
   }),
 


### PR DESCRIPTION
## Summary

- Gateway `patients.careTeam.getByPatient` LEFT JOINs `users` to project `provider_name` + `provider_specialty` (roster-level specialty wins, falls back to the user's profile specialty).
- Clinician-chart Overview tab renders `name — specialty` per role and falls back to "Unknown provider" when the joined user row is missing (stale roster entries / deleted users).
- Backwards-compatible: the existing `provider_id`, `role`, `specialty`, etc. fields remain in the response shape so the patient-portal consumers keep working.

## Test plan

- [x] `pnpm --filter @carebridge/api-gateway test` — new `care-team-get-by-patient.test.ts` (4 tests) + full suite (545 tests) pass
- [x] `pnpm --filter @carebridge/clinician-portal test` — new `patient-chart-care-team-names.test.tsx` (3 tests) + full suite (268 tests) pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)
- [ ] Smoke-test the DVT scenario chart and confirm the three rows render as `Dr. Sarah Smith — Hematology/Oncology`, `Dr. Michael Jones — Interventional Radiology`, `Rachel Torres, RN — Oncology`

Closes #1304