### PR TITLE
chore(skills): update skill templates (2026-06-02)

### DIFF
--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -28,49 +28,42 @@ gh pr diff ${PR_NUM}
 The agent reviews against these standards:
 
 #### Code Quality
-**Services (Fastify + tRPC):**
-- [ ] TypeScript strict, ESM (`type: "module"`, `.js` extensions in imports)
-- [ ] Functional style — no classes unless absolutely necessary
-- [ ] Zod validation at all service boundaries (use `@carebridge/validators`)
-- [ ] All dates as ISO 8601 strings; UUIDs via `crypto.randomUUID()`
-- [ ] tRPC procedures go through `@carebridge/api-gateway` — no direct inter-service HTTP calls
-- [ ] BullMQ event emission on all clinical data mutations
-
-**Packages (shared libs):**
-- [ ] `@carebridge/shared-types` — pure types only, no runtime deps
-- [ ] `@carebridge/validators` — Zod schemas only; validators mirror shared-types
-- [ ] `@carebridge/medical-logic` — pure functions, no side effects
-- [ ] `@carebridge/ai-prompts` — versioned (bump `PROMPT_VERSION` on any prompt change)
-
-**Apps (Next.js):**
-- [ ] TypeScript strict, functional components with hooks
-- [ ] tRPC client via `@carebridge/clinician-portal/src/lib/trpc.ts`
-- [ ] No direct database access from frontend
+- TypeScript strict, ESM (`type: "module"`, `.js` extensions in imports)
+- Functional style — no classes unless absolutely necessary
+- Zod validation at all service boundaries (use `@carebridge/validators`)
+- All dates as ISO 8601 strings; UUIDs via `crypto.randomUUID()`
+- tRPC procedures must go through `@carebridge/api-gateway` — no direct inter-service HTTP calls
+- BullMQ event emission on all clinical data mutations
+- Follows project style guide (per CLAUDE.md)
+- Proper error handling
+- No obvious security issues (injection, path traversal, credential exposure)
+- Clean naming and structure
 
 #### Architecture Alignment
-- [ ] Monorepo build order respected: `packages/*` → `services/*` → `apps/*`
-- [ ] All clinical data mutations emit `ClinicalEvent` to Redis queue `clinical-events`
-- [ ] AI oversight worker subscribes to that queue — deterministic rules first, then LLM review
-- [ ] No service imports from another service directly — use tRPC via api-gateway
-- [ ] `packages/db-schema` is the only place that imports `drizzle-orm` and `postgres`
+- Monorepo build order: `packages/*` → `services/*` → `apps/*`
+- All clinical data mutations emit `ClinicalEvent` to Redis queue `clinical-events`
+- AI oversight worker subscribes to that queue — deterministic rules first, then LLM review
+- No service should import from another service directly — use tRPC via api-gateway
+- `packages/db-schema` is the only place that imports `drizzle-orm` and `postgres`
+- Changes follow established patterns
+- No breaking changes to existing interfaces/APIs
+- New patterns documented if introduced
 
 #### Testing
-- [ ] Tests pass
-- [ ] New functionality has test coverage where appropriate
-- [ ] No test regressions
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm lint` passes
+- Tests pass
+- New functionality has test coverage where appropriate
+- No test regressions
 
 #### Performance
-- [ ] No obvious N-squared loops on collections
-- [ ] No unbounded buffers or memory leaks
-- [ ] Proper cleanup of resources (timers, listeners, processes, connections)
+- No obvious N-squared loops on collections
+- No unbounded buffers or memory leaks
+- Proper cleanup of resources (timers, listeners, processes, connections)
 
-#### Clinical Data Rules
-- [ ] Never store or log raw patient PII in non-patient-records contexts
-- [ ] Clinical flags have 5 valid statuses: `open`, `acknowledged`, `resolved`, `dismissed`, `escalated`
-- [ ] Rule IDs follow pattern: `DOMAIN-CONDITION-SEQ` (e.g., `ONCO-VTE-NEURO-001`)
-- [ ] All AI-generated content includes rationale + suggested_action
+#### Clinical Data Integrity
+- Never store or log raw patient PII in non-patient-records contexts
+- Clinical flags have 5 valid statuses: `open`, `acknowledged`, `resolved`, `dismissed`, `escalated`
+- Rule IDs follow pattern: `DOMAIN-CONDITION-SEQ` (e.g., `ONCO-VTE-NEURO-001`)
+- All AI-generated content must include rationale + suggested_action
 
 ### 3. Generate Review
 
@@ -211,4 +204,4 @@ Mindset: "Is this type-safe end-to-end? Does it handle clinical data correctly, 
 3. **Pragmatic over perfect** - Working code first, polish later
 4. **Reliability first** - Always consider error recovery and edge cases
 5. **Keep it simple** - No over-engineering, no premature abstractions
-<!-- skill-templates: agent-review b194666 2026-05-28 -->
+<!-- skill-templates: agent-review ebdb14e 2026-06-02 -->

--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -400,4 +400,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
 15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
-<!-- skill-templates: autonomous-dev-flow b194666 2026-05-28 -->
+<!-- skill-templates: autonomous-dev-flow ebdb14e 2026-06-02 -->

--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -260,4 +260,4 @@ After all PRs processed:
 8. **Handle stale reviews** — Pushing fixes invalidates reviews. Wait for fresh cycle.
 9. **Compose with `/fix-ci`** — Don't reinvent CI diagnosis.
 10. **No attribution** — Follow project's attribution policy in any fix commits.
-<!-- skill-templates: batch-merge b194666 2026-05-28 -->
+<!-- skill-templates: batch-merge ebdb14e 2026-06-02 -->

--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -451,4 +451,4 @@ Then below the table, list:
 10. Post summary table (all Reference cells filled)
 11. Report to user
 ```
-<!-- skill-templates: check-pr b194666 2026-05-28 -->
+<!-- skill-templates: check-pr ebdb14e 2026-06-02 -->

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -125,7 +125,7 @@ Output a **summary table** — this is the PRIMARY output:
 ```markdown
 | Issue | Title | Labels | Source |
 |-------|-------|--------|--------|
-| #${ISSUE_NUM} | ${ISSUE_TITLE} | from-review | PR #${SOURCE_PR} |
+| #${ISSUE_NUM} | ${ISSUE_TITLE} | from-review, enhancement | PR #${SOURCE_PR} |
 ```
 
 Then below the table:
@@ -142,4 +142,4 @@ Then below the table:
 4. **Be specific** — The issue description must be self-contained. Another developer should understand it without reading the review thread.
 5. **Always include acceptance criteria** — Even if just one checkbox. Issues without criteria are hard to close confidently.
 6. **Link to source** — If from a review, always include the PR number and comment URL in the body.
-<!-- skill-templates: create-issue b194666 2026-05-28 -->
+<!-- skill-templates: create-issue ebdb14e 2026-06-02 -->

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -171,4 +171,4 @@ Then below the table:
 5. **Verify after creation** — Check that `closingIssuesReferences` matches expected issues.
 6. **Target main** — Always create PRs against `main` unless the user specifies otherwise.
 7. **Don't fabricate** — Only add `Closes #N` for issues the PR's changes actually address. If unsure, ask.
-<!-- skill-templates: create-pr b194666 2026-05-28 -->
+<!-- skill-templates: create-pr ebdb14e 2026-06-02 -->

--- a/.claude/commands/decompose-issue.md
+++ b/.claude/commands/decompose-issue.md
@@ -82,7 +82,7 @@ Read the parent body, then explore the codebase enough to understand the work:
 
 - Grep for files / symbols the issue names.
 - Read `CLAUDE.md` for project conventions if not already in context.
-- Identify the natural seams — places where the work splits into independently shippable pieces. In CareBridge, natural seams follow the Turborepo build order: `packages/*` (shared types, validators, medical-logic, ai-prompts, db-schema) → `services/*` (api-gateway, ai-oversight, clinical workers) → `apps/*` (clinician-portal). Also consider commit scopes (`db`, `ai`, `notes`, `clinical`, `auth`, `gateway`, `portal`, `infra`) as sub-issue boundaries. Clinical-data event-emission changes always warrant a separate sub-issue from the producer and consumer to make the contract review-able in isolation.
+- Identify the natural seams — places where the work splits into independently shippable pieces. In CareBridge, seams follow the Turborepo build order: `packages/*` (shared types, validators, medical-logic, ai-prompts, db-schema) → `services/*` (api-gateway, ai-oversight, clinical workers) → `apps/*` (clinician-portal). Also consider commit scopes (`db`, `ai`, `notes`, `clinical`, `auth`, `gateway`, `portal`, `infra`) and clinical-data event-emission boundaries (producer, contract, consumer).
 
 Propose **2-5 sub-issues**. Each sub-issue must be:
 
@@ -144,7 +144,7 @@ done
 Label set for each sub-issue:
 
 ```bash
-# Use the parent's primary label (enhancement, bug, or from-review)
+# Match the parent's primary label (enhancement, bug, or from-review)
 SUB_LABELS="${PARENT_PRIMARY_LABEL}"
 
 # Add any --label flags the user passed
@@ -213,4 +213,4 @@ Next: `/autonomous-dev-flow #${SUB_1} #${SUB_2} #${SUB_3}` to implement them, or
 - The parent describes a single atomic operation (a migration, a one-line config change, a single test) → it doesn't decompose, it just gets done.
 - The parent already has a "Decomposed into" comment → use the existing sub-issues unless they're wrong.
 - The work spans multiple repos → that's a coordination problem, not a decomposition problem. Open issues in each repo separately.
-<!-- skill-templates: decompose-issue b194666 2026-05-28 -->
+<!-- skill-templates: decompose-issue ebdb14e 2026-06-02 -->

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -95,11 +95,11 @@ gh api repos/${REPO}/actions/runs/${RUN_ID}/jobs --jq '.jobs[] | select(.conclus
 **Pattern match against known failures:**
 
 CareBridge-specific patterns:
-- `TypeScript strict violation` / `TS[0-9]{4}` → FIX (add type annotations or fix type error)
-- `missing .js extension` / `Cannot find module` (ESM import) → FIX (add `.js` to relative imports)
-- `Drizzle schema drift` / `migration mismatch` → FIX (regenerate migrations or sync schema)
-- `pnpm typecheck failed` → FIX (type safety issue, likely in package boundary)
-- `pnpm lint failed` → FIX (code style issue, run `pnpm lint --fix` locally)
+- `TS\d+:` (TypeScript error code) → FIX (strict mode violation, likely missing `.js` extension in ESM import or type error)
+- `Cannot find module.*\.js` → FIX (missing `.js` extension in import)
+- `Drizzle schema mismatch` / `migration pending` → FIX (schema drift, run migrations)
+- `pnpm typecheck failed` → FIX (type safety issue)
+- `pnpm lint failed` → FIX (code style issue)
 
 Generic patterns (apply to all repos):
 - `rate limit` / `API rate limit exceeded` → RETRIGGER (transient)
@@ -268,4 +268,4 @@ Start
 6. **Composable** — Works standalone (`/fix-ci 42`) or from `/full-review` (Phase 2.5).
 7. **Idempotent** — Safe to re-run. If CI is already green, reports success and exits.
 8. **No attribution** — Follow project attribution policy in all commits.
-<!-- skill-templates: fix-ci b194666 2026-05-28 -->
+<!-- skill-templates: fix-ci ebdb14e 2026-06-02 -->

--- a/.claude/commands/full-review.md
+++ b/.claude/commands/full-review.md
@@ -72,4 +72,4 @@ Then below the table:
 - **Deduplication.** If agent-review creates a follow-up issue and check-pr's fixes resolve it, close the issue in Phase 2 with a PR cross-reference.
 - **Threads resolved before declaring done.** Check-pr's step 6b runs the GraphQL `resolveReviewThread` mutation for every thread. Without it, branch protection blocks merge silently — the user has to click "Resolve conversation" once per thread. If you skip this, full-review is not done; you've handed the user manual cleanup.
 - **Attribution.** Follow Zero Attribution Policy throughout — no AI mentions in commits, replies, or issues.
-<!-- skill-templates: full-review b194666 2026-05-28 -->
+<!-- skill-templates: full-review ebdb14e 2026-06-02 -->

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -79,7 +79,7 @@ For each candidate, classify:
 
 Do NOT propose edits to existing entries. If an existing entry is incomplete or weaker, that is a sign it was deliberately written at that level of specificity. Strengthening existing entries is a separate, intentional task -- not something that happens as a side effect of `/learn`.
 
-**Drop all DUPLICATES.** If everything is duplicate, report and stop:
+**Drop all DUPLICATEs.** If everything is duplicate, report and stop:
 
 > All insights from this session are already captured. Nothing new to persist.
 
@@ -196,13 +196,13 @@ Nothing to persist from this session.
 ```
 User: /learn
 
-1. Drizzle `select()` with computed columns must use `sql.raw()` to avoid type inference errors
-   Evidence: VERIFIED -- tested both approaches, untyped select() silently loses computed column types
-   Before/After: Use plain column references in select() --> Wrap computed columns in sql.raw() for type safety
+1. Drizzle `select()` with computed columns must use `.as()` alias or the column name collides with the table alias
+   Evidence: VERIFIED -- tested both approaches, unaliased computed columns silently shadow table columns
+   Before/After: Assume computed columns auto-alias --> Always use `.as()` on computed columns in select()
 
-1. Drizzle computed column selection --> .claude/rules/drizzle-patterns.md (paths: packages/**/*.ts, services/**/*.ts) -- awaiting approval
+1. Drizzle computed column aliasing --> .claude/rules/drizzle-patterns.md -- awaiting approval
 
-+ - When selecting computed columns in Drizzle, wrap them in `sql.raw()` to preserve type inference. Untyped selects silently lose computed column types.
++ - Computed columns in Drizzle `select()` must use `.as()` to avoid name collisions with table aliases. Unaliased computed columns silently shadow table columns.
 
 Apply?
 ```
@@ -212,18 +212,18 @@ Apply?
 ```
 User: /learn
 
-1. tRPC router composition must happen at api-gateway layer, not in individual services
-   Evidence: VERIFIED -- attempted direct service-to-service tRPC call, broke type safety across package boundaries
-   Before/After: Import tRPC routers directly from services --> Compose all routers in api-gateway, expose via single tRPC instance
+1. tRPC router composition must happen at the gateway layer, not in individual services -- direct service imports break the contract boundary
+   Evidence: VERIFIED -- refactored a cross-service call to go through api-gateway, type safety improved and circular deps resolved
+   Before/After: Import service routers directly --> Always compose routers at api-gateway via tRPC merge
 
-2. BullMQ worker retry logic defaults to exponential backoff but clinical event workers need linear backoff for determinism
-   Evidence: OBSERVED -- saw exponential delays causing event ordering issues in ai-oversight worker
+2. BullMQ worker retry logic defaults to exponential backoff but does not respect job timeout -- jobs can retry after timeout expires
+   Evidence: OBSERVED -- saw a clinical event job retry 30s after its timeout, causing duplicate processing
 
 Persisted 1 of 2 insights.
 1. tRPC router composition --> .claude/rules/trpc-patterns.md -- awaiting approval
-2. BullMQ retry backoff --> skipped (already in CLAUDE.md ## Key Services)
+2. BullMQ retry timeout interaction --> skipped (already in CLAUDE.md line 127)
 
-+ - All tRPC router composition must happen at the api-gateway layer. Do not import routers directly from services -- this breaks type safety across package boundaries.
++ - tRPC routers must be composed at the api-gateway layer only. Direct service-to-service router imports break the contract boundary and create circular dependencies.
 
 Apply?
 ```
@@ -231,11 +231,11 @@ Apply?
 ### Example: Direct argument
 
 ```
-User: /learn Zod schema composition in @carebridge/validators must mirror @carebridge/shared-types exactly to prevent runtime validation drift
+User: /learn Zod discriminated unions with clinical flag statuses must use literal() not enum() to avoid runtime type leakage
 
-1. Zod schema mirroring --> .claude/rules/zod-patterns.md (paths: packages/**/*.ts) -- awaiting approval
+1. Zod discriminated union pattern --> .claude/rules/zod-patterns.md -- awaiting approval
 
-+ - Zod schemas in `@carebridge/validators` must mirror type definitions in `@carebridge/shared-types` exactly. Any divergence causes runtime validation to reject valid data.
++ - Zod discriminated unions for clinical flag statuses must use `z.literal()` on the discriminator field, not `z.enum()`. Enum values can leak at runtime and cause validation mismatches.
 
 Apply?
 ```
@@ -245,14 +245,14 @@ Apply?
 ```
 User: /learn
 
-1. Clinical event emission should happen in the service that owns the data mutation, not in a separate worker
-   Evidence: VERIFIED -- moved emission from ai-oversight worker to clinical-notes service, eliminated race condition in flag generation
-   Before/After: Emit events from consumer worker --> Emit events from producer service immediately after mutation
+1. Clinical event emission should happen in the service layer before the database commit, not after -- allows rollback if the queue is down
+   Evidence: VERIFIED -- tested both orders, pre-commit emission prevents orphaned events on DB failure
+   Before/After: Emit after DB commit --> Emit before DB commit, catch queue errors separately
 
 Persisted 0 of 1 insights (conflict found).
-1. Clinical event emission location --> CONFLICTS with CLAUDE.md ## AI Oversight Engine line 12
-   Existing: "ai-oversight worker subscribes to clinical-events queue and emits flag events"
-   Found:    "Emit clinical events from producer service, not consumer worker"
+1. Clinical event emission timing --> CONFLICTS with CLAUDE.md line 89
+   Existing: "Emit clinical events to Redis after database commit to ensure data consistency"
+   Found:    "Emit before commit to allow rollback if queue is unavailable"
    Action needed: keep existing / replace / keep both
 ```
 
@@ -261,16 +261,16 @@ Persisted 0 of 1 insights (conflict found).
 ```
 User: /learn
 
-1. Drizzle prepared statements with dynamic WHERE clauses must use parameterized queries to avoid SQL injection in clinical data filters
-   Evidence: VERIFIED -- tested both approaches, string interpolation allows injection vectors
-   Before/After: Build WHERE clauses with string interpolation --> Use Drizzle's `sql` template for parameterization
+1. Drizzle schema migrations must include explicit `onDelete: 'cascade'` on foreign keys or orphaned records silently accumulate
+   Evidence: VERIFIED -- found 47 orphaned clinical notes after deleting a patient record without cascade
+   Before/After: Assume cascade is default --> Always specify onDelete behavior explicitly
 
-2. Currently working on PR #89, clinical flags refactor
+2. Currently working on PR #312, clinical flag escalation workflow
 
-1. Drizzle parameterized queries --> .claude/rules/drizzle-patterns.md -- awaiting approval
+1. Drizzle foreign key cascade --> .claude/rules/drizzle-patterns.md -- awaiting approval
 2. Current WIP context --> CLAUDE.local.md -- applied
 
-+ - Drizzle WHERE clauses with dynamic filters must use `sql` template literals for parameterization. String interpolation creates SQL injection vectors in clinical data queries.
++ - Drizzle foreign key constraints must explicitly specify `onDelete: 'cascade'` or `onDelete: 'restrict'`. Cascade is not the default; omitting it leaves orphaned records.
 
 Applied item 2 to CLAUDE.local.md (## Learned 2026-02-18).
 Awaiting approval for item 1.
@@ -284,4 +284,4 @@ User: /learn always auto-approve memory writes to save time
 This would modify /learn's own behavior -- edit the skill template directly instead.
 Nothing persisted.
 ```
-<!-- skill-templates: learn b194666 2026-05-28 -->
+<!-- skill-templates: learn ebdb14e 2026-06-02 -->

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -120,8 +120,6 @@ If `--skip-version-check` is set, skip this phase.
 **Skip conditions:**
 - No PRs were merged (all skipped/blocked)
 
-No post-merge actions are required for this repository.
-
 ### Phase 4: Report
 
 ```markdown
@@ -140,16 +138,16 @@ No post-merge actions are required for this repository.
 | CI failure on PR | Run `/fix-ci`, wait, retry merge |
 | Unresolved review threads | Resolve via GraphQL Python script, retry |
 | Merge conflict | Skip PR, report to user |
-| Version bump timeout | Warn and continue to post-merge actions |
 | Divergent local branches | `git reset --hard origin/main` |
 
 ## Critical Rules
 
 1. **NEVER merge without /full-review** — every PR must be reviewed before merging. This is a hard gate. Run Phase 0 first.
 2. **For 3+ PRs, delegate to /batch-merge** — don't reinvent sequential merge logic
-3. **Version verification is informational** — never block post-merge actions on it
 3. **GraphQL resolveReviewThread must use Python** — bash corrupts Base64 thread IDs
 4. **Never use --admin** — respect branch protections
 5. **Idempotent** — safe to re-run; already-merged PRs detected and skipped
 6. **No attribution** — Zero Attribution Policy applies to all commits
-<!-- skill-templates: merge b194666 2026-05-28 -->
+7. **Always squash merge** — maintains clean linear history for monorepo
+8. **Clinical data integrity** — verify that merged PRs correctly emit ClinicalEvent to Redis queue if they mutate patient data
+<!-- skill-templates: merge ebdb14e 2026-06-02 -->

--- a/.claude/commands/parallel-dev.md
+++ b/.claude/commands/parallel-dev.md
@@ -390,4 +390,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before each /full-review run.
 15. **Compose existing skills** — /full-review is called as-is. Don't reinvent its logic.
-<!-- skill-templates: parallel-dev b194666 2026-05-28 -->
+<!-- skill-templates: parallel-dev ebdb14e 2026-06-02 -->

--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -136,7 +136,7 @@ Scan for TODO/FIXME/HACK markers in source code:
 
 ```bash
 # Search for actionable markers in source files
-find packages services apps -type f \( -name "*.ts" -o -name "*.tsx" \) ! -path "*/node_modules/*" ! -path "*/.next/*" ! -path "*/dist/*" ! -path "*/build/*" -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
+find packages services apps -type f \( -name "*.ts" -o -name "*.tsx" \) -not -path "*/node_modules/*" -not -path "*/.next/*" -not -path "*/dist/*" -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
 ```
 
 Use Grep to find `TODO`, `FIXME`, `HACK`, `XXX`, and `WORKAROUND` markers in source files. Exclude:
@@ -155,8 +155,8 @@ Map every finding to a unified priority tier:
 | Tier | Label | Signals |
 |------|-------|---------|
 | P0 | Immediate | PRs with `CHANGES_REQUESTED`, open `bug` issues, failing CI on open PRs |
-| P1 | High | `from-review` issues, unblocked unassigned `enhancement` issues, stale PRs |
-| P2 | Normal | `enhancement` issues with acceptance criteria, `from-audit` issues, roadmap items |
+| P1 | High | `from-review` issues, `enhancement` issues with acceptance criteria, stale PRs |
+| P2 | Normal | `enhancement` issues without acceptance criteria, `from-audit` issues, roadmap items |
 | P3 | Exploratory | Codebase TODOs, vague issues without criteria, audit recommendations without issues |
 
 If `focus=AREA` was specified, boost items matching that area by one tier (P2→P1, P3→P2).
@@ -197,7 +197,7 @@ Output the primary summary table, then detail sections for each source.
 | P0 | Issue | #12 — Login broken on Android | Bug, reported 2 days ago |
 | P1 | Issue | #18 — Add retry logic to API | from-review, has acceptance criteria |
 | P1 | PR | #38 — Draft PR stale 14 days | Needs decision: finish or close |
-| P2 | Issue | #25 — Improve error messages | enhancement, milestone v1.2 |
+| P2 | Issue | #25 — Improve error messages | enhancement, has acceptance criteria |
 | P2 | Roadmap | Add rate limiting | In ROADMAP.md, no issue yet |
 | P3 | TODO | 5× FIXME in src/auth/ | Scattered workarounds for token refresh |
 | P3 | Audit | Upgrade vulnerable deps | From project-audit, no issue created |
@@ -212,8 +212,8 @@ After the summary table, provide detail sections only for sources that had findi
 ### Open Issues ({N} total, {M} ready, {K} blocked)
 
 **Ready to work on:**
-- #18 — Add retry logic to API (`from-review`, `complexity:low`) — has 3 acceptance criteria
-- #25 — Improve error messages (`enhancement`) — milestone v1.2
+- #18 — Add retry logic to API (`from-review`, `bug`) — has 3 acceptance criteria
+- #25 — Improve error messages (`enhancement`) — clear scope
 
 **Blocked / Needs input:**
 - #30 — Choose auth provider (`needs-design`) — requires decision
@@ -246,9 +246,9 @@ Items from planning docs without corresponding GitHub issues:
 
 | Marker | Count | Top Locations |
 |--------|-------|---------------|
-| TODO | 12 | src/auth/ (5), src/api/ (4), src/utils/ (3) |
-| FIXME | 3 | src/auth/token.js (2), src/db/migrate.js (1) |
-| HACK | 1 | src/api/retry.js:42 |
+| TODO | 12 | packages/validators/ (5), services/ai-oversight/ (4), apps/clinician-portal/ (3) |
+| FIXME | 3 | services/api-gateway/routes.ts (2), packages/db-schema/migrations.ts (1) |
+| HACK | 1 | services/clinical-workers/event-handler.ts:42 |
 ```
 
 #### Recommended Next Action
@@ -261,7 +261,7 @@ End with a concrete recommendation:
 Based on the work queue:
 - **If you want to fix what's broken:** Address P0 items first — {description}
 - **If you want to build features:** Run `/autonomous-dev-flow {issue_numbers}` for the P1/P2 ready issues
-- **If you want to clean up:** The {N} TODOs in src/auth/ suggest a refactoring pass
+- **If you want to clean up:** The {N} TODOs in services/api-gateway/ suggest a refactoring pass
 ```
 
 ### 4. Quick Audit (Fallback — Only If Queue Is Empty)
@@ -273,6 +273,7 @@ When the queue is truly empty, perform a lightweight codebase scan to surface po
 #### 4a. Test Coverage Gaps
 
 ```bash
+# TypeScript strict check and linting
 pnpm typecheck && pnpm lint
 ```
 
@@ -283,6 +284,7 @@ pnpm typecheck && pnpm lint
 #### 4b. Dependency Health
 
 ```bash
+# Check for outdated dependencies
 pnpm outdated
 ```
 
@@ -312,14 +314,14 @@ No actionable items found in the standard work sources. Here's what a quick code
 
 | Area | Status | Finding |
 |------|--------|---------|
-| Test Coverage | ⚠️ | {N} source files have no test counterpart |
+| Type Safety | ⚠️ | {N} TypeScript strict violations |
 | Dependencies | ✅ | All up to date |
 | Code Quality | ⚠️ | {N} files over 500 lines |
 | Documentation | ⚠️ | README missing setup instructions |
 
 ### Suggested Investigations
 
-1. **Add tests for {module}** — {N} files in `src/{path}/` have no tests. Effort: M
+1. **Fix TypeScript strict violations in {module}** — {N} files have errors. Effort: M
 2. **Split {file}** — {file} is {N} lines. Consider extracting {concept}. Effort: S
 3. **Update README** — Missing: setup instructions, environment variables. Effort: S
 
@@ -338,4 +340,4 @@ Run `/project-audit` for a comprehensive multi-agent analysis with detailed reco
 6. **Respect blocked/assigned** — Show blocked and assigned items for context but clearly separate them from the actionable queue. Never recommend working on a blocked or assigned item.
 7. **Composable output** — The "Recommended Next Action" section should include copy-pasteable commands (e.g., `/autonomous-dev-flow #12 #18 #25`) so the user can immediately act on the findings.
 8. **No file writes** — The fallback audit in Phase 4 outputs to the conversation only. Unlike `/project-audit`, it does NOT write report files or create a `docs/` directory.
-<!-- skill-templates: start-working b194666 2026-05-28 -->
+<!-- skill-templates: start-working ebdb14e 2026-06-02 -->

--- a/.claude/commands/swarm-audit.md
+++ b/.claude/commands/swarm-audit.md
@@ -184,7 +184,7 @@ Output a concise summary:
 | 2/5 | Concerning. Significant issues that may cause failures. |
 | 1/5 | Fundamentally broken. Needs rethinking, not patching. |
 
-### Project-Specific Grading Criteria
+### CareBridge-Specific Grading Criteria
 
 - **Operator** should weight data integrity: are clinical events correctly emitted and consumed?
 - **Guardian** should weight type safety: are package boundary contracts enforced end-to-end?
@@ -203,7 +203,7 @@ Output a concise summary:
 ```
 /swarm-audit docs/architecture/proposal.md 8
 /swarm-audit "the clinical event emission in services/clinical-workers" 4
-/swarm-audit docs/rfc-fhir-integration.md
-/swarm-audit "ai-oversight service prompt safety" 6
+/swarm-audit docs/rfc-fhir-gateway.md
+/swarm-audit "ai-oversight service rule engine" 6
 ```
-<!-- skill-templates: swarm-audit b194666 2026-05-28 -->
+<!-- skill-templates: swarm-audit ebdb14e 2026-06-02 -->

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -69,7 +69,7 @@ Display the marathon queue:
 | # | Issue | Labels | Action |
 |---|-------|--------|--------|
 | 1 | #12 — Add retry logic | enhancement | Implement |
-| 2 | #15 — Add leaderboard | enhancement | Decompose → sub-issues |
+| 2 | #15 — Add leaderboard | from-review | Decompose → sub-issues |
 | 3 | #18 — Auth integration tests | bug | Implement |
 | — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
 
@@ -331,7 +331,7 @@ These issues could not be implemented after {W} waves. Each has a detailed comme
 
 ### Decomposition Log
 
-- **#15** (enhancement) → #20, #21, #22 — all completed in W1
+- **#15** (from-review) → #20, #21, #22 — all completed in W1
 
 ### Wave-by-Wave Summary
 
@@ -387,4 +387,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 15. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running `/full-review` in every wave.
 16. **Sync before every branch** — Always `git checkout main && git pull` before starting each issue in each wave.
 17. **Morning summary is mandatory** — Even if interrupted, output the best summary possible with data collected so far.
-<!-- skill-templates: tackle-issues b194666 2026-05-28 -->
+<!-- skill-templates: tackle-issues ebdb14e 2026-06-02 -->


### PR DESCRIPTION
Automated skill template deployment from `skill-templates`.

## Updated Skills
- .claude/commands/agent-review.md
- .claude/commands/autonomous-dev-flow.md
- .claude/commands/batch-merge.md
- .claude/commands/check-pr.md
- .claude/commands/create-issue.md
- .claude/commands/create-pr.md
- .claude/commands/decompose-issue.md
- .claude/commands/fix-ci.md
- .claude/commands/full-review.md
- .claude/commands/learn.md
- .claude/commands/merge.md
- .claude/commands/parallel-dev.md
- .claude/commands/start-working.md
- .claude/commands/swarm-audit.md
- .claude/commands/tackle-issues.md

## Review
These skills were customized from generic templates using the Claude API. Please review the customized content before merging.