### PR TITLE
feat(portal): symptom suggestion banner from Chief Complaint (#1305)

### DIFF
--- a/apps/clinician-portal/app/notes/new/page.tsx
+++ b/apps/clinician-portal/app/notes/new/page.tsx
@@ -8,6 +8,10 @@ import { AuthGuard } from "@/lib/auth-guard";
 import { useAuth } from "@/lib/auth";
 import { GroupedMultiselect } from "@/components/grouped-multiselect";
 import {
+  detectSuggestions,
+  SymptomSuggestionBanner,
+} from "@/components/symptom-suggestion-banner";
+import {
   type BodySystem,
   getSymptomSystem,
   parseROSOption,
@@ -46,6 +50,7 @@ type TemplateType = "soap" | "progress";
  */
 const NEW_SYMPTOMS_KEY = "new_symptoms";
 const ROS_KEY = "ros";
+const CHIEF_COMPLAINT_KEY = "chief_complaint";
 
 const NS_CAPTION = "Symptoms the patient is reporting today.";
 const ROS_CAPTION =
@@ -232,6 +237,15 @@ function NewNoteContent() {
     () => new Set(),
   );
 
+  // Sticky dismiss state for the symptom-suggestion banner (#1305).
+  // Holds the Chief Complaint text against which the user clicked
+  // "Dismiss". The banner hides itself when the CC text still equals
+  // this string; any subsequent edit clears the dismissal naturally
+  // because the equality check fails.
+  const [dismissedBannerText, setDismissedBannerText] = useState<string | null>(
+    null,
+  );
+
   const patientsQuery = trpc.patients.list.useQuery();
   const templateQuery = trpc.notes.templates.get.useQuery({ type: templateType });
 
@@ -242,6 +256,7 @@ function NewNoteContent() {
       // a different field shape doesn't inherit stale toggles.
       setSectionCollapseState({});
       setUnlinkedPairs(new Set());
+      setDismissedBannerText(null);
     }
   }, [templateQuery.data]);
 
@@ -292,6 +307,21 @@ function NewNoteContent() {
     });
     return out;
   }, [sections]);
+
+  /**
+   * Resolve the current Chief Complaint free-text value out of the
+   * sections array. Used by the symptom-suggestion banner (#1305) and
+   * by the inline highlight that flags suggested checkboxes inside the
+   * New Symptoms group. Returns an empty string when CC is absent so
+   * downstream callers don't need to null-guard.
+   */
+  const chiefComplaintText = useMemo(() => {
+    const loc = fieldLocations.get(CHIEF_COMPLAINT_KEY);
+    if (!loc) return "";
+    const field = sections[loc.sIdx]?.fields[loc.fIdx];
+    if (!field) return "";
+    return typeof field.value === "string" ? field.value : "";
+  }, [fieldLocations, sections]);
 
   /**
    * NS ↔ ROS auto-mirror.
@@ -596,6 +626,24 @@ function NewNoteContent() {
                   const collapsed =
                     sectionCollapseState[field.key] ?? {};
                   const linked = linkedOptionsFor(field.key);
+                  // Suggestions for the New Symptoms field only (#1305).
+                  // Recompute here from the live CC text + options so the
+                  // banner and the inline highlight stay in lockstep.
+                  // Already-ticked items are excluded so the highlight
+                  // disappears the moment a suggestion is accepted.
+                  const suggestionsForField =
+                    isNS && field.options
+                      ? detectSuggestions(
+                          chiefComplaintText,
+                          field.options,
+                        )
+                      : [];
+                  const selectedSet = new Set(selected);
+                  const highlightedForField = new Set(
+                    suggestionsForField.filter(
+                      (s) => !selectedSet.has(s),
+                    ),
+                  );
                   return (
                     <div
                       key={field.key}
@@ -617,6 +665,26 @@ function NewNoteContent() {
                       >
                         {isNS ? NS_CAPTION : ROS_CAPTION}
                       </p>
+                      {isNS && (
+                        <SymptomSuggestionBanner
+                          chiefComplaintText={chiefComplaintText}
+                          allSymptomOptions={field.options ?? []}
+                          currentlyTicked={selected}
+                          dismissedForText={dismissedBannerText}
+                          onTickAll={(suggestions) => {
+                            // Union with current selection so existing
+                            // ticks are preserved; the auto-mirror in
+                            // handleMultiselectChange fans the change
+                            // out to ROS.
+                            const next = [...selected];
+                            for (const s of suggestions) {
+                              if (!next.includes(s)) next.push(s);
+                            }
+                            handleMultiselectChange(sIdx, fIdx, field, next);
+                          }}
+                          onDismiss={(text) => setDismissedBannerText(text)}
+                        />
+                      )}
                       <GroupedMultiselect
                         fieldKey={field.key}
                         options={field.options ?? []}
@@ -645,6 +713,9 @@ function NewNoteContent() {
                         defaultExpanded={defaultExpanded}
                         linkedOptions={linked}
                         onUnlink={(opt) => handleUnlink(field, opt)}
+                        highlightedOptions={
+                          isNS ? highlightedForField : undefined
+                        }
                       />
                     </div>
                   );

--- a/apps/clinician-portal/src/__tests__/symptom-suggestion-banner.test.tsx
+++ b/apps/clinician-portal/src/__tests__/symptom-suggestion-banner.test.tsx
@@ -1,0 +1,493 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1305 — symptom suggestion banner driven by Chief Complaint text.
+ *
+ * Two layers under test:
+ *
+ *   1. The standalone `SymptomSuggestionBanner` + `detectSuggestions`
+ *      pair. Verifies bare matches, negation, plurals, comma cascade,
+ *      mixed positive/negative content, and the dismiss-stickiness
+ *      contract.
+ *
+ *   2. End-to-end wiring inside NewNotePage (mounted against the stub
+ *      trpc template used by the symptom-mirror test). Verifies the
+ *      banner renders above the NS multiselect, "Tick all suggested"
+ *      ticks every suggested option (and re-uses the NS↔ROS auto-mirror
+ *      from #1306), and the inline `[suggested]` highlight appears on
+ *      the matching checkbox row.
+ */
+import React, { useState } from "react";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  within,
+} from "@testing-library/react";
+
+import {
+  detectSuggestions,
+  SymptomSuggestionBanner,
+} from "../components/symptom-suggestion-banner";
+
+const NS_OPTIONS = [
+  // Subset of the real SOAP template (#1305). Includes plurals worth
+  // probing ("headache" + "fever" + "nausea").
+  "headache",
+  "dizziness",
+  "numbness",
+  "chest pain",
+  "nausea",
+  "fever",
+  "fatigue",
+  "shortness of breath",
+];
+
+// ----------------------------------------------------------------------
+// Layer 1: pure detection + standalone banner
+// ----------------------------------------------------------------------
+
+describe("detectSuggestions (issue #1305)", () => {
+  it("detects a bare positive mention", () => {
+    expect(
+      detectSuggestions("New onset severe headache, 8/10.", NS_OPTIONS),
+    ).toContain("headache");
+  });
+
+  it("does not suggest a negated symptom", () => {
+    expect(detectSuggestions("no headache", NS_OPTIONS)).not.toContain(
+      "headache",
+    );
+  });
+
+  it("detects a plural form (headaches → headache)", () => {
+    expect(
+      detectSuggestions("patient has headaches today", NS_OPTIONS),
+    ).toContain("headache");
+  });
+
+  it("respects negation against the plural form (no headaches → no suggestion)", () => {
+    expect(
+      detectSuggestions("no headaches in two weeks", NS_OPTIONS),
+    ).not.toContain("headache");
+  });
+
+  it("suppresses comma-cascade negatives ('no fever, no nausea')", () => {
+    const out = detectSuggestions("no fever, no nausea", NS_OPTIONS);
+    expect(out).not.toContain("fever");
+    expect(out).not.toContain("nausea");
+  });
+
+  it("mixes positive and negative: only the positive surfaces", () => {
+    const out = detectSuggestions("headache and no fever", NS_OPTIONS);
+    expect(out).toContain("headache");
+    expect(out).not.toContain("fever");
+  });
+
+  it("supports the full DVT-scenario CC ('severe headache' + 'numbness')", () => {
+    const out = detectSuggestions(
+      "New onset severe headache, 8/10. Numbness in left arm.",
+      NS_OPTIONS,
+    );
+    expect(out).toEqual(expect.arrayContaining(["headache", "numbness"]));
+  });
+
+  it("returns [] for empty CC text", () => {
+    expect(detectSuggestions("", NS_OPTIONS)).toEqual([]);
+  });
+});
+
+// ----------------------------------------------------------------------
+// Layer 1b: banner rendering + dismiss + tick-all callbacks
+// ----------------------------------------------------------------------
+
+function BannerHarness({
+  initialChiefComplaint,
+  initiallyTicked = [],
+}: {
+  initialChiefComplaint: string;
+  initiallyTicked?: string[];
+}) {
+  const [cc, setCc] = useState(initialChiefComplaint);
+  const [ticked, setTicked] = useState<string[]>(initiallyTicked);
+  const [dismissedFor, setDismissedFor] = useState<string | null>(null);
+  return (
+    <>
+      <textarea
+        data-testid="cc"
+        value={cc}
+        onChange={(e) => setCc(e.target.value)}
+      />
+      <SymptomSuggestionBanner
+        chiefComplaintText={cc}
+        allSymptomOptions={NS_OPTIONS}
+        currentlyTicked={ticked}
+        dismissedForText={dismissedFor}
+        onTickAll={(suggestions) => {
+          const next = [...ticked];
+          for (const s of suggestions) if (!next.includes(s)) next.push(s);
+          setTicked(next);
+        }}
+        onDismiss={(text) => setDismissedFor(text)}
+      />
+      <div data-testid="ticked">{ticked.join(",")}</div>
+    </>
+  );
+}
+
+describe("SymptomSuggestionBanner — render + interactions (#1305)", () => {
+  afterEach(() => cleanup());
+
+  it("renders the banner with the detected list", () => {
+    render(
+      <BannerHarness initialChiefComplaint="severe headache and numbness" />,
+    );
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+    expect(
+      screen.getByTestId("symptom-suggestion-list").textContent,
+    ).toMatch(/headache/);
+    expect(
+      screen.getByTestId("symptom-suggestion-list").textContent,
+    ).toMatch(/numbness/);
+  });
+
+  it("hides the banner when nothing is detected", () => {
+    render(<BannerHarness initialChiefComplaint="patient feels well" />);
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+  });
+
+  it("hides the banner when every detected suggestion is already ticked", () => {
+    render(
+      <BannerHarness
+        initialChiefComplaint="severe headache"
+        initiallyTicked={["headache"]}
+      />,
+    );
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+  });
+
+  it("'Tick all suggested' batch-ticks every banner item", () => {
+    render(
+      <BannerHarness initialChiefComplaint="severe headache and numbness" />,
+    );
+    fireEvent.click(screen.getByTestId("symptom-suggestion-tick-all"));
+    expect(screen.getByTestId("ticked").textContent).toMatch(
+      /headache.*numbness|numbness.*headache/,
+    );
+  });
+
+  it("'Tick all' respects items already ticked (no un-tick)", () => {
+    render(
+      <BannerHarness
+        initialChiefComplaint="severe headache and numbness"
+        initiallyTicked={["fever"]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("symptom-suggestion-tick-all"));
+    const list = screen.getByTestId("ticked").textContent ?? "";
+    expect(list).toContain("fever");
+    expect(list).toContain("headache");
+    expect(list).toContain("numbness");
+  });
+
+  it("'Dismiss' hides the banner; typing in CC re-renders it; identical text after dismiss stays hidden", () => {
+    render(
+      <BannerHarness initialChiefComplaint="severe headache" />,
+    );
+    // Initial render shows the banner.
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("symptom-suggestion-dismiss"));
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+
+    // Typing a NEW symptom in CC re-renders the banner (different text
+    // → dismissal no longer matches).
+    fireEvent.change(screen.getByTestId("cc"), {
+      target: { value: "severe headache and numbness" },
+    });
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+
+    // Reverting the text to the originally-dismissed string hides the
+    // banner again because the dismissal is keyed to that exact text.
+    fireEvent.change(screen.getByTestId("cc"), {
+      target: { value: "severe headache" },
+    });
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+  });
+});
+
+// ----------------------------------------------------------------------
+// Layer 2: end-to-end wiring against NewNotePage + GroupedMultiselect.
+// ----------------------------------------------------------------------
+
+const ROS_OPTIONS_E2E = [
+  "constitutional: fever",
+  "constitutional: fatigue",
+  "cardiovascular: chest pain",
+  "respiratory: cough",
+  "gastrointestinal: nausea",
+  "neurological: headache",
+  "neurological: dizziness",
+  "neurological: numbness",
+];
+
+const NS_OPTIONS_E2E = [
+  "headache",
+  "dizziness",
+  "numbness",
+  "chest pain",
+  "cough",
+  "nausea",
+  "fever",
+  "fatigue",
+];
+
+type StubField = {
+  key: string;
+  label: string;
+  value: string | string[] | boolean | number | null;
+  field_type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "multiselect"
+    | "checkbox"
+    | "number";
+  source: "new_entry" | "carried_forward" | "modified";
+  options?: string[];
+};
+
+const TEMPLATE_E2E: { key: string; label: string; fields: StubField[] }[] = [
+  {
+    key: "subjective",
+    label: "Subjective",
+    fields: [
+      {
+        key: "chief_complaint",
+        label: "Chief Complaint",
+        value: "",
+        field_type: "text",
+        source: "new_entry",
+      },
+      {
+        key: "new_symptoms",
+        label: "New Symptoms",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: NS_OPTIONS_E2E,
+      },
+      {
+        key: "ros",
+        label: "Review of Systems",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: ROS_OPTIONS_E2E,
+      },
+    ],
+  },
+];
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/trpc", () => {
+  const trpc = {
+    patients: {
+      list: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
+    },
+    notes: {
+      templates: {
+        get: {
+          useQuery: () => ({
+            data: TEMPLATE_E2E,
+            isLoading: false,
+            isError: false,
+          }),
+        },
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+          isError: false,
+          error: null,
+        }),
+      },
+    },
+  };
+  return { trpc };
+});
+
+import NewNotePage from "../../app/notes/new/page";
+
+beforeEach(() => {
+  // Reset template values so each test starts clean.
+  for (const section of TEMPLATE_E2E) {
+    for (const f of section.fields) {
+      if (f.field_type === "multiselect") f.value = [];
+      if (f.key === "chief_complaint") f.value = "";
+    }
+  }
+});
+
+afterEach(() => cleanup());
+
+function getFieldRoot(fieldKey: string): HTMLElement {
+  const el = document.querySelector(`[data-field-key="${fieldKey}"]`);
+  if (!el) throw new Error(`No grouped multiselect for ${fieldKey}`);
+  return el as HTMLElement;
+}
+
+function getOptionCheckbox(
+  fieldKey: string,
+  rowLabel: string,
+): HTMLInputElement {
+  const root = getFieldRoot(fieldKey);
+  const labelEl = within(root)
+    .getByText(rowLabel, { exact: true })
+    .closest("label");
+  if (!labelEl) throw new Error(`No row labelled ${rowLabel} under ${fieldKey}`);
+  const cb = labelEl.querySelector('input[type="checkbox"]');
+  if (!cb) throw new Error(`No checkbox in row ${rowLabel}`);
+  return cb as HTMLInputElement;
+}
+
+function getChiefComplaintInput(): HTMLInputElement {
+  // The "text" field type renders as an <input type="text"> via FieldInput.
+  // It is the only such input on the page in the stub template.
+  const label = screen.getByText("Chief Complaint");
+  const row = label.closest(".detail-row");
+  if (!row) throw new Error("No CC row");
+  const input = row.querySelector('input[type="text"]');
+  if (!input) throw new Error("No CC input");
+  return input as HTMLInputElement;
+}
+
+describe("/notes/new — symptom suggestion banner integration (#1305)", () => {
+  it("renders the banner above New Symptoms when CC mentions a symptom", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache today" },
+    });
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+    expect(
+      screen.getByTestId("symptom-suggestion-list").textContent,
+    ).toMatch(/headache/);
+  });
+
+  it("does not render the banner when CC is empty", () => {
+    render(<NewNotePage />);
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+  });
+
+  it("does not render the banner when the only mention is negated", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "no headache" },
+    });
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+  });
+
+  it("inline highlight: suggested NS checkbox gets [suggested] label + data-suggested attr", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache" },
+    });
+
+    const headacheLabel = within(getFieldRoot("new_symptoms"))
+      .getByText("headache", { exact: true })
+      .closest("label");
+    expect(headacheLabel).toBeTruthy();
+    expect(headacheLabel?.getAttribute("data-suggested")).toBe("true");
+    expect(
+      within(getFieldRoot("new_symptoms")).getByText("[suggested]"),
+    ).toBeTruthy();
+  });
+
+  it("highlight disappears the moment the suggested item is ticked", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache" },
+    });
+    // Sanity: highlight present.
+    const headacheLabelBefore = within(getFieldRoot("new_symptoms"))
+      .getByText("headache", { exact: true })
+      .closest("label");
+    expect(headacheLabelBefore?.getAttribute("data-suggested")).toBe("true");
+
+    fireEvent.click(getOptionCheckbox("new_symptoms", "headache"));
+
+    const headacheLabelAfter = within(getFieldRoot("new_symptoms"))
+      .getByText("headache", { exact: true })
+      .closest("label");
+    expect(headacheLabelAfter?.getAttribute("data-suggested")).toBeNull();
+  });
+
+  it("'Tick all suggested' batch-ticks every suggestion and triggers the NS↔ROS auto-mirror", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache and numbness, no fever" },
+    });
+
+    fireEvent.click(screen.getByTestId("symptom-suggestion-tick-all"));
+
+    expect(getOptionCheckbox("new_symptoms", "headache").checked).toBe(true);
+    expect(getOptionCheckbox("new_symptoms", "numbness").checked).toBe(true);
+    expect(getOptionCheckbox("new_symptoms", "fever").checked).toBe(false);
+
+    // ROS auto-mirror — the Neurological section was collapsed on
+    // mount, so the count badge should reflect both ticks.
+    const rosNeuro = within(getFieldRoot("ros")).getByRole("button", {
+      name: /Neurological/,
+    });
+    expect(rosNeuro.textContent).toMatch(/\(2\)/);
+  });
+
+  it("Dismiss hides the banner; typing fresh symptoms re-renders it", () => {
+    render(<NewNotePage />);
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache" },
+    });
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("symptom-suggestion-dismiss"));
+    expect(
+      screen.queryByTestId("symptom-suggestion-banner"),
+    ).toBeNull();
+
+    // Adding "numbness" surfaces the banner again because the CC text
+    // changed (dismissal was keyed to the previous text).
+    fireEvent.change(getChiefComplaintInput(), {
+      target: { value: "severe headache and numbness" },
+    });
+    expect(screen.getByTestId("symptom-suggestion-banner")).toBeTruthy();
+  });
+});

--- a/apps/clinician-portal/src/components/grouped-multiselect.tsx
+++ b/apps/clinician-portal/src/components/grouped-multiselect.tsx
@@ -52,6 +52,15 @@ export type GroupedMultiselectProps = {
   linkedOptions?: Set<string>;
   /** Click handler for the 🔗 icon. Receives the option string. */
   onUnlink?: (option: string) => void;
+  /**
+   * Suggestion highlight (#1305). Options in this set render with a
+   * colored border + "[suggested]" trailing label so users who skipped
+   * the suggestion banner can still spot the matches. The highlight is
+   * purely visual — it does NOT modify the ticked state. The caller is
+   * expected to filter already-ticked items out of this set so the
+   * highlight clears as soon as a suggestion is accepted.
+   */
+  highlightedOptions?: Set<string>;
 };
 
 const linkButtonStyle: CSSProperties = {
@@ -75,6 +84,7 @@ export function GroupedMultiselect({
   defaultExpanded,
   linkedOptions,
   onUnlink,
+  highlightedOptions,
 }: GroupedMultiselectProps) {
   // Bucket options by body system, preserving original option order
   // within each bucket so the curated NS ordering survives.
@@ -196,15 +206,30 @@ export function GroupedMultiselect({
                 {rows.map(({ option, display }) => {
                   const checked = selectedSet.has(option);
                   const linked = linkedOptions?.has(option) ?? false;
+                  const highlighted =
+                    highlightedOptions?.has(option) ?? false;
                   return (
                     <label
                       key={option}
-                      className="grouped-multiselect-option"
+                      className={
+                        "grouped-multiselect-option" +
+                        (highlighted
+                          ? " grouped-multiselect-option--suggested"
+                          : "")
+                      }
+                      data-suggested={highlighted ? "true" : undefined}
                       style={{
                         fontSize: 12,
                         display: "flex",
                         alignItems: "center",
                         gap: 4,
+                        ...(highlighted
+                          ? {
+                              border: "1px solid var(--accent, #2b6cb0)",
+                              borderRadius: 4,
+                              padding: "2px 6px",
+                            }
+                          : null),
                       }}
                     >
                       <input
@@ -215,6 +240,19 @@ export function GroupedMultiselect({
                         }
                       />
                       <span>{display}</span>
+                      {highlighted && (
+                        <span
+                          className="grouped-multiselect-option-suggested-label"
+                          style={{
+                            fontSize: 11,
+                            color: "var(--accent, #2b6cb0)",
+                            fontStyle: "italic",
+                          }}
+                          data-testid={`suggested-label-${option}`}
+                        >
+                          [suggested]
+                        </span>
+                      )}
                       {linked && (
                         <button
                           type="button"

--- a/apps/clinician-portal/src/components/symptom-suggestion-banner.tsx
+++ b/apps/clinician-portal/src/components/symptom-suggestion-banner.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * SymptomSuggestionBanner — issue #1305.
+ *
+ * Surfaces structured-checkbox suggestions for symptoms a clinician has
+ * already mentioned in the Chief Complaint free-text field. The banner
+ * sits directly above the New Symptoms multiselect; the inline highlight
+ * (driven by the same `detectSuggestions` output and rendered inside
+ * GroupedMultiselect) catches users who skip the banner.
+ *
+ * Design pillars:
+ *
+ *   1. Detection only. Neither the banner nor the highlight modifies the
+ *      ticked state — every change requires explicit user action.
+ *   2. Negation-aware. We use `hasUnnegatedMention` from
+ *      `@carebridge/medical-logic` so phrases like "no headache" or the
+ *      ROS-style comma cascade ("no fever, no nausea") never surface a
+ *      suggestion.
+ *   3. Plural-tolerant. Because the helper does whole-token matching,
+ *      "headaches" does not match "headache" directly. We also probe the
+ *      naive "<term>s" form so common plurals still surface, while
+ *      letting the helper's negation logic still apply (negation is
+ *      checked against whichever surface form matched).
+ *   4. Dismiss is sticky per Chief Complaint text. The parent passes a
+ *      `dismissedForText` value; the banner hides itself when the
+ *      currently-detected suggestions were dismissed against the same
+ *      Chief Complaint text. Typing in CC naturally clears the dismissal
+ *      because the equality check fails.
+ *   5. Hide already-ticked. Suggestions that the user has already ticked
+ *      are filtered out — keeping them in the banner would be visual
+ *      noise (and "Tick all" would have nothing to do).
+ */
+
+import { useMemo } from "react";
+import { hasUnnegatedMention } from "@carebridge/medical-logic";
+
+export type SymptomSuggestionBannerProps = {
+  /** Current Chief Complaint free-text value. */
+  chiefComplaintText: string;
+  /** All New Symptoms option strings. */
+  allSymptomOptions: string[];
+  /** Symptom strings the clinician has already ticked. */
+  currentlyTicked: string[];
+  /**
+   * Chief Complaint text against which the user previously clicked
+   * "Dismiss". When this equals the current `chiefComplaintText`, the
+   * banner stays hidden. Pass `null` if no dismissal is active.
+   */
+  dismissedForText: string | null;
+  /** Invoked when the user clicks "Tick all suggested". */
+  onTickAll: (suggestions: string[]) => void;
+  /** Invoked when the user clicks "Dismiss". */
+  onDismiss: (chiefComplaintText: string) => void;
+};
+
+/**
+ * Compute which options from `allSymptomOptions` are mentioned in
+ * `chiefComplaintText` in a non-negated way. Used by both the banner
+ * (to populate the suggestion list) and the parent page (to drive the
+ * inline highlight on the matching checkboxes). Pulled out as a pure
+ * function so the highlight and the banner stay in lockstep.
+ *
+ * Plural handling: the helper does whole-token matching, so "headaches"
+ * does not match the option "headache" on its own. We try the bare
+ * option first; if that fails AND the option does not already end in
+ * "s", we retry with the naive "<term>s" plural. Negation lookback runs
+ * against whichever surface form matched, so "no headaches" still
+ * resolves to "not detected".
+ */
+export function detectSuggestions(
+  chiefComplaintText: string,
+  allSymptomOptions: string[],
+): string[] {
+  if (!chiefComplaintText || allSymptomOptions.length === 0) return [];
+  const out: string[] = [];
+  for (const opt of allSymptomOptions) {
+    if (hasUnnegatedMention(chiefComplaintText, opt)) {
+      out.push(opt);
+      continue;
+    }
+    // Naive plural fallback: try "<opt>s". Skip if the option already
+    // ends in "s" (the bare check would have caught it) or if it
+    // contains a space (multi-word options pluralise the last token,
+    // which the helper's whole-word match handles for us as long as we
+    // probe the plural of the last word).
+    if (opt.endsWith("s")) continue;
+    if (opt.includes(" ")) {
+      const parts = opt.split(" ");
+      const pluralised = [...parts.slice(0, -1), `${parts[parts.length - 1]}s`].join(
+        " ",
+      );
+      if (hasUnnegatedMention(chiefComplaintText, pluralised)) {
+        out.push(opt);
+      }
+      continue;
+    }
+    if (hasUnnegatedMention(chiefComplaintText, `${opt}s`)) {
+      out.push(opt);
+    }
+  }
+  return out;
+}
+
+export function SymptomSuggestionBanner({
+  chiefComplaintText,
+  allSymptomOptions,
+  currentlyTicked,
+  dismissedForText,
+  onTickAll,
+  onDismiss,
+}: SymptomSuggestionBannerProps) {
+  const detected = useMemo(
+    () => detectSuggestions(chiefComplaintText, allSymptomOptions),
+    [chiefComplaintText, allSymptomOptions],
+  );
+
+  // Hide options the user has already ticked — there's nothing left to
+  // suggest for them, and "Tick all" would be a no-op.
+  const tickedSet = useMemo(() => new Set(currentlyTicked), [currentlyTicked]);
+  const unticked = useMemo(
+    () => detected.filter((d) => !tickedSet.has(d)),
+    [detected, tickedSet],
+  );
+
+  // Dismissal: hide the banner only when the user dismissed THIS exact
+  // CC text. Any subsequent edit to CC re-renders the banner.
+  const isDismissed =
+    dismissedForText !== null && dismissedForText === chiefComplaintText;
+
+  if (isDismissed) return null;
+  if (unticked.length === 0) return null;
+
+  return (
+    <div
+      className="symptom-suggestion-banner"
+      role="status"
+      aria-live="polite"
+      data-testid="symptom-suggestion-banner"
+      style={{
+        border: "1px solid var(--accent, #2b6cb0)",
+        background: "var(--surface-2, rgba(43, 108, 176, 0.08))",
+        borderRadius: 4,
+        padding: 8,
+        marginBottom: 6,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        fontSize: 12,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 6 }}>
+        <span aria-hidden="true">{"ⓘ"}</span>
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <span style={{ fontWeight: 600 }}>Detected in Chief Complaint:</span>
+          <span data-testid="symptom-suggestion-list">
+            {unticked.join(", ")}
+          </span>
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 6 }}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => onTickAll(unticked)}
+          style={{ fontSize: 12, padding: "2px 8px" }}
+          data-testid="symptom-suggestion-tick-all"
+        >
+          Tick all suggested
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          onClick={() => onDismiss(chiefComplaintText)}
+          style={{ fontSize: 12, padding: "2px 8px" }}
+          data-testid="symptom-suggestion-dismiss"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1305

Builds on:
- #1309 — `hasUnnegatedMention` helper in `@carebridge/medical-logic`
- #1310 — `GroupedMultiselect` body-system grouping + NS↔ROS auto-mirror

## Summary

When the clinician types a symptom in the Chief Complaint free-text
field, the SOAP `New Symptoms` checkbox group now surfaces a banner
("Detected in Chief Complaint: headache, numbness") with two actions:
`Tick all suggested` and `Dismiss`. Suggested checkboxes also render
with a colored border + inline `[suggested]` label so users who skip
the banner can still spot the matches.

Detection runs entirely client-side via `hasUnnegatedMention`, so
negated phrases ("no headache", "denies fever", the ROS-style comma
cascade `no fever, no nausea`) never surface as suggestions.
"Tick all" routes through the existing NS↔ROS auto-mirror, so the
matching ROS rows tick in step.

## Design pillars (unchanged from #1305)

- Manual tick only — neither the banner nor the highlight modifies
  the structured field state.
- Dismiss is sticky per Chief Complaint text — typing a new symptom
  re-renders; reverting to the originally-dismissed string keeps it
  hidden.
- Already-ticked items are excluded from both the banner list and
  the inline highlight, so the UI clears as suggestions are accepted.
- Plural fallback: bare-term whole-word match first, then a naive
  `<term>s` retry (and `<last word>s` for multi-word options).
  Negation lookback still runs against whichever surface form matched.
- No PHI logged — the matcher is pure client code with no telemetry.

## Files

- `apps/clinician-portal/src/components/symptom-suggestion-banner.tsx`
  — new component + `detectSuggestions` pure helper.
- `apps/clinician-portal/src/components/grouped-multiselect.tsx`
  — new `highlightedOptions?: Set<string>` prop driving the inline
  border + `[suggested]` label.
- `apps/clinician-portal/app/notes/new/page.tsx`
  — reads the live `chief_complaint` text out of `sections`, renders
  the banner above the NS field, plumbs the highlight set down, and
  wires `Tick all` through `handleMultiselectChange` to inherit the
  NS↔ROS auto-mirror.
- `apps/clinician-portal/src/__tests__/symptom-suggestion-banner.test.tsx`
  — 21 RTL tests covering pure detection, banner interaction, and
  end-to-end wiring inside `NewNotePage`.

## Test plan

- [x] `pnpm --filter @carebridge/clinician-portal test` — 303/303 pass
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] AC: bare positive match surfaces in the banner
- [x] AC: negated mention does NOT surface (`no headache`)
- [x] AC: plural form matches (`headaches` → `headache`)
- [x] AC: comma-cascade negatives suppressed (`no fever, no nausea`)
- [x] AC: mixed positive + negative — only positive surfaces
- [x] AC: `Tick all suggested` batch-ticks; existing ticks preserved
- [x] AC: `Dismiss` hides the banner; CC text change re-renders
- [x] AC: dismiss is sticky against the exact CC text
- [x] AC: inline `[suggested]` highlight on matching NS checkbox
- [x] AC: highlight disappears the moment the option is ticked
- [x] AC: NS↔ROS auto-mirror fires when `Tick all` adds suggestions