### PR TITLE
feat(portal): symptom grouping + NS↔ROS auto-mirror (#1306)

### DIFF
--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -1017,3 +1017,23 @@ tr:hover td {
     animation-duration: 3s;
   }
 }
+
+/* GroupedMultiselect — issue #1306.
+   Below ~600px the section headers stay row-flow but each section's
+   option grid stacks vertically so a clinician on a phone doesn't get a
+   horizontally-cramped checkbox flow. */
+.grouped-multiselect {
+  width: 100%;
+}
+.grouped-multiselect-header:hover {
+  background: var(--surface-3, rgba(0, 0, 0, 0.04));
+}
+@media (max-width: 599px) {
+  .grouped-multiselect-options {
+    flex-direction: column !important;
+    align-items: flex-start;
+  }
+  .grouped-multiselect-option {
+    width: 100%;
+  }
+}

--- a/apps/clinician-portal/app/notes/new/page.tsx
+++ b/apps/clinician-portal/app/notes/new/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc";
 import { AuthGuard } from "@/lib/auth-guard";
 import { useAuth } from "@/lib/auth";
+import { GroupedMultiselect } from "@/components/grouped-multiselect";
+import {
+  type BodySystem,
+  getSymptomSystem,
+  parseROSOption,
+} from "@/lib/symptom-systems";
 
 type FieldType =
   | "text"
@@ -32,6 +38,55 @@ type NoteSection = {
 };
 
 type TemplateType = "soap" | "progress";
+
+/**
+ * NS and ROS field keys recognised by the SOAP template (see
+ * services/clinical-notes/src/templates/soap.ts). Keeping these as
+ * named constants lets the auto-mirror logic stay readable.
+ */
+const NEW_SYMPTOMS_KEY = "new_symptoms";
+const ROS_KEY = "ros";
+
+const NS_CAPTION = "Symptoms the patient is reporting today.";
+const ROS_CAPTION =
+  "Full systems review for the visit (“all systems negative” allowed).";
+
+/**
+ * Find the ROS option (e.g. "neurological: headache") whose suffix
+ * after the colon matches the bare NS symptom string. Used for the
+ * NS → ROS arm of the auto-mirror.
+ */
+function findROSOptionForSymptom(
+  symptom: string,
+  rosOptions: string[],
+): string | undefined {
+  const needle = symptom.toLowerCase().trim();
+  return rosOptions.find((opt) => {
+    const { symptom: suffix } = parseROSOption(opt);
+    return suffix.toLowerCase() === needle;
+  });
+}
+
+/**
+ * Reverse direction: given a positive ROS option, find the NS option
+ * whose label matches the ROS suffix. NS options are bare strings
+ * (no prefix) so the match is a direct equality.
+ */
+function findNSOptionForROS(
+  rosOption: string,
+  nsOptions: string[],
+): string | undefined {
+  const { symptom } = parseROSOption(rosOption);
+  const needle = symptom.toLowerCase().trim();
+  return nsOptions.find((opt) => opt.toLowerCase() === needle);
+}
+
+/**
+ * Stable key for a NS-ROS pair (used as the unlinked-pair identifier).
+ */
+function pairKey(nsOption: string, rosOption: string): string {
+  return `${nsOption}||${rosOption}`;
+}
 
 function FieldInput({
   field,
@@ -161,12 +216,32 @@ function NewNoteContent() {
   const [patientPrefillNotice, setPatientPrefillNotice] = useState<string>("");
   const [sections, setSections] = useState<NoteSection[]>([]);
 
+  // Per-field collapsed state for body-system groups, keyed as
+  // `{ [fieldKey]: { [BodySystem]: collapsed } }`. Lives in component
+  // state so the toggle state persists for the lifetime of the draft
+  // (closing/reopening the form during a single session keeps the
+  // user's view). #1306.
+  const [sectionCollapseState, setSectionCollapseState] = useState<
+    Record<string, Partial<Record<BodySystem, boolean>>>
+  >({});
+
+  // Pairs the user has explicitly unlinked via the 🔗 icon. Stored as
+  // `"<nsOption>||<rosOption>"` strings so the set is membership-cheap
+  // and easy to serialise if we later persist it. #1306.
+  const [unlinkedPairs, setUnlinkedPairs] = useState<Set<string>>(
+    () => new Set(),
+  );
+
   const patientsQuery = trpc.patients.list.useQuery();
   const templateQuery = trpc.notes.templates.get.useQuery({ type: templateType });
 
   useEffect(() => {
     if (templateQuery.data) {
       setSections(templateQuery.data as unknown as NoteSection[]);
+      // Switching templates resets per-field UI state so a draft with
+      // a different field shape doesn't inherit stale toggles.
+      setSectionCollapseState({});
+      setUnlinkedPairs(new Set());
     }
   }, [templateQuery.data]);
 
@@ -204,6 +279,212 @@ function NewNoteContent() {
       next[sectionIdx].fields[fieldIdx].source = "modified";
       return next;
     });
+  }
+
+  // Resolve which section + field index a key lives at. Used by the
+  // NS↔ROS auto-mirror to update the paired field in one render.
+  const fieldLocations = useMemo(() => {
+    const out = new Map<string, { sIdx: number; fIdx: number }>();
+    sections.forEach((s, sIdx) => {
+      s.fields.forEach((f, fIdx) => {
+        out.set(f.key, { sIdx, fIdx });
+      });
+    });
+    return out;
+  }, [sections]);
+
+  /**
+   * NS ↔ ROS auto-mirror.
+   *
+   * When the user ticks a NS option (e.g. "headache"), look up the
+   * matching ROS option ("neurological: headache") and tick that too,
+   * unless the pair has been explicitly unlinked. Untick mirrors the
+   * same way (positive on one side → positive on the other, untick on
+   * one side → untick on the other). Either direction works.
+   *
+   * The save payload still contains two independent arrays — the link
+   * is purely a UI affordance, so on submit the server sees whatever
+   * the final ticked state was.
+   */
+  const handleMultiselectChange = useCallback(
+    (
+      sIdx: number,
+      fIdx: number,
+      field: NoteField,
+      nextValue: string[],
+    ) => {
+      const prevValue = Array.isArray(field.value)
+        ? (field.value as string[])
+        : [];
+
+      // Compute additions / removals on this field.
+      const added = nextValue.filter((v) => !prevValue.includes(v));
+      const removed = prevValue.filter((v) => !nextValue.includes(v));
+
+      // Mirror only fires for the two known fields.
+      const isNS = field.key === NEW_SYMPTOMS_KEY;
+      const isROS = field.key === ROS_KEY;
+
+      // Apply this field's own change first.
+      setSections((prev) => {
+        const next = prev.map((s) => ({
+          ...s,
+          fields: s.fields.map((f) => ({ ...f })),
+        }));
+        next[sIdx].fields[fIdx].value = nextValue;
+        next[sIdx].fields[fIdx].source = "modified";
+
+        if (!(isNS || isROS)) return next;
+
+        // Find the paired field on the same section.
+        const partnerKey = isNS ? ROS_KEY : NEW_SYMPTOMS_KEY;
+        const loc = fieldLocations.get(partnerKey);
+        if (!loc) return next;
+
+        const partner = next[loc.sIdx].fields[loc.fIdx];
+        const partnerOptions = partner.options ?? [];
+        const partnerSelected = Array.isArray(partner.value)
+          ? [...(partner.value as string[])]
+          : [];
+
+        for (const add of added) {
+          const partnerOpt = isNS
+            ? findROSOptionForSymptom(add, partnerOptions)
+            : findNSOptionForROS(add, partnerOptions);
+          if (!partnerOpt) continue;
+          // The pair key is always nsOption||rosOption regardless of
+          // which side we came from.
+          const key = isNS
+            ? pairKey(add, partnerOpt)
+            : pairKey(partnerOpt, add);
+          if (unlinkedPairs.has(key)) continue;
+          if (!partnerSelected.includes(partnerOpt)) {
+            partnerSelected.push(partnerOpt);
+          }
+        }
+        for (const drop of removed) {
+          const partnerOpt = isNS
+            ? findROSOptionForSymptom(drop, partnerOptions)
+            : findNSOptionForROS(drop, partnerOptions);
+          if (!partnerOpt) continue;
+          const key = isNS
+            ? pairKey(drop, partnerOpt)
+            : pairKey(partnerOpt, drop);
+          if (unlinkedPairs.has(key)) continue;
+          const idx = partnerSelected.indexOf(partnerOpt);
+          if (idx >= 0) partnerSelected.splice(idx, 1);
+        }
+
+        next[loc.sIdx].fields[loc.fIdx] = {
+          ...partner,
+          value: partnerSelected,
+          source: "modified",
+        };
+        return next;
+      });
+    },
+    [fieldLocations, unlinkedPairs],
+  );
+
+  /**
+   * Toggle one body-system group's collapsed state. Falls back to the
+   * default expansion (NS expanded / ROS collapsed) on first touch so
+   * the first click feels intentional rather than no-op.
+   */
+  const toggleSection = useCallback(
+    (fieldKey: string, system: BodySystem, defaultExpanded: boolean) => {
+      setSectionCollapseState((prev) => {
+        const fieldState = prev[fieldKey] ?? {};
+        const current =
+          fieldState[system] !== undefined
+            ? fieldState[system]!
+            : !defaultExpanded;
+        return {
+          ...prev,
+          [fieldKey]: {
+            ...fieldState,
+            [system]: !current,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  /**
+   * Unlink a NS/ROS pair via the 🔗 icon. The icon dispatches the bare
+   * option the user clicked on; we resolve the partner and record the
+   * pair as unlinked. Future ticks on either side no longer mirror.
+   */
+  const handleUnlink = useCallback(
+    (sourceField: NoteField, option: string) => {
+      const isNS = sourceField.key === NEW_SYMPTOMS_KEY;
+      const isROS = sourceField.key === ROS_KEY;
+      if (!(isNS || isROS)) return;
+      const partnerKey = isNS ? ROS_KEY : NEW_SYMPTOMS_KEY;
+      const loc = fieldLocations.get(partnerKey);
+      if (!loc) return;
+      const partnerOptions =
+        sections[loc.sIdx].fields[loc.fIdx].options ?? [];
+      const partnerOpt = isNS
+        ? findROSOptionForSymptom(option, partnerOptions)
+        : findNSOptionForROS(option, partnerOptions);
+      if (!partnerOpt) return;
+      const key = isNS
+        ? pairKey(option, partnerOpt)
+        : pairKey(partnerOpt, option);
+      setUnlinkedPairs((prev) => {
+        if (prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+    },
+    [fieldLocations, sections],
+  );
+
+  /**
+   * Compute the set of currently-linked option strings (within a given
+   * field) for the 🔗 indicator. A row is "linked" when (a) it is
+   * ticked, (b) the partner field also has its analog ticked, and (c)
+   * the pair is not in `unlinkedPairs`.
+   */
+  function linkedOptionsFor(fieldKey: string): Set<string> {
+    const out = new Set<string>();
+    const nsLoc = fieldLocations.get(NEW_SYMPTOMS_KEY);
+    const rosLoc = fieldLocations.get(ROS_KEY);
+    if (!nsLoc || !rosLoc) return out;
+    const nsField = sections[nsLoc.sIdx].fields[nsLoc.fIdx];
+    const rosField = sections[rosLoc.sIdx].fields[rosLoc.fIdx];
+    const nsSelected = Array.isArray(nsField.value)
+      ? (nsField.value as string[])
+      : [];
+    const rosSelected = Array.isArray(rosField.value)
+      ? (rosField.value as string[])
+      : [];
+    const rosOptions = rosField.options ?? [];
+    const nsOptions = nsField.options ?? [];
+    for (const ns of nsSelected) {
+      const ros = findROSOptionForSymptom(ns, rosOptions);
+      if (!ros) continue;
+      if (!rosSelected.includes(ros)) continue;
+      if (unlinkedPairs.has(pairKey(ns, ros))) continue;
+      if (fieldKey === NEW_SYMPTOMS_KEY) out.add(ns);
+      if (fieldKey === ROS_KEY) out.add(ros);
+    }
+    // Cover ROS-side selections that also have a NS analog — usually
+    // the same pair the loop above already added, but guards against
+    // ROS-only entries with a matching NS that the NS-side loop missed
+    // due to ordering quirks.
+    for (const ros of rosSelected) {
+      const ns = findNSOptionForROS(ros, nsOptions);
+      if (!ns) continue;
+      if (!nsSelected.includes(ns)) continue;
+      if (unlinkedPairs.has(pairKey(ns, ros))) continue;
+      if (fieldKey === NEW_SYMPTOMS_KEY) out.add(ns);
+      if (fieldKey === ROS_KEY) out.add(ros);
+    }
+    return out;
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -299,19 +580,90 @@ function NewNoteContent() {
           sections.map((section, sIdx) => (
             <div key={section.key} className="detail-card" style={{ marginBottom: 16 }}>
               <div className="detail-card-title">{section.label}</div>
-              {section.fields.map((field, fIdx) => (
-                <div
-                  key={field.key}
-                  className="detail-row"
-                  style={{ flexDirection: "column", gap: 4, alignItems: "stretch" }}
-                >
-                  <label className="detail-label">{field.label}</label>
-                  <FieldInput
-                    field={field}
-                    onChange={(v) => updateField(sIdx, fIdx, v)}
-                  />
-                </div>
-              ))}
+              {section.fields.map((field, fIdx) => {
+                const isNS = field.key === NEW_SYMPTOMS_KEY;
+                const isROS = field.key === ROS_KEY;
+                const isGrouped =
+                  (isNS || isROS) &&
+                  field.field_type === "multiselect" &&
+                  Array.isArray(field.options);
+
+                if (isGrouped) {
+                  const defaultExpanded = isNS;
+                  const selected = Array.isArray(field.value)
+                    ? (field.value as string[])
+                    : [];
+                  const collapsed =
+                    sectionCollapseState[field.key] ?? {};
+                  const linked = linkedOptionsFor(field.key);
+                  return (
+                    <div
+                      key={field.key}
+                      className="detail-row"
+                      style={{
+                        flexDirection: "column",
+                        gap: 4,
+                        alignItems: "stretch",
+                      }}
+                    >
+                      <label className="detail-label">{field.label}</label>
+                      <p
+                        className="grouped-multiselect-caption"
+                        style={{
+                          fontSize: 12,
+                          color: "var(--text-muted)",
+                          margin: 0,
+                        }}
+                      >
+                        {isNS ? NS_CAPTION : ROS_CAPTION}
+                      </p>
+                      <GroupedMultiselect
+                        fieldKey={field.key}
+                        options={field.options ?? []}
+                        selected={selected}
+                        onChange={(next) =>
+                          handleMultiselectChange(sIdx, fIdx, field, next)
+                        }
+                        groupOf={
+                          isNS
+                            ? (opt) => ({
+                                system: getSymptomSystem(opt),
+                                display: opt,
+                              })
+                            : (opt) => {
+                                const parsed = parseROSOption(opt);
+                                return {
+                                  system: parsed.system,
+                                  display: parsed.symptom,
+                                };
+                              }
+                        }
+                        collapsed={collapsed}
+                        onToggleSection={(system) =>
+                          toggleSection(field.key, system, defaultExpanded)
+                        }
+                        defaultExpanded={defaultExpanded}
+                        linkedOptions={linked}
+                        onUnlink={(opt) => handleUnlink(field, opt)}
+                      />
+                    </div>
+                  );
+                }
+
+                return (
+                  <div
+                    key={field.key}
+                    className="detail-row"
+                    style={{ flexDirection: "column", gap: 4, alignItems: "stretch" }}
+                  >
+                    <label className="detail-label">{field.label}</label>
+                    <FieldInput
+                      field={field}
+                      onChange={(v) => updateField(sIdx, fIdx, v)}
+                    />
+                  </div>
+                );
+              })}
             </div>
           ))
         )}

--- a/apps/clinician-portal/src/__tests__/grouped-multiselect.test.tsx
+++ b/apps/clinician-portal/src/__tests__/grouped-multiselect.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1306 — collapsible body-system grouping for the SOAP Subjective
+ * checkboxes. These tests pin the rendering contract of the reusable
+ * GroupedMultiselect component:
+ *
+ *   1. Section order follows BODY_SYSTEM_ORDER (Neurological,
+ *      Cardiovascular, Respiratory, Gastrointestinal, Constitutional)
+ *      with anything else sorted alphabetically after.
+ *   2. defaultExpanded=true renders every section expanded; the option
+ *      grids are visible and the count badge is hidden.
+ *   3. defaultExpanded=false collapses every section by default and a
+ *      "(N)" count badge appears next to systems with ticked items.
+ *   4. Clicking a header toggles the section's expanded state via the
+ *      onToggleSection callback.
+ *   5. Linked options render a 🔗 icon next to the row label, and
+ *      clicking that icon dispatches onUnlink with the bare option.
+ */
+import React, { useState } from "react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+
+import {
+  type BodySystem,
+  getSymptomSystem,
+  parseROSOption,
+} from "@/lib/symptom-systems";
+import { GroupedMultiselect } from "../components/grouped-multiselect";
+
+// Wrapper that lets us drive the controlled collapsed/selected state
+// from inside the test, so we exercise the same code paths the real
+// NewNoteContent uses.
+function Harness({
+  options,
+  initiallySelected = [],
+  defaultExpanded,
+  linkedOptions,
+  onUnlink,
+  fieldKey = "new_symptoms",
+}: {
+  options: string[];
+  initiallySelected?: string[];
+  defaultExpanded: boolean;
+  linkedOptions?: Set<string>;
+  onUnlink?: (opt: string) => void;
+  fieldKey?: string;
+}) {
+  const [selected, setSelected] = useState<string[]>(initiallySelected);
+  const [collapsed, setCollapsed] = useState<
+    Partial<Record<BodySystem, boolean>>
+  >({});
+  return (
+    <GroupedMultiselect
+      fieldKey={fieldKey}
+      options={options}
+      selected={selected}
+      onChange={setSelected}
+      groupOf={
+        fieldKey === "ros"
+          ? (o) => {
+              const p = parseROSOption(o);
+              return { system: p.system, display: p.symptom };
+            }
+          : (o) => ({ system: getSymptomSystem(o), display: o })
+      }
+      collapsed={collapsed}
+      onToggleSection={(s) =>
+        setCollapsed((prev) => {
+          const cur =
+            prev[s] !== undefined ? prev[s]! : !defaultExpanded;
+          return { ...prev, [s]: !cur };
+        })
+      }
+      defaultExpanded={defaultExpanded}
+      linkedOptions={linkedOptions}
+      onUnlink={onUnlink}
+    />
+  );
+}
+
+const NS_OPTIONS = [
+  "headache",
+  "dizziness",
+  "chest pain",
+  "cough",
+  "nausea",
+  "fever",
+];
+
+const ROS_OPTIONS = [
+  "constitutional: fever",
+  "cardiovascular: chest pain",
+  "respiratory: cough",
+  "gastrointestinal: nausea",
+  "neurological: headache",
+];
+
+describe("GroupedMultiselect (issue #1306)", () => {
+  afterEach(() => cleanup());
+
+  it("renders body-system sections in canonical order (Neuro → Cardio → Resp → GI → Constitutional)", () => {
+    render(<Harness options={NS_OPTIONS} defaultExpanded={true} />);
+    const headings = screen
+      .getAllByRole("button", { expanded: true })
+      .map((b) => b.textContent?.replace(/[▾▸]\s*/g, "").trim() ?? "");
+    expect(headings).toEqual([
+      "Neurological",
+      "Cardiovascular",
+      "Respiratory",
+      "Gastrointestinal",
+      "Constitutional",
+    ]);
+  });
+
+  it("defaults to ALL EXPANDED when defaultExpanded=true (New Symptoms)", () => {
+    render(<Harness options={NS_OPTIONS} defaultExpanded={true} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBe(5);
+    for (const b of buttons) {
+      expect(b.getAttribute("aria-expanded")).toBe("true");
+      expect(b.textContent?.startsWith("▾")).toBe(true);
+    }
+  });
+
+  it("defaults to ALL COLLAPSED when defaultExpanded=false (Review of Systems)", () => {
+    render(
+      <Harness
+        options={ROS_OPTIONS}
+        defaultExpanded={false}
+        fieldKey="ros"
+      />,
+    );
+    const buttons = screen.getAllByRole("button");
+    for (const b of buttons) {
+      expect(b.getAttribute("aria-expanded")).toBe("false");
+      expect(b.textContent?.startsWith("▸")).toBe(true);
+    }
+    // No option region is visible.
+    expect(screen.queryAllByRole("region")).toHaveLength(0);
+  });
+
+  it("displays (N) count next to collapsed sections with ticked items", () => {
+    render(
+      <Harness
+        options={ROS_OPTIONS}
+        initiallySelected={[
+          "constitutional: fever",
+          "neurological: headache",
+        ]}
+        defaultExpanded={false}
+        fieldKey="ros"
+      />,
+    );
+    // Section labels include the count for systems with selections.
+    const constitutional = screen.getByRole("button", {
+      name: /Constitutional/,
+    });
+    expect(constitutional.textContent).toMatch(/\(1\)/);
+    const neuro = screen.getByRole("button", { name: /Neurological/ });
+    expect(neuro.textContent).toMatch(/\(1\)/);
+    // Sections without ticked items do not show the badge.
+    const respiratory = screen.getByRole("button", { name: /Respiratory/ });
+    expect(respiratory.textContent).not.toMatch(/\(/);
+  });
+
+  it("toggles expand/collapse when the header is clicked", () => {
+    render(<Harness options={NS_OPTIONS} defaultExpanded={true} />);
+    const neuro = screen.getByRole("button", { name: /Neurological/ });
+    expect(neuro.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(neuro);
+    expect(neuro.getAttribute("aria-expanded")).toBe("false");
+    expect(neuro.textContent?.startsWith("▸")).toBe(true);
+
+    fireEvent.click(neuro);
+    expect(neuro.getAttribute("aria-expanded")).toBe("true");
+    expect(neuro.textContent?.startsWith("▾")).toBe(true);
+  });
+
+  it("renders the 🔗 icon next to linked options and dispatches onUnlink when clicked", () => {
+    const onUnlink = vi.fn();
+    render(
+      <Harness
+        options={NS_OPTIONS}
+        initiallySelected={["headache"]}
+        defaultExpanded={true}
+        linkedOptions={new Set(["headache"])}
+        onUnlink={onUnlink}
+      />,
+    );
+    const unlinkBtn = screen.getByRole("button", {
+      name: /Unlink headache/i,
+    });
+    expect(unlinkBtn).toBeTruthy();
+    fireEvent.click(unlinkBtn);
+    expect(onUnlink).toHaveBeenCalledWith("headache");
+  });
+
+  it("does not render the 🔗 icon for non-linked checked rows", () => {
+    render(
+      <Harness
+        options={NS_OPTIONS}
+        initiallySelected={["headache", "dizziness"]}
+        defaultExpanded={true}
+        linkedOptions={new Set(["headache"])}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Unlink headache/i }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /Unlink dizziness/i }),
+    ).toBeNull();
+  });
+
+  it("uses the parsed ROS suffix as the row label", () => {
+    render(
+      <Harness
+        options={ROS_OPTIONS}
+        defaultExpanded={true}
+        fieldKey="ros"
+      />,
+    );
+    // The Neurological section row should read 'headache', not
+    // 'neurological: headache'.
+    const neuroRegion = screen
+      .getByRole("button", { name: /Neurological/ })
+      .nextElementSibling;
+    expect(neuroRegion).toBeTruthy();
+    expect(within(neuroRegion as HTMLElement).getByText("headache")).toBeTruthy();
+  });
+});

--- a/apps/clinician-portal/src/__tests__/new-note-symptom-mirror.test.tsx
+++ b/apps/clinician-portal/src/__tests__/new-note-symptom-mirror.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1306 — NS ↔ ROS auto-mirror integration on /notes/new.
+ *
+ * These tests mount the real NewNotePage with a stub trpc that hands
+ * back a SOAP-shaped template containing the two multiselect fields,
+ * then drive the page through realistic interactions:
+ *
+ *   1. Captions appear under the NS and ROS field labels.
+ *   2. NS defaults to fully expanded; ROS defaults to fully collapsed.
+ *   3. Ticking a NS option (headache) auto-ticks the matching ROS
+ *      option ("neurological: headache") and a 🔗 indicator renders
+ *      next to BOTH rows.
+ *   4. Clicking the 🔗 icon unlinks the pair: the icon disappears, and
+ *      subsequent ticks/unticks on either side no longer mirror.
+ *   5. Reverse-direction mirror: ticking the ROS row also ticks the
+ *      bare NS option, and 🔗 renders on both rows.
+ */
+import React from "react";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+
+// ---------------------------------------------------------------------
+// Mock state shared across tests. Reset in beforeEach.
+// ---------------------------------------------------------------------
+
+type StubField = {
+  key: string;
+  label: string;
+  value: string | string[] | boolean | number | null;
+  field_type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "multiselect"
+    | "checkbox"
+    | "number";
+  source: "new_entry" | "carried_forward" | "modified";
+  options?: string[];
+};
+
+const ROS_OPTIONS = [
+  "constitutional: fever",
+  "constitutional: fatigue",
+  "constitutional: night sweats",
+  "cardiovascular: chest pain",
+  "respiratory: cough",
+  "gastrointestinal: nausea",
+  "neurological: headache",
+  "neurological: dizziness",
+];
+
+const NS_OPTIONS = [
+  "headache",
+  "dizziness",
+  "chest pain",
+  "cough",
+  "nausea",
+  "fever",
+  "fatigue",
+  "night sweats",
+];
+
+const TEMPLATE: { key: string; label: string; fields: StubField[] }[] = [
+  {
+    key: "subjective",
+    label: "Subjective",
+    fields: [
+      {
+        key: "new_symptoms",
+        label: "New Symptoms",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: NS_OPTIONS,
+      },
+      {
+        key: "ros",
+        label: "Review of Systems",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: ROS_OPTIONS,
+      },
+    ],
+  },
+];
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/trpc", () => {
+  const trpc = {
+    patients: {
+      list: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
+    },
+    notes: {
+      templates: {
+        get: {
+          useQuery: () => ({
+            data: TEMPLATE,
+            isLoading: false,
+            isError: false,
+          }),
+        },
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+          isError: false,
+          error: null,
+        }),
+      },
+    },
+  };
+  return { trpc };
+});
+
+import NewNotePage from "../../app/notes/new/page";
+
+beforeEach(() => {
+  // Reset the templates' top-level value arrays so each test starts
+  // from an empty selection. NoteField objects are cloned inside the
+  // page when setSections runs, so the parent ref stays stable.
+  for (const section of TEMPLATE) {
+    for (const f of section.fields) {
+      if (f.field_type === "multiselect") f.value = [];
+    }
+  }
+});
+
+afterEach(() => cleanup());
+
+// Helper to find a section header button within either NS or ROS by
+// the surrounding `data-field-key` wrapper.
+function getFieldRoot(fieldKey: string): HTMLElement {
+  const el = document.querySelector(`[data-field-key="${fieldKey}"]`);
+  if (!el) throw new Error(`No grouped multiselect for ${fieldKey}`);
+  return el as HTMLElement;
+}
+
+function getHeader(
+  fieldKey: string,
+  systemLabel: RegExp | string,
+): HTMLButtonElement {
+  const root = getFieldRoot(fieldKey);
+  return within(root).getByRole("button", { name: systemLabel }) as HTMLButtonElement;
+}
+
+function getOptionCheckbox(
+  fieldKey: string,
+  rowLabel: string,
+): HTMLInputElement {
+  const root = getFieldRoot(fieldKey);
+  // Row label is the <span> text — locate by visible text and walk
+  // up to the surrounding <label>.
+  const labelEl = within(root)
+    .getByText(rowLabel, { exact: true })
+    .closest("label");
+  if (!labelEl) throw new Error(`No row labelled ${rowLabel} under ${fieldKey}`);
+  const cb = labelEl.querySelector('input[type="checkbox"]');
+  if (!cb) throw new Error(`No checkbox in row ${rowLabel}`);
+  return cb as HTMLInputElement;
+}
+
+describe("/notes/new — NS ↔ ROS auto-mirror (#1306)", () => {
+  it("renders captions under both NS and ROS field labels", () => {
+    render(<NewNotePage />);
+    expect(
+      screen.getByText(/Symptoms the patient is reporting today\./i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Full systems review for the visit/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("defaults: NS sections all expanded, ROS sections all collapsed", () => {
+    render(<NewNotePage />);
+
+    const nsRoot = getFieldRoot("new_symptoms");
+    const nsButtons = within(nsRoot).getAllByRole("button");
+    for (const b of nsButtons) {
+      expect(b.getAttribute("aria-expanded")).toBe("true");
+    }
+
+    const rosRoot = getFieldRoot("ros");
+    const rosButtons = within(rosRoot).getAllByRole("button");
+    for (const b of rosButtons) {
+      expect(b.getAttribute("aria-expanded")).toBe("false");
+    }
+  });
+
+  it("ticking NS 'headache' auto-ticks ROS 'neurological: headache' and shows 🔗 on both rows", () => {
+    render(<NewNotePage />);
+
+    // Expand the ROS Neurological section so we can inspect the row.
+    fireEvent.click(getHeader("ros", /Neurological/));
+
+    const nsHeadache = getOptionCheckbox("new_symptoms", "headache");
+    fireEvent.click(nsHeadache);
+
+    // ROS row got auto-ticked.
+    const rosHeadache = getOptionCheckbox("ros", "headache");
+    expect(rosHeadache.checked).toBe(true);
+
+    // 🔗 unlink button is present next to BOTH rows.
+    const nsRoot = getFieldRoot("new_symptoms");
+    const rosRoot = getFieldRoot("ros");
+    expect(
+      within(nsRoot).getByRole("button", { name: /Unlink headache/i }),
+    ).toBeTruthy();
+    expect(
+      within(rosRoot).getByRole("button", { name: /Unlink headache/i }),
+    ).toBeTruthy();
+  });
+
+  it("clicking the 🔗 icon unlinks the pair; the icon disappears and future ticks no longer mirror", () => {
+    render(<NewNotePage />);
+    fireEvent.click(getHeader("ros", /Neurological/));
+
+    fireEvent.click(getOptionCheckbox("new_symptoms", "headache"));
+
+    // Unlink via the NS-side icon.
+    const nsRoot = getFieldRoot("new_symptoms");
+    const unlinkBtn = within(nsRoot).getByRole("button", {
+      name: /Unlink headache/i,
+    });
+    fireEvent.click(unlinkBtn);
+
+    // 🔗 disappears from both sides.
+    expect(
+      within(getFieldRoot("new_symptoms")).queryByRole("button", {
+        name: /Unlink headache/i,
+      }),
+    ).toBeNull();
+    expect(
+      within(getFieldRoot("ros")).queryByRole("button", {
+        name: /Unlink headache/i,
+      }),
+    ).toBeNull();
+
+    // Untick NS — ROS stays checked because the pair is unlinked.
+    fireEvent.click(getOptionCheckbox("new_symptoms", "headache"));
+    expect(getOptionCheckbox("ros", "headache").checked).toBe(true);
+    expect(getOptionCheckbox("new_symptoms", "headache").checked).toBe(false);
+
+    // Re-tick NS — ROS already checked, still no mirror activity, and
+    // no 🔗 reappears because the unlinked entry is sticky.
+    fireEvent.click(getOptionCheckbox("new_symptoms", "headache"));
+    expect(getOptionCheckbox("ros", "headache").checked).toBe(true);
+    expect(
+      within(getFieldRoot("new_symptoms")).queryByRole("button", {
+        name: /Unlink headache/i,
+      }),
+    ).toBeNull();
+  });
+
+  it("reverse-direction mirror: ticking ROS 'constitutional: fever' auto-ticks NS 'fever' and shows 🔗 on both", () => {
+    render(<NewNotePage />);
+    // Expand the ROS Constitutional section first.
+    fireEvent.click(getHeader("ros", /Constitutional/));
+
+    fireEvent.click(getOptionCheckbox("ros", "fever"));
+
+    // NS auto-ticked.
+    expect(getOptionCheckbox("new_symptoms", "fever").checked).toBe(true);
+
+    // 🔗 on both rows.
+    expect(
+      within(getFieldRoot("new_symptoms")).getByRole("button", {
+        name: /Unlink fever/i,
+      }),
+    ).toBeTruthy();
+    expect(
+      within(getFieldRoot("ros")).getByRole("button", {
+        name: /Unlink fever/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("collapsed ROS sections show (N) counts after auto-mirroring populates them", () => {
+    render(<NewNotePage />);
+
+    // Tick NS headache without expanding the ROS section — ROS
+    // remains collapsed but the count badge must surface.
+    fireEvent.click(getOptionCheckbox("new_symptoms", "headache"));
+
+    const rosNeuroHeader = getHeader("ros", /Neurological/);
+    expect(rosNeuroHeader.getAttribute("aria-expanded")).toBe("false");
+    expect(rosNeuroHeader.textContent).toMatch(/\(1\)/);
+  });
+});

--- a/apps/clinician-portal/src/components/grouped-multiselect.tsx
+++ b/apps/clinician-portal/src/components/grouped-multiselect.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/**
+ * GroupedMultiselect — issue #1306.
+ *
+ * Renders a multiselect checkbox grid grouped by body system. Each
+ * group is a collapsible section with a `▾`/`▸` toggle and (when
+ * collapsed) a `(N)` count of ticked items.
+ *
+ * Used for the SOAP Subjective "New Symptoms" and "Review of Systems"
+ * fields. The component is data-shape agnostic: the caller supplies
+ * the option list plus a `groupOf(option)` function that maps each
+ * raw option string to a body-system bucket. The caller also owns the
+ * collapse state and the optional NS↔ROS link affordances.
+ *
+ * Mobile responsiveness (<600px) is driven by the `grouped-multiselect`
+ * class hooks consumed by globals.css.
+ */
+
+import { type CSSProperties, useMemo } from "react";
+import {
+  type BodySystem,
+  sortBodySystems,
+} from "@/lib/symptom-systems";
+
+export type GroupedMultiselectProps = {
+  /** Identifier used to namespace ids (e.g. `new_symptoms`). */
+  fieldKey: string;
+  /** Raw options exactly as they appear in the template. */
+  options: string[];
+  /** Currently selected option strings. */
+  selected: string[];
+  /** Notified when the selection changes. */
+  onChange: (next: string[]) => void;
+  /**
+   * Maps an option to its body-system bucket. The result drives both
+   * grouping (which section a row belongs in) and the display label
+   * (what the row shows in the row body).
+   */
+  groupOf: (option: string) => { system: BodySystem; display: string };
+  /** Per-system collapsed state. Missing key → use `defaultExpanded`. */
+  collapsed: Partial<Record<BodySystem, boolean>>;
+  /** Toggle handler — flips the collapsed state for one system. */
+  onToggleSection: (system: BodySystem) => void;
+  /** Initial expansion state for sections not in `collapsed`. */
+  defaultExpanded: boolean;
+  /**
+   * Linked indicator: when an option string appears in this set, a 🔗
+   * indicator renders next to the row. Clicking the icon invokes
+   * `onUnlink` for the option.
+   */
+  linkedOptions?: Set<string>;
+  /** Click handler for the 🔗 icon. Receives the option string. */
+  onUnlink?: (option: string) => void;
+};
+
+const linkButtonStyle: CSSProperties = {
+  marginLeft: 4,
+  padding: 0,
+  border: "none",
+  background: "transparent",
+  cursor: "pointer",
+  fontSize: 12,
+  lineHeight: 1,
+};
+
+export function GroupedMultiselect({
+  fieldKey,
+  options,
+  selected,
+  onChange,
+  groupOf,
+  collapsed,
+  onToggleSection,
+  defaultExpanded,
+  linkedOptions,
+  onUnlink,
+}: GroupedMultiselectProps) {
+  // Bucket options by body system, preserving original option order
+  // within each bucket so the curated NS ordering survives.
+  const buckets = useMemo(() => {
+    const map = new Map<BodySystem, { option: string; display: string }[]>();
+    for (const opt of options) {
+      const { system, display } = groupOf(opt);
+      const arr = map.get(system) ?? [];
+      arr.push({ option: opt, display });
+      map.set(system, arr);
+    }
+    return map;
+  }, [options, groupOf]);
+
+  const orderedSystems = useMemo(
+    () => sortBodySystems([...buckets.keys()]),
+    [buckets],
+  );
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  function toggleOption(option: string, checked: boolean) {
+    if (checked) {
+      if (!selectedSet.has(option)) {
+        onChange([...selected, option]);
+      }
+    } else {
+      onChange(selected.filter((s) => s !== option));
+    }
+  }
+
+  return (
+    <div
+      className="grouped-multiselect"
+      data-field-key={fieldKey}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      {orderedSystems.map((system) => {
+        const rows = buckets.get(system) ?? [];
+        const checkedCount = rows.filter((r) => selectedSet.has(r.option))
+          .length;
+        const isCollapsed =
+          collapsed[system] !== undefined
+            ? collapsed[system]!
+            : !defaultExpanded;
+        const headerId = `${fieldKey}-${system.replace(/[^a-zA-Z0-9]/g, "_")}-header`;
+        const regionId = `${fieldKey}-${system.replace(/[^a-zA-Z0-9]/g, "_")}-region`;
+
+        return (
+          <section
+            key={system}
+            className="grouped-multiselect-section"
+            data-system={system}
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              overflow: "hidden",
+            }}
+          >
+            <button
+              type="button"
+              id={headerId}
+              className="grouped-multiselect-header"
+              aria-expanded={!isCollapsed}
+              aria-controls={regionId}
+              onClick={() => onToggleSection(system)}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "6px 8px",
+                background: "var(--surface-2, transparent)",
+                border: "none",
+                borderBottom: isCollapsed
+                  ? "none"
+                  : "1px solid var(--border)",
+                cursor: "pointer",
+                fontSize: 13,
+                fontWeight: 600,
+                textAlign: "left",
+              }}
+            >
+              <span aria-hidden="true" style={{ width: "1em" }}>
+                {isCollapsed ? "▸" : "▾"}
+              </span>
+              <span>{system}</span>
+              {isCollapsed && checkedCount > 0 && (
+                <span
+                  className="grouped-multiselect-count"
+                  style={{
+                    marginLeft: 4,
+                    fontSize: 12,
+                    color: "var(--text-muted)",
+                    fontWeight: 400,
+                  }}
+                >
+                  ({checkedCount})
+                </span>
+              )}
+            </button>
+            {!isCollapsed && (
+              <div
+                id={regionId}
+                role="region"
+                aria-labelledby={headerId}
+                className="grouped-multiselect-options"
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 6,
+                  padding: 8,
+                }}
+              >
+                {rows.map(({ option, display }) => {
+                  const checked = selectedSet.has(option);
+                  const linked = linkedOptions?.has(option) ?? false;
+                  return (
+                    <label
+                      key={option}
+                      className="grouped-multiselect-option"
+                      style={{
+                        fontSize: 12,
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 4,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) =>
+                          toggleOption(option, e.target.checked)
+                        }
+                      />
+                      <span>{display}</span>
+                      {linked && (
+                        <button
+                          type="button"
+                          aria-label={`Unlink ${display} from the matching entry`}
+                          title="Unlink this pair — each row will then track independently"
+                          onClick={(e) => {
+                            // Prevent the surrounding <label> from
+                            // toggling the checkbox when the icon is
+                            // clicked.
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onUnlink?.(option);
+                          }}
+                          style={linkButtonStyle}
+                          data-linked-option={option}
+                        >
+                          <span aria-hidden="true">{"🔗"}</span>
+                        </button>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/clinician-portal/src/lib/symptom-systems.ts
+++ b/apps/clinician-portal/src/lib/symptom-systems.ts
@@ -1,0 +1,169 @@
+/**
+ * Body-system grouping for the SOAP Subjective checkboxes.
+ *
+ * Issue #1306 — clinicians scan by body system, so the New Symptoms grid
+ * and the Review of Systems grid both render as collapsible sections
+ * grouped by body system instead of one flat checkbox flow.
+ *
+ * Two inputs feed grouping:
+ *
+ *   1. New Symptoms options are raw lowercase strings (e.g. "headache",
+ *      "chest pain"). They have no prefix, so we look them up in the
+ *      curated SYMPTOM_SYSTEM_MAP below. Anything unmapped falls back
+ *      to "Other" so the UI never silently drops an option.
+ *
+ *   2. Review of Systems options come from the shared template as
+ *      "<system-key>: <symptom>" pairs (e.g. "constitutional: fever").
+ *      We split on the first colon and map the prefix through
+ *      ROS_PREFIX_TO_SYSTEM to a canonical title-cased body system.
+ *
+ * BODY_SYSTEM_ORDER pins the render order. Per the design, the five
+ * "common" systems lead in a clinically motivated order, then anything
+ * else falls back to alphabetical (handled by the caller, not here).
+ */
+
+export type BodySystem =
+  | "Neurological"
+  | "Cardiovascular"
+  | "Respiratory"
+  | "Gastrointestinal"
+  | "Constitutional"
+  | "Eyes"
+  | "ENT"
+  | "Genitourinary"
+  | "Musculoskeletal"
+  | "Skin"
+  | "Psychiatric"
+  | "Endocrine"
+  | "Hematologic"
+  | "Allergic/Immunologic"
+  | "Other";
+
+/**
+ * Canonical render order for body-system sections.
+ * The first five are the design-pinned "lead" order; remaining systems
+ * sort alphabetically after these via the consumer.
+ */
+export const BODY_SYSTEM_ORDER: BodySystem[] = [
+  "Neurological",
+  "Cardiovascular",
+  "Respiratory",
+  "Gastrointestinal",
+  "Constitutional",
+];
+
+/**
+ * Lookup of a New Symptoms label to its body system. Mirrors the
+ * groupings hard-coded in services/clinical-notes/src/templates/soap.ts
+ * so the UI grouping stays in lockstep with the template's intent.
+ */
+export const SYMPTOM_SYSTEM_MAP: Record<string, BodySystem> = {
+  // Neurological
+  headache: "Neurological",
+  dizziness: "Neurological",
+  numbness: "Neurological",
+  tingling: "Neurological",
+  "vision changes": "Neurological",
+  "speech difficulty": "Neurological",
+  confusion: "Neurological",
+  syncope: "Neurological",
+  seizure: "Neurological",
+  // Cardiovascular
+  "chest pain": "Cardiovascular",
+  palpitations: "Cardiovascular",
+  edema: "Cardiovascular",
+  // Respiratory
+  cough: "Respiratory",
+  "shortness of breath": "Respiratory",
+  wheezing: "Respiratory",
+  // Gastrointestinal
+  nausea: "Gastrointestinal",
+  vomiting: "Gastrointestinal",
+  diarrhea: "Gastrointestinal",
+  "abdominal pain": "Gastrointestinal",
+  // Constitutional
+  fever: "Constitutional",
+  fatigue: "Constitutional",
+  "weight loss": "Constitutional",
+  "night sweats": "Constitutional",
+};
+
+/**
+ * Canonical title-cased body system per ROS prefix. Aligns with the
+ * ROS_SYSTEMS keys in @carebridge/shared-types/notes.ts.
+ */
+export const ROS_PREFIX_TO_SYSTEM: Record<string, BodySystem> = {
+  constitutional: "Constitutional",
+  eyes: "Eyes",
+  ent: "ENT",
+  cardiovascular: "Cardiovascular",
+  respiratory: "Respiratory",
+  gi: "Gastrointestinal",
+  gastrointestinal: "Gastrointestinal",
+  genitourinary: "Genitourinary",
+  gu: "Genitourinary",
+  ms: "Musculoskeletal",
+  musculoskeletal: "Musculoskeletal",
+  skin: "Skin",
+  neuro: "Neurological",
+  neurological: "Neurological",
+  psych: "Psychiatric",
+  psychiatric: "Psychiatric",
+  endocrine: "Endocrine",
+  heme: "Hematologic",
+  hematologic: "Hematologic",
+  allergic_immunologic: "Allergic/Immunologic",
+  "allergic/immunologic": "Allergic/Immunologic",
+};
+
+/**
+ * Look up the body system for a New Symptoms label. Unknown labels
+ * fall back to "Other" so the UI surfaces them in their own section
+ * rather than dropping the checkbox.
+ */
+export function getSymptomSystem(label: string): BodySystem {
+  return SYMPTOM_SYSTEM_MAP[label] ?? "Other";
+}
+
+/**
+ * Parse a ROS option (e.g. "constitutional: fever") into its body
+ * system + bare symptom label. Returns "Other" for options that do
+ * not match the "<prefix>: <suffix>" shape, so unprefixed strings
+ * still appear (in an "Other" section) instead of being lost.
+ */
+export function parseROSOption(option: string): {
+  system: BodySystem;
+  symptom: string;
+} {
+  const colon = option.indexOf(":");
+  if (colon === -1) {
+    return { system: "Other", symptom: option.trim() };
+  }
+  const prefix = option.slice(0, colon).trim().toLowerCase();
+  const symptom = option.slice(colon + 1).trim();
+  const system = ROS_PREFIX_TO_SYSTEM[prefix] ?? "Other";
+  return { system, symptom };
+}
+
+/**
+ * Sort a set of body systems with the canonical leaders first and the
+ * remainder alphabetical. Used to render section headers in the order
+ * the design requires.
+ */
+export function sortBodySystems(systems: BodySystem[]): BodySystem[] {
+  const present = new Set(systems);
+  const lead = BODY_SYSTEM_ORDER.filter((s) => present.has(s));
+  const rest = systems
+    .filter((s) => !BODY_SYSTEM_ORDER.includes(s))
+    .sort((a, b) => a.localeCompare(b));
+  // De-dupe while preserving the lead-first ordering.
+  const seen = new Set<BodySystem>();
+  const out: BodySystem[] = [];
+  for (const s of [...lead, ...rest]) {
+    if (!seen.has(s)) {
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #1306

## Summary

Restructures the SOAP Subjective checkboxes (New Symptoms + Review of Systems) so clinicians scan by body system instead of a flat horizontal flow, and links the two fields with an auto-mirror so ticking once updates both sides. Design captured in the issue.

- `GroupedMultiselect` renders each body system as a collapsible section (`▾`/`▸` toggle, `aria-expanded`, `(N)` count when collapsed).
- New Symptoms defaults to ALL EXPANDED; Review of Systems defaults to ALL COLLAPSED. Per-field collapsed state persists across re-renders of the draft.
- Section order: Neurological → Cardiovascular → Respiratory → Gastrointestinal → Constitutional, then any others alphabetical (utility `sortBodySystems`).
- NS ↔ ROS auto-mirror: ticking "headache" in NS auto-ticks "neurological: headache" in ROS (and vice versa). Both rows display a 🔗 indicator. Clicking 🔗 records the pair as unlinked — subsequent edits track independently and the icon disappears.
- New `apps/clinician-portal/src/lib/symptom-systems.ts` is the single source for NS labels → body system + ROS prefix → body system. Anything unmapped falls back to "Other" so no checkbox is silently dropped.
- Mobile (<600px): the option grid inside each section stacks vertically via `globals.css` media query.
- Foundation for #1305 (suggestion banner) — banner will sit above the grouped checkbox area without further restructuring.

## Test plan

RTL tests live in `apps/clinician-portal/src/__tests__/`:

- [x] `grouped-multiselect.test.tsx` — section render order matches canonical, default expansion for NS vs ROS, (N) count in collapsed state, header click toggles expand/collapse, 🔗 icon visibility + click dispatches `onUnlink`, ROS suffix renders as the row label.
- [x] `new-note-symptom-mirror.test.tsx` — captions appear under NS and ROS, NS defaults expanded / ROS defaults collapsed, ticking NS "headache" auto-ticks ROS "neurological: headache" with 🔗 on both, clicking 🔗 unlinks (icon disappears + subsequent edits no longer mirror), reverse direction (ROS "constitutional: fever" → NS "fever"), (N) count surfaces on collapsed ROS sections that gained items via mirror.
- [x] `pnpm --filter @carebridge/clinician-portal test` — 282 / 282 pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (only pre-existing warnings unrelated to this PR).