### PR TITLE
feat(bridge): wire contract + scope-doc fix

### DIFF
--- a/docs/clinician-bridge-mvp.md
+++ b/docs/clinician-bridge-mvp.md
@@ -94,15 +94,29 @@ an EHR account, a CareBridge account, or any persistent infrastructure.
   self-identification land in `audit_log` (append-only, 7-year
   retention per `docs/hipaa-retention.md`).
 
-## Out-of-Repo Dependencies
+## Relay Endpoints (live on the bridge app)
 
-- **MedLens** must expose two endpoints for the bridge to work:
-  1. `POST /v1/pair` (caregiver-driven, returns a token + code + QR
-     payload).
-  2. `GET /v1/captures/:id?token=...` (token-scoped, returns the
-     timeline JSON the bridge expects).
-- These belong in the MedLens repo. File a tracking issue there once
-  this doc lands.
+Per **D1 — relay transport**, the relay endpoints live on the bridge
+app itself (Next.js API routes on the same Vercel deployment), not on
+MedLens. MedLens is a client to these endpoints:
+
+| Endpoint | Caller | Purpose |
+|---|---|---|
+| `POST /api/v1/pair` | MedLens | Caregiver phone uploads an encrypted ciphertext blob, gets back `{ capture_id, display_code, expires_at, decryption_key }`. The relay keeps the ciphertext for 15 min and never sees the decryption key after this response. |
+| `GET /api/v1/captures/[id]` | Bridge UI | Bridge fetches the encrypted envelope by `capture_id`; decryption happens client-side using the key from the QR/code. |
+
+Wire contract types: `BridgePairRecord`, `BridgePairRequest`,
+`BridgeCaptureEnvelope`, `BridgeQrPayload` — see
+`packages/shared-types/src/bridge-protocol.ts` and the Zod schemas in
+`bridge-protocol.schemas.ts`. The decrypted payload is a FHIR R4 Bundle
+(MedLens already emits this via its outbox builder; the bridge consumes
+it through the existing `services/fhir-gateway` mappers).
+
+**Out-of-repo work**: MedLens needs a "Share with clinician" UI that
+(a) builds a FHIR R4 bundle from the local timeline, (b) AES-256-GCM
+encrypts the bundle with a freshly-generated 256-bit key, (c) POSTs the
+ciphertext to `/api/v1/pair`, (d) renders the returned token as a QR +
+6-char display code. Tracked as a sibling PR in the MedLens repo.
 
 ## File Layout
 
@@ -158,19 +172,21 @@ a clinician partner asks for it.
 
 - **M1 — Scaffold.** Empty Next.js app, "Hello bridge" landing page,
   deployed to Vercel under `bridge.carebridge.health`.
-- **M2 — Pairing.** QR/code entry → mocked capture fetch → static
-  timeline render.
-- **M3 — Rule wiring.** Real tRPC call to `api-gateway`, real rule
-  output rendered with citations.
-- **M4 — MedLens endpoint.** Real `POST /v1/pair` and
-  `GET /v1/captures/:id` in MedLens; bridge wired to live capture.
+- **M2 — Pairing.** Relay endpoints (`POST /api/v1/pair`,
+  `GET /api/v1/captures/[id]`), QR/code entry on the landing page,
+  session route renders a captured FHIR bundle from a local fixture.
+- **M3 — MedLens client.** "Share with clinician" UI in MedLens —
+  builds a FHIR bundle from the local timeline, encrypts client-side,
+  POSTs to the relay, renders QR + 6-char code.
+- **M4 — Rule wiring.** Bridge calls `api-gateway`/`ai-oversight`
+  against the decrypted bundle, real rule output rendered with
+  citations.
 - **M5 — Audit log + capture-hash.** Audit writes confirmed,
   `capture_hash` schema add merged.
-- **M6 — Disclaimer + self-ID UI.** PostMortemBanner, optional
-  clinician name/role input.
+- **M6 — Self-ID UI polish.** Optional clinician name/role input.
 
-Each milestone is one PR. M1–M3 are CareBridge-side; M4 is MedLens-side;
-M5 spans both repos.
+Each milestone is one PR. M1, M2, M4, M5, M6 are CareBridge-side;
+M3 is MedLens-side; M5 spans both repos.
 
 ## What This Doc Is Not
 

--- a/packages/shared-types/src/__tests__/bridge-protocol.test.ts
+++ b/packages/shared-types/src/__tests__/bridge-protocol.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  bridgeDisplayCodeSchema,
+  bridgeDecryptionKeySchema,
+  bridgeCiphertextSchema,
+  bridgePairRecordSchema,
+  bridgePairRequestSchema,
+  bridgeCaptureEnvelopeSchema,
+  bridgeQrPayloadSchema,
+} from "../bridge-protocol.schemas.js";
+
+const VALID_KEY = "a".repeat(43);
+const VALID_UUID = "00000000-0000-4000-8000-000000000000";
+const VALID_CIPHERTEXT = "A".repeat(128);
+const VALID_TIMESTAMP = "2026-05-29T10:00:00.000Z";
+
+describe("bridgeDisplayCodeSchema", () => {
+  it("accepts a valid 6-char base32 code", () => {
+    for (const code of ["K7M4QZ", "ABCDEF", "23456789".slice(0, 6)]) {
+      expect(bridgeDisplayCodeSchema.safeParse(code).success).toBe(true);
+    }
+  });
+
+  it("rejects codes containing the ambiguous chars 0, O, 1, I", () => {
+    for (const code of ["K0M4QZ", "K7O4QZ", "K7M1QZ", "I7M4QZ"]) {
+      expect(bridgeDisplayCodeSchema.safeParse(code).success).toBe(false);
+    }
+  });
+
+  it("rejects wrong-length codes", () => {
+    for (const code of ["K7M4Q", "K7M4QZZ", ""]) {
+      expect(bridgeDisplayCodeSchema.safeParse(code).success).toBe(false);
+    }
+  });
+
+  it("rejects lowercase", () => {
+    expect(bridgeDisplayCodeSchema.safeParse("k7m4qz").success).toBe(false);
+  });
+});
+
+describe("bridgeDecryptionKeySchema", () => {
+  it("accepts a 43-char base64url string", () => {
+    expect(bridgeDecryptionKeySchema.safeParse(VALID_KEY).success).toBe(true);
+  });
+
+  it("rejects keys with base64 padding (=)", () => {
+    const padded = "a".repeat(42) + "=";
+    expect(bridgeDecryptionKeySchema.safeParse(padded).success).toBe(false);
+  });
+
+  it("rejects keys with the wrong length (32-byte AES-256-GCM only)", () => {
+    expect(bridgeDecryptionKeySchema.safeParse("a".repeat(22)).success).toBe(false); // 16-byte key
+    expect(bridgeDecryptionKeySchema.safeParse("a".repeat(86)).success).toBe(false); // 64-byte
+  });
+});
+
+describe("bridgeCiphertextSchema", () => {
+  it("accepts a base64url string within bounds", () => {
+    expect(bridgeCiphertextSchema.safeParse(VALID_CIPHERTEXT).success).toBe(true);
+  });
+
+  it("rejects ciphertext below the floor (would be smaller than IV+tag)", () => {
+    expect(bridgeCiphertextSchema.safeParse("A".repeat(32)).success).toBe(false);
+  });
+
+  it("rejects ciphertext exceeding the 100KB cap", () => {
+    expect(bridgeCiphertextSchema.safeParse("A".repeat(100_001)).success).toBe(false);
+  });
+
+  it("rejects non-base64url characters", () => {
+    const bad = "A".repeat(63) + "!";
+    expect(bridgeCiphertextSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("bridgePairRecordSchema", () => {
+  const valid = {
+    capture_id: VALID_UUID,
+    display_code: "K7M4QZ",
+    expires_at: VALID_TIMESTAMP,
+    decryption_key: VALID_KEY,
+  };
+
+  it("accepts a complete valid record", () => {
+    expect(bridgePairRecordSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects on a missing field", () => {
+    const { decryption_key: _omit, ...partial } = valid;
+    expect(bridgePairRecordSchema.safeParse(partial).success).toBe(false);
+  });
+});
+
+describe("bridgePairRequestSchema", () => {
+  it("accepts a request with no caregiver_label", () => {
+    expect(
+      bridgePairRequestSchema.safeParse({ ciphertext: VALID_CIPHERTEXT }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a request with a label up to 80 chars", () => {
+    expect(
+      bridgePairRequestSchema.safeParse({
+        ciphertext: VALID_CIPHERTEXT,
+        caregiver_label: "a".repeat(80),
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects a label over 80 chars", () => {
+    expect(
+      bridgePairRequestSchema.safeParse({
+        ciphertext: VALID_CIPHERTEXT,
+        caregiver_label: "a".repeat(81),
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("bridgeCaptureEnvelopeSchema", () => {
+  it("accepts a complete envelope", () => {
+    expect(
+      bridgeCaptureEnvelopeSchema.safeParse({
+        capture_id: VALID_UUID,
+        ciphertext: VALID_CIPHERTEXT,
+        uploaded_at: VALID_TIMESTAMP,
+        expires_at: VALID_TIMESTAMP,
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("bridgeQrPayloadSchema", () => {
+  it("accepts a v1 payload", () => {
+    expect(
+      bridgeQrPayloadSchema.safeParse({
+        v: "1",
+        token: {
+          capture_id: VALID_UUID,
+          display_code: "K7M4QZ",
+          expires_at: VALID_TIMESTAMP,
+          decryption_key: VALID_KEY,
+        },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an unknown protocol version", () => {
+    expect(
+      bridgeQrPayloadSchema.safeParse({
+        v: "2",
+        token: {
+          capture_id: VALID_UUID,
+          display_code: "K7M4QZ",
+          expires_at: VALID_TIMESTAMP,
+          decryption_key: VALID_KEY,
+        },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared-types/src/bridge-protocol.schemas.ts
+++ b/packages/shared-types/src/bridge-protocol.schemas.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+/**
+ * Runtime schemas for the bridge protocol — see
+ * `./bridge-protocol.ts` for the types and `docs/clinician-bridge-mvp.md`
+ * for the full architecture.
+ *
+ * The relay validates inbound requests against these schemas before
+ * touching storage. They are intentionally strict — anything outside
+ * the contract should be rejected, not coerced.
+ */
+
+/** Base32 character set without 0/O/1/I (Crockford-ish), 6 chars. */
+export const bridgeDisplayCodeSchema = z
+  .string()
+  .regex(
+    /^[ABCDEFGHJKLMNPQRSTUVWXYZ2-9]{6}$/,
+    "display_code must be 6 base32 characters (A-Z minus O/I, 2-9 minus 0/1)",
+  );
+
+/** UUID v4 produced by the relay at pair time. */
+export const bridgeCaptureIdSchema = z.string().uuid();
+
+/**
+ * AES-256-GCM key, base64url-encoded. Decoded length is exactly 32 bytes
+ * (256 bits). The base64url representation is 43 characters with no
+ * padding.
+ */
+export const bridgeDecryptionKeySchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]{43}$/, "decryption_key must be 43 base64url chars (32-byte key, no padding)");
+
+/**
+ * Ciphertext envelope. Format: base64url-encoded IV (12 bytes) + GCM
+ * ciphertext + auth tag (16 bytes). Min ciphertext payload is the
+ * smallest credible FHIR bundle (~256 bytes) after encryption; max is
+ * 64 KiB to bound relay memory.
+ *
+ * After base64url-decode the binary blob is `IV (12) || ciphertext ||
+ * authTag (16)`, so we accept any base64url string between 64 and
+ * 100_000 characters.
+ */
+export const bridgeCiphertextSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_-]+$/, "ciphertext must be base64url-encoded")
+  .min(64)
+  .max(100_000);
+
+/** Caregiver-set label; bridge displays verbatim, capped to keep UI tidy. */
+export const bridgeCaregiverLabelSchema = z.string().max(80).optional();
+
+export const bridgePairRecordSchema = z.object({
+  capture_id: bridgeCaptureIdSchema,
+  display_code: bridgeDisplayCodeSchema,
+  expires_at: z.string().datetime(),
+  decryption_key: bridgeDecryptionKeySchema,
+});
+
+export const bridgePairRequestSchema = z.object({
+  ciphertext: bridgeCiphertextSchema,
+  caregiver_label: bridgeCaregiverLabelSchema,
+});
+
+export const bridgeCaptureEnvelopeSchema = z.object({
+  capture_id: bridgeCaptureIdSchema,
+  ciphertext: bridgeCiphertextSchema,
+  uploaded_at: z.string().datetime(),
+  expires_at: z.string().datetime(),
+});
+
+export const bridgeQrPayloadSchema = z.object({
+  v: z.literal("1"),
+  token: bridgePairRecordSchema,
+});

--- a/packages/shared-types/src/bridge-protocol.ts
+++ b/packages/shared-types/src/bridge-protocol.ts
@@ -1,0 +1,100 @@
+/**
+ * Bridge protocol — wire contract for the MedLens → clinician-bridge handoff.
+ *
+ * See `docs/clinician-bridge-mvp.md` for the full architecture. The protocol
+ * is small by design: the relay holds an opaque encrypted blob, and the
+ * decryption key never touches the relay — it travels with the paired
+ * token (QR + 6-char code) directly from the caregiver's phone to the
+ * clinician's device.
+ *
+ * The decrypted payload is a FHIR R4 Bundle (see
+ * `services/fhir-gateway/src/schemas/bundle.ts` — `fhirBundleSchema`).
+ * This file does not redeclare the payload shape; it only defines the
+ * envelope and the pair-token shape.
+ *
+ * Token lifetime: 15 minutes, single-use. Code length: 6 characters,
+ * base32 ([A-Z2-7], excludes 0/O/1/I to avoid OCR ambiguity).
+ */
+
+/**
+ * The pair record returned by `POST /api/v1/pair` to the MedLens client.
+ *
+ * The caregiver's phone shows `display_code` to the clinician (and/or
+ * encodes everything into a QR for scanning).
+ */
+export interface BridgePairRecord {
+  /** Opaque capture identifier; bridge fetches from `/api/v1/captures/{capture_id}`. */
+  capture_id: string;
+  /** 6-character base32 code, e.g. "K7M4QZ". Excludes 0/O/1/I. */
+  display_code: string;
+  /** ISO 8601 timestamp; 15 minutes from issuance. */
+  expires_at: string;
+  /**
+   * Base64url-encoded AES-256-GCM key. Never sent to the relay after
+   * pair creation — the relay rotates it out of memory and only retains
+   * the encrypted ciphertext. The bridge receives this key via the
+   * QR/code payload and decrypts client-side.
+   */
+  decryption_key: string;
+}
+
+/**
+ * The QR/code-embedded token the clinician's bridge device parses.
+ * Identical to BridgePairRecord — kept as a distinct name to make the
+ * "moving over the air gap (QR scan)" intent obvious at call sites.
+ */
+export type BridgePairToken = BridgePairRecord;
+
+/**
+ * The envelope the relay actually stores. Contains only ciphertext and
+ * non-identifying metadata. PHI lives inside `ciphertext` and is
+ * opaque to the relay.
+ */
+export interface BridgeCaptureEnvelope {
+  capture_id: string;
+  /**
+   * Base64url-encoded AES-256-GCM output. The first 12 bytes (after
+   * base64url-decode) are the IV; the remainder is ciphertext +
+   * 16-byte auth tag (GCM standard layout).
+   */
+  ciphertext: string;
+  /** ISO 8601 timestamp of upload. */
+  uploaded_at: string;
+  /** ISO 8601 timestamp of TTL expiry; equal to `BridgePairRecord.expires_at`. */
+  expires_at: string;
+}
+
+/**
+ * Request body for `POST /api/v1/pair` from the MedLens client. The
+ * client encrypts the FHIR Bundle locally before sending; the relay
+ * only sees ciphertext.
+ *
+ * The relay returns a `BridgePairRecord` and stores the envelope under
+ * `capture_id` for 15 minutes.
+ */
+export interface BridgePairRequest {
+  ciphertext: string;
+  /**
+   * Free-text caregiver label, e.g. "for Dr. Smith" or "ER trip 5/29".
+   * Display-only in the bridge UI; helps a clinician confirm they have
+   * the right capture. Capped at 80 chars by the relay.
+   */
+  caregiver_label?: string;
+}
+
+/**
+ * The pairing payload encoded into the QR.
+ *
+ * Format: JSON-stringified `BridgePairToken`, then base64url. The
+ * leading `v` byte (currently `"1"`) lets us version the format if we
+ * later need to embed additional fields.
+ *
+ * Helper functions for encoding/decoding live in
+ * `apps/clinician-bridge/src/lib/pair-token.ts` so the bridge app and
+ * MedLens (which will vendor a copy) implement the same algorithm.
+ */
+export interface BridgeQrPayload {
+  /** Format version. `"1"` at MVP. */
+  v: "1";
+  token: BridgePairToken;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -11,3 +11,5 @@ export * from "./ai-flags.schemas.js";
 export * from "./auth.schemas.js";
 export * from "./care-team.schemas.js";
 export * from "./scheduling.schemas.js";
+export * from "./bridge-protocol.js";
+export * from "./bridge-protocol.schemas.js";


### PR DESCRIPTION
## Summary

Defines the wire envelope for the MedLens → clinician-bridge handoff, and corrects a leftover scope-doc inconsistency.

## What's in it

**New types in `@carebridge/shared-types`** (`bridge-protocol.ts` + Zod schemas):
- `BridgePairRecord` — returned by `POST /api/v1/pair`
- `BridgePairRequest` — MedLens → relay upload body
- `BridgeCaptureEnvelope` — what the relay stores (ciphertext only)
- `BridgeQrPayload` — versioned (`v: "1"`) format encoded into the QR

**Payload format is FHIR R4 Bundle** — MedLens already emits this via `buildBundleFromOutboxItem`, and CareBridge already ingests it via `services/fhir-gateway` mappers. The protocol file deliberately does not redeclare the payload.

**Scope-doc correction**: D1 (the locked-in relay transport decision) moved the pairing endpoints onto the bridge app's API routes. The old "Out-of-Repo Dependencies" section still had them living on MedLens — fixed. Milestones M2–M6 reordered to match (M2 builds the relay, M3 builds the MedLens client, M4 wires rules).

## Security notes

- `display_code` regex excludes `0/O/1/I` (Crockford-ish, no OCR ambiguity)
- `decryption_key` regex enforces 43 base64url chars = exactly 32 bytes = AES-256-GCM key length
- `ciphertext` upper bound is 100 KiB to bound relay memory
- The relay never persists the decryption key; it travels QR-only

## Test plan

- [x] `pnpm --filter @carebridge/shared-types test` — 233/233
- [x] `pnpm --filter @carebridge/shared-types build` clean
- [ ] Pre-merge: rebase if main moved