### PR TITLE
fix(portal): clarify refill page sends a message, not a script

### DIFF
--- a/apps/patient-portal/app/refill/page.tsx
+++ b/apps/patient-portal/app/refill/page.tsx
@@ -100,7 +100,7 @@ export default function RefillPage() {
   return (
     <div style={{ maxWidth: 700, margin: "0 auto" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem" }}>
-        <h2 style={{ margin: 0 }}>Request Medication Refill</h2>
+        <h2 style={{ margin: 0 }}>Message Your Provider About a Refill</h2>
         <button
           onClick={() => router.push("/")}
           style={{ background: "none", border: "1px solid #444", color: "#999", padding: "0.5rem 1rem", borderRadius: 6, cursor: "pointer" }}
@@ -109,9 +109,31 @@ export default function RefillPage() {
         </button>
       </div>
 
+      <div
+        role="note"
+        style={{
+          backgroundColor: "#3b2a0f",
+          border: "1px solid #b45309",
+          borderRadius: 8,
+          padding: "0.75rem 1rem",
+          marginBottom: "1.5rem",
+          color: "#fef3c7",
+          fontSize: "0.85rem",
+          lineHeight: 1.5,
+        }}
+      >
+        <strong style={{ color: "#fbbf24" }}>Important:</strong> This sends a
+        message to your care team. It does <strong>not</strong> submit a
+        prescription to your pharmacy. Your provider will review your request
+        and either order a refill through their normal e-prescribing workflow
+        or respond with questions. If you are running out of an urgent
+        medication, call your provider directly.
+      </div>
+
       <p style={{ color: "#999", fontSize: "0.85rem", marginBottom: "1.5rem" }}>
-        Select a medication to request a refill. Your prescribing provider will receive
-        the request and can approve or deny it.
+        Select a medication to message your provider about. The message goes to
+        your prescribing provider (or your primary care team member if the
+        prescriber is unavailable).
       </p>
 
       {isUnlinked && (
@@ -151,11 +173,11 @@ export default function RefillPage() {
 
             {successMedId === med.id ? (
               <span role="status" aria-live="polite" style={{ color: "#22c55e", fontSize: "0.8rem", fontWeight: 600 }}>
-                &#x2713; Refill requested!
+                &#x2713; Message sent to provider
               </span>
             ) : errorMedId === med.id ? (
               <span role="alert" style={{ color: "#ef4444", fontSize: "0.8rem", fontWeight: 600 }}>
-                &#x2717; Request failed. Try again.
+                &#x2717; Could not send message. Try again.
               </span>
             ) : (
               <button
@@ -172,7 +194,7 @@ export default function RefillPage() {
                   opacity: submittingMedId === med.id ? 0.6 : 1,
                 }}
               >
-                {submittingMedId === med.id ? "Requesting..." : "Request Refill"}
+                {submittingMedId === med.id ? "Sending..." : "Message Provider"}
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary

Refill page copy implied a prescription was submitted to the patient's pharmacy. It wasn't — the page opens a \`messaging.createConversation\` conversation with the prescribing provider. There is no e-prescribing pipeline today.

Swarm audit's Guardian agent flagged this as a 3am-page-scenario class deception (patient runs out of an anticoagulant believing the refill was filed). This PR addresses the immediate copy/UX layer of that finding. The underlying option of building a real Surescripts/RxNorm gateway is a separate (much larger) decision.

## Changes

| What | Before | After |
|---|---|---|
| Page header | \`Request Medication Refill\` | \`Message Your Provider About a Refill\` |
| Top banner | (none) | Prominent \`role=note\` warning explaining this is NOT a pharmacy submission, with directive to call provider for urgent meds |
| Body copy | "Select a medication to request a refill" | "Select a medication to message your provider about" |
| Per-med button | \`Request Refill\` | \`Message Provider\` |
| In-flight button | \`Requesting…\` | \`Sending…\` |
| Success copy | \`✓ Refill requested!\` | \`✓ Message sent to provider\` |
| Error copy | \`✗ Request failed. Try again.\` | \`✗ Could not send message. Try again.\` |

Backend message body (subject + body sent to the provider's inbox) intentionally unchanged — provider-side framing as a refill request is accurate; the deception was patient-side.

## Test plan

- [x] grep confirms no other patient-facing surface still reads "Request Refill" / "Refill requested" (only matches are now the internal handler function name \`handleRequestRefill\`, the internal message subject for the provider, and an unrelated epic-connector smoke script).
- [x] No tests exist for this page yet (one of the audit's open items — pre-existing).
- [x] Page-level tsc errors are all pre-existing project-config / module-resolution issues unrelated to this change.

## Audit closure

Closes Guardian finding #1 ("Refill UX deception") from \`docs/audit-results/project-state-mychart-parity-epic-coexistence/03-guardian.md\`.