### PR TITLE
fix(portal): symptom UX polish bundle (#1311, #1312, #1313, #1314)

### DIFF
--- a/apps/clinician-portal/app/globals.css
+++ b/apps/clinician-portal/app/globals.css
@@ -1028,7 +1028,11 @@ tr:hover td {
 .grouped-multiselect-header:hover {
   background: var(--surface-3, rgba(0, 0, 0, 0.04));
 }
-@media (max-width: 599px) {
+@media (max-width: 767px) {
+  /* #1313 — align the GroupedMultiselect stacking rule with the
+     portal-standard 767px breakpoint so 600-767px devices (small
+     landscape tablets, foldable inner displays) get the same column
+     layout as phones. */
   .grouped-multiselect-options {
     flex-direction: column !important;
     align-items: flex-start;

--- a/apps/clinician-portal/app/notes/new/page.tsx
+++ b/apps/clinician-portal/app/notes/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { trpc } from "@/lib/trpc";
 import { AuthGuard } from "@/lib/auth-guard";
@@ -16,6 +16,14 @@ import {
   getSymptomSystem,
   parseROSOption,
 } from "@/lib/symptom-systems";
+import {
+  findNSOptionForROS,
+  findROSOptionForSymptom,
+} from "@/lib/symptom-normalization";
+import {
+  usePersistedRecord,
+  usePersistedStringSet,
+} from "@/lib/use-persisted-symptom-state";
 
 type FieldType =
   | "text"
@@ -57,41 +65,20 @@ const ROS_CAPTION =
   "Full systems review for the visit (“all systems negative” allowed).";
 
 /**
- * Find the ROS option (e.g. "neurological: headache") whose suffix
- * after the colon matches the bare NS symptom string. Used for the
- * NS → ROS arm of the auto-mirror.
- */
-function findROSOptionForSymptom(
-  symptom: string,
-  rosOptions: string[],
-): string | undefined {
-  const needle = symptom.toLowerCase().trim();
-  return rosOptions.find((opt) => {
-    const { symptom: suffix } = parseROSOption(opt);
-    return suffix.toLowerCase() === needle;
-  });
-}
-
-/**
- * Reverse direction: given a positive ROS option, find the NS option
- * whose label matches the ROS suffix. NS options are bare strings
- * (no prefix) so the match is a direct equality.
- */
-function findNSOptionForROS(
-  rosOption: string,
-  nsOptions: string[],
-): string | undefined {
-  const { symptom } = parseROSOption(rosOption);
-  const needle = symptom.toLowerCase().trim();
-  return nsOptions.find((opt) => opt.toLowerCase() === needle);
-}
-
-/**
  * Stable key for a NS-ROS pair (used as the unlinked-pair identifier).
  */
 function pairKey(nsOption: string, rosOption: string): string {
   return `${nsOption}||${rosOption}`;
 }
+
+/**
+ * localStorage keys for the persisted symptom UX state. A single global
+ * key per slot (rather than per-draft) means a clinician's collapse and
+ * unlink preferences follow them across drafts, which matches the
+ * specialty-driven workflow the affordance was designed for. #1311.
+ */
+const COLLAPSE_STORAGE_KEY = "cb-symptom-collapse-state";
+const UNLINKED_PAIRS_STORAGE_KEY = "cb-symptom-unlinked-pairs";
 
 function FieldInput({
   field,
@@ -222,19 +209,19 @@ function NewNoteContent() {
   const [sections, setSections] = useState<NoteSection[]>([]);
 
   // Per-field collapsed state for body-system groups, keyed as
-  // `{ [fieldKey]: { [BodySystem]: collapsed } }`. Lives in component
-  // state so the toggle state persists for the lifetime of the draft
-  // (closing/reopening the form during a single session keeps the
-  // user's view). #1306.
-  const [sectionCollapseState, setSectionCollapseState] = useState<
+  // `{ [fieldKey]: { [BodySystem]: collapsed } }`. Persisted to
+  // localStorage so the affordance survives template changes, remounts,
+  // and tab reloads. #1311.
+  const [sectionCollapseState, setSectionCollapseState] = usePersistedRecord<
     Record<string, Partial<Record<BodySystem, boolean>>>
-  >({});
+  >(COLLAPSE_STORAGE_KEY, {});
 
   // Pairs the user has explicitly unlinked via the 🔗 icon. Stored as
-  // `"<nsOption>||<rosOption>"` strings so the set is membership-cheap
-  // and easy to serialise if we later persist it. #1306.
-  const [unlinkedPairs, setUnlinkedPairs] = useState<Set<string>>(
-    () => new Set(),
+  // `"<nsOption>||<rosOption>"` strings so the set is membership-cheap.
+  // Persisted to localStorage so the unlink choice survives remounts
+  // and reloads. #1311.
+  const [unlinkedPairs, setUnlinkedPairs] = usePersistedStringSet(
+    UNLINKED_PAIRS_STORAGE_KEY,
   );
 
   // Sticky dismiss state for the symptom-suggestion banner (#1305).
@@ -249,16 +236,33 @@ function NewNoteContent() {
   const patientsQuery = trpc.patients.list.useQuery();
   const templateQuery = trpc.notes.templates.get.useQuery({ type: templateType });
 
+  // Track the template type that produced the currently-loaded sections
+  // so we only reset per-field UI state when the user actually switches
+  // template type. On a fresh mount the template fetch resolves with
+  // the SAME type that's already selected; without this guard the reset
+  // would clobber persisted state restored from localStorage. #1311.
+  const lastLoadedTemplateType = useRef<TemplateType | null>(null);
+
   useEffect(() => {
-    if (templateQuery.data) {
-      setSections(templateQuery.data as unknown as NoteSection[]);
+    if (!templateQuery.data) return;
+    setSections(templateQuery.data as unknown as NoteSection[]);
+    if (
+      lastLoadedTemplateType.current !== null &&
+      lastLoadedTemplateType.current !== templateType
+    ) {
       // Switching templates resets per-field UI state so a draft with
       // a different field shape doesn't inherit stale toggles.
       setSectionCollapseState({});
       setUnlinkedPairs(new Set());
       setDismissedBannerText(null);
     }
-  }, [templateQuery.data]);
+    lastLoadedTemplateType.current = templateType;
+  }, [
+    templateQuery.data,
+    templateType,
+    setSectionCollapseState,
+    setUnlinkedPairs,
+  ]);
 
   // Reconcile a prefilled patientId against the loaded patient list. If
   // the id isn't present (deleted, not accessible, malformed), clear it
@@ -438,7 +442,7 @@ function NewNoteContent() {
         };
       });
     },
-    [],
+    [setSectionCollapseState],
   );
 
   /**
@@ -470,7 +474,7 @@ function NewNoteContent() {
         return next;
       });
     },
-    [fieldLocations, sections],
+    [fieldLocations, sections, setUnlinkedPairs],
   );
 
   /**

--- a/apps/clinician-portal/src/__tests__/new-note-plural-mirror.test.tsx
+++ b/apps/clinician-portal/src/__tests__/new-note-plural-mirror.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1314 — integration: NS "vision changes" should auto-mirror to
+ * ROS "eyes: vision change" through the page-level handler, exercising
+ * the normalised matcher introduced for this issue.
+ *
+ * The shared SOAP template (`@carebridge/shared-types/notes`) has NS
+ * "vision changes" (plural) and the ROS catalog uses "eyes: vision
+ * change" (singular). Before this fix, the bare exact-match auto-mirror
+ * silently dropped the pairing because "changes" !== "change".
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  within,
+} from "@testing-library/react";
+
+type StubField = {
+  key: string;
+  label: string;
+  value: string | string[] | boolean | number | null;
+  field_type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "multiselect"
+    | "checkbox"
+    | "number";
+  source: "new_entry" | "carried_forward" | "modified";
+  options?: string[];
+};
+
+// Minimal template focused on the plural-drift case.
+const NS_OPTIONS = ["vision changes", "tingling", "headache"];
+const ROS_OPTIONS = [
+  "eyes: vision change",
+  "neurological: headache",
+];
+
+const TEMPLATE: { key: string; label: string; fields: StubField[] }[] = [
+  {
+    key: "subjective",
+    label: "Subjective",
+    fields: [
+      {
+        key: "new_symptoms",
+        label: "New Symptoms",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: NS_OPTIONS,
+      },
+      {
+        key: "ros",
+        label: "Review of Systems",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: ROS_OPTIONS,
+      },
+    ],
+  },
+];
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/trpc", () => {
+  const trpc = {
+    patients: {
+      list: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
+    },
+    notes: {
+      templates: {
+        get: {
+          useQuery: () => ({
+            data: TEMPLATE,
+            isLoading: false,
+            isError: false,
+          }),
+        },
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+          isError: false,
+          error: null,
+        }),
+      },
+    },
+  };
+  return { trpc };
+});
+
+import NewNotePage from "../../app/notes/new/page";
+
+beforeEach(() => {
+  for (const section of TEMPLATE) {
+    for (const f of section.fields) {
+      if (f.field_type === "multiselect") f.value = [];
+    }
+  }
+  localStorage.clear();
+});
+
+afterEach(() => cleanup());
+
+function getFieldRoot(fieldKey: string): HTMLElement {
+  const el = document.querySelector(`[data-field-key="${fieldKey}"]`);
+  if (!el) throw new Error(`No grouped multiselect for ${fieldKey}`);
+  return el as HTMLElement;
+}
+
+function getHeader(
+  fieldKey: string,
+  systemLabel: RegExp | string,
+): HTMLButtonElement {
+  const root = getFieldRoot(fieldKey);
+  return within(root).getByRole("button", {
+    name: systemLabel,
+  }) as HTMLButtonElement;
+}
+
+function getOptionCheckbox(
+  fieldKey: string,
+  rowLabel: string,
+): HTMLInputElement {
+  const root = getFieldRoot(fieldKey);
+  const labelEl = within(root)
+    .getByText(rowLabel, { exact: true })
+    .closest("label");
+  if (!labelEl)
+    throw new Error(`No row labelled ${rowLabel} under ${fieldKey}`);
+  const cb = labelEl.querySelector('input[type="checkbox"]');
+  if (!cb) throw new Error(`No checkbox in row ${rowLabel}`);
+  return cb as HTMLInputElement;
+}
+
+describe("/notes/new — NS↔ROS plural drift (#1314)", () => {
+  it("ticking NS 'vision changes' auto-mirrors ROS 'eyes: vision change'", () => {
+    render(<NewNotePage />);
+    fireEvent.click(getHeader("ros", /Eyes/));
+
+    const nsBox = getOptionCheckbox("new_symptoms", "vision changes");
+    fireEvent.click(nsBox);
+
+    // ROS "vision change" got auto-ticked despite the singular/plural
+    // mismatch.
+    expect(
+      getOptionCheckbox("ros", "vision change").checked,
+    ).toBe(true);
+  });
+
+  it("ticking ROS 'eyes: vision change' auto-mirrors NS 'vision changes'", () => {
+    render(<NewNotePage />);
+    fireEvent.click(getHeader("ros", /Eyes/));
+
+    fireEvent.click(getOptionCheckbox("ros", "vision change"));
+
+    expect(
+      getOptionCheckbox("new_symptoms", "vision changes").checked,
+    ).toBe(true);
+  });
+
+  it("distinctive NS symptom with no ROS counterpart does not error", () => {
+    render(<NewNotePage />);
+
+    // NS "tingling" has no ROS counterpart. Ticking it should be a
+    // no-op on the ROS side — no error, no spurious matches. We rely
+    // on (a) the click not throwing, and (b) all ROS sections still
+    // reporting aria-expanded="false" with no (N) count badge (i.e.
+    // nothing got auto-ticked).
+    expect(() => {
+      fireEvent.click(getOptionCheckbox("new_symptoms", "tingling"));
+    }).not.toThrow();
+
+    const rosRoot = getFieldRoot("ros");
+    const rosButtons = within(rosRoot).getAllByRole("button");
+    for (const b of rosButtons) {
+      // No section gained a count badge from a spurious mirror.
+      expect(b.textContent).not.toMatch(/\(/);
+    }
+  });
+});

--- a/apps/clinician-portal/src/__tests__/new-note-state-persistence.test.tsx
+++ b/apps/clinician-portal/src/__tests__/new-note-state-persistence.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1311 — integration: collapse state and unlinked-pair state
+ * survive a page remount via localStorage. We mount, drive a toggle,
+ * unmount, mount again, and assert the previous state is restored.
+ */
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  within,
+} from "@testing-library/react";
+
+type StubField = {
+  key: string;
+  label: string;
+  value: string | string[] | boolean | number | null;
+  field_type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "multiselect"
+    | "checkbox"
+    | "number";
+  source: "new_entry" | "carried_forward" | "modified";
+  options?: string[];
+};
+
+const ROS_OPTIONS = [
+  "constitutional: fever",
+  "neurological: headache",
+];
+const NS_OPTIONS = ["fever", "headache"];
+
+const TEMPLATE: { key: string; label: string; fields: StubField[] }[] = [
+  {
+    key: "subjective",
+    label: "Subjective",
+    fields: [
+      {
+        key: "new_symptoms",
+        label: "New Symptoms",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: NS_OPTIONS,
+      },
+      {
+        key: "ros",
+        label: "Review of Systems",
+        value: [],
+        field_type: "multiselect",
+        source: "new_entry",
+        options: ROS_OPTIONS,
+      },
+    ],
+  },
+];
+
+vi.mock("@/lib/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  useAuth: () => ({ user: { id: "u-1", role: "physician", name: "T" } }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/trpc", () => {
+  const trpc = {
+    patients: {
+      list: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
+    },
+    notes: {
+      templates: {
+        get: {
+          useQuery: () => ({
+            data: TEMPLATE,
+            isLoading: false,
+            isError: false,
+          }),
+        },
+      },
+      create: {
+        useMutation: () => ({
+          mutate: vi.fn(),
+          isPending: false,
+          isError: false,
+          error: null,
+        }),
+      },
+    },
+  };
+  return { trpc };
+});
+
+import NewNotePage from "../../app/notes/new/page";
+
+beforeEach(() => {
+  for (const section of TEMPLATE) {
+    for (const f of section.fields) {
+      if (f.field_type === "multiselect") f.value = [];
+    }
+  }
+  localStorage.clear();
+});
+
+afterEach(() => cleanup());
+
+function getFieldRoot(fieldKey: string): HTMLElement {
+  const el = document.querySelector(`[data-field-key="${fieldKey}"]`);
+  if (!el) throw new Error(`No grouped multiselect for ${fieldKey}`);
+  return el as HTMLElement;
+}
+
+function getHeader(
+  fieldKey: string,
+  systemLabel: RegExp | string,
+): HTMLButtonElement {
+  const root = getFieldRoot(fieldKey);
+  return within(root).getByRole("button", {
+    name: systemLabel,
+  }) as HTMLButtonElement;
+}
+
+describe("/notes/new — section collapse persists across remounts (#1311)", () => {
+  it("collapsing a NS section persists to localStorage and rehydrates on remount", () => {
+    const first = render(<NewNotePage />);
+    const nsNeuro = getHeader("new_symptoms", /Neurological/);
+    // NS defaults to expanded; collapse it.
+    expect(nsNeuro.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(nsNeuro);
+    expect(nsNeuro.getAttribute("aria-expanded")).toBe("false");
+
+    first.unmount();
+
+    // Fresh mount — the previously-collapsed Neurological section
+    // should still be collapsed.
+    render(<NewNotePage />);
+    const remountedHeader = getHeader("new_symptoms", /Neurological/);
+    expect(remountedHeader.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("expanding a ROS section persists across remounts", () => {
+    const first = render(<NewNotePage />);
+    const rosNeuro = getHeader("ros", /Neurological/);
+    // ROS defaults to collapsed; expand it.
+    expect(rosNeuro.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(rosNeuro);
+    expect(rosNeuro.getAttribute("aria-expanded")).toBe("true");
+
+    first.unmount();
+
+    render(<NewNotePage />);
+    const remountedHeader = getHeader("ros", /Neurological/);
+    expect(remountedHeader.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/apps/clinician-portal/src/__tests__/new-note-symptom-mirror.test.tsx
+++ b/apps/clinician-portal/src/__tests__/new-note-symptom-mirror.test.tsx
@@ -147,6 +147,9 @@ beforeEach(() => {
       if (f.field_type === "multiselect") f.value = [];
     }
   }
+  // Clear persisted UI state (#1311) so prior tests in this file don't
+  // leak collapse/unlink state into the next test's render.
+  localStorage.clear();
 });
 
 afterEach(() => cleanup());

--- a/apps/clinician-portal/src/__tests__/symptom-normalization.test.ts
+++ b/apps/clinician-portal/src/__tests__/symptom-normalization.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #1314 — NS↔ROS auto-mirror normalisation.
+ *
+ * The first iteration of the auto-mirror used an exact (case-insensitive)
+ * suffix match: NS "vision changes" wouldn't auto-mirror to
+ * ROS "eyes: vision change" because "changes" !== "change". This is the
+ * same plural drift the symptom-suggestion-banner already handles via a
+ * naive trailing-"s" strip. Centralising that helper here lets BOTH
+ * features share the rule.
+ *
+ * These tests pin the behaviour:
+ *
+ *   1. normalizeSymptomLabel lowercases, trims, and strips a single
+ *      trailing "s" if present (single-pass; "kiss" stays "kis").
+ *      (This matches the deliberately-naive normalisation used in the
+ *      banner — we are not trying to be a real stemmer here.)
+ *   2. findROSOptionForSymptom returns an EXACT post-normalisation match
+ *      ahead of any other candidate, even when multiple suffixes resolve
+ *      to the same normalised form.
+ *   3. findROSOptionForSymptom returns the first option deterministically
+ *      when multiple options normalise to the same value.
+ *   4. Distinctive symptoms with no ROS counterpart return undefined.
+ *   5. findNSOptionForROS applies the same normalisation symmetrically.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  findNSOptionForROS,
+  findROSOptionForSymptom,
+  normalizeSymptomLabel,
+} from "../lib/symptom-normalization";
+
+describe("normalizeSymptomLabel (#1314)", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeSymptomLabel("  Headache  ")).toBe("headache");
+  });
+
+  it("strips a single trailing 's'", () => {
+    expect(normalizeSymptomLabel("changes")).toBe("change");
+    expect(normalizeSymptomLabel("vision changes")).toBe("vision change");
+  });
+
+  it("does not touch words without a trailing 's'", () => {
+    expect(normalizeSymptomLabel("headache")).toBe("headache");
+    expect(normalizeSymptomLabel("tingling")).toBe("tingling");
+  });
+
+  it("strips exactly one trailing 's' per call (single-pass)", () => {
+    // We're deliberately non-recursive: "kiss" → "kis" in one pass.
+    // The caller is expected to call this helper once per comparison.
+    expect(normalizeSymptomLabel("kiss")).toBe("kis");
+  });
+
+  it("handles empty / whitespace-only input", () => {
+    expect(normalizeSymptomLabel("")).toBe("");
+    expect(normalizeSymptomLabel("   ")).toBe("");
+  });
+});
+
+describe("findROSOptionForSymptom (#1314)", () => {
+  const ROS = [
+    "constitutional: fever",
+    "eyes: vision change",
+    "neurological: headache",
+    "neurological: vision changes",
+    "neurological: dizziness",
+  ];
+
+  it("matches a plural NS label to a singular ROS suffix", () => {
+    // NS "vision changes" should auto-mirror to ROS "eyes: vision change"
+    // once normalisation strips the trailing "s" from both.
+    const opt = findROSOptionForSymptom("vision changes", [
+      "eyes: vision change",
+    ]);
+    expect(opt).toBe("eyes: vision change");
+  });
+
+  it("matches a singular NS label to a plural ROS suffix", () => {
+    const opt = findROSOptionForSymptom("vision change", [
+      "neurological: vision changes",
+    ]);
+    expect(opt).toBe("neurological: vision changes");
+  });
+
+  it("returns undefined when no ROS option matches", () => {
+    // NS "tingling" has no ROS counterpart in the curated list; we expect
+    // a graceful undefined so the auto-mirror simply does nothing.
+    expect(findROSOptionForSymptom("tingling", ROS)).toBeUndefined();
+  });
+
+  it("prefers an EXACT post-normalisation match over a later partial-normal", () => {
+    // Both "eyes: vision change" and "neurological: vision changes"
+    // normalise to "vision change". When the NS label "vision change"
+    // arrives, the EXACT (no-strip) match should win — `eyes: vision
+    // change` is preferred because its suffix already matches without
+    // pluralisation surgery.
+    const opt = findROSOptionForSymptom("vision change", ROS);
+    expect(opt).toBe("eyes: vision change");
+  });
+
+  it("returns the first match deterministically when multiple normalise equal", () => {
+    // Two ROS options both require an "s"-strip to match "vision changes".
+    const tied = [
+      "neurological: vision changes",
+      "eyes: vision changes",
+    ];
+    const opt = findROSOptionForSymptom("vision change", tied);
+    expect(opt).toBe("neurological: vision changes");
+  });
+
+  it("is case-insensitive and trims input", () => {
+    const opt = findROSOptionForSymptom("  HEADACHE ", ROS);
+    expect(opt).toBe("neurological: headache");
+  });
+});
+
+describe("findNSOptionForROS (#1314)", () => {
+  const NS = ["headache", "vision changes", "tingling", "fever"];
+
+  it("applies the same normalisation in reverse (ROS singular → NS plural)", () => {
+    // ROS "eyes: vision change" should resolve back to NS "vision
+    // changes".
+    const opt = findNSOptionForROS("eyes: vision change", NS);
+    expect(opt).toBe("vision changes");
+  });
+
+  it("returns undefined when no NS option matches", () => {
+    expect(
+      findNSOptionForROS("psych: anxiety", NS),
+    ).toBeUndefined();
+  });
+
+  it("prefers an exact (no-strip) match before falling back to normalisation", () => {
+    const tied = ["fever", "fevers"];
+    const opt = findNSOptionForROS("constitutional: fever", tied);
+    expect(opt).toBe("fever");
+  });
+});

--- a/apps/clinician-portal/src/__tests__/symptom-ux-polish.test.tsx
+++ b/apps/clinician-portal/src/__tests__/symptom-ux-polish.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Bundle of regression tests for the post-#1310 polish work:
+ *
+ *   - #1312 — 🔗 unlink button must meet WCAG 2.5.5 (44×44 hit area).
+ *     jsdom doesn't compute layout, so we assert the inline style
+ *     declares min-width / min-height ≥ 44px.
+ *   - #1313 — the GroupedMultiselect mobile breakpoint must use the
+ *     portal-standard 767px instead of the ad-hoc 599px the PR
+ *     originally shipped with.
+ */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { GroupedMultiselect } from "../components/grouped-multiselect";
+import {
+  type BodySystem,
+  getSymptomSystem,
+} from "../lib/symptom-systems";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GLOBALS_CSS_PATH = resolve(__dirname, "../../app/globals.css");
+
+afterEach(() => cleanup());
+
+describe("🔗 unlink button hit area (#1312)", () => {
+  it("declares min-width and min-height ≥ 44px on the unlink button", () => {
+    const onUnlink = vi.fn();
+    const collapsed: Partial<Record<BodySystem, boolean>> = {};
+    render(
+      <GroupedMultiselect
+        fieldKey="new_symptoms"
+        options={["headache"]}
+        selected={["headache"]}
+        onChange={() => {}}
+        groupOf={(o) => ({ system: getSymptomSystem(o), display: o })}
+        collapsed={collapsed}
+        onToggleSection={() => {}}
+        defaultExpanded={true}
+        linkedOptions={new Set(["headache"])}
+        onUnlink={onUnlink}
+      />,
+    );
+    const btn = screen.getByRole("button", {
+      name: /Unlink headache/i,
+    }) as HTMLButtonElement;
+    // The inline style on the button must declare a 44px floor on BOTH
+    // dimensions. We read the literal style attribute because jsdom
+    // does not compute layout boxes.
+    const style = btn.getAttribute("style") ?? "";
+    expect(style).toMatch(/min-width:\s*44px/);
+    expect(style).toMatch(/min-height:\s*44px/);
+  });
+
+  it("is centered so the visible 🔗 doesn't grow with the hit area", () => {
+    const onUnlink = vi.fn();
+    render(
+      <GroupedMultiselect
+        fieldKey="new_symptoms"
+        options={["headache"]}
+        selected={["headache"]}
+        onChange={() => {}}
+        groupOf={(o) => ({ system: getSymptomSystem(o), display: o })}
+        collapsed={{}}
+        onToggleSection={() => {}}
+        defaultExpanded={true}
+        linkedOptions={new Set(["headache"])}
+        onUnlink={onUnlink}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /Unlink headache/i });
+    const style = btn.getAttribute("style") ?? "";
+    // align-items / justify-content centering keeps the emoji visually
+    // small inside the 44×44 hit area.
+    expect(style).toMatch(/align-items:\s*center/);
+    expect(style).toMatch(/justify-content:\s*center/);
+  });
+});
+
+describe("GroupedMultiselect mobile breakpoint (#1313)", () => {
+  const css = readFileSync(GLOBALS_CSS_PATH, "utf8");
+
+  it("no longer uses the ad-hoc 599px breakpoint for grouped-multiselect-options", () => {
+    // Find the .grouped-multiselect-options rule body and verify it
+    // sits under the 767px block, NOT under a 599px block.
+    expect(css).not.toMatch(
+      /@media\s*\(\s*max-width:\s*599px\s*\)\s*\{[^}]*grouped-multiselect-options/s,
+    );
+  });
+
+  it("uses the portal-standard 767px breakpoint for the grouped-multiselect stacking rule", () => {
+    // The .grouped-multiselect-options column-stack rule must live
+    // inside one of the existing 767px blocks.
+    const pattern =
+      /@media\s*\(\s*max-width:\s*767px\s*\)\s*\{[\s\S]*?\.grouped-multiselect-options\s*\{[\s\S]*?flex-direction:\s*column[\s\S]*?\}/;
+    expect(css).toMatch(pattern);
+  });
+});

--- a/apps/clinician-portal/src/__tests__/use-persisted-symptom-state.test.tsx
+++ b/apps/clinician-portal/src/__tests__/use-persisted-symptom-state.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #1311 — persist sectionCollapseState + unlinkedPairs across
+ * remounts and page reloads. The implementation lives in
+ * `usePersistedSymptomState` which wraps `useState` with a localStorage
+ * read on mount + write-on-change. These tests pin the persistence
+ * contract:
+ *
+ *   1. Initial mount with no stored value uses the supplied default.
+ *   2. State changes flush to localStorage under the supplied key.
+ *   3. A fresh mount (simulating page reload) restores the stored value.
+ *   4. A malformed stored value falls back to the default silently.
+ *   5. Both the Record and Set variants serialise without losing data.
+ */
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  usePersistedRecord,
+  usePersistedStringSet,
+} from "../lib/use-persisted-symptom-state";
+
+const STORAGE_KEY_RECORD = "cb-symptom-collapse-state";
+const STORAGE_KEY_SET = "cb-symptom-unlinked-pairs";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function RecordHarness({
+  storageKey,
+}: {
+  storageKey: string;
+}) {
+  const [state, setState] = usePersistedRecord<
+    Record<string, Record<string, boolean>>
+  >(storageKey, {});
+  return (
+    <div>
+      <span data-testid="record-json">{JSON.stringify(state)}</span>
+      <button
+        type="button"
+        data-testid="record-set"
+        onClick={() =>
+          setState({
+            new_symptoms: { Neurological: true },
+          })
+        }
+      >
+        set
+      </button>
+    </div>
+  );
+}
+
+function SetHarness({ storageKey }: { storageKey: string }) {
+  const [set, setSet] = usePersistedStringSet(storageKey);
+  return (
+    <div>
+      <span data-testid="set-size">{set.size}</span>
+      <span data-testid="set-has-foo">
+        {set.has("foo||bar") ? "yes" : "no"}
+      </span>
+      <button
+        type="button"
+        data-testid="set-add"
+        onClick={() => {
+          setSet((prev) => {
+            const next = new Set(prev);
+            next.add("foo||bar");
+            return next;
+          });
+        }}
+      >
+        add
+      </button>
+    </div>
+  );
+}
+
+describe("usePersistedRecord (#1311)", () => {
+  it("returns the default value when no stored entry exists", () => {
+    render(<RecordHarness storageKey={STORAGE_KEY_RECORD} />);
+    expect(screen.getByTestId("record-json").textContent).toBe("{}");
+  });
+
+  it("writes state changes to localStorage", () => {
+    render(<RecordHarness storageKey={STORAGE_KEY_RECORD} />);
+    fireEvent.click(screen.getByTestId("record-set"));
+    const stored = localStorage.getItem(STORAGE_KEY_RECORD);
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored as string)).toEqual({
+      new_symptoms: { Neurological: true },
+    });
+  });
+
+  it("restores state on remount (simulates page reload)", () => {
+    // Pre-populate as if a previous mount had set state.
+    localStorage.setItem(
+      STORAGE_KEY_RECORD,
+      JSON.stringify({ new_symptoms: { Neurological: true } }),
+    );
+    render(<RecordHarness storageKey={STORAGE_KEY_RECORD} />);
+    expect(
+      JSON.parse(screen.getByTestId("record-json").textContent ?? "null"),
+    ).toEqual({ new_symptoms: { Neurological: true } });
+  });
+
+  it("falls back to default silently when stored payload is malformed", () => {
+    localStorage.setItem(STORAGE_KEY_RECORD, "{not json");
+    render(<RecordHarness storageKey={STORAGE_KEY_RECORD} />);
+    expect(screen.getByTestId("record-json").textContent).toBe("{}");
+  });
+});
+
+describe("usePersistedStringSet (#1311)", () => {
+  it("starts empty when no stored entry exists", () => {
+    render(<SetHarness storageKey={STORAGE_KEY_SET} />);
+    expect(screen.getByTestId("set-size").textContent).toBe("0");
+    expect(screen.getByTestId("set-has-foo").textContent).toBe("no");
+  });
+
+  it("persists additions to localStorage as a JSON array", () => {
+    render(<SetHarness storageKey={STORAGE_KEY_SET} />);
+    fireEvent.click(screen.getByTestId("set-add"));
+    const stored = localStorage.getItem(STORAGE_KEY_SET);
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored as string);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toContain("foo||bar");
+  });
+
+  it("rehydrates a Set from a JSON array on remount", () => {
+    localStorage.setItem(
+      STORAGE_KEY_SET,
+      JSON.stringify(["foo||bar", "baz||qux"]),
+    );
+    render(<SetHarness storageKey={STORAGE_KEY_SET} />);
+    expect(screen.getByTestId("set-size").textContent).toBe("2");
+    expect(screen.getByTestId("set-has-foo").textContent).toBe("yes");
+  });
+
+  it("falls back to empty Set on malformed payload", () => {
+    localStorage.setItem(STORAGE_KEY_SET, "not-json-at-all");
+    render(<SetHarness storageKey={STORAGE_KEY_SET} />);
+    expect(screen.getByTestId("set-size").textContent).toBe("0");
+  });
+});

--- a/apps/clinician-portal/src/components/grouped-multiselect.tsx
+++ b/apps/clinician-portal/src/components/grouped-multiselect.tsx
@@ -63,6 +63,12 @@ export type GroupedMultiselectProps = {
   highlightedOptions?: Set<string>;
 };
 
+/**
+ * 🔗 unlink button hit area must meet WCAG 2.5.5 (44×44 CSS pixels).
+ * The emoji itself stays visually small via flex centering so the row
+ * height isn't bloated — the increased size lives in the click target,
+ * not the visible glyph. #1312.
+ */
 const linkButtonStyle: CSSProperties = {
   marginLeft: 4,
   padding: 0,
@@ -71,6 +77,11 @@ const linkButtonStyle: CSSProperties = {
   cursor: "pointer",
   fontSize: 12,
   lineHeight: 1,
+  minWidth: 44,
+  minHeight: 44,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
 };
 
 export function GroupedMultiselect({

--- a/apps/clinician-portal/src/lib/symptom-normalization.ts
+++ b/apps/clinician-portal/src/lib/symptom-normalization.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared symptom-label normalisation + NS↔ROS matching helpers.
+ *
+ * Issue #1314 — the original auto-mirror in `apps/clinician-portal/app/
+ * notes/new/page.tsx` did an exact case-insensitive suffix match. That
+ * silently dropped pairings like NS "vision changes" ↔ ROS "eyes: vision
+ * change" because of plural/singular drift. We centralise the naive
+ * trailing-"s" strip the symptom-suggestion-banner already uses for
+ * detection, and apply it to BOTH sides of the comparison.
+ *
+ * Naming: "naive" is intentional — this is not a real stemmer, just the
+ * minimum normalisation that handles the common plural/singular spelling
+ * drift seen in the curated symptom catalog.
+ *
+ * Matching contract:
+ *
+ *   1. Exact (post-lowercase + trim) matches always win over a
+ *      normalised match. This avoids the surprise of an exactly-spelled
+ *      symptom getting overridden by a plural-stripped near-match.
+ *   2. When multiple options normalise to the same form, return the
+ *      first occurrence deterministically — preserving the curated
+ *      ordering in the catalog.
+ *   3. Unknown symptoms return `undefined` so callers can gracefully
+ *      skip the auto-mirror step.
+ */
+
+import { parseROSOption } from "./symptom-systems";
+
+/**
+ * Lowercase, trim, and strip a single trailing "s" if present.
+ *
+ * This is the same normalisation the symptom-suggestion-banner uses to
+ * tolerate the "headache"/"headaches" split. It is single-pass — "kiss"
+ * becomes "kis" rather than "k" — because the catalog never spells a
+ * symptom with multiple trailing "s"es in a way we care about, and
+ * being non-recursive keeps the helper unambiguous.
+ */
+export function normalizeSymptomLabel(s: string): string {
+  const lower = s.toLowerCase().trim();
+  if (lower.length > 1 && lower.endsWith("s")) {
+    return lower.slice(0, -1);
+  }
+  return lower;
+}
+
+/**
+ * Find the first ROS option whose post-colon suffix matches the supplied
+ * NS symptom string. Prefers an exact match (post-lowercase + trim) over
+ * a normalised match — the latter is the plural-tolerant fallback.
+ *
+ * Returns `undefined` when no option matches under either rule.
+ */
+export function findROSOptionForSymptom(
+  symptom: string,
+  rosOptions: string[],
+): string | undefined {
+  const exactNeedle = symptom.toLowerCase().trim();
+  const normalNeedle = normalizeSymptomLabel(symptom);
+
+  // First pass: exact match wins.
+  for (const opt of rosOptions) {
+    const { symptom: suffix } = parseROSOption(opt);
+    if (suffix.toLowerCase().trim() === exactNeedle) return opt;
+  }
+  // Second pass: normalised match handles plural/singular drift.
+  for (const opt of rosOptions) {
+    const { symptom: suffix } = parseROSOption(opt);
+    if (normalizeSymptomLabel(suffix) === normalNeedle) return opt;
+  }
+  return undefined;
+}
+
+/**
+ * Reverse direction: given a ROS option, find the matching NS option
+ * whose bare label corresponds. NS options are unprefixed strings so
+ * the comparison is a direct label match (with the same normalisation).
+ */
+export function findNSOptionForROS(
+  rosOption: string,
+  nsOptions: string[],
+): string | undefined {
+  const { symptom } = parseROSOption(rosOption);
+  const exactNeedle = symptom.toLowerCase().trim();
+  const normalNeedle = normalizeSymptomLabel(symptom);
+
+  for (const opt of nsOptions) {
+    if (opt.toLowerCase().trim() === exactNeedle) return opt;
+  }
+  for (const opt of nsOptions) {
+    if (normalizeSymptomLabel(opt) === normalNeedle) return opt;
+  }
+  return undefined;
+}

--- a/apps/clinician-portal/src/lib/use-persisted-symptom-state.ts
+++ b/apps/clinician-portal/src/lib/use-persisted-symptom-state.ts
@@ -1,0 +1,102 @@
+/**
+ * Persistence hooks for the symptom UX state — issue #1311.
+ *
+ * The /notes/new page keeps two pieces of UI-only state that the
+ * inspector flagged as resetting on remount or page reload:
+ *
+ *   - `sectionCollapseState` — per-field per-body-system collapsed flag.
+ *   - `unlinkedPairs` — set of `"<nsOption>||<rosOption>"` strings the
+ *     user has explicitly unlinked.
+ *
+ * Both round-trip through localStorage so the affordance survives
+ * navigation, refresh, and tab restoration. We deliberately use a
+ * single global key per slot (rather than a per-draft key) so the
+ * affordance also persists across drafts for the same clinician — when
+ * a clinician collapses the GU section because their specialty is
+ * oncology, that preference should follow them to the next draft too.
+ *
+ * Both hooks share a write-on-change effect that JSON-serialises the
+ * current value back into localStorage. The initial read happens lazily
+ * in a useState initialiser so SSR doesn't crash on a missing window.
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+/**
+ * Persist any JSON-serialisable Record-shaped value behind a string key.
+ * Falls back to the supplied default on first mount and on malformed
+ * payloads.
+ */
+export function usePersistedRecord<T extends Record<string, unknown>>(
+  storageKey: string,
+  defaultValue: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => readJSON(storageKey, defaultValue));
+
+  useEffect(() => {
+    writeJSON(storageKey, state);
+  }, [storageKey, state]);
+
+  return [state, setState];
+}
+
+/**
+ * Persist a Set<string> behind a string key. The Set is serialised as a
+ * JSON array (Sets aren't natively JSON-serialisable) and rehydrated on
+ * mount. The setter exposes the standard `Dispatch<SetStateAction<...>>`
+ * signature so callers can use `setSet(prev => new Set(prev).add(x))`
+ * just like a regular `useState<Set<string>>`.
+ */
+export function usePersistedStringSet(
+  storageKey: string,
+): [Set<string>, Dispatch<SetStateAction<Set<string>>>] {
+  const [state, setState] = useState<Set<string>>(() => {
+    const arr = readJSON<string[]>(storageKey, []);
+    return new Set(Array.isArray(arr) ? arr : []);
+  });
+
+  useEffect(() => {
+    if (typeof localStorage === "undefined") return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify([...state]));
+    } catch {
+      // localStorage may be unavailable (private mode quota, etc.);
+      // silently skip so the UI keeps working.
+    }
+  }, [storageKey, state]);
+
+  const stableSetter = useCallback<Dispatch<SetStateAction<Set<string>>>>(
+    (action) => {
+      setState((prev) =>
+        typeof action === "function"
+          ? (action as (p: Set<string>) => Set<string>)(prev)
+          : action,
+      );
+    },
+    [],
+  );
+
+  return [state, stableSetter];
+}
+
+function readJSON<T>(key: string, fallback: T): T {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const parsed = JSON.parse(raw) as T;
+    return parsed ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJSON<T>(key: string, value: T): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // quota / private mode — fail open so UI keeps working.
+  }
+}


### PR DESCRIPTION
Bundled polish PR addressing the four follow-ups filed against PR #1310 (symptom UX). Each fix is additive and scoped to the symptom UX files; no other features touched.

Closes #1311
Closes #1312
Closes #1313
Closes #1314

## Fixes

### #1311 — persist sectionCollapseState + unlinkedPairs

`apps/clinician-portal/app/notes/new/page.tsx` previously kept both UI-state slots in `useState` only, so a fresh mount or page reload cleared them. Persistence is now handled via two custom hooks in `apps/clinician-portal/src/lib/use-persisted-symptom-state.ts`:

- `usePersistedRecord<T>(key, default)` — wraps `useState` with a localStorage read on mount + write-on-change.
- `usePersistedStringSet(key)` — same contract for `Set<string>`, serialised as a JSON array.

Both keyed by global slots (`cb-symptom-collapse-state`, `cb-symptom-unlinked-pairs`) — the affordance also follows the clinician across drafts, matching the specialty-driven usage pattern.

The template-fetch `useEffect` was also tightened so it only resets per-field UI state when the user actually switches template type (tracked via `lastLoadedTemplateType` ref). Without that guard, the initial fetch resolution on every fresh mount would clobber the just-restored persisted state.

### #1312 — 🔗 unlink button hit area meets WCAG 2.5.5

`apps/clinician-portal/src/components/grouped-multiselect.tsx` — `linkButtonStyle` bumped to `minWidth: 44`, `minHeight: 44`, with flex centering so the visible emoji stays compact inside the larger hit area.

### #1313 — GroupedMultiselect mobile breakpoint aligned to 767px

`apps/clinician-portal/app/globals.css` — the `@media (max-width: 599px)` block was rewritten to `@media (max-width: 767px)`, matching the existing portal mobile breakpoint. Devices in the 600-767px range (small landscape tablets, foldable inner displays) now get the same column-stack layout as phones, consistent with the rest of the mobile styling.

### #1314 — NS↔ROS auto-mirror handles plural/singular drift

New helper `apps/clinician-portal/src/lib/symptom-normalization.ts`:

- `normalizeSymptomLabel(s)` — lowercases, trims, and strips a single trailing "s" (same naive plural the symptom-suggestion-banner uses).
- `findROSOptionForSymptom` / `findNSOptionForROS` — two-pass matchers: exact (lowercase + trim) match wins, normalised match is the plural-tolerant fallback. Multi-match returns first occurrence deterministically.

The page-level `handleMultiselectChange` and `handleUnlink` now import these so NS "vision changes" auto-mirrors to ROS "eyes: vision change" (and vice versa). Distinct symptoms with no counterpart (NS "tingling") gracefully return `undefined` and the mirror is a no-op.

## Test plan

- [x] `apps/clinician-portal/src/__tests__/symptom-normalization.test.ts` — 14 cases: `normalizeSymptomLabel` rules, exact-before-normalised preference, deterministic tie-break, undefined for distinctive symptoms, symmetric ROS↔NS.
- [x] `apps/clinician-portal/src/__tests__/use-persisted-symptom-state.test.tsx` — 8 cases covering Record and Set variants: default value, write-on-change, restore-on-remount, malformed payload fallback.
- [x] `apps/clinician-portal/src/__tests__/symptom-ux-polish.test.tsx` — `min-width: 44px` / `min-height: 44px` on the rendered unlink button (jsdom can't compute layout, so we assert the inline style declaration directly), plus a static CSS regression that the GroupedMultiselect stacking rule lives under the 767px block (not 599px).
- [x] `apps/clinician-portal/src/__tests__/new-note-plural-mirror.test.tsx` — integration: NS "vision changes" auto-mirrors ROS "eyes: vision change", reverse direction works, NS "tingling" (no counterpart) is a graceful no-op.
- [x] `apps/clinician-portal/src/__tests__/new-note-state-persistence.test.tsx` — integration: collapsing a NS section persists to localStorage and rehydrates on remount; expanding a ROS section persists across remounts.
- [x] Full clinician-portal vitest suite (334 tests) green.
- [x] `pnpm lint` clean — no new warnings introduced in touched files.