### PR TITLE
fix(ai): negation-aware symptom matcher (#1307)

### DIFF
--- a/packages/medical-logic/src/__tests__/symptom-negation.test.ts
+++ b/packages/medical-logic/src/__tests__/symptom-negation.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+
+import { hasUnnegatedMention } from "../symptom-negation.js";
+
+describe("hasUnnegatedMention — positive matches", () => {
+  it("returns true for the bare term", () => {
+    expect(hasUnnegatedMention("fever", "fever")).toBe(true);
+  });
+
+  it("returns true for the term in a positive sentence", () => {
+    expect(hasUnnegatedMention("reports fever and chills", "fever")).toBe(true);
+  });
+
+  it("returns true for the term embedded in a positive HPI", () => {
+    expect(
+      hasUnnegatedMention(
+        "Patient presents with fever 101.5 starting yesterday morning.",
+        "fever",
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive for both haystack and needle", () => {
+    expect(hasUnnegatedMention("Reports FEVER overnight", "Fever")).toBe(true);
+  });
+
+  it("matches multi-word terms", () => {
+    expect(
+      hasUnnegatedMention("Patient has neck stiffness", "neck stiffness"),
+    ).toBe(true);
+  });
+
+  it("returns true when one mention is negated but another later mention is positive", () => {
+    expect(
+      hasUnnegatedMention(
+        "No fever on admission; now reports fever 102 overnight.",
+        "fever",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when the negation marker is further than the lookback window", () => {
+    // "no" is well outside the ~5-token window before "fever".
+    expect(
+      hasUnnegatedMention(
+        "No headache, no nausea, no vomiting, no chest pain at admission. Six hours later the nurse charted fever 102.",
+        "fever",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("hasUnnegatedMention — negation forms", () => {
+  it("'no <term>' is negated", () => {
+    expect(hasUnnegatedMention("no fever", "fever")).toBe(false);
+  });
+
+  it("'denies <term>' is negated", () => {
+    expect(hasUnnegatedMention("patient denies fever", "fever")).toBe(false);
+  });
+
+  it("'without <term>' is negated", () => {
+    expect(
+      hasUnnegatedMention("admitted without fever or chills", "fever"),
+    ).toBe(false);
+  });
+
+  it("'absent <term>' is negated", () => {
+    expect(hasUnnegatedMention("fever absent on exam", "fever")).toBe(false);
+  });
+
+  it("'absence of <term>' is negated", () => {
+    expect(
+      hasUnnegatedMention("notable for the absence of fever", "fever"),
+    ).toBe(false);
+  });
+
+  it("'negative for <term>' is negated", () => {
+    expect(
+      hasUnnegatedMention("ROS negative for fever, chills, nausea", "fever"),
+    ).toBe(false);
+  });
+
+  it("'<term>-free' is negated", () => {
+    expect(hasUnnegatedMention("patient is fever-free x 24h", "fever")).toBe(
+      false,
+    );
+  });
+
+  it("'no h/o <term>' is negated", () => {
+    expect(hasUnnegatedMention("no h/o fever", "fever")).toBe(false);
+  });
+
+  it("'no history of <term>' is negated", () => {
+    expect(
+      hasUnnegatedMention("no history of fever or weight loss", "fever"),
+    ).toBe(false);
+  });
+
+  it("'not <term>' is negated", () => {
+    expect(hasUnnegatedMention("patient is not febrile", "febrile")).toBe(
+      false,
+    );
+  });
+});
+
+describe("hasUnnegatedMention — comma-separated list of negatives", () => {
+  it("treats each comma-separated item as inheriting the leading 'no'", () => {
+    // Reproduction case from issue #1307.
+    const hpi =
+      "No prior headache history of this severity, no migraine history, no recent head trauma, no fever, no neck stiffness, no nausea or vomiting.";
+    expect(hasUnnegatedMention(hpi, "fever")).toBe(false);
+    expect(hasUnnegatedMention(hpi, "neck stiffness")).toBe(false);
+    expect(hasUnnegatedMention(hpi, "nausea")).toBe(false);
+  });
+
+  it("does not negate later positive findings just because an earlier item was negated", () => {
+    const hpi = "No fever. Reports headache 8/10.";
+    expect(hasUnnegatedMention(hpi, "fever")).toBe(false);
+    expect(hasUnnegatedMention(hpi, "headache")).toBe(true);
+  });
+
+  it("handles ROS-style 'negative for X, Y, Z' lists", () => {
+    const ros = "ROS negative for fever, chills, night sweats, weight loss.";
+    expect(hasUnnegatedMention(ros, "fever")).toBe(false);
+    expect(hasUnnegatedMention(ros, "chills")).toBe(false);
+    expect(hasUnnegatedMention(ros, "night sweats")).toBe(false);
+    expect(hasUnnegatedMention(ros, "weight loss")).toBe(false);
+  });
+});
+
+describe("hasUnnegatedMention — edge cases", () => {
+  it("returns false when the term is absent", () => {
+    expect(hasUnnegatedMention("patient reports headache", "fever")).toBe(
+      false,
+    );
+  });
+
+  it("returns false on empty haystack", () => {
+    expect(hasUnnegatedMention("", "fever")).toBe(false);
+  });
+
+  it("returns false on empty term", () => {
+    expect(hasUnnegatedMention("some text", "")).toBe(false);
+  });
+
+  it("does not match the term as a substring of another word", () => {
+    // 'fevered' should match (same lemma), but 'feverfew' (an herb) should not.
+    // For the simple word-boundary version we match whole-word only.
+    expect(hasUnnegatedMention("taking feverfew tea", "fever")).toBe(false);
+  });
+});

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -7,3 +7,4 @@ export * from "./medication-frequency.js";
 export * from "./allergen-synonyms.js";
 export * from "./cross-reactivity-map.js";
 export * from "./patient-education.js";
+export * from "./symptom-negation.js";

--- a/packages/medical-logic/src/symptom-negation.ts
+++ b/packages/medical-logic/src/symptom-negation.ts
@@ -1,0 +1,236 @@
+/**
+ * Negation-aware symptom detection (#1307).
+ *
+ * Clinical free text — chief complaint, HPI, ROS — routinely lists what a
+ * patient is NOT experiencing alongside what they are. A naive
+ * `text.includes("fever")` check fires the febrile-neutropenia rule even on a
+ * note whose HPI explicitly says "no fever, no neck stiffness, no nausea",
+ * which trains clinicians to dismiss the warning and undermines true
+ * febrile-neutropenia alerts (a 60-minute time-to-antibiotic emergency).
+ *
+ * `hasUnnegatedMention` returns true only when `term` appears in `text` AND
+ * the immediately preceding ~5-token window does not contain a negation
+ * marker. The helper is intentionally small and deterministic — no LLM, no
+ * sprawling regex zoo — so it can be reused by the UI symptom autocomplete
+ * (#1305) without dragging a heavy NLP dependency into the browser bundle.
+ *
+ * Negation forms handled:
+ *   - `no <term>`                   ("no fever")
+ *   - `not <term>`                  ("patient is not febrile")
+ *   - `denies <term>`               ("denies fever")
+ *   - `without <term>`              ("admitted without fever")
+ *   - `absent <term>`               ("fever absent on exam" — post-term)
+ *   - `absence of <term>`           ("absence of fever")
+ *   - `negative for <term>`         ("ROS negative for fever, chills")
+ *   - `<term>-free`                 ("fever-free x 24h")
+ *   - `no h/o <term>`               ("no h/o fever")
+ *   - `no history of <term>`        ("no history of fever")
+ *
+ * Comma-separated list form (common in HPI/ROS) — "no fever, no neck
+ * stiffness, no nausea" — works without special handling because each item
+ * carries its own leading "no" within the lookback window. The
+ * "negative for X, Y, Z" form is supported because the lookback walks
+ * through commas; tokens before commas still count toward the window.
+ */
+
+// Negation markers that appear BEFORE the term within the lookback window.
+const PRE_NEGATIONS = new Set([
+  "no",
+  "not",
+  "denies",
+  "denied",
+  "without",
+  "absent",
+  "absence",
+  "negative",
+  "neg",
+]);
+
+// Words that often appear between a pre-negation and the term and should
+// not "consume" the negator. E.g. "no h/o fever" has tokens [no, h, o, fever];
+// "no history of fever" has [no, history, of, fever]; "negative for fever"
+// has [negative, for, fever]. These linker tokens get skipped when scanning
+// back so the window stays anchored on the term itself.
+const LINKER_TOKENS = new Set([
+  "for",
+  "of",
+  "any",
+  "the",
+  "a",
+  "an",
+  "h",
+  "o",
+  "ho",
+  "h/o",
+  "hx",
+  "history",
+  "evidence",
+  "signs",
+  "sign",
+  "symptoms",
+  "symptom",
+  "complaints",
+  "complaint",
+]);
+
+// Tokens that terminate the lookback — a sentence boundary breaks the
+// negation chain. Commas DO NOT terminate (so "no fever, chills" negates
+// both items in the list).
+const HARD_BOUNDARIES = new Set([".", ";", ":", "!", "?"]);
+
+// Conjunctions that bridge list items and should NOT break a negation chain.
+const SOFT_BRIDGES = new Set([",", "and", "or"]);
+
+const LOOKBACK_WINDOW = 5;
+
+/**
+ * Tokenize a free-text clinical string into a flat list of lower-cased
+ * tokens, preserving sentence-terminator punctuation and commas as their
+ * own tokens so the negation scanner can detect boundaries and bridges.
+ *
+ * Slashes (h/o), apostrophes, and hyphens are kept inside tokens so
+ * "fever-free" tokenizes as a single hyphenated token, which lets us
+ * detect the post-term "-free" negation form by simple suffix check.
+ */
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+  // Split on whitespace; then split off leading/trailing punctuation that
+  // matters (.,;:!?) while keeping hyphens and slashes inside the token.
+  for (const raw of text.toLowerCase().split(/\s+/)) {
+    if (!raw) continue;
+    let current = raw;
+    // Strip leading boundary punctuation.
+    while (current.length > 0 && /^[.,;:!?]/.test(current)) {
+      tokens.push(current[0]!);
+      current = current.slice(1);
+    }
+    // Collect trailing boundary punctuation to push AFTER the word body.
+    const trailing: string[] = [];
+    while (current.length > 0 && /[.,;:!?]$/.test(current)) {
+      trailing.unshift(current.slice(-1));
+      current = current.slice(0, -1);
+    }
+    if (current.length > 0) tokens.push(current);
+    for (const t of trailing) tokens.push(t);
+  }
+  return tokens;
+}
+
+/**
+ * Find all start indices in `tokens` where the (already-tokenized) `needle`
+ * appears as a contiguous sub-sequence. Returns indices into the haystack
+ * tokens array, NOT character offsets.
+ */
+function findTermStartIndices(
+  haystack: string[],
+  needle: string[],
+): number[] {
+  const out: number[] = [];
+  if (needle.length === 0) return out;
+  for (let i = 0; i + needle.length <= haystack.length; i++) {
+    let matched = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) out.push(i);
+  }
+  return out;
+}
+
+/**
+ * Return true if the token at `termStart` is negated by something in the
+ * preceding ~5 non-linker tokens, OR by a post-term marker ("absent",
+ * "<term>-free").
+ */
+function isOccurrenceNegated(
+  tokens: string[],
+  termStart: number,
+  termLength: number,
+): boolean {
+  // ── Post-term negation: "fever absent" / "fever absent on exam" ─────────
+  const postIdx = termStart + termLength;
+  if (postIdx < tokens.length) {
+    const next = tokens[postIdx]!;
+    if (next === "absent") return true;
+  }
+
+  // ── Post-term hyphenated form: "fever-free" tokenized as one token ─────
+  // Tokenizer keeps hyphens inside tokens, so "fever-free" matched against
+  // the needle "fever" via the multi-token sub-sequence search WOULD NOT
+  // match (the haystack token is "fever-free", not "fever"). Handle it by
+  // checking any token in haystack that contains the needle followed by
+  // "-free" or "-negative".
+  // (See the explicit scan below — easier than threading through the loop.)
+
+  // ── Pre-term negation: scan backwards up to LOOKBACK_WINDOW non-linker
+  // tokens. Stop on hard sentence boundaries.
+  let stepsTaken = 0;
+  for (let i = termStart - 1; i >= 0 && stepsTaken < LOOKBACK_WINDOW; i--) {
+    const tok = tokens[i]!;
+    if (HARD_BOUNDARIES.has(tok)) return false;
+    if (SOFT_BRIDGES.has(tok)) {
+      // Don't count comma/and/or against the window — they bridge list
+      // items but do not consume a "slot".
+      continue;
+    }
+    if (LINKER_TOKENS.has(tok)) {
+      // Skip linkers (for, of, h, history, ...) without consuming a slot.
+      continue;
+    }
+    if (PRE_NEGATIONS.has(tok)) return true;
+    stepsTaken++;
+  }
+  return false;
+}
+
+/**
+ * Return true if `term` appears in `text` as a non-negated mention.
+ *
+ * - Empty `text` or empty `term` → false.
+ * - Term matching is whole-word (so "feverfew" does NOT match "fever").
+ * - Multi-word terms ("neck stiffness") are supported.
+ * - Case-insensitive on both sides.
+ *
+ * If ANY occurrence of the term in the text is non-negated, returns true.
+ * Only when EVERY occurrence is negated does it return false. This matches
+ * the clinical intent: a single positive mention overrides earlier
+ * negatives ("No fever on admission; now reports fever 102").
+ */
+export function hasUnnegatedMention(text: string, term: string): boolean {
+  if (!text || !term) return false;
+  const haystack = tokenize(text);
+  const needle = tokenize(term);
+  if (needle.length === 0) return false;
+
+  // Detect "<term>-free" / "<term>-negative" suffix forms directly on the
+  // raw lowercase haystack tokens, since the tokenizer keeps hyphens in
+  // the token body.
+  const hyphenatedNegatedForms = new Set<string>();
+  const needleJoined = needle.join("-");
+  hyphenatedNegatedForms.add(`${needleJoined}-free`);
+  hyphenatedNegatedForms.add(`${needleJoined}-negative`);
+
+  // Walk the haystack for either the whole-word multi-token needle OR a
+  // hyphenated negated form.
+  const occurrences = findTermStartIndices(haystack, needle);
+
+  // If there are no whole-word occurrences but a hyphenated-negated form
+  // exists, the term DID appear in the text — but only in a negated form.
+  // Return false: no unnegated mention.
+  if (occurrences.length === 0) {
+    for (const tok of haystack) {
+      if (hyphenatedNegatedForms.has(tok)) return false;
+    }
+    return false;
+  }
+
+  for (const start of occurrences) {
+    if (!isOccurrenceNegated(haystack, start, needle.length)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
+++ b/services/ai-oversight/src/__tests__/cross-specialty-rules.test.ts
@@ -970,6 +970,121 @@ describe("CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 — ANC-aware rules", () => {
       flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001"),
     ).toBeUndefined();
   });
+
+  // ── #1307 negation regression suite ────────────────────────────────────
+  describe("negation handling for fever mention in free-text symptoms (#1307)", () => {
+    // Reproduction case: Margaret Chen, Stage III breast cancer on chemo,
+    // signed SOAP note whose HPI lists "no fever, no neck stiffness, ...".
+    // ANC unknown so CHEMO-FEVER-001 was firing as a warning before #1307.
+    const reproductionCtx = (
+      overrides: Partial<PatientContext> = {},
+    ): PatientContext => ({
+      active_diagnoses: ["Stage III breast cancer"],
+      active_diagnosis_codes: ["C50.911"],
+      active_medications: ["Cisplatin"],
+      new_symptoms: [
+        "New onset severe headache, started this morning, 8/10 intensity. Numbness in left arm.",
+        "No prior headache history of this severity, no migraine history, no recent head trauma, no fever, no neck stiffness, no nausea or vomiting.",
+        "headache",
+        "numbness",
+      ],
+      care_team_specialties: ["oncology"],
+      ...overrides,
+    });
+
+    it("does NOT fire CHEMO-FEVER-001 on the smoke-test reproduction case", () => {
+      const flags = checkCrossSpecialtyPatterns(reproductionCtx());
+      expect(
+        flags.find((f) => f.rule_id === "CHEMO-FEVER-001"),
+      ).toBeUndefined();
+      expect(
+        flags.find((f) => f.rule_id === "CHEMO-NEUTRO-FEVER-001"),
+      ).toBeUndefined();
+    });
+
+    it("STILL fires CHEMO-FEVER-001 when the chief complaint is positive fever", () => {
+      // Regression guard: ensure the negation fix didn't silence true
+      // fever presentations.
+      const ctx = reproductionCtx({
+        new_symptoms: ["fever 102 x 2 days, productive cough"],
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CHEMO-FEVER-001",
+      );
+      expect(flag).toBeDefined();
+      expect(flag!.severity).toBe("warning");
+    });
+
+    it("does NOT fire on 'denies fever'", () => {
+      const ctx = reproductionCtx({
+        new_symptoms: ["denies fever, denies chills"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CHEMO-FEVER-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does NOT fire on 'without fever'", () => {
+      const ctx = reproductionCtx({
+        new_symptoms: ["admitted without fever or other constitutional symptoms"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CHEMO-FEVER-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does NOT fire on 'negative for fever'", () => {
+      const ctx = reproductionCtx({
+        new_symptoms: ["ROS negative for fever, chills, night sweats"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CHEMO-FEVER-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does NOT fire on 'fever-free'", () => {
+      const ctx = reproductionCtx({
+        new_symptoms: ["patient has been fever-free x 24 hours"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CHEMO-FEVER-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("does NOT fire on 'no h/o fever'", () => {
+      const ctx = reproductionCtx({
+        new_symptoms: ["no h/o fever this admission"],
+      });
+      expect(
+        checkCrossSpecialtyPatterns(ctx).find(
+          (f) => f.rule_id === "CHEMO-FEVER-001",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("FIRES when an early negated mention is followed by a later positive mention", () => {
+      // Mixed-signal case: HPI denies fever on admission but nurse charts
+      // an overnight fever later in the same note. The positive mention
+      // wins — the patient currently has a fever and the rule must fire.
+      const ctx = reproductionCtx({
+        new_symptoms: [
+          "No fever on admission. Six hours later T 102.1 with rigors, now febrile.",
+        ],
+      });
+      const flag = checkCrossSpecialtyPatterns(ctx).find(
+        (f) => f.rule_id === "CHEMO-FEVER-001",
+      );
+      expect(flag).toBeDefined();
+    });
+  });
 });
 
 describe("ONCO-VTE-NEURO-001 — Cancer + VTE + neurological symptom", () => {

--- a/services/ai-oversight/src/__tests__/rules.test.ts
+++ b/services/ai-oversight/src/__tests__/rules.test.ts
@@ -82,6 +82,24 @@ vi.mock("@carebridge/medical-logic", () => {
       return diffMs / (365.25 * 24 * 60 * 60 * 1000);
     },
     getVitalRangeForAge,
+    // Stubs for symbols that cross-specialty.ts imports but rules.test.ts
+    // does not exercise directly. parseFrequencyText/deserializeFrequency/
+    // estimateDailyDose are only hit by medication-daily-dose rules whose
+    // tests live elsewhere; returning sentinels keeps the module load
+    // happy without changing behavior in this file.
+    parseFrequencyText: () => null,
+    deserializeFrequency: () => null,
+    estimateDailyDose: () => null,
+    // #1307: negation-aware symptom matcher used by CHEMO-FEVER-* and
+    // CROSS-IMMUNOSUPPRESSED-FEVER-001. Tests in this file feed structured
+    // single-term entries like "fever 101.5" rather than free-text HPI, so
+    // a simple case-insensitive substring check preserves prior behavior
+    // while exposing the export name the rule module imports.
+    hasUnnegatedMention: (text: string, term: string) =>
+      typeof text === "string" &&
+      typeof term === "string" &&
+      term.length > 0 &&
+      text.toLowerCase().includes(term.toLowerCase()),
   };
 });
 

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -12,6 +12,7 @@ import {
   parseFrequencyText,
   deserializeFrequency,
   estimateDailyDose,
+  hasUnnegatedMention,
 } from "@carebridge/medical-logic";
 import { QTC_PATTERN } from "./drug-interactions.js";
 import { METFORMIN_PATTERN, NSAID_PATTERN } from "./shared-drug-patterns.js";
@@ -216,8 +217,31 @@ const ANTICOAGULANT_PATTERN =
 const CHEMO_MED_PATTERN =
   /chemo|capecitabine|xeloda|cisplatin|carboplatin|doxorubicin|cyclophosphamide|paclitaxel|docetaxel|methotrexate|5-fu|fluorouracil/i;
 
-/** Fever-symptom pattern shared across CHEMO-* rules. */
-const FEVER_SYMPTOM_PATTERN = /fever|febrile|temperature|chills/i;
+/**
+ * Fever-equivalent terms checked by the negation-aware matcher. Each entry
+ * is tested independently via `hasUnnegatedMention` so that HPI phrasing
+ * like "no fever, denies chills, temperature 98.6 on admission" does not
+ * trigger the CHEMO-* fever rules (#1307).
+ */
+const FEVER_TERMS = ["fever", "febrile", "temperature", "chills"] as const;
+
+/**
+ * Returns true when any string in `symptoms` contains a non-negated mention
+ * of a fever-equivalent term. Replaces a substring scan that false-
+ * positived on negated mentions — see #1307. Each symptom entry is checked
+ * independently because the clinical-notes service concatenates
+ * chief-complaint, HPI, and structured new-symptom items into the same
+ * `new_symptoms` array; per-entry scanning keeps negation windows local
+ * to a single field.
+ */
+function hasUnnegatedFever(symptoms: readonly string[]): boolean {
+  for (const entry of symptoms) {
+    for (const term of FEVER_TERMS) {
+      if (hasUnnegatedMention(entry, term)) return true;
+    }
+  }
+  return false;
+}
 
 /** ICD-10 pattern for active VTE / DVT / PE diagnoses. */
 const VTE_ICD10_PATTERN = /^(I26|I80|I82)\./;
@@ -723,9 +747,9 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       const onChemo = ctx.active_medications.some((m) =>
         CHEMO_MED_PATTERN.test(m),
       );
-      const hasFever = ctx.new_symptoms.some((s) =>
-        FEVER_SYMPTOM_PATTERN.test(s),
-      );
+      // Negation-aware match (#1307): a SOAP HPI of "no fever, no chills"
+      // must not trip this rule even though the substring "fever" is present.
+      const hasFever = hasUnnegatedFever(ctx.new_symptoms);
       if (!onChemo || !hasFever) return false;
       const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
       // ANC >= 1500 → normal neutrophil count, suppress (avoid alert fatigue).
@@ -754,9 +778,8 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       const onChemo = ctx.active_medications.some((m) =>
         CHEMO_MED_PATTERN.test(m),
       );
-      const hasFever = ctx.new_symptoms.some((s) =>
-        FEVER_SYMPTOM_PATTERN.test(s),
-      );
+      // Negation-aware (#1307) — see CHEMO-FEVER-001 above.
+      const hasFever = hasUnnegatedFever(ctx.new_symptoms);
       if (!onChemo || !hasFever) return false;
       const anc = ctx.recent_labs?.find((l) => /\bANC\b/i.test(l.name))?.value;
       // Only fire when ANC is known AND below the febrile-neutropenia threshold.
@@ -1481,7 +1504,9 @@ const CROSS_SPECIALTY_RULES: CrossSpecialtyRule[] = [
       );
       const onChemo = ctx.active_medications.some((m) => CHEMO_MED_PATTERN.test(m));
       if (hasCancerDx && onChemo) return false;
-      return ctx.new_symptoms.some((s) => FEVER_SYMPTOM_PATTERN.test(s));
+      // Negation-aware (#1307) — keeps a SOAP HPI that says "no fever"
+      // from firing the non-chemo immunosuppressant fever rule too.
+      return hasUnnegatedFever(ctx.new_symptoms);
     },
     severity: "warning" as const,
     category: "cross-specialty" as const,


### PR DESCRIPTION
Closes #1307

## Smoke-test reproduction

Margaret Chen (Stage III breast cancer, on cisplatin) signed a SOAP note this morning whose HPI explicitly says:

> No prior headache history of this severity, no migraine history, no recent head trauma, **no fever**, no neck stiffness, no nausea or vomiting.

The patient's Chief Complaint and structured `new_symptoms` carried **no** fever signal — just `headache` and `numbness`. CHEMO-FEVER-001 fired anyway because the rule did a naive substring scan over the concatenated symptom text (chief complaint + HPI + structured array) and matched the literal token `fever` inside `no fever`. The result was a false-positive warning telling Dr Smith to "obtain CBC urgently to rule out febrile neutropenia."

This is exactly the failure mode that turns the febrile-neutropenia warning into noise. A 60-minute time-to-antibiotic emergency cannot afford alert fatigue.

## Fix

1. **New shared helper** — `hasUnnegatedMention(text, term)` in `packages/medical-logic/src/symptom-negation.ts`. Tokenises the haystack, locates the term, scans the preceding ~5 non-linker tokens for a negation marker, and also detects post-term forms (`fever absent`, `fever-free`). Returns `true` only if at least one occurrence of the term is non-negated, so a mixed-signal note ("no fever on admission; now reports T 102.1") still fires.
2. **Wire the rules** — `CHEMO-FEVER-001`, `CHEMO-NEUTRO-FEVER-001`, and `CROSS-IMMUNOSUPPRESSED-FEVER-001` now call `hasUnnegatedFever()` instead of `FEVER_SYMPTOM_PATTERN.test()`.
3. **Tests** — 24 unit tests on the helper + 8 integration tests on the rule engine including the exact reproduction case.

The helper deliberately lives in `@carebridge/medical-logic` so the UI symptom autocomplete tracked in #1305 can share it. Single source of truth, browser-bundle-safe (no NLP dependency).

## Test plan

- [x] `pnpm --filter @carebridge/medical-logic test` — 566 tests pass, 24 new
- [x] `pnpm --filter @carebridge/ai-oversight test` — 953 tests pass, 8 new integration tests under `CHEMO-FEVER-001 / CHEMO-NEUTRO-FEVER-001 › negation handling for fever mention in free-text symptoms (#1307)`
- [x] `pnpm typecheck` — all 38 packages green
- [x] `pnpm lint` — all 21 lint tasks green

Negation forms covered by unit + integration tests:
- `no fever`
- `not febrile`
- `denies fever`
- `without fever`
- `absent fever` / `fever absent`
- `absence of fever`
- `negative for fever`
- `fever-free`
- `no h/o fever`
- `no history of fever`
- Comma-separated lists: "no fever, no chills, no nausea"
- ROS-style: "ROS negative for fever, chills, night sweats"

Regression guards:
- Positive fever in chief complaint still fires (`new_symptoms: ["fever 102 x 2 days, productive cough"]`)
- Mixed-signal note (negated then positive) fires on the positive mention
- Existing CHEMO-FEVER ANC-stratified tests all still pass