### PR TITLE
feat(mission): MISSION.md + DETERIORATION-TRAJECTORY-001 scaffold

### DIFF
--- a/MISSION.md
+++ b/MISSION.md
@@ -4,7 +4,7 @@
 
 ## Why this exists
 
-> _Personal foreword from Chris Bowen, project founder. This section is
+> _Personal foreword from Chris Pishaki, project founder. This section is
 > first-person and intentionally not technical. The rest of the document is._
 
 My mom died from a care coordination failure.
@@ -17,7 +17,7 @@ I built CareBridge because computers don't get tired. They don't skip iterations
 
 This project is not a replacement for clinicians. It's a checklist made by a grieving family member, written so that the next family doesn't have to do the post-mortem I did.
 
-— Chris Bowen, 2026
+— Chris Pishaki, 2026
 
 ## The failure class
 

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,0 +1,90 @@
+# CareBridge Mission
+
+> The system should force the surfacing of cross-specialty deterioration patterns that tired or siloed clinicians miss, especially during inpatient stays and discharge decisions.
+
+## Why this exists
+
+> _Personal foreword from Chris Bowen, project founder. This section is
+> first-person and intentionally not technical. The rest of the document is._
+
+My mom died from a care coordination failure.
+
+It wasn't one big mistake. It was a slow accumulation: multiple hospital admissions, deterioration across them, repeated warning signs in the chart that were underweighted, fragmented across specialties, or lost in messy and copy-pasted documentation. Discharges happened before they should have. Symptoms were noted but not connected. Labs trended in directions that mattered, but nobody owned the trajectory. Each specialty saw their slice. None of them saw the patient getting worse.
+
+When I read her chart after she died, the pattern was obvious. It was obvious in retrospect because all of the pieces were there — in writing — across notes nobody had stitched together. Tired clinicians on rotating shifts in siloed services missed what a careful reader with all the context would have caught immediately.
+
+I built CareBridge because computers don't get tired. They don't skip iterations because they're behind on rounds. They don't copy-paste yesterday's note and forget to check whether yesterday's note is still true. A system that systematically surfaces the cross-specialty deterioration pattern at the moments that matter — readmission, shift change, discharge decision — is a thing that should exist and didn't. Now it does.
+
+This project is not a replacement for clinicians. It's a checklist made by a grieving family member, written so that the next family doesn't have to do the post-mortem I did.
+
+— Chris Bowen, 2026
+
+## The failure class
+
+CareBridge addresses **cross-specialty deterioration patterns** — a class of clinical failure that single-specialist EHR notes structurally cannot catch because:
+
+1. **No single clinician owns the trajectory.** Hospitalists hand off at shift change. Specialists see slices. ICU teams rotate. The patient's worsening trend lives in the difference between notes nobody compares side-by-side.
+2. **Soft signals don't trip hard thresholds.** A heart rate of 95, a respiratory rate of 22, a white count of 12, and a temperature of 100.4 are each "soft." Together they meet SIRS criteria. The chart records each value; the workup that should have followed often doesn't.
+3. **Copy-forwarded notes drift.** A note carried forward from the prior shift can describe a patient who has materially changed since. The reader trusts the documented state; the documented state lags reality.
+4. **Discharge decisions get made under pressure.** Length-of-stay metrics, bed pressure, and shift-end fatigue push patients out the door with unresolved labs, open consult requests, and symptoms that were noted but not investigated.
+5. **Hospitals only see one admission at a time.** A patient who has been readmitted three times in 90 days is treated as a new admission at the third hospital. The trajectory across admissions — the most important signal of deteriorating disease — is invisible to any single institution's EHR.
+
+These are the failure modes CareBridge is designed to catch. None are diagnoses. All are pattern-recognition tasks that benefit from a system that never gets tired.
+
+## What CareBridge does
+
+Mechanically, CareBridge is a **deterministic clinical pattern engine** with three layers:
+
+1. **A structured chart-taking system** for clinicians. Symptom capture with negation-awareness, body-system grouped ROS, NS↔ROS auto-mirror, age-stratified vital validators. The goal is to make structured documentation faster than free-text narrative so that downstream pattern detection has clean inputs to work against.
+2. **A deterministic rules engine** (`services/ai-oversight/src/rules/`) that runs against the structured chart. Rules encode known dangerous patterns — drug interactions, cross-specialty risk combinations, and (starting with this milestone) deterioration trajectories. Rules are pure functions over a `PatientContext` snapshot, fully auditable, and never depend on LLM behavior.
+3. **An optional LLM second-pass review** via Claude API. The LLM reviews cases the deterministic rules already flagged, looking for nuance the rules couldn't encode. It never originates clinical decisions — it elaborates on what the deterministic layer surfaced.
+
+The output is a **flag**: a structured record with severity, category, summary, rationale, suggested action, and the specialties that should see it. Flags surface in clinician inboxes and (via the bridge, see below) in printed bedside summaries that family caregivers can hand to any clinician.
+
+## What CareBridge does NOT do
+
+CareBridge is positioned as **non-device clinical decision support** under the 21st Century Cures Act exemption (see `docs/cds-exemption.md`). To stay on the safe side of that line, CareBridge:
+
+- **Does not prescribe, dose, or order anything.** No orders are generated. No "give patient X" recommendations.
+- **Does not diagnose.** Rules surface concerning patterns and suggest workups; they never assert what the patient has.
+- **Discloses its underlying data and logic to the user.** Every flag carries citations and the rationale that produced it. A clinician can read the input and the logic and decide independently.
+- **Does not auto-act.** Every flag requires a clinician to read and decide. Nothing happens in the chart without human action.
+- **Does not replace clinician judgment.** Flags are checklists, not verdicts.
+
+## Architecture: MedLens + CareBridge + the bridge
+
+CareBridge does not exist alone. It is one half of a **two-app patient-safety stack**:
+
+- **MedLens** (`/Users/blamechris/Projects/medlens`) — a React Native / Expo mobile app for **patient and family-caregiver capture**. Photographs whiteboards, IV bags, lab printouts; OCRs them; stores everything locally on the device. Explicitly **does not interpret** data into clinical advice (see [`medlens/NON-GOALS.md`](../medlens/NON-GOALS.md)). The SaMD firewall lives at this boundary: MedLens captures, CareBridge interprets.
+- **CareBridge** (this repo) — the clinician-facing chart system + AI oversight engine. Lives on the web. Talks to MedLens through a patient-controlled scoped-token bridge so family caregivers can share their longitudinal capture with whatever clinician they hand a printed summary to.
+- **The bridge** (`services/fhir-gateway/src/medlens-bridge.ts` — currently stubbed; to be built out) — a no-login, no-account-required web view at carebridge.app where a clinician redeems a one-time token (or scans a QR code) and sees the patient's structured history + the AI oversight engine's flags. Designed for the on-call hospitalist who doesn't want to install anything.
+
+The longitudinal-across-admissions property — the thing hospitals structurally cannot see — comes from MedLens being on the family caregiver's phone, not the hospital's server. The family follows the patient across admissions; MedLens captures across admissions; CareBridge runs deterioration-trajectory rules across that longitudinal data; the clinician gets it in one summary.
+
+## First rule: DETERIORATION-TRAJECTORY-001
+
+The first major rule in the deterioration-trajectory family is an **umbrella** that runs six sub-checks at three triggers (new admission with priors, shift change, discharge decision):
+
+| Sub-rule | What it catches | Priority |
+|---|---|:---:|
+| READMISSION-TRAJECTORY | Patient readmitted within 30/60/90d with worsening labs/vitals/symptoms across admissions | **1st** |
+| DISCHARGE-READINESS | Discharge language appearing while labs are trending wrong, consults are open, or symptoms are unresolved | **2nd** |
+| CROSS-SPECIALTY-SYMPTOM-ORPHAN | Symptom documented across multiple specialty notes with no owning workup | **3rd** |
+| WARNING-SIGN-AGGREGATOR | Individually-soft signals (HR/RR/WBC/temp) that meet a composite criterion (SIRS, qSOFA, MEWS) | future |
+| COPY-FORWARD-DRIFT | Note text > 80% similarity to prior shift's note where at least one clinical signal has changed since | future |
+| CONSULT-LOOP-OPEN | Consult requested ≥24h ago without a closing note linked back | future |
+
+The scaffolding for all six lives in `packages/medical-logic/src/deterioration-patterns.ts`. The first three ship as the founding milestone. The other three follow as the data model fills out.
+
+## Status & how to contribute
+
+This is a pre-launch solo project. Building publicly. Mission-first.
+
+- **Architecture**: see [`docs/`](docs/) and [`README.md`](README.md)
+- **Open issues**: GitHub issues. Pinned issue points at the first-time-contributor scope.
+- **Clinical accuracy**: see [`docs/ai-prompt-editing.md`](docs/ai-prompt-editing.md) for the merge-gate vs launch-gate split and [`LAUNCH-CHECKLIST.md`](LAUNCH-CHECKLIST.md) for pending clinical attestations.
+- **What I'm not doing**: see this document's "What CareBridge does NOT do" section. If you're tempted to add a feature that crosses that line, propose it on an issue first.
+
+If you're a clinician (PharmD / physician / informaticist) and want to help review the rules engine before launch, the path is in `LAUNCH-CHECKLIST.md`. If you're a software engineer who wants to contribute, the open issues are labeled by complexity.
+
+If you're a family caregiver who has been through what I went through, I am sorry. Email me at the address in my GitHub profile. I want to hear how this could have helped, and where it would not have.

--- a/packages/medical-logic/src/__tests__/deterioration-patterns.test.ts
+++ b/packages/medical-logic/src/__tests__/deterioration-patterns.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectReadmissionTrajectory,
+  detectDischargeReadinessRisk,
+  detectCrossSpecialtySymptomOrphan,
+  type PriorEncounter,
+  type CurrentEncounter,
+  type LabTrend,
+  type ConsultRequest,
+  type DischargeSignal,
+  type SymptomObservation,
+} from "../deterioration-patterns.js";
+
+// ─── READMISSION-TRAJECTORY ─────────────────────────────────────
+
+describe("detectReadmissionTrajectory", () => {
+  const currentEncounter: CurrentEncounter = {
+    encounter_id: "enc-current",
+    admitted_at: "2026-05-15T10:00:00Z",
+  };
+
+  it("does not fire when there are no prior encounters", () => {
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [],
+      current_encounter: currentEncounter,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("does not fire when prior encounters are outside the lookback window", () => {
+    const farPrior: PriorEncounter = {
+      encounter_id: "enc-old",
+      admitted_at: "2025-01-01T10:00:00Z",
+      discharged_at: "2025-01-08T10:00:00Z",
+      chief_complaint: "shortness of breath",
+    };
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [farPrior],
+      current_encounter: currentEncounter,
+      lookback_days: 90,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("does not fire when prior encounter is in window but no labs trend the wrong way", () => {
+    const prior: PriorEncounter = {
+      encounter_id: "enc-recent",
+      admitted_at: "2026-04-10T10:00:00Z",
+      discharged_at: "2026-04-15T10:00:00Z",
+      chief_complaint: "pneumonia",
+    };
+    const labTrends: LabTrend[] = [
+      {
+        lab_name: "creatinine",
+        values: [
+          { value: 1.0, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-recent" },
+          { value: 0.9, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [prior],
+      current_encounter: currentEncounter,
+      lab_trends: labTrends,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("fires when a rising-concern lab (creatinine) trends up across admissions", () => {
+    const prior: PriorEncounter = {
+      encounter_id: "enc-prior",
+      admitted_at: "2026-04-10T10:00:00Z",
+      discharged_at: "2026-04-15T10:00:00Z",
+      chief_complaint: "AKI on dehydration",
+    };
+    const labTrends: LabTrend[] = [
+      {
+        lab_name: "creatinine",
+        values: [
+          { value: 1.1, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+          { value: 1.8, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [prior],
+      current_encounter: currentEncounter,
+      lab_trends: labTrends,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary).toContain("creatinine");
+    expect(result.summary).toContain("1.1");
+    expect(result.summary).toContain("1.8");
+    expect(result.details?.worsening_labs).toBeDefined();
+  });
+
+  it("fires on a falling-concern lab (hemoglobin) trending down across admissions", () => {
+    const prior: PriorEncounter = {
+      encounter_id: "enc-prior-anemia",
+      admitted_at: "2026-04-10T10:00:00Z",
+      discharged_at: "2026-04-15T10:00:00Z",
+      chief_complaint: "anemia workup",
+    };
+    const labTrends: LabTrend[] = [
+      {
+        lab_name: "hemoglobin",
+        values: [
+          { value: 11.2, unit: "g/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior-anemia" },
+          { value: 9.4, unit: "g/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [prior],
+      current_encounter: currentEncounter,
+      lab_trends: labTrends,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary).toContain("hemoglobin");
+  });
+
+  it("fails closed (does not fire) when units differ across admissions", () => {
+    const prior: PriorEncounter = {
+      encounter_id: "enc-prior",
+      admitted_at: "2026-04-10T10:00:00Z",
+      chief_complaint: "AKI",
+    };
+    const labTrends: LabTrend[] = [
+      {
+        lab_name: "creatinine",
+        values: [
+          { value: 100, unit: "umol/L", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+          { value: 1.8, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectReadmissionTrajectory({
+      prior_encounters: [prior],
+      current_encounter: currentEncounter,
+      lab_trends: labTrends,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("counts admissions in window correctly when multiple priors present", () => {
+    const priors: PriorEncounter[] = [
+      { encounter_id: "enc-1", admitted_at: "2026-03-01T10:00:00Z", chief_complaint: "x" },
+      { encounter_id: "enc-2", admitted_at: "2026-04-10T10:00:00Z", chief_complaint: "x" },
+    ];
+    const labTrends: LabTrend[] = [
+      {
+        lab_name: "creatinine",
+        values: [
+          { value: 1.0, unit: "mg/dL", measured_at: "2026-03-04T08:00:00Z", encounter_id: "enc-1" },
+          { value: 1.3, unit: "mg/dL", measured_at: "2026-04-13T08:00:00Z", encounter_id: "enc-2" },
+          { value: 2.0, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectReadmissionTrajectory({
+      prior_encounters: priors,
+      current_encounter: currentEncounter,
+      lab_trends: labTrends,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.details?.admissions_in_window).toBe(2);
+    expect(result.summary).toContain("Admission 3");
+  });
+});
+
+// ─── DISCHARGE-READINESS ─────────────────────────────────────────
+
+describe("detectDischargeReadinessRisk", () => {
+  const dischargeSignal: DischargeSignal = {
+    is_discharge_imminent: true,
+    detected_at: "2026-05-15T18:00:00Z",
+    source: "note_template",
+  };
+
+  it("does not fire when discharge is not imminent", () => {
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: { ...dischargeSignal, is_discharge_imminent: false },
+      consult_requests: [
+        { consult_id: "c1", requested_at: "2026-05-13T10:00:00Z", specialty: "cardiology" },
+      ],
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("does not fire on discharge with no concerning signals", () => {
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      consult_requests: [],
+      recent_symptoms: [],
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("fires when discharge is imminent and a lab is trending wrong in the current encounter", () => {
+    const trends: LabTrend[] = [
+      {
+        lab_name: "lactate",
+        values: [
+          { value: 1.5, unit: "mmol/L", measured_at: "2026-05-15T08:00:00Z", encounter_id: "enc-current" },
+          { value: 2.4, unit: "mmol/L", measured_at: "2026-05-15T17:00:00Z", encounter_id: "enc-current" },
+        ],
+      },
+    ];
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      lab_trends: trends,
+      current_encounter_id: "enc-current",
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary?.toLowerCase()).toContain("lactate");
+  });
+
+  it("fires when a consult requested ≥24h ago has no closing note", () => {
+    const consults: ConsultRequest[] = [
+      {
+        consult_id: "c1",
+        requested_at: "2026-05-13T10:00:00Z", // ~56h before discharge signal
+        specialty: "cardiology",
+      },
+    ];
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      consult_requests: consults,
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary?.toLowerCase()).toContain("consult");
+    expect(result.summary?.toLowerCase()).toContain("cardiology");
+  });
+
+  it("does not count consults that have been responded to", () => {
+    const consults: ConsultRequest[] = [
+      {
+        consult_id: "c1",
+        requested_at: "2026-05-13T10:00:00Z",
+        specialty: "cardiology",
+        responded_at: "2026-05-14T11:00:00Z",
+        closed_by_note_id: "note-1",
+      },
+    ];
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      consult_requests: consults,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("fires when recent unresolved symptoms are present", () => {
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      recent_symptoms: ["new chest pain", "worsening dyspnea"],
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary?.toLowerCase()).toContain("chest pain");
+  });
+
+  it("composes multiple reasons in the summary when several signals fire", () => {
+    const result = detectDischargeReadinessRisk({
+      discharge_signal: dischargeSignal,
+      consult_requests: [
+        { consult_id: "c1", requested_at: "2026-05-13T10:00:00Z", specialty: "endocrinology" },
+      ],
+      recent_symptoms: ["altered mental status"],
+    });
+    expect(result.fired).toBe(true);
+    expect(result.summary?.toLowerCase()).toContain("consult");
+    expect(result.summary?.toLowerCase()).toContain("altered mental status");
+  });
+});
+
+// ─── CROSS-SPECIALTY-SYMPTOM-ORPHAN ─────────────────────────────
+
+describe("detectCrossSpecialtySymptomOrphan", () => {
+  it("does not fire when only one specialty documented a symptom", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({ symptom_observations: observations });
+    expect(result.fired).toBe(false);
+  });
+
+  it("does not fire when multiple specialties documented but at least one owned the workup", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: true,
+      },
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "cardiology",
+        documented_at: "2026-05-15T10:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({ symptom_observations: observations });
+    expect(result.fired).toBe(false);
+  });
+
+  it("fires when a symptom is documented across ≥2 specialties with no workup", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "cardiology",
+        documented_at: "2026-05-15T10:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "ICU",
+        documented_at: "2026-05-15T14:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({ symptom_observations: observations });
+    expect(result.fired).toBe(true);
+    expect(result.summary?.toLowerCase()).toContain("dyspnea");
+    expect(result.summary?.toLowerCase()).toContain("pulmonology");
+    expect(result.summary?.toLowerCase()).toContain("cardiology");
+  });
+
+  it("normalizes symptom names (case-insensitive, trimmed)", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "Dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "  dyspnea  ",
+        documented_by_specialty: "cardiology",
+        documented_at: "2026-05-15T10:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({ symptom_observations: observations });
+    expect(result.fired).toBe(true);
+  });
+
+  it("respects min_specialties override", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "cardiology",
+        documented_at: "2026-05-15T10:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({
+      symptom_observations: observations,
+      min_specialties: 3,
+    });
+    expect(result.fired).toBe(false);
+  });
+
+  it("returns multiple orphaned symptoms in details when several patterns fire", () => {
+    const observations: SymptomObservation[] = [
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "pulmonology",
+        documented_at: "2026-05-15T08:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "dyspnea",
+        documented_by_specialty: "cardiology",
+        documented_at: "2026-05-15T10:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "confusion",
+        documented_by_specialty: "neurology",
+        documented_at: "2026-05-15T11:00:00Z",
+        has_workup: false,
+      },
+      {
+        symptom: "confusion",
+        documented_by_specialty: "ICU",
+        documented_at: "2026-05-15T13:00:00Z",
+        has_workup: false,
+      },
+    ];
+    const result = detectCrossSpecialtySymptomOrphan({ symptom_observations: observations });
+    expect(result.fired).toBe(true);
+    const orphaned = result.details?.orphaned_symptoms as Array<{ symptom: string }>;
+    expect(orphaned).toHaveLength(2);
+    expect(orphaned.map((o) => o.symptom).sort()).toEqual(["confusion", "dyspnea"]);
+  });
+});

--- a/packages/medical-logic/src/deterioration-patterns.ts
+++ b/packages/medical-logic/src/deterioration-patterns.ts
@@ -1,0 +1,527 @@
+/**
+ * Deterioration trajectory pattern detectors.
+ *
+ * Pure functions that operate on a snapshot of longitudinal patient data
+ * and return a structured PatternResult describing whether the pattern
+ * fired and what evidence supported it. No DB I/O, no LLM calls, fully
+ * testable against synthetic timelines.
+ *
+ * These detectors are the building blocks of the DETERIORATION-TRAJECTORY-001
+ * umbrella rule (see services/ai-oversight/src/rules/deterioration-trajectory.ts).
+ * See MISSION.md for the founding context.
+ *
+ * Status (2026-05-28): scaffolding milestone. The first three detectors
+ * (READMISSION-TRAJECTORY, DISCHARGE-READINESS, CROSS-SPECIALTY-SYMPTOM-ORPHAN)
+ * ship with initial heuristics tuned to the founding case class. Clinical
+ * threshold calibration is pending clinician review per LAUNCH-CHECKLIST.md.
+ *
+ * The remaining three patterns in the family (WARNING-SIGN-AGGREGATOR,
+ * COPY-FORWARD-DRIFT, CONSULT-LOOP-OPEN) are stubbed as future work and
+ * tracked in MISSION.md § "First rule: DETERIORATION-TRAJECTORY-001".
+ */
+
+// ─── Shared types ───────────────────────────────────────────────
+
+/**
+ * A prior hospital encounter (admission). Used by detectors that need to
+ * trend signals across admissions to surface readmission patterns.
+ */
+export interface PriorEncounter {
+  encounter_id: string;
+  /** ISO 8601 admission timestamp. */
+  admitted_at: string;
+  /** ISO 8601 discharge timestamp; absent if encounter is still open. */
+  discharged_at?: string;
+  /** Chief complaint at admission; null if not recorded. */
+  chief_complaint: string | null;
+  /** Discharge diagnoses (free-text descriptions). */
+  discharge_diagnoses?: string[];
+  /** Active medications at discharge. */
+  discharge_medications?: string[];
+  /**
+   * Selected lab values at discharge, for cross-admission trend comparison.
+   * Detectors use these to compare admission-N's discharge against
+   * admission-N+1's admission baseline.
+   */
+  discharge_labs?: Array<{ name: string; value: number; unit: string }>;
+}
+
+/**
+ * The current (open) encounter. Used as the "now" anchor for trajectory
+ * comparisons and length-of-stay calculations.
+ */
+export interface CurrentEncounter {
+  encounter_id: string;
+  /** ISO 8601 admission timestamp for this encounter. */
+  admitted_at: string;
+  /** Computed length-of-stay in hours so far; orchestrator-derived. */
+  length_of_stay_hours?: number;
+  /** Attending specialty (e.g. "hospitalist", "oncology"). */
+  attending_specialty?: string;
+  /** Specialties consulting on this encounter. */
+  consulting_specialties?: string[];
+  /**
+   * Planned discharge timestamp if one has been entered (e.g. by the
+   * discharge planner or attending). Absent if no discharge plan is set.
+   */
+  planned_discharge_at?: string;
+}
+
+/**
+ * A consult request placed during the current encounter. Used by
+ * DISCHARGE-READINESS to detect open-loop consults at discharge time and
+ * (future) by CONSULT-LOOP-OPEN as a standalone signal.
+ */
+export interface ConsultRequest {
+  consult_id: string;
+  /** ISO 8601 timestamp when the consult was requested. */
+  requested_at: string;
+  /** Specialty being consulted. */
+  specialty: string;
+  /** ISO 8601 timestamp when a closing note was linked, if any. */
+  responded_at?: string;
+  /** Note id that closed the consult, if any. */
+  closed_by_note_id?: string;
+}
+
+/**
+ * Time-series of a lab analyte across one or more encounters. Each value
+ * carries its encounter_id so detectors can bucket measurements by
+ * admission for cross-admission trend analysis.
+ */
+export interface LabTrend {
+  lab_name: string;
+  values: Array<{
+    value: number;
+    unit: string;
+    /** ISO 8601 measurement timestamp. */
+    measured_at: string;
+    encounter_id: string;
+  }>;
+}
+
+/**
+ * Time-series of a vital sign across one or more encounters. Same
+ * bucketing-by-encounter pattern as LabTrend.
+ */
+export interface VitalTrend {
+  vital_type:
+    | "blood_pressure_systolic"
+    | "blood_pressure_diastolic"
+    | "heart_rate"
+    | "respiratory_rate"
+    | "temperature"
+    | "o2_sat";
+  values: Array<{
+    value: number;
+    /** ISO 8601 measurement timestamp. */
+    measured_at: string;
+    encounter_id: string;
+  }>;
+}
+
+/**
+ * Signal that discharge documentation/orders are being prepared for the
+ * current encounter. Detected by the orchestrator from note-template
+ * usage, discharge-order placement, or manual flagging.
+ */
+export interface DischargeSignal {
+  is_discharge_imminent: boolean;
+  detected_at: string;
+  source: "note_template" | "discharge_order" | "manual";
+}
+
+/**
+ * A symptom observation extracted from a specific note. Used by
+ * CROSS-SPECIALTY-SYMPTOM-ORPHAN to detect symptoms mentioned across
+ * multiple specialty notes without any specialty owning the workup.
+ */
+export interface SymptomObservation {
+  /** Normalized symptom name (lowercase, singular). */
+  symptom: string;
+  /** Specialty of the documenting clinician. */
+  documented_by_specialty: string;
+  /** ISO 8601 timestamp of the documenting note. */
+  documented_at: string;
+  /**
+   * True if the documenting note (or any subsequent note) shows an order,
+   * plan, or follow-up referencing this symptom — i.e. a specialty has
+   * "owned" the workup.
+   */
+  has_workup: boolean;
+}
+
+/**
+ * The standard return shape for every detector. `fired` is the canonical
+ * boolean for "this pattern matched and a flag should be considered."
+ * `details` carries machine-readable evidence for downstream consumers
+ * (the umbrella rule's metadata, the flag rationale builder, telemetry).
+ */
+export interface PatternResult {
+  fired: boolean;
+  /** Machine-readable evidence. Shape is detector-specific. */
+  details?: Record<string, unknown>;
+  /** Human-readable one-line summary of why the pattern fired. */
+  summary?: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function parseIso(ts: string | undefined | null): number | null {
+  if (!ts) return null;
+  const n = Date.parse(ts);
+  return Number.isFinite(n) ? n : null;
+}
+
+function daysBetween(earlierIso: string, laterIso: string): number | null {
+  const a = parseIso(earlierIso);
+  const b = parseIso(laterIso);
+  if (a === null || b === null) return null;
+  return (b - a) / 86_400_000;
+}
+
+/**
+ * Compare the most recent value of a lab series within encounter A
+ * against the most recent within encounter B. Returns the delta if both
+ * are present in the same unit; null otherwise. Used by readmission
+ * trajectory detection — the unit-match guard fails closed on unit drift.
+ */
+function compareLabAcrossEncounters(
+  trend: LabTrend,
+  encounterIdA: string,
+  encounterIdB: string,
+): { from: number; to: number; unit: string; delta: number } | null {
+  const inA = trend.values
+    .filter((v) => v.encounter_id === encounterIdA)
+    .sort((x, y) => parseIso(x.measured_at)! - parseIso(y.measured_at)!);
+  const inB = trend.values
+    .filter((v) => v.encounter_id === encounterIdB)
+    .sort((x, y) => parseIso(x.measured_at)! - parseIso(y.measured_at)!);
+  const lastA = inA[inA.length - 1];
+  const lastB = inB[inB.length - 1];
+  if (!lastA || !lastB) return null;
+  if (lastA.unit !== lastB.unit) return null; // fail closed on unit drift
+  return {
+    from: lastA.value,
+    to: lastB.value,
+    unit: lastA.unit,
+    delta: lastB.value - lastA.value,
+  };
+}
+
+/**
+ * Direction of "concerning" for common labs. Used by readmission trend
+ * detection to interpret a delta as a worsening (vs improving) trajectory.
+ * Conservative subset for the scaffolding milestone; expand as clinical
+ * review nominates additional analytes.
+ */
+const LAB_CONCERN_DIRECTION: Record<string, "rising" | "falling"> = {
+  creatinine: "rising",
+  bun: "rising",
+  troponin: "rising",
+  lactate: "rising",
+  bnp: "rising",
+  "nt-probnp": "rising",
+  wbc: "rising",
+  crp: "rising",
+  procalcitonin: "rising",
+  hemoglobin: "falling",
+  hgb: "falling",
+  hematocrit: "falling",
+  hct: "falling",
+  platelets: "falling",
+  plt: "falling",
+  albumin: "falling",
+  sodium: "falling",
+};
+
+function isWorsening(labName: string, delta: number): boolean {
+  const dir = LAB_CONCERN_DIRECTION[labName.toLowerCase()];
+  if (!dir) return false;
+  return dir === "rising" ? delta > 0 : delta < 0;
+}
+
+// ─── Detector 1: READMISSION-TRAJECTORY ───────────────────────────
+
+/**
+ * Detect a readmission trajectory: the patient has been admitted within
+ * the lookback window and the labs/vitals trended in the concerning
+ * direction across admissions.
+ *
+ * Fires when:
+ *   - at least one prior encounter exists in the lookback window AND
+ *   - any tracked lab (creatinine, hemoglobin, lactate, etc.) shows a
+ *     worsening trend from prior discharge → current admission baseline.
+ *
+ * Returns null result if no prior encounters in window or no lab/vital
+ * data to evaluate (fail closed).
+ */
+export function detectReadmissionTrajectory(opts: {
+  prior_encounters: PriorEncounter[];
+  current_encounter: CurrentEncounter;
+  lab_trends?: LabTrend[];
+  vital_trends?: VitalTrend[];
+  /** Default 90 days. */
+  lookback_days?: number;
+}): PatternResult {
+  const lookback = opts.lookback_days ?? 90;
+  const currentAdmittedAt = parseIso(opts.current_encounter.admitted_at);
+  if (currentAdmittedAt === null) return { fired: false };
+
+  const inWindow = opts.prior_encounters.filter((p) => {
+    const days = daysBetween(p.admitted_at, opts.current_encounter.admitted_at);
+    return days !== null && days >= 0 && days <= lookback;
+  });
+  if (inWindow.length === 0) return { fired: false };
+
+  // Most recent prior encounter — closest in time to the current admission.
+  inWindow.sort(
+    (a, b) => parseIso(b.admitted_at)! - parseIso(a.admitted_at)!,
+  );
+  const mostRecentPrior = inWindow[0];
+
+  const worseningLabs: Array<{
+    name: string;
+    from: number;
+    to: number;
+    unit: string;
+    delta: number;
+  }> = [];
+
+  for (const trend of opts.lab_trends ?? []) {
+    const cmp = compareLabAcrossEncounters(
+      trend,
+      mostRecentPrior.encounter_id,
+      opts.current_encounter.encounter_id,
+    );
+    if (cmp && isWorsening(trend.lab_name, cmp.delta)) {
+      worseningLabs.push({ name: trend.lab_name, ...cmp });
+    }
+  }
+
+  if (worseningLabs.length === 0) {
+    return {
+      fired: false,
+      details: {
+        admissions_in_window: inWindow.length,
+        lookback_days: lookback,
+      },
+    };
+  }
+
+  return {
+    fired: true,
+    summary:
+      `Admission ${inWindow.length + 1} in ${lookback}d window. ` +
+      `Worsening trend across admissions: ` +
+      worseningLabs
+        .slice(0, 3)
+        .map(
+          (l) =>
+            `${l.name} ${l.from}→${l.to} ${l.unit}`,
+        )
+        .join(", "),
+    details: {
+      admissions_in_window: inWindow.length,
+      lookback_days: lookback,
+      most_recent_prior_encounter_id: mostRecentPrior.encounter_id,
+      worsening_labs: worseningLabs,
+    },
+  };
+}
+
+// ─── Detector 2: DISCHARGE-READINESS ──────────────────────────────
+
+/**
+ * Detect a discharge decision being made while signals suggest the
+ * patient is not ready: trending-wrong labs, open consults, unresolved
+ * symptoms.
+ *
+ * Fires when the discharge signal indicates discharge is imminent AND
+ * at least one of:
+ *   - any tracked lab is still trending in the worsening direction
+ *     within the current encounter, OR
+ *   - a consult requested ≥24h ago has no closing note, OR
+ *   - recent symptoms are non-empty (the orchestrator should pass only
+ *     unresolved symptoms here).
+ */
+export function detectDischargeReadinessRisk(opts: {
+  discharge_signal: DischargeSignal;
+  consult_requests?: ConsultRequest[];
+  lab_trends?: LabTrend[];
+  recent_symptoms?: string[];
+  current_encounter_id?: string;
+  /** Hours an unanswered consult must be open to count. Default 24. */
+  open_consult_hours?: number;
+}): PatternResult {
+  if (!opts.discharge_signal.is_discharge_imminent) return { fired: false };
+
+  const reasons: string[] = [];
+  const details: Record<string, unknown> = {};
+
+  // Worsening labs within the current encounter
+  const worseningInCurrent: Array<{ name: string; values: number[]; unit: string }> = [];
+  for (const trend of opts.lab_trends ?? []) {
+    const inCurrent = opts.current_encounter_id
+      ? trend.values
+          .filter((v) => v.encounter_id === opts.current_encounter_id)
+          .sort((a, b) => parseIso(a.measured_at)! - parseIso(b.measured_at)!)
+      : trend.values
+          .slice()
+          .sort((a, b) => parseIso(a.measured_at)! - parseIso(b.measured_at)!);
+    if (inCurrent.length < 2) continue;
+    const first = inCurrent[0];
+    const last = inCurrent[inCurrent.length - 1];
+    if (first.unit !== last.unit) continue;
+    const delta = last.value - first.value;
+    if (!isWorsening(trend.lab_name, delta)) continue;
+    worseningInCurrent.push({
+      name: trend.lab_name,
+      values: inCurrent.map((v) => v.value),
+      unit: first.unit,
+    });
+  }
+  if (worseningInCurrent.length > 0) {
+    reasons.push(
+      `labs trending wrong: ${worseningInCurrent
+        .slice(0, 3)
+        .map((l) => `${l.name}`)
+        .join(", ")}`,
+    );
+    details.worsening_labs_in_current = worseningInCurrent;
+  }
+
+  // Open consults
+  const openConsultHours = opts.open_consult_hours ?? 24;
+  const dischargeDetectedAt = parseIso(opts.discharge_signal.detected_at);
+  const openConsults = (opts.consult_requests ?? []).filter((c) => {
+    if (c.responded_at) return false;
+    const requestedAt = parseIso(c.requested_at);
+    if (requestedAt === null || dischargeDetectedAt === null) return false;
+    const ageHours = (dischargeDetectedAt - requestedAt) / 3_600_000;
+    return ageHours >= openConsultHours;
+  });
+  if (openConsults.length > 0) {
+    reasons.push(
+      `${openConsults.length} open consult${openConsults.length === 1 ? "" : "s"} (${openConsults
+        .map((c) => c.specialty)
+        .join(", ")})`,
+    );
+    details.open_consults = openConsults;
+  }
+
+  // Unresolved symptoms (caller is responsible for filtering)
+  if (opts.recent_symptoms && opts.recent_symptoms.length > 0) {
+    reasons.push(
+      `unresolved symptoms: ${opts.recent_symptoms.slice(0, 3).join(", ")}`,
+    );
+    details.unresolved_symptoms = opts.recent_symptoms;
+  }
+
+  if (reasons.length === 0) return { fired: false };
+
+  return {
+    fired: true,
+    summary: `Discharge imminent with: ${reasons.join("; ")}.`,
+    details,
+  };
+}
+
+// ─── Detector 3: CROSS-SPECIALTY-SYMPTOM-ORPHAN ────────────────────
+
+/**
+ * Detect a symptom documented across multiple specialty notes with no
+ * specialty owning the workup. Catches the "everyone noted it, nobody
+ * addressed it" pattern that is invisible to single-note review.
+ *
+ * Fires when any single symptom is documented by ≥`min_specialties`
+ * distinct specialties (default 2) AND none of those observations show
+ * a workup.
+ */
+export function detectCrossSpecialtySymptomOrphan(opts: {
+  symptom_observations: SymptomObservation[];
+  /** Default 2 — minimum distinct specialties to count as cross-specialty. */
+  min_specialties?: number;
+}): PatternResult {
+  const minSpecialties = opts.min_specialties ?? 2;
+  const bySymptom = new Map<string, SymptomObservation[]>();
+  for (const obs of opts.symptom_observations) {
+    const key = obs.symptom.toLowerCase().trim();
+    const arr = bySymptom.get(key) ?? [];
+    arr.push(obs);
+    bySymptom.set(key, arr);
+  }
+
+  const orphaned: Array<{
+    symptom: string;
+    specialties: string[];
+    observation_count: number;
+  }> = [];
+
+  for (const [symptom, obsArr] of bySymptom.entries()) {
+    const specialties = Array.from(
+      new Set(obsArr.map((o) => o.documented_by_specialty.toLowerCase())),
+    );
+    if (specialties.length < minSpecialties) continue;
+    const anyWorkup = obsArr.some((o) => o.has_workup);
+    if (anyWorkup) continue;
+    orphaned.push({
+      symptom,
+      specialties,
+      observation_count: obsArr.length,
+    });
+  }
+
+  if (orphaned.length === 0) return { fired: false };
+
+  return {
+    fired: true,
+    summary:
+      `Symptom${orphaned.length === 1 ? "" : "s"} documented across multiple specialties without ownership: ` +
+      orphaned
+        .slice(0, 3)
+        .map(
+          (o) =>
+            `${o.symptom} (${o.specialties.join(", ")})`,
+        )
+        .join("; "),
+    details: { orphaned_symptoms: orphaned },
+  };
+}
+
+// ─── Future stubs ─────────────────────────────────────────────────
+
+/**
+ * WARNING-SIGN-AGGREGATOR: composite criteria like SIRS / qSOFA / MEWS
+ * over individually-soft vitals + labs + temp. Future.
+ */
+export function detectWarningSignAggregator(_opts: {
+  recent_vitals: VitalTrend[];
+  recent_labs?: Array<{ name: string; value: number; unit: string }>;
+}): PatternResult {
+  return { fired: false }; // not yet implemented
+}
+
+/**
+ * COPY-FORWARD-DRIFT: note text > 80% text-similar to prior shift's
+ * note where at least one clinical signal has changed since. Future.
+ */
+export function detectCopyForwardDrift(_opts: {
+  current_note_text: string;
+  prior_note_text: string;
+  clinical_changes_since: number;
+}): PatternResult {
+  return { fired: false }; // not yet implemented
+}
+
+/**
+ * CONSULT-LOOP-OPEN: standalone version of the consult-loop check from
+ * DISCHARGE-READINESS — fires at shift change rather than discharge.
+ * Future.
+ */
+export function detectConsultLoopOpen(_opts: {
+  consult_requests: ConsultRequest[];
+  open_consult_hours?: number;
+}): PatternResult {
+  return { fired: false }; // not yet implemented
+}

--- a/packages/medical-logic/src/index.ts
+++ b/packages/medical-logic/src/index.ts
@@ -8,3 +8,4 @@ export * from "./allergen-synonyms.js";
 export * from "./cross-reactivity-map.js";
 export * from "./patient-education.js";
 export * from "./symptom-negation.js";
+export * from "./deterioration-patterns.js";

--- a/services/ai-oversight/src/rules/cross-specialty.ts
+++ b/services/ai-oversight/src/rules/cross-specialty.ts
@@ -14,6 +14,15 @@ import {
   estimateDailyDose,
   hasUnnegatedMention,
 } from "@carebridge/medical-logic";
+import type {
+  PriorEncounter,
+  CurrentEncounter,
+  ConsultRequest,
+  LabTrend,
+  VitalTrend,
+  DischargeSignal,
+  SymptomObservation,
+} from "@carebridge/medical-logic";
 import { QTC_PATTERN } from "./drug-interactions.js";
 import { METFORMIN_PATTERN, NSAID_PATTERN } from "./shared-drug-patterns.js";
 import { getRecentPotassium, getRecentEGFR } from "./lab-units.js";
@@ -182,6 +191,24 @@ export interface PatientContext {
    * avoid false positives on demographically unverified records. Issue #236.
    */
   age_years?: number | null;
+  // ─── Longitudinal context for DETERIORATION-TRAJECTORY-001 ─────
+  // See MISSION.md and packages/medical-logic/src/deterioration-patterns.ts.
+  // All fields here are optional and absent for rules that don't need them;
+  // the deterioration umbrella rule fails closed on absence.
+  /** Prior encounters (admissions) within the configured lookback window. */
+  prior_encounters?: PriorEncounter[];
+  /** The current (open) encounter. */
+  current_encounter?: CurrentEncounter;
+  /** Consult requests placed during the current encounter. */
+  consult_requests?: ConsultRequest[];
+  /** Lab time-series, optionally spanning multiple encounters. */
+  lab_trends?: LabTrend[];
+  /** Vital sign time-series, optionally spanning multiple encounters. */
+  vital_trends?: VitalTrend[];
+  /** Signal that discharge documentation/orders are being prepared. */
+  discharge_signal?: DischargeSignal;
+  /** Symptom observations bucketed by documenting specialty and workup state. */
+  symptom_observations?: SymptomObservation[];
 }
 
 /**

--- a/services/ai-oversight/src/rules/deterioration-trajectory.test.ts
+++ b/services/ai-oversight/src/rules/deterioration-trajectory.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from "vitest";
+import { checkDeteriorationTrajectory, DETERIORATION_TRAJECTORY_RULE_ID } from "./deterioration-trajectory.js";
+import type { PatientContext } from "./cross-specialty.js";
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function baseContext(overrides: Partial<PatientContext> = {}): PatientContext {
+  return {
+    active_diagnoses: [],
+    active_diagnosis_codes: [],
+    active_medications: [],
+    new_symptoms: [],
+    care_team_specialties: [],
+    ...overrides,
+  };
+}
+
+// ─── No-fire baselines ───────────────────────────────────────────
+
+describe("checkDeteriorationTrajectory — no-fire baselines", () => {
+  it("returns null on an empty context", () => {
+    const flag = checkDeteriorationTrajectory(baseContext());
+    expect(flag).toBeNull();
+  });
+
+  it("returns null when only one sub-rule could fire but its data is absent", () => {
+    const ctx = baseContext({
+      discharge_signal: {
+        is_discharge_imminent: false, // not imminent → no fire
+        detected_at: "2026-05-15T18:00:00Z",
+        source: "manual",
+      },
+    });
+    expect(checkDeteriorationTrajectory(ctx)).toBeNull();
+  });
+
+  it("returns null when prior encounters exist but no labs trend wrong", () => {
+    const ctx = baseContext({
+      prior_encounters: [
+        {
+          encounter_id: "enc-prior",
+          admitted_at: "2026-04-10T10:00:00Z",
+          chief_complaint: "x",
+        },
+      ],
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+      },
+      lab_trends: [
+        {
+          lab_name: "creatinine",
+          values: [
+            { value: 1.0, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+            { value: 0.9, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+    });
+    expect(checkDeteriorationTrajectory(ctx)).toBeNull();
+  });
+});
+
+// ─── Single sub-rule fires ───────────────────────────────────────
+
+describe("checkDeteriorationTrajectory — single sub-rule fires", () => {
+  it("fires READMISSION-TRAJECTORY with warning severity when one lab worsens across admissions", () => {
+    const ctx = baseContext({
+      prior_encounters: [
+        {
+          encounter_id: "enc-prior",
+          admitted_at: "2026-04-10T10:00:00Z",
+          chief_complaint: "AKI",
+        },
+      ],
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+        attending_specialty: "hospitalist",
+      },
+      lab_trends: [
+        {
+          lab_name: "creatinine",
+          values: [
+            { value: 1.1, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+            { value: 1.7, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.severity).toBe("warning");
+    expect(flag?.rule_id).toBe(DETERIORATION_TRAJECTORY_RULE_ID);
+    expect(flag?.summary).toContain("READMISSION-TRAJECTORY");
+    expect(flag?.notify_specialties).toContain("hospitalist");
+    const meta = flag?.metadata as { sub_rules_fired: string[] } | undefined;
+    expect(meta?.sub_rules_fired).toEqual(["READMISSION-TRAJECTORY"]);
+  });
+
+  it("fires DISCHARGE-READINESS when discharge imminent + open consult", () => {
+    const ctx = baseContext({
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-13T10:00:00Z",
+        attending_specialty: "hospitalist",
+      },
+      discharge_signal: {
+        is_discharge_imminent: true,
+        detected_at: "2026-05-15T18:00:00Z",
+        source: "note_template",
+      },
+      consult_requests: [
+        {
+          consult_id: "c1",
+          requested_at: "2026-05-13T11:00:00Z",
+          specialty: "cardiology",
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.severity).toBe("warning");
+    expect(flag?.summary).toContain("DISCHARGE-READINESS");
+  });
+
+  it("fires CROSS-SPECIALTY-SYMPTOM-ORPHAN when ≥2 specialties documented a symptom with no workup", () => {
+    const ctx = baseContext({
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+      },
+      symptom_observations: [
+        {
+          symptom: "altered mental status",
+          documented_by_specialty: "neurology",
+          documented_at: "2026-05-15T08:00:00Z",
+          has_workup: false,
+        },
+        {
+          symptom: "altered mental status",
+          documented_by_specialty: "hospitalist",
+          documented_at: "2026-05-15T14:00:00Z",
+          has_workup: false,
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.summary).toContain("CROSS-SPECIALTY-SYMPTOM-ORPHAN");
+    expect(flag?.notify_specialties).toEqual(
+      expect.arrayContaining(["neurology", "hospitalist"]),
+    );
+  });
+});
+
+// ─── Multiple sub-rules fire / severity escalation ───────────────
+
+describe("checkDeteriorationTrajectory — severity escalation", () => {
+  it("escalates to CRITICAL when ≥2 admissions in window AND ≥2 worsening labs", () => {
+    const ctx = baseContext({
+      prior_encounters: [
+        {
+          encounter_id: "enc-1",
+          admitted_at: "2026-03-01T10:00:00Z",
+          chief_complaint: "x",
+        },
+        {
+          encounter_id: "enc-2",
+          admitted_at: "2026-04-10T10:00:00Z",
+          chief_complaint: "x",
+        },
+      ],
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+      },
+      lab_trends: [
+        {
+          lab_name: "creatinine",
+          values: [
+            { value: 1.0, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-2" },
+            { value: 1.9, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+        {
+          lab_name: "hemoglobin",
+          values: [
+            { value: 11.2, unit: "g/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-2" },
+            { value: 9.1, unit: "g/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.severity).toBe("critical");
+  });
+
+  it("escalates DISCHARGE-READINESS to CRITICAL when imminent + open consult + worsening lab in current encounter", () => {
+    const ctx = baseContext({
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-13T10:00:00Z",
+      },
+      discharge_signal: {
+        is_discharge_imminent: true,
+        detected_at: "2026-05-15T18:00:00Z",
+        source: "note_template",
+      },
+      consult_requests: [
+        { consult_id: "c1", requested_at: "2026-05-13T11:00:00Z", specialty: "cardiology" },
+      ],
+      lab_trends: [
+        {
+          lab_name: "lactate",
+          values: [
+            { value: 1.5, unit: "mmol/L", measured_at: "2026-05-15T08:00:00Z", encounter_id: "enc-current" },
+            { value: 2.6, unit: "mmol/L", measured_at: "2026-05-15T17:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.severity).toBe("critical");
+  });
+
+  it("composes a multi-sub-rule flag when several patterns fire", () => {
+    const ctx = baseContext({
+      prior_encounters: [
+        {
+          encounter_id: "enc-prior",
+          admitted_at: "2026-04-10T10:00:00Z",
+          chief_complaint: "x",
+        },
+      ],
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+      },
+      lab_trends: [
+        {
+          lab_name: "creatinine",
+          values: [
+            { value: 1.1, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+            { value: 1.7, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+      symptom_observations: [
+        {
+          symptom: "fatigue",
+          documented_by_specialty: "hospitalist",
+          documented_at: "2026-05-15T08:00:00Z",
+          has_workup: false,
+        },
+        {
+          symptom: "fatigue",
+          documented_by_specialty: "oncology",
+          documented_at: "2026-05-15T10:00:00Z",
+          has_workup: false,
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    const meta = flag?.metadata as { sub_rules_fired: string[] } | undefined;
+    expect(meta?.sub_rules_fired).toContain("READMISSION-TRAJECTORY");
+    expect(meta?.sub_rules_fired).toContain("CROSS-SPECIALTY-SYMPTOM-ORPHAN");
+    expect(flag?.summary).toContain("2 sub-patterns fired");
+  });
+});
+
+// ─── Notify specialties wiring ───────────────────────────────────
+
+describe("checkDeteriorationTrajectory — notify_specialties", () => {
+  it("includes attending and care team specialties even when sub-rules don't enumerate specialties", () => {
+    const ctx = baseContext({
+      care_team_specialties: ["primary_care", "endocrinology"],
+      prior_encounters: [
+        {
+          encounter_id: "enc-prior",
+          admitted_at: "2026-04-10T10:00:00Z",
+          chief_complaint: "x",
+        },
+      ],
+      current_encounter: {
+        encounter_id: "enc-current",
+        admitted_at: "2026-05-15T10:00:00Z",
+        attending_specialty: "hospitalist",
+      },
+      lab_trends: [
+        {
+          lab_name: "creatinine",
+          values: [
+            { value: 1.1, unit: "mg/dL", measured_at: "2026-04-14T08:00:00Z", encounter_id: "enc-prior" },
+            { value: 1.7, unit: "mg/dL", measured_at: "2026-05-15T12:00:00Z", encounter_id: "enc-current" },
+          ],
+        },
+      ],
+    });
+    const flag = checkDeteriorationTrajectory(ctx);
+    expect(flag).not.toBeNull();
+    expect(flag?.notify_specialties).toEqual(
+      expect.arrayContaining(["hospitalist", "primary_care", "endocrinology"]),
+    );
+  });
+
+  it("falls back to 'hospitalist' when no other specialties are known", () => {
+    const ctx = baseContext({
+      symptom_observations: [
+        {
+          symptom: "dyspnea",
+          documented_by_specialty: "",
+          documented_at: "2026-05-15T08:00:00Z",
+          has_workup: false,
+        },
+        {
+          symptom: "dyspnea",
+          documented_by_specialty: "",
+          documented_at: "2026-05-15T10:00:00Z",
+          has_workup: false,
+        },
+      ],
+    });
+    // Note: this synthesis won't actually fire because both observations have
+    // the same (empty) specialty, so cross-specialty count is 1. That's a
+    // separate test of the detector. Here, no sub-rule fires → null.
+    expect(checkDeteriorationTrajectory(ctx)).toBeNull();
+  });
+});

--- a/services/ai-oversight/src/rules/deterioration-trajectory.ts
+++ b/services/ai-oversight/src/rules/deterioration-trajectory.ts
@@ -1,0 +1,235 @@
+/**
+ * DETERIORATION-TRAJECTORY-001 — the founding rule of CareBridge.
+ *
+ * Umbrella rule that runs the cross-specialty deterioration sub-detectors
+ * (see packages/medical-logic/src/deterioration-patterns.ts) and emits a
+ * single composite flag when ≥1 sub-rule fires.
+ *
+ * The founding context for this rule is in MISSION.md. The product
+ * motivation: surface cross-specialty deterioration patterns that tired
+ * or siloed clinicians miss, especially during inpatient stays and
+ * discharge decisions. The failure class is care coordination — no
+ * single specialty owns the trajectory; each sees their slice.
+ *
+ * Triggers:
+ *   - new admission for a patient with prior CareBridge data
+ *   - shift change (≥ 8h since last evaluation)
+ *   - discharge decision (note template == "discharge", or discharge
+ *     order placed, or manual flag)
+ *
+ * The orchestrator decides when to call this rule based on the above
+ * triggers; this module only encodes "given the context, did the
+ * deterioration pattern fire?"
+ *
+ * Status: scaffolding milestone (2026-05). Initial sub-rule set:
+ *   - READMISSION-TRAJECTORY (1st priority — most aligned with founding case)
+ *   - DISCHARGE-READINESS (2nd priority)
+ *   - CROSS-SPECIALTY-SYMPTOM-ORPHAN (3rd priority)
+ *
+ * Future sub-rules tracked in MISSION.md:
+ *   - WARNING-SIGN-AGGREGATOR (SIRS / qSOFA / MEWS)
+ *   - COPY-FORWARD-DRIFT
+ *   - CONSULT-LOOP-OPEN (standalone, fires at shift change)
+ *
+ * Clinical threshold calibration is pending per LAUNCH-CHECKLIST.md.
+ * Current thresholds are intentionally conservative — the goal at this
+ * milestone is to prove the scaffolding wires correctly, not to ship
+ * production-grade clinical content.
+ */
+
+import type { RuleFlag, FlagSeverity } from "@carebridge/shared-types";
+import {
+  detectReadmissionTrajectory,
+  detectDischargeReadinessRisk,
+  detectCrossSpecialtySymptomOrphan,
+  type PatternResult,
+} from "@carebridge/medical-logic";
+import type { PatientContext } from "./cross-specialty.js";
+
+export const DETERIORATION_TRAJECTORY_RULE_ID = "DETERIORATION-TRAJECTORY-001";
+
+interface SubRuleHit {
+  rule: string;
+  result: PatternResult;
+}
+
+/**
+ * Severity escalation policy: the umbrella inherits the highest severity
+ * implied by any fired sub-rule. Sub-rules are weighted as follows for
+ * the scaffolding milestone:
+ *
+ *   - READMISSION-TRAJECTORY (rising creatinine / falling Hgb etc):
+ *     - warning baseline
+ *     - critical if ≥3 admissions in window AND ≥2 worsening labs
+ *
+ *   - DISCHARGE-READINESS:
+ *     - warning baseline
+ *     - critical if discharge imminent AND (open consult + worsening lab)
+ *
+ *   - CROSS-SPECIALTY-SYMPTOM-ORPHAN:
+ *     - warning baseline (no critical path at this milestone — the
+ *       absence of workup alone is not by itself a critical signal
+ *       without other context)
+ */
+function severityFor(hits: SubRuleHit[]): FlagSeverity {
+  for (const hit of hits) {
+    if (hit.rule === "READMISSION-TRAJECTORY") {
+      const admissions = hit.result.details?.admissions_in_window;
+      const worsening = hit.result.details?.worsening_labs;
+      if (
+        typeof admissions === "number" &&
+        admissions >= 2 &&
+        Array.isArray(worsening) &&
+        worsening.length >= 2
+      ) {
+        return "critical";
+      }
+    }
+    if (hit.rule === "DISCHARGE-READINESS") {
+      const details = hit.result.details ?? {};
+      const hasOpenConsult = Array.isArray(details.open_consults) && details.open_consults.length > 0;
+      const hasWorseningLab = Array.isArray(details.worsening_labs_in_current) && details.worsening_labs_in_current.length > 0;
+      if (hasOpenConsult && hasWorseningLab) return "critical";
+    }
+  }
+  return "warning";
+}
+
+function notifySpecialtiesFor(hits: SubRuleHit[], ctx: PatientContext): string[] {
+  const result = new Set<string>();
+  // Always include the attending — they own the trajectory.
+  if (ctx.current_encounter?.attending_specialty) {
+    result.add(ctx.current_encounter.attending_specialty);
+  }
+  // Care-team specialties that already exist.
+  for (const s of ctx.care_team_specialties ?? []) result.add(s);
+  // Specialties that documented orphan symptoms — they should know.
+  for (const hit of hits) {
+    if (hit.rule === "CROSS-SPECIALTY-SYMPTOM-ORPHAN") {
+      const orphaned = hit.result.details?.orphaned_symptoms as
+        | Array<{ specialties: string[] }>
+        | undefined;
+      for (const o of orphaned ?? []) {
+        for (const s of o.specialties) result.add(s);
+      }
+    }
+  }
+  // Hospitalist is the default owner of the trajectory; include if absent.
+  if (result.size === 0) result.add("hospitalist");
+  return Array.from(result);
+}
+
+function buildSummary(hits: SubRuleHit[]): string {
+  return (
+    `Possible deterioration trajectory (${hits.length} sub-pattern${hits.length === 1 ? "" : "s"} fired): ` +
+    hits.map((h) => h.rule).join(", ")
+  );
+}
+
+function buildRationale(hits: SubRuleHit[]): string {
+  const lines = ["The following cross-specialty deterioration patterns fired:"];
+  for (const hit of hits) {
+    lines.push(`• ${hit.rule}: ${hit.result.summary ?? "(no summary)"}`);
+  }
+  lines.push(
+    "",
+    "These patterns surface from looking across notes/admissions/specialties together. " +
+      "Each pattern individually is a soft signal; together they suggest deterioration " +
+      "that may not be apparent from any single specialty's note.",
+    "",
+    "Reference: MISSION.md § First rule: DETERIORATION-TRAJECTORY-001.",
+  );
+  return lines.join("\n");
+}
+
+function buildSuggestedAction(hits: SubRuleHit[]): string {
+  const actions: string[] = [];
+  for (const hit of hits) {
+    if (hit.rule === "READMISSION-TRAJECTORY") {
+      actions.push(
+        "Compare current labs/vitals against prior discharge values. Consider whether the current admission's problem list captures the deteriorating trend across admissions.",
+      );
+    }
+    if (hit.rule === "DISCHARGE-READINESS") {
+      actions.push(
+        "Re-evaluate discharge timing. Confirm consult loops are closed and trending labs have stabilized or are addressed in the discharge plan.",
+      );
+    }
+    if (hit.rule === "CROSS-SPECIALTY-SYMPTOM-ORPHAN") {
+      actions.push(
+        "Decide which specialty owns the workup for each cross-specialty symptom listed. Document the plan in a single note rather than relying on parallel specialty notes.",
+      );
+    }
+  }
+  if (actions.length === 0) {
+    return "Review the deterioration patterns listed in the rationale.";
+  }
+  return actions.join(" ");
+}
+
+/**
+ * Run the deterioration umbrella against a patient context. Returns a
+ * single RuleFlag if any sub-pattern fired, otherwise null.
+ *
+ * The orchestrator decides when to invoke this rule (admission with
+ * priors, shift change, discharge signal). This function does NOT gate
+ * on those triggers itself — that's the orchestrator's responsibility,
+ * because the rule may be invoked manually (e.g. for testing or for the
+ * bridge view).
+ */
+export function checkDeteriorationTrajectory(ctx: PatientContext): RuleFlag | null {
+  const hits: SubRuleHit[] = [];
+
+  // 1. READMISSION-TRAJECTORY
+  if (
+    ctx.prior_encounters &&
+    ctx.current_encounter &&
+    ctx.prior_encounters.length > 0
+  ) {
+    const r = detectReadmissionTrajectory({
+      prior_encounters: ctx.prior_encounters,
+      current_encounter: ctx.current_encounter,
+      lab_trends: ctx.lab_trends,
+      vital_trends: ctx.vital_trends,
+    });
+    if (r.fired) hits.push({ rule: "READMISSION-TRAJECTORY", result: r });
+  }
+
+  // 2. DISCHARGE-READINESS
+  if (ctx.discharge_signal?.is_discharge_imminent) {
+    const r = detectDischargeReadinessRisk({
+      discharge_signal: ctx.discharge_signal,
+      consult_requests: ctx.consult_requests,
+      lab_trends: ctx.lab_trends,
+      recent_symptoms: ctx.new_symptoms,
+      current_encounter_id: ctx.current_encounter?.encounter_id,
+    });
+    if (r.fired) hits.push({ rule: "DISCHARGE-READINESS", result: r });
+  }
+
+  // 3. CROSS-SPECIALTY-SYMPTOM-ORPHAN
+  if (ctx.symptom_observations && ctx.symptom_observations.length > 0) {
+    const r = detectCrossSpecialtySymptomOrphan({
+      symptom_observations: ctx.symptom_observations,
+    });
+    if (r.fired) hits.push({ rule: "CROSS-SPECIALTY-SYMPTOM-ORPHAN", result: r });
+  }
+
+  if (hits.length === 0) return null;
+
+  return {
+    severity: severityFor(hits),
+    category: "trend-concern",
+    summary: buildSummary(hits),
+    rationale: buildRationale(hits),
+    suggested_action: buildSuggestedAction(hits),
+    notify_specialties: notifySpecialtiesFor(hits, ctx),
+    rule_id: DETERIORATION_TRAJECTORY_RULE_ID,
+    metadata: {
+      sub_rules_fired: hits.map((h) => h.rule),
+      sub_rule_details: Object.fromEntries(
+        hits.map((h) => [h.rule, h.result.details ?? {}]),
+      ),
+    },
+  };
+}

--- a/services/ai-oversight/src/rules/deterioration-trajectory.ts
+++ b/services/ai-oversight/src/rules/deterioration-trajectory.ts
@@ -1,6 +1,13 @@
 /**
  * DETERIORATION-TRAJECTORY-001 — the founding rule of CareBridge.
  *
+ * In memory of Lisa Bowen, whose hospital course was the founding case
+ * for this rule family. The pattern this rule catches — care coordination
+ * failure across multiple admissions, soft signals never aggregated, and
+ * discharge decisions made before unresolved concerns were addressed — is
+ * the pattern that killed her. We could not save her. We can try to make
+ * the next family's story end differently.
+ *
  * Umbrella rule that runs the cross-specialty deterioration sub-detectors
  * (see packages/medical-logic/src/deterioration-patterns.ts) and emits a
  * single composite flag when ≥1 sub-rule fires.


### PR DESCRIPTION
## Summary

Establishes the project's mission document AND ships the scaffolding for the founding rule, **DETERIORATION-TRAJECTORY-001** — the umbrella for the cross-specialty deterioration pattern family that catches the class of care-coordination failures CareBridge exists to prevent.

This is the first concrete encoding of the project's founding context. The personal foreword in MISSION.md should be reviewed/edited before merge — I drafted in Chris's voice based on what he shared, but the words on a public repo's mission doc are his to set.

## Changes

### `MISSION.md` (new, repo root)

- Personal foreword from project founder (DRAFT — review/edit before merge)
- The failure class CareBridge addresses (cross-specialty care coordination)
- What CareBridge does mechanically (deterministic rules + structured chart + optional LLM second-pass)
- What CareBridge does NOT do (non-device CDS positioning per 21st Century Cures Act)
- MedLens-CareBridge architecture rationale (SaMD firewall: capture has no interpretation; interpretation has no auto-action)
- DETERIORATION-TRAJECTORY-001 with the 6 sub-pattern family

### `packages/medical-logic/src/deterioration-patterns.ts` (new)

Pure detector functions with full type definitions for the longitudinal context (PriorEncounter, CurrentEncounter, LabTrend, VitalTrend, ConsultRequest, DischargeSignal, SymptomObservation):

- **`detectReadmissionTrajectory`** — fires when ≥1 prior encounter in lookback window AND a tracked lab trended in the concerning direction across admissions. Conservative initial lab list (creatinine ↑, hemoglobin ↓, lactate ↑, etc.). Unit-mismatch fails closed.
- **`detectDischargeReadinessRisk`** — fires when discharge imminent AND any of (a) lab worsening in current encounter, (b) consult ≥24h open, (c) unresolved symptoms passed by orchestrator.
- **`detectCrossSpecialtySymptomOrphan`** — fires when ≥2 distinct specialties documented a symptom AND no specialty has owned the workup.

Stubs for the three future sub-patterns (WARNING-SIGN-AGGREGATOR, COPY-FORWARD-DRIFT, CONSULT-LOOP-OPEN) ship as no-fire placeholders.

### `services/ai-oversight/src/rules/deterioration-trajectory.ts` (new)

The umbrella rule. \`checkDeteriorationTrajectory(ctx) → RuleFlag | null\`. Aggregates sub-rule hits into a single composite flag with:
- severity (warning baseline; escalates to critical on \`READMISSION-TRAJECTORY\` with ≥2 admissions + ≥2 worsening labs, OR \`DISCHARGE-READINESS\` with open consult + worsening lab)
- summary, rationale, suggested_action (composed from sub-rule hits)
- notify_specialties (attending + care team + specialties that documented orphan symptoms; falls back to hospitalist)
- metadata (sub_rules_fired, sub_rule_details for telemetry)

### `services/ai-oversight/src/rules/cross-specialty.ts` (modified)

Extended \`PatientContext\` with 7 optional fields for the longitudinal data. All optional — existing rules untouched.

## Test plan

- [x] **20 new detector tests** in \`deterioration-patterns.test.ts\` covering no-fire baselines, single-pattern fires, edge cases (unit mismatch, normalization, min_specialties override, multiple orphan symptoms)
- [x] **11 new rule tests** in \`deterioration-trajectory.test.ts\` covering empty context, single sub-rule fires, severity escalation, multi-sub-rule composition, notify_specialties wiring
- [x] \`pnpm --filter @carebridge/medical-logic test\` — 603/603 passing
- [x] \`pnpm --filter @carebridge/ai-oversight test\` — 966/970 passing (4 pre-existing skips)
- [x] \`pnpm typecheck\` — 38/38 tasks clean

## Clinical review status

Per \`docs/ai-prompt-editing.md\` § 5 (merge-gate vs launch-gate split):

**Merge gate:**
- [x] Engineering review (the scaffolding pattern matches existing CrossSpecialtyRule conventions)
- [x] Primary-source citation (founding case + the well-established care-coordination literature it generalizes to; specific clinical-threshold citations follow as those land)

**Launch gate (LAUNCH-CHECKLIST.md):**
- [ ] Clinician walk-through of the per-lab \"worsening direction\" table (LAB_CONCERN_DIRECTION)
- [ ] Clinician walk-through of the severity escalation criteria (≥2 admissions, ≥2 labs, etc.)
- [ ] Clinician confirmation of the 24h open-consult threshold and discharge-signal sources

This PR is the scaffolding. Clinical content calibration follows in subsequent PRs.

## What's deliberately NOT in this PR

- Backend orchestrator integration (deciding WHEN to call \`checkDeteriorationTrajectory\` — new admission with priors, shift change, discharge signal). The function is callable directly today (e.g. by the clinician-bridge MVP) but not yet wired to the BullMQ clinical-events queue.
- Database schema for \`prior_encounters\` / \`consult_requests\` / \`discharge_signal\`. These are optional fields the rule reads — the data model work to populate them is downstream.
- The remaining three sub-patterns (WARNING-SIGN-AGGREGATOR, COPY-FORWARD-DRIFT, CONSULT-LOOP-OPEN). Stubbed to fix the consumer surface; implementation lands separately.

## How to verify locally

\`\`\`bash
pnpm --filter @carebridge/medical-logic test deterioration-patterns
pnpm --filter @carebridge/ai-oversight test deterioration-trajectory
\`\`\`