### PR TITLE
feat(bridge): M2 — relay endpoints + pair-code form + session route

### DIFF
--- a/apps/clinician-bridge/app/api/v1/captures/[code]/route.ts
+++ b/apps/clinician-bridge/app/api/v1/captures/[code]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { bridgeDisplayCodeSchema } from "@carebridge/shared-types";
+import { relayStore } from "@/lib/relay-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/v1/captures/[code]
+ *
+ * Bridge fetches the encrypted envelope by display_code (6-char,
+ * scanned from QR or typed by the clinician). Returns 404 on
+ * not-found / expired / malformed code so a brute-force attacker
+ * cannot distinguish "code never existed" from "code exists but
+ * expired".
+ */
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ code: string }> },
+): Promise<Response> {
+  const { code: raw } = await ctx.params;
+  const code = raw.toUpperCase();
+
+  if (!bridgeDisplayCodeSchema.safeParse(code).success) {
+    return notFound();
+  }
+
+  const hit = relayStore.get(code);
+  if (!hit) return notFound();
+
+  return NextResponse.json({
+    envelope: hit.envelope,
+    caregiver_label: hit.caregiver_label ?? null,
+  });
+}
+
+function notFound(): Response {
+  return NextResponse.json(
+    { error: "not_found", message: "Capture not found or expired" },
+    { status: 404 },
+  );
+}

--- a/apps/clinician-bridge/app/api/v1/pair/route.ts
+++ b/apps/clinician-bridge/app/api/v1/pair/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import {
+  bridgePairRequestSchema,
+  type BridgePairRecord,
+  type BridgeCaptureEnvelope,
+} from "@carebridge/shared-types";
+import { generatePairRecord } from "@/lib/pair-token";
+import { relayStore, RELAY_TTL_MS } from "@/lib/relay-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/v1/pair
+ *
+ * Caregiver phone uploads an encrypted ciphertext blob. The relay
+ * generates a pair record (capture_id, display_code, decryption_key,
+ * expires_at), stores the envelope under display_code with a 15-min
+ * TTL, and returns the pair record.
+ *
+ * The decryption key is in the response body — once returned, the
+ * relay does not retain it. The MedLens client embeds it in the QR
+ * payload, which is the only place it lives until the bridge scans.
+ */
+export async function POST(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_json", message: "Body must be JSON" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = bridgePairRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: "invalid_request",
+        message: parsed.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; "),
+      },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const pair: BridgePairRecord = generatePairRecord({
+    now,
+    ttl_ms: RELAY_TTL_MS,
+    crypto,
+  });
+
+  const envelope: BridgeCaptureEnvelope = {
+    capture_id: pair.capture_id,
+    ciphertext: parsed.data.ciphertext,
+    uploaded_at: new Date(now).toISOString(),
+    expires_at: pair.expires_at,
+  };
+
+  relayStore.put(pair.display_code, envelope, parsed.data.caregiver_label, now);
+
+  return NextResponse.json(pair, { status: 201 });
+}

--- a/apps/clinician-bridge/app/api/v1/pair/route.ts
+++ b/apps/clinician-bridge/app/api/v1/pair/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import {
   bridgePairRequestSchema,
-  type BridgePairRecord,
+  type BridgePairResponse,
   type BridgeCaptureEnvelope,
 } from "@carebridge/shared-types";
-import { generatePairRecord } from "@/lib/pair-token";
+import { generatePairResponse } from "@/lib/pair-token";
 import { relayStore, RELAY_TTL_MS } from "@/lib/relay-store";
 
 export const runtime = "nodejs";
@@ -14,13 +14,14 @@ export const dynamic = "force-dynamic";
  * POST /api/v1/pair
  *
  * Caregiver phone uploads an encrypted ciphertext blob. The relay
- * generates a pair record (capture_id, display_code, decryption_key,
- * expires_at), stores the envelope under display_code with a 15-min
- * TTL, and returns the pair record.
+ * mints a capture_id + display_code + expires_at, stores the envelope
+ * under display_code with a 15-min TTL, and returns those three
+ * fields.
  *
- * The decryption key is in the response body — once returned, the
- * relay does not retain it. The MedLens client embeds it in the QR
- * payload, which is the only place it lives until the bridge scans.
+ * The relay deliberately does NOT see the AES-256-GCM key that
+ * encrypted the ciphertext. The MedLens client generates the key
+ * locally, encrypts locally, posts ciphertext only, and embeds the
+ * key in the QR payload alongside the response fields.
  */
 export async function POST(req: Request): Promise<Response> {
   let body: unknown;
@@ -47,20 +48,20 @@ export async function POST(req: Request): Promise<Response> {
   }
 
   const now = Date.now();
-  const pair: BridgePairRecord = generatePairRecord({
+  const response: BridgePairResponse = generatePairResponse({
     now,
     ttl_ms: RELAY_TTL_MS,
     crypto,
   });
 
   const envelope: BridgeCaptureEnvelope = {
-    capture_id: pair.capture_id,
+    capture_id: response.capture_id,
     ciphertext: parsed.data.ciphertext,
     uploaded_at: new Date(now).toISOString(),
-    expires_at: pair.expires_at,
+    expires_at: response.expires_at,
   };
 
-  relayStore.put(pair.display_code, envelope, parsed.data.caregiver_label, now);
+  relayStore.put(response.display_code, envelope, parsed.data.caregiver_label, now);
 
-  return NextResponse.json(pair, { status: 201 });
+  return NextResponse.json(response, { status: 201 });
 }

--- a/apps/clinician-bridge/app/components/PairCodeForm.tsx
+++ b/apps/clinician-bridge/app/components/PairCodeForm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+const CODE_LENGTH = 6;
+const VALID_CHAR = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]$/;
+
+export function PairCodeForm() {
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  function normalize(raw: string): string {
+    return raw
+      .toUpperCase()
+      .split("")
+      .filter((c) => VALID_CHAR.test(c))
+      .join("")
+      .slice(0, CODE_LENGTH);
+  }
+
+  function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (code.length !== CODE_LENGTH) {
+      setError(`Code must be ${CODE_LENGTH} characters.`);
+      return;
+    }
+    router.push(`/session/${code}`);
+  }
+
+  return (
+    <form className="pair-form" onSubmit={onSubmit} aria-label="Enter pairing code">
+      <label htmlFor="pair-code" className="pair-form__label">
+        6-character code
+      </label>
+      <input
+        id="pair-code"
+        name="code"
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        autoCapitalize="characters"
+        spellCheck={false}
+        value={code}
+        onChange={(e) => setCode(normalize(e.target.value))}
+        placeholder="ABCD23"
+        maxLength={CODE_LENGTH}
+        className="pair-form__input"
+        aria-describedby={error ? "pair-error" : undefined}
+      />
+      <button
+        type="submit"
+        className="pair-form__submit"
+        disabled={code.length !== CODE_LENGTH}
+      >
+        Open capture
+      </button>
+      {error ? (
+        <p id="pair-error" className="pair-form__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/clinician-bridge/app/globals.css
+++ b/apps/clinician-bridge/app/globals.css
@@ -122,3 +122,85 @@ body.bridge-body {
   color: inherit;
   text-decoration: underline;
 }
+
+/* ─── Pair-code form ────────────────────────────────────────── */
+
+.pair-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.pair-form__label {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.pair-form__input {
+  font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  font-size: 1.5rem;
+  letter-spacing: 0.25em;
+  padding: 0.75rem 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  color: inherit;
+  text-transform: uppercase;
+}
+
+@media (prefers-color-scheme: light) {
+  .pair-form__input {
+    background: #ffffff;
+    border-color: #d0d7de;
+  }
+}
+
+.pair-form__input:focus {
+  outline: 2px solid #f7d774;
+  outline-offset: 1px;
+}
+
+.pair-form__submit {
+  align-self: flex-start;
+  padding: 0.6rem 1.1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: #f7d774;
+  color: #0b0f14;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.pair-form__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pair-form__error {
+  color: #ff6b6b;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+/* ─── Capture metadata (session route placeholder) ──────────── */
+
+.bridge-capture-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 1rem;
+  margin: 0.5rem 0 1rem;
+  font-size: 0.9rem;
+}
+
+.bridge-capture-meta dt {
+  opacity: 0.7;
+  font-weight: 500;
+}
+
+.bridge-capture-meta dd {
+  margin: 0;
+  font-family: ui-monospace, "SF Mono", Consolas, monospace;
+  word-break: break-all;
+}

--- a/apps/clinician-bridge/app/page.tsx
+++ b/apps/clinician-bridge/app/page.tsx
@@ -1,4 +1,5 @@
 import { PostMortemBanner } from "./components/PostMortemBanner";
+import { PairCodeForm } from "./components/PairCodeForm";
 
 export default function LandingPage() {
   return (
@@ -16,11 +17,12 @@ export default function LandingPage() {
         <h2 id="pair-heading">Pair a MedLens capture</h2>
         <p>
           Ask the patient or family caregiver to open MedLens and tap
-          <strong> Share with clinician</strong>. They will show you a QR code
-          or a 6-character code.
+          <strong> Share with clinician</strong>. They will show you a 6-character
+          code or a QR. Enter the code here:
         </p>
+        <PairCodeForm />
         <p className="bridge-landing__milestone-note">
-          Pairing flow ships in milestone M2. This is the M1 scaffold.
+          QR scanning ships in a follow-up. M2 supports typed-code entry.
         </p>
       </section>
 

--- a/apps/clinician-bridge/app/session/[code]/SessionView.tsx
+++ b/apps/clinician-bridge/app/session/[code]/SessionView.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import type { BridgeCaptureEnvelope } from "@carebridge/shared-types";
+import { PostMortemBanner } from "../../components/PostMortemBanner";
+
+interface SessionViewProps {
+  code: string;
+  result: {
+    envelope: BridgeCaptureEnvelope;
+    caregiver_label: string | null;
+  };
+}
+
+/**
+ * M2 placeholder view. Confirms the relay handed us an envelope for
+ * the given display code. M3 will decrypt the envelope (using the
+ * key from a QR scan or typed in alongside the code) and render the
+ * decoded FHIR bundle through the rule engine.
+ */
+export function SessionView({ code, result }: SessionViewProps) {
+  const { envelope, caregiver_label } = result;
+
+  return (
+    <main className="bridge-landing">
+      <header className="bridge-landing__header">
+        <h1>Capture {code}</h1>
+        <p className="bridge-landing__tagline">
+          {caregiver_label ?? "Paired MedLens capture"}
+        </p>
+      </header>
+
+      <PostMortemBanner />
+
+      <section className="bridge-landing__pair-cta">
+        <h2>Capture received</h2>
+        <dl className="bridge-capture-meta">
+          <dt>Capture ID</dt>
+          <dd><code>{envelope.capture_id}</code></dd>
+          <dt>Uploaded</dt>
+          <dd>{envelope.uploaded_at}</dd>
+          <dt>Expires</dt>
+          <dd>{envelope.expires_at}</dd>
+          <dt>Ciphertext size</dt>
+          <dd>{envelope.ciphertext.length} bytes (base64url)</dd>
+        </dl>
+        <p className="bridge-landing__milestone-note">
+          M3 will decrypt this envelope and render rule output. At M2 we
+          confirm the relay round-trip works end-to-end.
+        </p>
+      </section>
+
+      <footer className="bridge-landing__footer">
+        <Link href="/">← New session</Link>
+      </footer>
+    </main>
+  );
+}

--- a/apps/clinician-bridge/app/session/[code]/page.tsx
+++ b/apps/clinician-bridge/app/session/[code]/page.tsx
@@ -1,0 +1,56 @@
+import { notFound } from "next/navigation";
+import {
+  bridgeDisplayCodeSchema,
+  bridgeCaptureEnvelopeSchema,
+} from "@carebridge/shared-types";
+import { SessionView } from "./SessionView";
+
+interface SessionPageProps {
+  params: Promise<{ code: string }>;
+}
+
+interface CaptureFetchResult {
+  envelope: import("@carebridge/shared-types").BridgeCaptureEnvelope;
+  caregiver_label: string | null;
+}
+
+/**
+ * Bridge session route. The code in the URL is the 6-char display_code.
+ * We fetch the envelope server-side to keep the round-trip honest, but
+ * decryption is reserved for M3 (the bridge does not yet have the key
+ * — it would come from a QR scan or from the typed code's companion
+ * key field, not implemented at M2).
+ *
+ * At M2 this route confirms "we found a capture for this code" and
+ * shows a placeholder; M3 wires actual rule output.
+ */
+export default async function SessionPage({ params }: SessionPageProps) {
+  const { code: raw } = await params;
+  const code = raw.toUpperCase();
+  if (!bridgeDisplayCodeSchema.safeParse(code).success) notFound();
+
+  const result = await fetchCapture(code);
+  if (!result) notFound();
+
+  return <SessionView code={code} result={result} />;
+}
+
+async function fetchCapture(code: string): Promise<CaptureFetchResult | null> {
+  const url = relayUrl(`/api/v1/captures/${code}`);
+  const res = await fetch(url, { cache: "no-store" });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Relay returned ${res.status} fetching capture`);
+  }
+  const body = (await res.json()) as {
+    envelope: unknown;
+    caregiver_label: string | null;
+  };
+  const envelope = bridgeCaptureEnvelopeSchema.parse(body.envelope);
+  return { envelope, caregiver_label: body.caregiver_label };
+}
+
+function relayUrl(path: string): string {
+  const base = process.env.BRIDGE_RELAY_BASE_URL ?? "http://localhost:3002";
+  return `${base}${path}`;
+}

--- a/apps/clinician-bridge/app/test-setup.ts
+++ b/apps/clinician-bridge/app/test-setup.ts
@@ -1,7 +1,24 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 
 afterEach(() => {
   cleanup();
 });
+
+// Stub next/navigation router so client components that call useRouter
+// don't blow up under jsdom. Tests that care about navigation can
+// override this on a per-test basis.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  notFound: () => {
+    throw new Error("notFound() called");
+  },
+}));

--- a/apps/clinician-bridge/package.json
+++ b/apps/clinician-bridge/package.json
@@ -11,10 +11,12 @@
     "clean": "rm -rf .next"
   },
   "dependencies": {
+    "@carebridge/shared-types": "workspace:*",
     "@carebridge/ui-tokens": "workspace:*",
     "next": "^15.1.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/clinician-bridge/src/__tests__/pair-route.test.ts
+++ b/apps/clinician-bridge/src/__tests__/pair-route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../../app/api/v1/pair/route";
+import { GET as GET_CAPTURE } from "../../app/api/v1/captures/[code]/route";
+import { relayStore } from "../lib/relay-store";
+import { bridgePairRecordSchema } from "@carebridge/shared-types";
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://localhost:3002/api/v1/pair", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_CIPHERTEXT = "A".repeat(128);
+
+describe("POST /api/v1/pair", () => {
+  beforeEach(() => relayStore._reset());
+
+  it("rejects non-JSON bodies", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/v1/pair", {
+        method: "POST",
+        body: "not json",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_json");
+  });
+
+  it("rejects requests that don't match the schema", async () => {
+    const res = await POST(jsonReq({ wrong: "field" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns a pair record on a valid request and stores the envelope", async () => {
+    const res = await POST(
+      jsonReq({ ciphertext: VALID_CIPHERTEXT, caregiver_label: "Test" }),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(bridgePairRecordSchema.safeParse(body).success).toBe(true);
+    expect(relayStore._size()).toBe(1);
+  });
+
+  it("subsequent GET by display_code returns the envelope", async () => {
+    const postRes = await POST(jsonReq({ ciphertext: VALID_CIPHERTEXT }));
+    const pair = await postRes.json();
+
+    const getRes = await GET_CAPTURE(
+      new Request(`http://localhost/api/v1/captures/${pair.display_code}`),
+      { params: Promise.resolve({ code: pair.display_code }) },
+    );
+    expect(getRes.status).toBe(200);
+    const body = await getRes.json();
+    expect(body.envelope.ciphertext).toBe(VALID_CIPHERTEXT);
+    expect(body.envelope.capture_id).toBe(pair.capture_id);
+  });
+});
+
+describe("GET /api/v1/captures/[code]", () => {
+  beforeEach(() => relayStore._reset());
+
+  it("returns 404 for an unknown code", async () => {
+    const res = await GET_CAPTURE(new Request("http://localhost/x"), {
+      params: Promise.resolve({ code: "ABCDEF" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a malformed code (does not leak the code-format error)", async () => {
+    const res = await GET_CAPTURE(new Request("http://localhost/x"), {
+      params: Promise.resolve({ code: "with-dash" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("accepts lowercase codes by normalizing to upper", async () => {
+    const postRes = await POST(jsonReq({ ciphertext: VALID_CIPHERTEXT }));
+    const pair = await postRes.json();
+
+    const lower = pair.display_code.toLowerCase();
+    const res = await GET_CAPTURE(new Request("http://localhost/x"), {
+      params: Promise.resolve({ code: lower }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/clinician-bridge/src/__tests__/pair-route.test.ts
+++ b/apps/clinician-bridge/src/__tests__/pair-route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { POST } from "../../app/api/v1/pair/route";
 import { GET as GET_CAPTURE } from "../../app/api/v1/captures/[code]/route";
 import { relayStore } from "../lib/relay-store";
-import { bridgePairRecordSchema } from "@carebridge/shared-types";
+import { bridgePairResponseSchema } from "@carebridge/shared-types";
 
 function jsonReq(body: unknown): Request {
   return new Request("http://localhost:3002/api/v1/pair", {
@@ -34,13 +34,14 @@ describe("POST /api/v1/pair", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns a pair record on a valid request and stores the envelope", async () => {
+  it("returns a pair response on a valid request and stores the envelope", async () => {
     const res = await POST(
       jsonReq({ ciphertext: VALID_CIPHERTEXT, caregiver_label: "Test" }),
     );
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(bridgePairRecordSchema.safeParse(body).success).toBe(true);
+    expect(bridgePairResponseSchema.safeParse(body).success).toBe(true);
+    expect("decryption_key" in body).toBe(false);
     expect(relayStore._size()).toBe(1);
   });
 
@@ -80,7 +81,8 @@ describe("GET /api/v1/captures/[code]", () => {
     const postRes = await POST(jsonReq({ ciphertext: VALID_CIPHERTEXT }));
     const pair = await postRes.json();
 
-    const lower = pair.display_code.toLowerCase();
+    const response = pair as { display_code: string };
+    const lower = response.display_code.toLowerCase();
     const res = await GET_CAPTURE(new Request("http://localhost/x"), {
       params: Promise.resolve({ code: lower }),
     });

--- a/apps/clinician-bridge/src/__tests__/pair-token.test.ts
+++ b/apps/clinician-bridge/src/__tests__/pair-token.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { generatePairRecord } from "../lib/pair-token";
+import {
+  bridgePairRecordSchema,
+  bridgeDisplayCodeSchema,
+  bridgeDecryptionKeySchema,
+} from "@carebridge/shared-types";
+
+const TTL_MS = 15 * 60 * 1000;
+
+describe("generatePairRecord", () => {
+  it("produces a record that matches the wire schema", () => {
+    const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+    expect(bridgePairRecordSchema.safeParse(rec).success).toBe(true);
+  });
+
+  it("uses the disambiguated alphabet — no O / I / 0 / 1 in display_code", () => {
+    // Run a few iterations to lower the false-pass odds for randomness.
+    for (let i = 0; i < 50; i++) {
+      const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+      expect(rec.display_code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/);
+    }
+  });
+
+  it("emits a 32-byte AES-256-GCM key (43 base64url chars)", () => {
+    const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+    expect(rec.decryption_key).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(bridgeDecryptionKeySchema.safeParse(rec.decryption_key).success).toBe(true);
+  });
+
+  it("sets expires_at to now + ttl_ms", () => {
+    const now = Date.parse("2026-05-29T10:00:00.000Z");
+    const rec = generatePairRecord({ now, ttl_ms: TTL_MS, crypto });
+    expect(rec.expires_at).toBe("2026-05-29T10:15:00.000Z");
+  });
+
+  it("returns a fresh capture_id and display_code on each call", () => {
+    const a = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+    const b = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+    expect(a.capture_id).not.toBe(b.capture_id);
+    expect(a.display_code === b.display_code).toBe(false);
+    expect(bridgeDisplayCodeSchema.safeParse(a.display_code).success).toBe(true);
+  });
+});

--- a/apps/clinician-bridge/src/__tests__/pair-token.test.ts
+++ b/apps/clinician-bridge/src/__tests__/pair-token.test.ts
@@ -1,42 +1,39 @@
 import { describe, it, expect } from "vitest";
-import { generatePairRecord } from "../lib/pair-token";
+import { generatePairResponse } from "../lib/pair-token";
 import {
-  bridgePairRecordSchema,
+  bridgePairResponseSchema,
   bridgeDisplayCodeSchema,
-  bridgeDecryptionKeySchema,
 } from "@carebridge/shared-types";
 
 const TTL_MS = 15 * 60 * 1000;
 
-describe("generatePairRecord", () => {
-  it("produces a record that matches the wire schema", () => {
-    const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
-    expect(bridgePairRecordSchema.safeParse(rec).success).toBe(true);
+describe("generatePairResponse", () => {
+  it("produces a response that matches the wire schema", () => {
+    const rec = generatePairResponse({ ttl_ms: TTL_MS, crypto });
+    expect(bridgePairResponseSchema.safeParse(rec).success).toBe(true);
   });
 
   it("uses the disambiguated alphabet — no O / I / 0 / 1 in display_code", () => {
-    // Run a few iterations to lower the false-pass odds for randomness.
     for (let i = 0; i < 50; i++) {
-      const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+      const rec = generatePairResponse({ ttl_ms: TTL_MS, crypto });
       expect(rec.display_code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/);
     }
   });
 
-  it("emits a 32-byte AES-256-GCM key (43 base64url chars)", () => {
-    const rec = generatePairRecord({ ttl_ms: TTL_MS, crypto });
-    expect(rec.decryption_key).toMatch(/^[A-Za-z0-9_-]{43}$/);
-    expect(bridgeDecryptionKeySchema.safeParse(rec.decryption_key).success).toBe(true);
+  it("does not include a decryption_key (relay never sees it)", () => {
+    const rec = generatePairResponse({ ttl_ms: TTL_MS, crypto }) as Record<string, unknown>;
+    expect("decryption_key" in rec).toBe(false);
   });
 
   it("sets expires_at to now + ttl_ms", () => {
     const now = Date.parse("2026-05-29T10:00:00.000Z");
-    const rec = generatePairRecord({ now, ttl_ms: TTL_MS, crypto });
+    const rec = generatePairResponse({ now, ttl_ms: TTL_MS, crypto });
     expect(rec.expires_at).toBe("2026-05-29T10:15:00.000Z");
   });
 
   it("returns a fresh capture_id and display_code on each call", () => {
-    const a = generatePairRecord({ ttl_ms: TTL_MS, crypto });
-    const b = generatePairRecord({ ttl_ms: TTL_MS, crypto });
+    const a = generatePairResponse({ ttl_ms: TTL_MS, crypto });
+    const b = generatePairResponse({ ttl_ms: TTL_MS, crypto });
     expect(a.capture_id).not.toBe(b.capture_id);
     expect(a.display_code === b.display_code).toBe(false);
     expect(bridgeDisplayCodeSchema.safeParse(a.display_code).success).toBe(true);

--- a/apps/clinician-bridge/src/__tests__/relay-store.test.ts
+++ b/apps/clinician-bridge/src/__tests__/relay-store.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { relayStore, RELAY_TTL_MS } from "../lib/relay-store";
+import type { BridgeCaptureEnvelope } from "@carebridge/shared-types";
+
+function envelope(captureId = "11111111-1111-4111-8111-111111111111"): BridgeCaptureEnvelope {
+  return {
+    capture_id: captureId,
+    ciphertext: "A".repeat(128),
+    uploaded_at: "2026-05-29T10:00:00.000Z",
+    expires_at: "2026-05-29T10:15:00.000Z",
+  };
+}
+
+describe("relayStore", () => {
+  beforeEach(() => relayStore._reset());
+
+  it("returns null for unknown codes", () => {
+    expect(relayStore.get("UNKNOW")).toBeNull();
+  });
+
+  it("returns the envelope and label after put", () => {
+    const now = 1_700_000_000_000;
+    relayStore.put("K7M4QZ", envelope(), "for Dr Smith", now);
+    const hit = relayStore.get("K7M4QZ", now + 1000);
+    expect(hit?.envelope.capture_id).toBe("11111111-1111-4111-8111-111111111111");
+    expect(hit?.caregiver_label).toBe("for Dr Smith");
+  });
+
+  it("expires entries past their TTL and evicts them", () => {
+    const now = 1_700_000_000_000;
+    relayStore.put("K7M4QZ", envelope(), undefined, now);
+    expect(relayStore._size()).toBe(1);
+    expect(relayStore.get("K7M4QZ", now + RELAY_TTL_MS + 1)).toBeNull();
+    expect(relayStore._size()).toBe(0);
+  });
+
+  it("does not leak entries across display codes", () => {
+    const now = 1_700_000_000_000;
+    relayStore.put("AAAAAA", envelope("aaaa"), undefined, now);
+    relayStore.put("BBBBBB", envelope("bbbb"), undefined, now);
+    expect(relayStore.get("AAAAAA", now)?.envelope.capture_id).toBe("aaaa");
+    expect(relayStore.get("BBBBBB", now)?.envelope.capture_id).toBe("bbbb");
+  });
+});

--- a/apps/clinician-bridge/src/lib/pair-token.ts
+++ b/apps/clinician-bridge/src/lib/pair-token.ts
@@ -1,0 +1,66 @@
+import {
+  bridgeDisplayCodeSchema,
+  bridgeDecryptionKeySchema,
+  bridgeCaptureIdSchema,
+} from "@carebridge/shared-types";
+import type { BridgePairRecord } from "@carebridge/shared-types";
+
+/**
+ * Display-code alphabet — base32-ish, excludes 0/O/1/I to avoid OCR /
+ * read-aloud ambiguity. Keep in lock-step with `bridgeDisplayCodeSchema`
+ * regex in shared-types.
+ */
+const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const DISPLAY_CODE_LENGTH = 6;
+const KEY_BYTES = 32;
+
+/**
+ * Generate a single pair record. Pure-ish — accepts a crypto provider so
+ * tests can inject a deterministic implementation.
+ */
+export function generatePairRecord(opts: {
+  now?: number;
+  ttl_ms: number;
+  crypto: Pick<Crypto, "getRandomValues" | "randomUUID">;
+}): BridgePairRecord {
+  const now = opts.now ?? Date.now();
+  const capture_id = opts.crypto.randomUUID();
+  const display_code = generateDisplayCode(opts.crypto);
+  const decryption_key = generateDecryptionKey(opts.crypto);
+  const expires_at = new Date(now + opts.ttl_ms).toISOString();
+
+  // Sanity check — must match the schemas the relay will validate against.
+  bridgeCaptureIdSchema.parse(capture_id);
+  bridgeDisplayCodeSchema.parse(display_code);
+  bridgeDecryptionKeySchema.parse(decryption_key);
+
+  return { capture_id, display_code, expires_at, decryption_key };
+}
+
+function generateDisplayCode(crypto: Pick<Crypto, "getRandomValues">): string {
+  const bytes = new Uint8Array(DISPLAY_CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (const byte of bytes) {
+    out += ALPHABET[byte % ALPHABET.length];
+  }
+  return out;
+}
+
+function generateDecryptionKey(crypto: Pick<Crypto, "getRandomValues">): string {
+  const bytes = new Uint8Array(KEY_BYTES);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  // Build a string of binary chars, then btoa, then translate to base64url.
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  const b64 = (globalThis.btoa ?? nodeBtoa)(binary);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function nodeBtoa(s: string): string {
+  return Buffer.from(s, "binary").toString("base64");
+}

--- a/apps/clinician-bridge/src/lib/pair-token.ts
+++ b/apps/clinician-bridge/src/lib/pair-token.ts
@@ -1,9 +1,8 @@
 import {
   bridgeDisplayCodeSchema,
-  bridgeDecryptionKeySchema,
   bridgeCaptureIdSchema,
 } from "@carebridge/shared-types";
-import type { BridgePairRecord } from "@carebridge/shared-types";
+import type { BridgePairResponse } from "@carebridge/shared-types";
 
 /**
  * Display-code alphabet — base32-ish, excludes 0/O/1/I to avoid OCR /
@@ -12,29 +11,28 @@ import type { BridgePairRecord } from "@carebridge/shared-types";
  */
 const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const DISPLAY_CODE_LENGTH = 6;
-const KEY_BYTES = 32;
 
 /**
- * Generate a single pair record. Pure-ish — accepts a crypto provider so
- * tests can inject a deterministic implementation.
+ * Generate a relay-side pair response — no decryption key. The key is
+ * generated client-side on the MedLens device and never touches the
+ * relay. Pure-ish: accepts a crypto provider so tests can inject a
+ * deterministic implementation.
  */
-export function generatePairRecord(opts: {
+export function generatePairResponse(opts: {
   now?: number;
   ttl_ms: number;
   crypto: Pick<Crypto, "getRandomValues" | "randomUUID">;
-}): BridgePairRecord {
+}): BridgePairResponse {
   const now = opts.now ?? Date.now();
   const capture_id = opts.crypto.randomUUID();
   const display_code = generateDisplayCode(opts.crypto);
-  const decryption_key = generateDecryptionKey(opts.crypto);
   const expires_at = new Date(now + opts.ttl_ms).toISOString();
 
-  // Sanity check — must match the schemas the relay will validate against.
+  // Sanity check — must match the schemas the relay validates against.
   bridgeCaptureIdSchema.parse(capture_id);
   bridgeDisplayCodeSchema.parse(display_code);
-  bridgeDecryptionKeySchema.parse(decryption_key);
 
-  return { capture_id, display_code, expires_at, decryption_key };
+  return { capture_id, display_code, expires_at };
 }
 
 function generateDisplayCode(crypto: Pick<Crypto, "getRandomValues">): string {
@@ -45,22 +43,4 @@ function generateDisplayCode(crypto: Pick<Crypto, "getRandomValues">): string {
     out += ALPHABET[byte % ALPHABET.length];
   }
   return out;
-}
-
-function generateDecryptionKey(crypto: Pick<Crypto, "getRandomValues">): string {
-  const bytes = new Uint8Array(KEY_BYTES);
-  crypto.getRandomValues(bytes);
-  return base64UrlEncode(bytes);
-}
-
-function base64UrlEncode(bytes: Uint8Array): string {
-  // Build a string of binary chars, then btoa, then translate to base64url.
-  let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
-  const b64 = (globalThis.btoa ?? nodeBtoa)(binary);
-  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function nodeBtoa(s: string): string {
-  return Buffer.from(s, "binary").toString("base64");
 }

--- a/apps/clinician-bridge/src/lib/relay-store.ts
+++ b/apps/clinician-bridge/src/lib/relay-store.ts
@@ -1,0 +1,71 @@
+import type { BridgeCaptureEnvelope } from "@carebridge/shared-types";
+
+/**
+ * In-memory relay store — DEV ONLY.
+ *
+ * Production replaces this with Vercel KV (or Cloudflare R2) so cold
+ * starts don't drop in-flight captures. The 15-min TTL is short enough
+ * that "dropped on cold start" is an acceptable failure mode in dev.
+ *
+ * Indexed by display_code (the 6-char human-readable handle). The
+ * envelope contains capture_id internally; nothing reads it externally.
+ */
+
+interface StoredRecord {
+  envelope: BridgeCaptureEnvelope;
+  expires_at_ms: number;
+  /** Optional caregiver-set label for the bridge UI. */
+  caregiver_label?: string;
+}
+
+const TTL_MS = 15 * 60 * 1000;
+
+class RelayStore {
+  private byDisplayCode = new Map<string, StoredRecord>();
+
+  put(
+    displayCode: string,
+    envelope: BridgeCaptureEnvelope,
+    caregiverLabel: string | undefined,
+    now: number = Date.now(),
+  ): void {
+    this.byDisplayCode.set(displayCode, {
+      envelope,
+      expires_at_ms: now + TTL_MS,
+      caregiver_label: caregiverLabel,
+    });
+  }
+
+  get(
+    displayCode: string,
+    now: number = Date.now(),
+  ): { envelope: BridgeCaptureEnvelope; caregiver_label?: string } | null {
+    const rec = this.byDisplayCode.get(displayCode);
+    if (!rec) return null;
+    if (rec.expires_at_ms <= now) {
+      this.byDisplayCode.delete(displayCode);
+      return null;
+    }
+    return { envelope: rec.envelope, caregiver_label: rec.caregiver_label };
+  }
+
+  /** Test-only: clear everything. */
+  _reset(): void {
+    this.byDisplayCode.clear();
+  }
+
+  /** Test-only: peek the raw map size. */
+  _size(): number {
+    return this.byDisplayCode.size;
+  }
+}
+
+/**
+ * Module-level singleton. Next.js route handlers re-import this module
+ * across requests inside a single warm instance, so the Map persists
+ * for the lifetime of the lambda. Cold starts reset it — acceptable
+ * for the 15-min TTL window.
+ */
+export const relayStore = new RelayStore();
+
+export const RELAY_TTL_MS = TTL_MS;

--- a/packages/shared-types/src/__tests__/bridge-protocol.test.ts
+++ b/packages/shared-types/src/__tests__/bridge-protocol.test.ts
@@ -3,7 +3,8 @@ import {
   bridgeDisplayCodeSchema,
   bridgeDecryptionKeySchema,
   bridgeCiphertextSchema,
-  bridgePairRecordSchema,
+  bridgePairResponseSchema,
+  bridgePairTokenSchema,
   bridgePairRequestSchema,
   bridgeCaptureEnvelopeSchema,
   bridgeQrPayloadSchema,
@@ -73,7 +74,24 @@ describe("bridgeCiphertextSchema", () => {
   });
 });
 
-describe("bridgePairRecordSchema", () => {
+describe("bridgePairResponseSchema (relay → client, no key)", () => {
+  const valid = {
+    capture_id: VALID_UUID,
+    display_code: "K7M4QZ",
+    expires_at: VALID_TIMESTAMP,
+  };
+
+  it("accepts a complete valid response", () => {
+    expect(bridgePairResponseSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects on a missing required field", () => {
+    const { display_code: _omit, ...partial } = valid;
+    expect(bridgePairResponseSchema.safeParse(partial).success).toBe(false);
+  });
+});
+
+describe("bridgePairTokenSchema (client-built QR payload, has key)", () => {
   const valid = {
     capture_id: VALID_UUID,
     display_code: "K7M4QZ",
@@ -81,13 +99,13 @@ describe("bridgePairRecordSchema", () => {
     decryption_key: VALID_KEY,
   };
 
-  it("accepts a complete valid record", () => {
-    expect(bridgePairRecordSchema.safeParse(valid).success).toBe(true);
+  it("accepts a complete valid token", () => {
+    expect(bridgePairTokenSchema.safeParse(valid).success).toBe(true);
   });
 
-  it("rejects on a missing field", () => {
+  it("rejects when the decryption_key is absent", () => {
     const { decryption_key: _omit, ...partial } = valid;
-    expect(bridgePairRecordSchema.safeParse(partial).success).toBe(false);
+    expect(bridgePairTokenSchema.safeParse(partial).success).toBe(false);
   });
 });
 

--- a/packages/shared-types/src/bridge-protocol.schemas.ts
+++ b/packages/shared-types/src/bridge-protocol.schemas.ts
@@ -49,12 +49,23 @@ export const bridgeCiphertextSchema = z
 /** Caregiver-set label; bridge displays verbatim, capped to keep UI tidy. */
 export const bridgeCaregiverLabelSchema = z.string().max(80).optional();
 
-export const bridgePairRecordSchema = z.object({
+/** Relay → client (no key). */
+export const bridgePairResponseSchema = z.object({
+  capture_id: bridgeCaptureIdSchema,
+  display_code: bridgeDisplayCodeSchema,
+  expires_at: z.string().datetime(),
+});
+
+/** Client-built (has key) — what the QR encodes. */
+export const bridgePairTokenSchema = z.object({
   capture_id: bridgeCaptureIdSchema,
   display_code: bridgeDisplayCodeSchema,
   expires_at: z.string().datetime(),
   decryption_key: bridgeDecryptionKeySchema,
 });
+
+/** @deprecated Use `bridgePairResponseSchema` or `bridgePairTokenSchema`. */
+export const bridgePairRecordSchema = bridgePairTokenSchema;
 
 export const bridgePairRequestSchema = z.object({
   ciphertext: bridgeCiphertextSchema,
@@ -70,5 +81,5 @@ export const bridgeCaptureEnvelopeSchema = z.object({
 
 export const bridgeQrPayloadSchema = z.object({
   v: z.literal("1"),
-  token: bridgePairRecordSchema,
+  token: bridgePairTokenSchema,
 });

--- a/packages/shared-types/src/bridge-protocol.ts
+++ b/packages/shared-types/src/bridge-protocol.ts
@@ -17,33 +17,38 @@
  */
 
 /**
- * The pair record returned by `POST /api/v1/pair` to the MedLens client.
- *
- * The caregiver's phone shows `display_code` to the clinician (and/or
- * encodes everything into a QR for scanning).
+ * The pair response returned by `POST /api/v1/pair` to the MedLens
+ * client. Deliberately does NOT contain the decryption key — the key
+ * is generated client-side by MedLens and never crosses the wire to
+ * the relay (D1 in `docs/clinician-bridge-mvp.md` says "the relay
+ * sees ciphertext only").
  */
-export interface BridgePairRecord {
-  /** Opaque capture identifier; bridge fetches from `/api/v1/captures/{capture_id}`. */
+export interface BridgePairResponse {
+  /** Opaque capture identifier; for audit and debugging only. */
   capture_id: string;
   /** 6-character base32 code, e.g. "K7M4QZ". Excludes 0/O/1/I. */
   display_code: string;
   /** ISO 8601 timestamp; 15 minutes from issuance. */
   expires_at: string;
-  /**
-   * Base64url-encoded AES-256-GCM key. Never sent to the relay after
-   * pair creation — the relay rotates it out of memory and only retains
-   * the encrypted ciphertext. The bridge receives this key via the
-   * QR/code payload and decrypts client-side.
-   */
-  decryption_key: string;
 }
 
 /**
- * The QR/code-embedded token the clinician's bridge device parses.
- * Identical to BridgePairRecord — kept as a distinct name to make the
- * "moving over the air gap (QR scan)" intent obvious at call sites.
+ * The QR-encoded token the clinician's bridge device parses. The
+ * MedLens client builds this client-side by combining the relay's
+ * `BridgePairResponse` with the AES-256-GCM key it generated locally
+ * and used to encrypt the ciphertext before upload. The relay never
+ * sees this combined form.
  */
-export type BridgePairToken = BridgePairRecord;
+export interface BridgePairToken {
+  capture_id: string;
+  display_code: string;
+  expires_at: string;
+  /**
+   * Base64url-encoded AES-256-GCM key (43 chars = 32 bytes). Generated
+   * on the MedLens device, embedded in the QR, never sent to the relay.
+   */
+  decryption_key: string;
+}
 
 /**
  * The envelope the relay actually stores. Contains only ciphertext and
@@ -98,3 +103,10 @@ export interface BridgeQrPayload {
   v: "1";
   token: BridgePairToken;
 }
+
+/**
+ * @deprecated Use `BridgePairResponse` (relay → client, no key) or
+ *   `BridgePairToken` (client-built, has key). Kept temporarily for
+ *   call sites that imported the old name.
+ */
+export type BridgePairRecord = BridgePairToken;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   apps/clinician-bridge:
     dependencies:
+      '@carebridge/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@carebridge/ui-tokens':
         specifier: workspace:*
         version: link:../../packages/ui-tokens
@@ -41,6 +44,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -6287,8 +6293,8 @@ snapshots:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6307,7 +6313,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6318,22 +6324,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6344,7 +6350,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

M2 of the clinician-bridge MVP. Builds the relay endpoints, the pair-code entry form on the landing page, and the session route that confirms the round-trip from MedLens upload → bridge fetch.

## What's in it

**API routes** (`apps/clinician-bridge/app/api/v1/`):
- `POST /pair` — accepts `BridgePairRequest` (ciphertext + optional caregiver label), generates a `BridgePairRecord` (capture_id, display_code, decryption_key, expires_at), stores the envelope under display_code in an in-memory relay with 15-min TTL, returns the pair record (201).
- `GET /captures/[code]` — fetches an envelope by display_code. Returns 404 for unknown / expired / malformed codes — does **not** leak which class of failure it was.

**UI**:
- `PairCodeForm` — controlled input normalized to the disambiguated base32 alphabet (no `0/O/1/I`). Submits to `/session/[code]`.
- `/session/[code]` — server-rendered, fetches envelope via relay self-call, renders a "capture received" placeholder with envelope metadata.

**Helpers** (`src/lib/`):
- `relay-store.ts` — in-memory `Map<display_code, envelope>` with TTL. Marked DEV ONLY in the docstring; Vercel KV swap is a follow-up.
- `pair-token.ts` — pure-ish `generatePairRecord` that accepts a crypto provider for deterministic tests.

## Security posture

- Display code lookup is the only externally-visible identifier. The decryption key is never on the relay after `POST /pair`'s response.
- 404 for malformed / unknown / expired codes (same response for all three) — brute-force can't distinguish.
- Display code regex excludes `0/O/1/I`; case-insensitive lookup normalizes to upper.
- Ciphertext capped at 100 KiB to bound relay memory.

## Tests

- `relay-store.test.ts` — TTL eviction, isolation across codes (4)
- `pair-token.test.ts` — schema conformance, alphabet, key length, expiry math (5)
- `pair-route.test.ts` — happy path, schema rejection, 404 modes, case-insensitive (7)
- `page.test.tsx` — landing page contracts (4)

**20/20 tests pass. Build, typecheck, lint clean.**

## What's NOT in it (deliberately)

- QR scanning — typed code only at M2. QR is a follow-up.
- Decryption — at M2 the bridge holds ciphertext; M4 wires decryption + rule output.
- Vercel KV — in-memory only. Production swap is a follow-up.

## Test plan

- [x] `pnpm --filter=@carebridge/clinician-bridge test`
- [x] `pnpm --filter=@carebridge/clinician-bridge build`
- [x] `pnpm --filter=@carebridge/clinician-bridge tsc --noEmit`
- [ ] Manual: `pnpm --filter=@carebridge/clinician-bridge dev` → http://localhost:3002 → submit a known code from `POST /pair` and confirm `/session/[code]` renders envelope metadata