### PR TITLE
feat(bridge): M1 — apps/clinician-bridge scaffold + landing page

### DIFF
--- a/apps/clinician-bridge/.eslintrc.json
+++ b/apps/clinician-bridge/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/apps/clinician-bridge/app/components/PostMortemBanner.tsx
+++ b/apps/clinician-bridge/app/components/PostMortemBanner.tsx
@@ -1,0 +1,16 @@
+export function PostMortemBanner() {
+  return (
+    <aside
+      className="bridge-banner bridge-banner--disclaimer"
+      role="note"
+      aria-label="Decision support disclaimer"
+    >
+      <strong>Decision support, not a diagnosis.</strong>
+      <p>
+        The bridge surfaces cross-specialty patterns from the patient&apos;s
+        captured timeline. Every flag links to the source observation.
+        Clinical judgment remains with the treating clinician.
+      </p>
+    </aside>
+  );
+}

--- a/apps/clinician-bridge/app/globals.css
+++ b/apps/clinician-bridge/app/globals.css
@@ -1,0 +1,124 @@
+/*
+ * Clinician Bridge — bedside-first styling.
+ *
+ * Dark default reduces glare in low-light bedside use (per scope doc
+ * M6 plan, but applied from M1 since it costs nothing to do early).
+ * Honors prefers-color-scheme: light if the device explicitly opts in.
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  min-height: 100vh;
+}
+
+body.bridge-body {
+  background: #0b0f14;
+  color: #e6edf3;
+}
+
+@media (prefers-color-scheme: light) {
+  body.bridge-body {
+    background: #f6f8fa;
+    color: #1f2328;
+  }
+}
+
+.bridge-landing {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.bridge-landing__header h1 {
+  font-size: 1.75rem;
+  margin: 0 0 0.25rem;
+  letter-spacing: -0.01em;
+}
+
+.bridge-landing__tagline {
+  margin: 0;
+  opacity: 0.85;
+  font-size: 1rem;
+}
+
+.bridge-landing__pair-cta {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+@media (prefers-color-scheme: light) {
+  .bridge-landing__pair-cta {
+    background: #ffffff;
+    border-color: #d0d7de;
+  }
+}
+
+.bridge-landing__pair-cta h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+}
+
+.bridge-landing__pair-cta p {
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.bridge-landing__milestone-note {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.bridge-banner {
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+  line-height: 1.45;
+}
+
+.bridge-banner--disclaimer {
+  background: rgba(255, 200, 87, 0.12);
+  border: 1px solid rgba(255, 200, 87, 0.35);
+  color: #f7d774;
+}
+
+@media (prefers-color-scheme: light) {
+  .bridge-banner--disclaimer {
+    background: #fff8e1;
+    border-color: #d4a017;
+    color: #5a3d00;
+  }
+}
+
+.bridge-banner--disclaimer strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.bridge-banner--disclaimer p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.bridge-landing__footer {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.bridge-landing__footer a {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/apps/clinician-bridge/app/layout.tsx
+++ b/apps/clinician-bridge/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata, Viewport } from "next";
+import "@carebridge/ui-tokens/tokens.css";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "CareBridge | Clinician Bridge",
+  description:
+    "Bedside patient context from MedLens captures — surfaces cross-specialty deterioration patterns. Not a diagnosis tool.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="bridge-body">{children}</body>
+    </html>
+  );
+}

--- a/apps/clinician-bridge/app/page.test.tsx
+++ b/apps/clinician-bridge/app/page.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import LandingPage from "./page";
+
+describe("LandingPage", () => {
+  it("renders the bridge title", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByRole("heading", { name: /clinician bridge/i, level: 1 }),
+    ).toBeDefined();
+  });
+
+  it("shows the not-a-diagnosis disclaimer", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByText(/decision support, not a diagnosis/i),
+    ).toBeDefined();
+  });
+
+  it("explains the no-persistence safety posture", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByText(/does not store patient data/i),
+    ).toBeDefined();
+  });
+
+  it("points the clinician at the pair flow", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByRole("heading", { name: /pair a medlens capture/i }),
+    ).toBeDefined();
+  });
+});

--- a/apps/clinician-bridge/app/page.tsx
+++ b/apps/clinician-bridge/app/page.tsx
@@ -1,0 +1,39 @@
+import { PostMortemBanner } from "./components/PostMortemBanner";
+
+export default function LandingPage() {
+  return (
+    <main className="bridge-landing">
+      <header className="bridge-landing__header">
+        <h1>CareBridge Clinician Bridge</h1>
+        <p className="bridge-landing__tagline">
+          Bedside patient context from a MedLens capture.
+        </p>
+      </header>
+
+      <PostMortemBanner />
+
+      <section className="bridge-landing__pair-cta" aria-labelledby="pair-heading">
+        <h2 id="pair-heading">Pair a MedLens capture</h2>
+        <p>
+          Ask the patient or family caregiver to open MedLens and tap
+          <strong> Share with clinician</strong>. They will show you a QR code
+          or a 6-character code.
+        </p>
+        <p className="bridge-landing__milestone-note">
+          Pairing flow ships in milestone M2. This is the M1 scaffold.
+        </p>
+      </section>
+
+      <footer className="bridge-landing__footer">
+        <p>
+          This bridge does not store patient data. Closing this tab erases
+          everything on this device. See{" "}
+          <a href="https://github.com/blamechris/carebridge/blob/main/docs/clinician-bridge-mvp.md">
+            scope doc
+          </a>{" "}
+          for the safety posture.
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/apps/clinician-bridge/app/test-setup.ts
+++ b/apps/clinician-bridge/app/test-setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/clinician-bridge/next-env.d.ts
+++ b/apps/clinician-bridge/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/clinician-bridge/next.config.ts
+++ b/apps/clinician-bridge/next.config.ts
@@ -1,0 +1,27 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // Bridge is display-only. No service workers or background sync —
+  // the device should not retain PHI past the tab session. See
+  // docs/clinician-bridge-mvp.md § PHI / SaMD Posture.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Referrer-Policy", value: "no-referrer" },
+          {
+            key: "Service-Worker-Allowed",
+            value: "/__no_sw__",
+          },
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+          },
+        ],
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/apps/clinician-bridge/package.json
+++ b/apps/clinician-bridge/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@carebridge/clinician-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3002",
+    "build": "next build",
+    "start": "next start --port 3002",
+    "lint": "next lint",
+    "test": "vitest run",
+    "clean": "rm -rf .next"
+  },
+  "dependencies": {
+    "@carebridge/ui-tokens": "workspace:*",
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^15.1.0",
+    "jsdom": "^29.0.2",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/apps/clinician-bridge/tsconfig.json
+++ b/apps/clinician-bridge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/clinician-bridge/vitest.config.ts
+++ b/apps/clinician-bridge/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    globals: false,
+    environment: "jsdom",
+    include: ["app/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
+    setupFiles: ["./app/test-setup.ts"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@9.15.4",
   "scripts": {
-    "dev": "turbo dev --concurrency=25",
+    "dev": "turbo dev --concurrency=26",
     "build": "turbo build",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,52 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
 
+  apps/clinician-bridge:
+    dependencies:
+      '@carebridge/ui-tokens':
+        specifier: workspace:*
+        version: link:../../packages/ui-tokens
+      next:
+        specifier: ^15.1.0
+        version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      eslint-config-next:
+        specifier: ^15.1.0
+        version: 15.5.15(eslint@8.57.1)(typescript@5.9.3)
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.0.1)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(jsdom@29.0.2(@noble/hashes@2.0.1))(tsx@4.21.0)
+
   apps/clinician-portal:
     dependencies:
       '@carebridge/medical-logic':
@@ -2159,6 +2205,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}


### PR DESCRIPTION
## Summary

First milestone of the clinician-bridge MVP per [docs/clinician-bridge-mvp.md](https://github.com/blamechris/carebridge/blob/main/docs/clinician-bridge-mvp.md). A Next.js 15 app under `apps/clinician-bridge` with a single landing page, the "not a diagnosis" disclaimer, and the safety-posture footer.

**No QR scan, no MedLens fetch, no rule wiring yet** — those land in M2 and M3. This PR is intentionally just the scaffold.

## What's in it

- `apps/clinician-bridge/` — Next.js 15 app, dev port 3002, $0 Vercel-ready
- Landing page with bedside-first styling (dark default + light-mode opt-in)
- `PostMortemBanner` — the "decision support, not a diagnosis" component
- Safety headers: `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, service workers blocked
- 4 vitest tests covering landing-page contracts

## Posture (per scope doc D1–D4)

- No service workers, no `localStorage`, no `IndexedDB`, no background sync — there is literally no client storage code path
- Falls under existing §520(o) non-device CDS exemption (`docs/cds-exemption.md`)

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 4/4 passing
- [x] `pnpm build` — static build clean, 4 routes
- [x] `pnpm lint` — no warnings or errors
- [ ] Manual: `pnpm --filter=@carebridge/clinician-bridge dev` → http://localhost:3002 renders landing page with disclaimer + dark theme

## Next milestone

M2 — pairing flow (QR scanner + 6-char code entry, fetches a mocked capture from a local fixture). Will track as a separate issue once this lands.