### PR TITLE
chore(infra): refresh autonomous-dev-flow and tackle-issues from the registry

### DIFF
--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -1,15 +1,15 @@
 # /autonomous-dev-flow
 
-Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, and continue to the next issue. The user reviews and merges PRs asynchronously while work continues.
+Orchestrate long-running autonomous dev sessions — work through GitHub issues sequentially with TDD, create PRs, run /full-review, then merge or flag according to this repo's self-merge posture, and continue to the next issue. PRs that don't merge accumulate for asynchronous user review while work continues.
 
 ## Arguments
 
 - `$ARGUMENTS` - Issue source and options. Examples:
-  - `label:enhancement` (all open issues with this label)
+  - `label:bug` / `label:from-review` / `label:enhancement` (all open issues with this label)
   - `milestone:"v1.2"` (all open issues in milestone)
   - `#12 #15 #18` or `12 15 18` (specific issues by number)
-  - `label:enhancement max:5 sort:created-asc` (with options)
-  - If empty, auto-detect: scan open issues sorted by complexity (low first, then medium, skip high)
+  - `label:from-review max:5 sort:created-asc` (with options)
+  - If empty, auto-detect: scan open issues and order by this repo's priority labels — `bug` → `from-review` → `enhancement`, with `p1` → `p2` → `p3` breaking ties where present
   - Options: `max:N` (default 10, hard cap 15), `sort:created-asc` (default) or `sort:created-desc`
 
 ## Instructions
@@ -19,6 +19,10 @@ Orchestrate long-running autonomous dev sessions — work through GitHub issues 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
+# CareBridge branches carry conventional prefixes (feat/, fix/, refactor/, chore/,
+# docs/, test/). This skill only ever CREATES feat/<number>-<slug>, so the prefix
+# scans below key on feat/. Branches made by hand under the other prefixes are
+# still caught by the PR-title "#<issue>" scan that runs alongside the prefix scan.
 BRANCH_PREFIX="feat/"
 ```
 
@@ -27,9 +31,9 @@ Parse `$ARGUMENTS` to determine the issue source:
 - **Explicit list**: Strip `#` prefixes, run `gh issue view ${NUM} --json number,title,state,labels,body,assignees` for each
 - **Label**: `gh issue list --label "${LABEL}" --state open --json number,title,labels,assignees --limit ${MAX}`
 - **Milestone**: `gh issue list --milestone "${MILESTONE}" --state open --json number,title,labels,assignees --limit ${MAX}`
-- **Auto-detect** (empty args): `gh issue list --state open --json number,title,labels,assignees --limit 30` then sort by complexity label (low first, then medium, skip high)
+- **Auto-detect** (empty args): `gh issue list --state open --json number,title,labels,assignees --limit 30` then order by priority label (`bug` → `from-review` → `enhancement`; `p1`/`p2`/`p3` break ties). This repo has no `complexity:*` labels, so oversized issues are identified by scope in Phase 0.5, not by label.
 
-Apply sort order and cap to `max` (hard cap 15 — sessions beyond this rarely maintain quality). Recommended: 3-5 issues for first use; sessions of 10+ work best with well-specified, low-complexity issues.
+Apply sort order and cap to `max` (hard cap 15 — sessions beyond this rarely maintain quality). Recommended: 3-5 issues for first use; sessions of 10+ work best with well-specified, small-scope issues.
 
 **Filter out assigned issues** — exclude issues with assignees from the working queue. Show them in the queue table as informational but don't process them.
 
@@ -44,10 +48,10 @@ Apply sort order and cap to `max` (hard cap 15 — sessions beyond this rarely m
 
 | # | Issue | Labels | Action |
 |---|-------|--------|--------|
-| 1 | #12 — Add retry logic to API client | enhancement | Implement |
-| 2 | #15 — Add leaderboard system | complexity:high | Decompose → sub-issues |
-| — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
-| 3 | #18 — Add integration tests for auth flow | bug | Implement |
+| 1 | #12 — Retry the BullMQ clinical-events consumer on transient failure | enhancement | Implement |
+| 2 | #15 — Medication reconciliation across clinical-data + ai-oversight | enhancement | Decompose → sub-issues (spans 3 workspaces) |
+| — | #16 — Refactor the auth session store | enhancement | Assigned to @user (skipped) |
+| 3 | #18 — Integration tests for the auth MFA flow | test | Implement |
 
 Start autonomous dev session?
 ```
@@ -60,16 +64,16 @@ For each issue in work queue:
   TaskCreate: "Issue #N — <title>" with status pending
 ```
 
-### Phase 0.5: Auto-Decompose High-Complexity Issues
+### Phase 0.5: Auto-Decompose Oversized Issues
 
-When the queue contains issues that are too large to implement directly (e.g., issues touching 3+ packages/services), decompose them into smaller, independently implementable sub-issues BEFORE entering the core loop.
+When the queue contains issues that are too large to implement directly — in this repo, issues whose scope spans 3+ workspaces across `packages/`, `services/` and `apps/` — decompose them into smaller, independently implementable sub-issues BEFORE entering the core loop. There are no `complexity:*` labels here, so the trigger is scope, not a label.
 
-For each high-complexity issue:
+For each oversized issue:
 
 0. Check for prior decomposition — scan the issue's comments for an existing "Decomposed into #A, #B, #C" comment. If found, use those existing sub-issues instead of creating new ones.
 1. Read the full issue body: `gh issue view ${ISSUE_NUM} --json body,comments -q .`
 2. Understand the full scope — files involved, systems affected, testing needs
-3. Break into 2-5 sub-issues, each low or medium complexity
+3. Break into 2-5 sub-issues, each independently implementable. Prefer the Turborepo build order as the seam: `packages/*` → `services/*` → `apps/*`, one sub-issue per layer when an issue spans two or more. Clinical-data event-emission changes always get a sub-issue separate from producer and consumer, so the contract is reviewable in isolation.
 4. Create sub-issues via `gh issue create`:
 
 ```bash
@@ -85,7 +89,7 @@ Part of #${ISSUE_NUM}
 
 ## Implementation Plan
 
-- Files to modify: `src/path/to/file`
+- Files to modify: `services/<service>/src/<file>.ts`
 - Test strategy: Add tests for X behavior
 - Approach: [specific implementation details]
 
@@ -98,6 +102,8 @@ EOF
 
 SUB_NUM=$(basename "$SUB_URL")
 ```
+
+Sub-issue labels mirror the parent's primary label (`enhancement`, `bug`, or `from-review`). Parent linkage is the body line `Part of #N` only — this repo has no `parent:#N` label scheme and no parent-marker label.
 
 5. Insert sub-issues at FRONT of queue (context is fresh from reading the parent)
 6. Comment on parent issue: `gh issue comment ${ISSUE_NUM} --body "Decomposed into #A, #B, #C — each independently implementable with TDD."`
@@ -137,7 +143,8 @@ Note any merged PRs in the progress table. If on a stale branch, switch back to 
 Check for existing branches/PRs from a previous session for the current issue:
 
 ```bash
-# Check if issue already has a PR (search by title reference)
+# Check if issue already has a PR (search by title reference). This scan is what
+# catches work branched under the fix/, refactor/, chore/, docs/ or test/ prefixes.
 gh pr list --json number,title,headRefName,state --limit 50 \
   | jq --arg num "${ISSUE_NUM}" '[.[] | select(.title | contains("#" + $num))]'
 
@@ -181,7 +188,7 @@ Create branch following project conventions:
 ISSUE_TITLE=$(gh issue view "${ISSUE_NUM}" --json title -q '.title')
 SLUG=$(printf '%s' "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
 
-# Create branch from issue number + slug
+# CareBridge convention: feat/<number>-<slug>
 BRANCH="${BRANCH_PREFIX}${ISSUE_NUM}-${SLUG}"
 git checkout -b "${BRANCH}"
 ```
@@ -193,8 +200,18 @@ git checkout -b "${BRANCH}"
 Based on the issue's acceptance criteria, write tests that describe the desired behavior. Tests MUST fail before any implementation.
 
 ```bash
-# Run tests to confirm they fail
-pnpm typecheck && pnpm lint
+# Vitest, driven through Turborepo. The workspaces that run tests are listed in
+# vitest.workspace.ts. Test files live at:
+#   services/<svc>/src/__tests__/*.test.ts
+#   packages/<pkg>/src/__tests__/*.test.ts   (*.int.test.ts for DB-backed integration)
+#   apps/<app>/src/__tests__/*.test.ts and apps/<app>/**/*.test.tsx
+#
+# Whole workspace (what CI runs). DB-backed suites need Postgres up and migrations
+# applied first: docker-compose up -d && pnpm db:migrate
+pnpm test
+
+# Scope to the workspace you are changing while iterating
+pnpm --filter @carebridge/<workspace> test
 ```
 
 If tests pass immediately, the behavior already exists — investigate before proceeding. Either the issue is already resolved or the tests don't capture the right behavior.
@@ -204,8 +221,7 @@ If tests pass immediately, the behavior already exists — investigate before pr
 Write the minimum implementation to make all new tests pass. Don't over-engineer — just satisfy the tests.
 
 ```bash
-# Run tests to confirm they pass
-pnpm typecheck && pnpm lint
+pnpm test
 ```
 
 If tests still fail, iterate on the implementation until they pass. Do NOT move to REFACTOR until all tests are green.
@@ -216,10 +232,13 @@ With green tests as a safety net:
 - Remove duplication
 - Improve naming
 - Simplify logic
-- Ensure the code follows project conventions (per CLAUDE.md)
+- Ensure the code follows project conventions (per CLAUDE.md) — TypeScript strict, ESM with `.js` extensions in imports, functional style over classes, Zod validation at service boundaries, ISO 8601 date strings, `crypto.randomUUID()` for IDs
 
 ```bash
 # Run tests again to confirm refactoring didn't break anything
+pnpm test
+
+# Static gates — these mirror the CI jobs; run them before pushing
 pnpm typecheck && pnpm lint
 ```
 
@@ -241,7 +260,8 @@ Refs #${ISSUE_NUM}
 EOF
 )"
 
-# Commit scope conventions: db, ai, notes, clinical, auth, gateway, portal, infra
+# Types:  feat, fix, refactor, docs, test, chore, style, perf
+# Scopes: db, ai, notes, clinical, auth, gateway, portal, infra
 
 git push -u origin ${BRANCH}
 ```
@@ -272,8 +292,12 @@ Refs #${ISSUE_NUM}
 
 ## Test Plan
 
-- [ ] pnpm typecheck passes
-- [ ] pnpm lint passes
+- [ ] All new tests pass
+- [ ] Existing tests unbroken
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm build` passes
+- [ ] `pnpm test` passes
 - [ ] Affected service tested locally
 EOF
 )")
@@ -288,14 +312,14 @@ PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 2. Re-read the skill files for /full-review, /agent-review, and /check-pr
 
 Run `/full-review ${PR_NUM}`:
-- Phase 1: Agent review — deep expert review against project standards
-- Phase 2: Check-PR — process all review comments (Copilot + agent-review findings)
+- Phase 1: Agent review — deep expert review against project standards (the CareBridge Inspector persona)
+- Phase 2: Check-PR — process all review comments. Copilot review IS active on this repo, so expect Copilot comments alongside the agent-review findings.
 
 Capture results: verdict, findings counts, fixes committed, issues created/closed.
 
 **If critical findings exist:** Fix them (standard /full-review behavior handles this). Two fix attempts max — after that, flag the PR as "Needs attention" and move on.
 
-**Do NOT merge.** PRs accumulate for user review. The agent keeps working.
+**Do NOT merge — Critical Rule 5 withholds merge authority for this repo.** Rule 5 records whether this repo grants unattended merge authority at all; it is the only place that decides, and nothing here overrides it. Because it withholds that authority, the Unattended Merge Gate does not apply: never merge, never `gh pr merge --auto`, never enable GitHub auto-merge, never override branch protection — however clean the verdict is. Leave the PR open, flag it in the session report, and keep working. A clean review is not a reason to revisit that.
 
 ### Phase 6: Assess, Report, and Continue
 
@@ -303,7 +327,7 @@ Based on /full-review results, classify the PR:
 
 | Verdict | Meaning | Action |
 |---------|---------|--------|
-| Clean | No critical findings, all comments addressed | Edit PR body: `Refs` → `Closes`. Mark issue done, continue |
+| Clean | No critical findings, all comments addressed | Edit PR body: `Refs` → `Closes`. Then follow Critical Rule 5: this repo withholds merge authority, so leave the PR open and flag it for user review. Mark the issue done, continue |
 | Needs attention | Critical findings or unresolved comments | Keep `Refs` (don't auto-close). Flag for user, continue |
 | Broken | Tests failing after review fixes | Keep `Refs` (don't auto-close). Flag for user, continue |
 
@@ -319,12 +343,12 @@ Output cumulative progress table:
 ## Session Progress ({completed}/{total})
 
 | # | Issue | Branch | PR | Review | Status |
-|---|-------|--------|----|---------|----|
-| 1 | #12 — Add retry logic | 12-add-retry | #45 | Approve (0 critical) | Done |
-| 2 | #15 — Add leaderboard | — | — | — | Decomposed → #20, #21 |
-| 3 | #20 — Leaderboard data model | 20-lb-model | #46 | Approve (1 suggestion) | Done |
-| 4 | #18 — Add auth tests | — | — | — | In progress |
-| 5 | #22 — Update error handling | — | — | — | Queued |
+|---|-------|--------|----|--------|--------|
+| 1 | #12 — Retry BullMQ consumer | feat/12-retry-bullmq-consumer | #45 | Approve (0 critical) | Done — PR open |
+| 2 | #15 — Medication reconciliation | — | — | — | Decomposed → #20, #21 |
+| 3 | #20 — Reconciliation data model | feat/20-reconciliation-data-model | #46 | Approve (1 suggestion) | Done — PR open |
+| 4 | #18 — Auth MFA integration tests | — | — | — | In progress |
+| 5 | #22 — Harden clinical-flag status transitions | — | — | — | Queued |
 ```
 
 **CRITICAL: Never block the session on a flagged PR.** Flag and move on. The user handles flagged PRs during check-ins.
@@ -345,35 +369,47 @@ After all issues are processed (or the queue is exhausted), output final summary
 
 | # | Issue | PR | Review Verdict | Status |
 |---|-------|----|---------------|--------|
-| 1 | #12 — Add retry logic | [#45](url) | Approve | Ready to merge |
-| 2 | #15 — Add leaderboard | — | — | Decomposed → #20, #21, #22 |
-| 3 | #20 — Leaderboard data model | [#46](url) | Approve | Ready to merge |
-| 4 | #18 — Add auth tests | [#47](url) | Request Changes | Needs attention |
+| 1 | #12 — Retry BullMQ consumer | [#45](url) | Approve | Open — ready for review |
+| 2 | #15 — Medication reconciliation | — | — | Decomposed → #20, #21, #22 |
+| 3 | #20 — Reconciliation data model | [#46](url) | Approve | Open — ready for review |
+| 4 | #18 — Auth MFA integration tests | [#47](url) | Request Changes | Needs attention |
 
 ### Summary
-- **Ready to merge:** N PRs
-- **Needs attention:** M PRs (details below)
+- **Open and review-clean:** N PRs (ready for the user to merge)
+- **Open / needs attention:** M PRs (details below)
 - **Decomposed:** K issues → L sub-issues created
 - **Skipped:** J issues (reasons below)
 - **Issues created during reviews:** #A, #B, #C
 - **PRs merged by user during session:** #X, #Y
 
 ### Needs Attention
-- **PR #47** (#18 — Add auth tests): 1 critical finding — auth token not validated before use. See review comment.
+- **PR #47** (#18 — Auth MFA integration tests): 1 critical finding — TOTP replay window not enforced before use. See review comment.
 
 ### Skipped Issues
 - **#25**: Requires deployment setup — not automatable
 - **#30**: Needs user decision on provider choice
 
 ### Next Steps
-- Merge ready PRs
-- Address flagged PRs
+- Review and merge the review-clean PRs — this session merged nothing, because this repo withholds unattended merge authority
+- Address flagged PRs (each names its failed gate)
 - Review created issues for follow-up work
 ```
 
+## Session Boundaries
+
+Long autonomous runs are a sequence of bounded sessions, not one endless context — context re-reads dominate their cost, and a restart that halves context pays for itself within ~6–10 requests. When this skill runs inside a marathon (`/tackle-issues`), the wave boundary is the session boundary; run standalone, apply the same discipline at wave boundaries of its own (queue checkpoints — every few issues, and always before starting a large one). How a session ends at a wave boundary is **mode-aware**:
+
+- **Attended runs** — end the session at the wave boundary; the user/orchestrator relaunches the next segment seeded from the handoff note (`$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-handoff.md`) + the queue (`$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-queue.json`). Both live beside the brief vault and OUTSIDE the repo: `scratchpad/` is not in this repo's `.gitignore`, so an in-tree queue file would show up in `git status` and risk being committed.
+- **Unattended with a configured re-launcher** — none exists for this repo. There is no cron entry, no LaunchAgent and no `/loop` wrapper that restarts a CareBridge wave, so this branch never applies here; unattended runs take the branch below.
+- **Unattended with no re-launcher** — the live case for this repo. Do **NOT** end the session (nothing would relaunch it): write the handoff seed, force/await a compaction at the boundary so the next segment starts lean, and continue. The cost goal — shed context at the boundary — holds in every mode.
+
+- **~150K main-thread context ceiling.** Past ~150K tokens of main-thread context, finish the current issue only, write the short handoff note (queue position, open blockers, awaiting-user items, last verified merge), and end the session (unattended with no re-launcher: force a compaction instead). Resume Strategy below makes the fresh session lossless — it re-derives progress from GitHub state, so the handoff plus the queue is all the seed a restart needs.
+- **Cost circuit breaker at wave boundaries (queue checkpoints).** At each boundary, read cumulative session cost from the statusline, which surfaces the session's `cost.total_cost_usd`. No per-session budget is configured for this repo, so the breaker has no default threshold — it fires only against a budget the user names when starting the run, and absent one there is no automatic stop; say so in the handoff rather than assuming a limit. Over the named budget → write the handoff and **stop and notify** instead of continuing. This breaker is the sole sanctioned exception to Critical Rule 4's "everything after is fully autonomous".
+- **Verify state directly.** A background monitor ending is not a verdict — assert PR/CI state with a direct query before recording it, and re-check `mergeStateStatus` at the current head after any push.
+
 ## Resume Strategy
 
-This skill uses **GitHub state** for resume — no local state files.
+This skill resumes from **GitHub state** — GitHub remains the source of truth for issue/PR status. The wave handoff note (Session Boundaries) carries only session-boundary seeds — queue position, open blockers, awaiting-user items, last verified merge — and is disposable: everything in it is re-derivable from GitHub. It is a seed for the next segment, not a second source of truth.
 
 If a session is interrupted (crash, timeout, user stops it), re-running with the same arguments will:
 
@@ -381,23 +417,24 @@ If a session is interrupted (crash, timeout, user stops it), re-running with the
 2. Skip issues that already have merged or open PRs
 3. Resume from the first issue without a PR
 
-This makes the skill **idempotent** — safe to re-run without duplicating work.
+This makes the skill **idempotent** — safe to re-run without duplicating work. The same idempotence is what makes deliberate session-boundary restarts (above) lossless.
 
 ## Critical Rules
 
-1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions anywhere. Zero Attribution Policy.
+1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions anywhere. Zero Attribution Policy (see CLAUDE.md).
 2. **TDD is mandatory** — RED → GREEN → REFACTOR for every issue. No skipping tests. If pure docs/config, note why tests are N/A.
 3. **Branch from main every time** — Never stack branches. Each PR is independently mergeable in any order.
-4. **One confirmation point** — The initial queue approval. Everything after is fully autonomous.
-5. **Never merge** — PRs accumulate for user review. The agent keeps working.
+4. **One confirmation point** — The initial queue approval. Everything after is fully autonomous; the sole sanctioned stop is the cost circuit breaker (see Session Boundaries).
+5. **Self-merge authority for this repo** — NEVER merge, however clean the PR is. This repo does not grant unattended merge authority and the Unattended Merge Gate does not apply here. PRs accumulate for user review — flag each finished PR in the session report and keep working. A clean gate is not permission, because there is no gate to pass.
 6. **Never block on review findings** — Flag and move on. The user handles flagged PRs during check-ins.
 7. **Two fix attempts max** — If /full-review finds critical issues, fix them. If a second attempt still fails, flag and move on.
 8. **Progress table after every issue** — The user may check in at any time. The table must be current.
-9. **Respect the hard cap** — Max 15 issues per session. Refuse larger queues.
-10. **Resume from GitHub state** — No local state files. Query branches matching `BRANCH_PREFIX` and PR titles to detect prior work.
+9. **Respect the hard cap** — Max 15 issues per session segment (wave). Refuse larger queues.
+10. **Resume from GitHub state** — GitHub is the source of truth for issue/PR status; query branches matching `BRANCH_PREFIX` and PR titles to detect prior work. The wave handoff note is a disposable session-boundary seed, never a second source of truth.
 11. **Compose existing skills** — /full-review is called as-is (chains /agent-review → /check-pr). Don't reinvent their logic.
-12. **Decompose, don't skip** — High-complexity issues get broken into sub-issues, not skipped. Only skip truly non-automatable work.
+12. **Decompose, don't skip** — Oversized issues get broken into sub-issues, not skipped. Only skip truly non-automatable work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
 15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
-<!-- skill-templates: autonomous-dev-flow b194666 2026-05-28 -->
+
+<!-- skill-templates: autonomous-dev-flow 8196307 2026-08-01 -->

--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -369,9 +369,9 @@ After all issues are processed (or the queue is exhausted), output final summary
 
 | # | Issue | PR | Review Verdict | Status |
 |---|-------|----|---------------|--------|
-| 1 | #12 — Retry BullMQ consumer | [#45](url) | Approve | Open — ready for review |
+| 1 | #12 — Retry BullMQ consumer | [#45](url) | Approve | Open — ready for you to merge |
 | 2 | #15 — Medication reconciliation | — | — | Decomposed → #20, #21, #22 |
-| 3 | #20 — Reconciliation data model | [#46](url) | Approve | Open — ready for review |
+| 3 | #20 — Reconciliation data model | [#46](url) | Approve | Open — ready for you to merge |
 | 4 | #18 — Auth MFA integration tests | [#47](url) | Request Changes | Needs attention |
 
 ### Summary

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -68,7 +68,7 @@ BRANCH_PREFIX="feat/"
 # SCANS below must see every one of them or they miss merged session branches.
 # Observed across this repo's PR history plus the documented convention:
 # feat/, fix/, refactor/, chore/, docs/, test/.
-BRANCH_PREFIX_RE="^(feat|fix|refactor|chore|docs|test)/"
+BRANCH_PREFIX_RE="^(feat|fix|refactor|chore|docs|test|style|perf)/"
 ```
 
 Parse `$ARGUMENTS` — same as `/autonomous-dev-flow` but with higher defaults:

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -13,10 +13,10 @@ Composes `/autonomous-dev-flow` logic internally but adds multi-wave retry with 
   - `milestone:"v1.2"` (all open issues in milestone)
   - `#12 #15 #18` or `12 15 18` (specific issues by number)
   - `label:bug max:10 sort:created-asc` (with options)
-  - If empty, auto-detect: scan open issues sorted by complexity (low first, then medium, skip high)
+  - If empty, auto-detect: scan open issues and order by this repo's priority labels — `bug` → `from-review` → `enhancement`, with `p1` → `p2` → `p3` breaking ties where present
   - Options: `max:N` (default 20, hard cap 30), `sort:created-asc` (default) or `sort:created-desc`
   - `waves:N` (default 3, max 4) — maximum retry waves
-  - `merge:true` — run `/batch-merge all` after final wave (default: false)
+  - `merge:off` — disable the Unattended Merge Gate for this run; PRs accumulate for `/batch-merge`. Default is whatever Critical Rule 5 records for this repo; rule 5 withholds merge authority here, so this flag is redundant and `merge:on` is not honoured
 
 ## Instructions
 
@@ -36,6 +36,23 @@ Morning Summary        → Structured report of everything that happened
 
 Each wave runs the full Phase 1-6 cycle from `/autonomous-dev-flow` for each issue. The difference is what happens between waves and how retries are handled.
 
+### Session Boundaries and the Session Ledger
+
+A marathon spans multiple *sessions*, not one endless context. Context re-reads dominate marathon cost, so wave boundaries double as session boundaries:
+
+- **Session ledger + STATE header.** Keep an append-only session ledger at `$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-session-ledger.md` — deliberately OUTSIDE the repo, beside the brief vault, because nothing at this repo's root is gitignored for it and an in-tree ledger would show up in `git status` and risk being committed. Its top carries a rolling **STATE header** — a compact block (~2K tokens, hard-capped, rewritten in place) holding: current wave + position, queue pointer, open blockers, awaiting-user list, the last **verified** merge (PR + SHA), completions from the last wave, and a compact per-issue attempt table (issue# → attempts, last strategy tried, status) — the fields the Phase 4 convergence check reads instead of the full history. After a compaction or on a fresh session, the STATE header is the **only mandatory read**. The full history below it is consulted on-demand — allowed, and expected, for three purposes: the **Phase 4 convergence assessment**, **Phase 5 merge accounting**, and the **Phase 6 morning summary**. What is prohibited is the routine post-compaction top-to-bottom re-read as a ritual, not these accounting passes.
+- **Per-wave merge table.** At each wave boundary, append a **"Merged this wave"** table (PR, issue, review, checks, merge SHA) to the ledger history. Phases 5–6 aggregate these tables across all waves — with per-wave session restarts, "merged by this session" means the whole marathon, never just the last wave. Under this repo's withheld posture (Critical Rule 5) the session merges nothing, so this table records only merges the **user** performed mid-marathon; leave it out entirely when there are none.
+- **Shed context at each wave boundary — mode-aware.** When a wave completes (after Phase 2 replenishment and the Phase 4 convergence check), write/refresh the handoff note (`$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-handoff.md`) and the durable queue (`$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-queue.json` — kept outside the repo for the same reason as the ledger), update the STATE header, then:
+  - **Attended runs** — end the session; the user/orchestrator relaunches the next wave seeded from handoff note + queue + STATE header — never the full history.
+  - **Unattended with a configured re-launcher** — none exists for this repo. There is no cron entry, no LaunchAgent and no `/loop` wrapper that restarts a CareBridge wave, so this branch never applies here; unattended runs take the branch below.
+  - **Unattended with no re-launcher** — the live case for this repo. Do **NOT** end the session (nothing would relaunch it; the marathon would silently halt after one wave): write the STATE header, then force/await a compaction at the wave boundary so the next wave starts lean, and continue.
+  A restart (or boundary compaction) that halves context pays for itself within ~6–10 requests; the context-shedding goal holds in all three modes.
+- **~150K main-thread context ceiling.** Past ~150K tokens of main-thread context, finish the current issue only, write the handoff, end the session mid-wave if necessary (unattended with no re-launcher: force a compaction instead of ending).
+- **Per-wave cost circuit breaker.** At each wave boundary, read cumulative session cost from the statusline, which surfaces the session's `cost.total_cost_usd`. No per-session budget is configured for this repo, so the breaker has no default threshold — it fires only against a budget the user names when starting the marathon, and absent one there is no automatic stop; record that fact in the handoff rather than assuming a limit. Over the named budget → write the handoff and **stop and notify**; do not start the next wave. This breaker is the sole sanctioned exception to Critical Rule 4's "everything after is fully autonomous".
+- **Verify state directly, never from a stale reading.** A monitor/watcher ending is **not** a verdict — assert PR/CI state with a direct query before recording it. And `mergeStateStatus` is only meaningful at the **current** head — re-check it after any push before acting on a BLOCKED/CLEAN reading.
+
+`MASTER_LOG` (below) lives in the ledger; the STATE header summarizes it, and Resume Strategy re-derives ground truth from GitHub regardless.
+
 ### Phase 0: Marathon Setup
 
 ```bash
@@ -43,14 +60,21 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
 SESSION_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-# Branch prefix for session branches — uses feat/, fix/, refactor/, chore/, docs/ prefixes
+# Branch prefix for NEW session branches. This skill always builds branches as
+# "${BRANCH_PREFIX}${ISSUE_NUM}-${SLUG}", so it only ever creates feat/.
 BRANCH_PREFIX="feat/"
+
+# CareBridge branches carry conventional-commit prefixes, and the merge/resume
+# SCANS below must see every one of them or they miss merged session branches.
+# Observed across this repo's PR history plus the documented convention:
+# feat/, fix/, refactor/, chore/, docs/, test/.
+BRANCH_PREFIX_RE="^(feat|fix|refactor|chore|docs|test)/"
 ```
 
 Parse `$ARGUMENTS` — same as `/autonomous-dev-flow` but with higher defaults:
 - `max` defaults to 20, hard cap 30
 - `waves` defaults to 3, max 4
-- `merge` defaults to false
+- self-merge follows Critical Rule 5 for this repo — which withholds it, so nothing this session produces is merged by the session and no flag can change that
 
 Build the initial queue using the same logic as `/autonomous-dev-flow` Phase 0:
 - Fetch issues by label, milestone, explicit list, or auto-detect
@@ -68,13 +92,13 @@ Display the marathon queue:
 
 | # | Issue | Labels | Action |
 |---|-------|--------|--------|
-| 1 | #12 — Add retry logic | enhancement | Implement |
-| 2 | #15 — Add leaderboard | enhancement | Decompose → sub-issues |
-| 3 | #18 — Auth integration tests | bug | Implement |
-| — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
+| 1 | #12 — Retry the BullMQ clinical-events consumer | enhancement | Implement |
+| 2 | #15 — Medication reconciliation across clinical-data + ai-oversight | enhancement | Decompose → sub-issues (spans 3 workspaces) |
+| 3 | #18 — Integration tests for the auth MFA flow | test | Implement |
+| — | #16 — Refactor the auth session store | enhancement | Assigned to @user (skipped) |
 
 **Mode:** Unattended marathon (up to {W} waves)
-**Merge after:** {Yes/No}
+**Self-merge:** Withheld by this repo (per Critical Rule 5) — every PR is left open for review
 **Estimated scope:** {N} issues × {W} max waves
 
 Start marathon session?
@@ -95,7 +119,7 @@ For each issue in the current wave's queue, run the full `/autonomous-dev-flow` 
 
 1. **Sync Check** — `git checkout main && git pull origin main`
 2. **Issue Understanding** — Read issue, identify files, plan approach
-3. **Implementation (TDD)** — Branch, RED-GREEN-REFACTOR
+3. **Implementation (TDD)** — Branch, RED-GREEN-REFACTOR; `pnpm test` for the cycle, `pnpm typecheck && pnpm lint` before pushing
 4. **Commit and PR** — Push, create PR
 5. **Full Review** — `/full-review` with pre-skill checkpoint
 6. **Assess and Report** — Classify verdict, update progress
@@ -104,7 +128,7 @@ For each issue in the current wave's queue, run the full `/autonomous-dev-flow` 
 
 - **Two fix attempts per issue per wave** (same as original). If still failing after 2 attempts, mark as `retry` instead of just `flagged`.
 - **Track the failure reason** in `MASTER_LOG` — this informs the retry strategy in later waves.
-- **High-complexity decomposition** happens in Wave 1 only. Sub-issues created during decomposition are added to the current wave's queue (not deferred to Wave 2).
+- **Oversized-issue decomposition** happens in Wave 1 only. This repo has no `complexity:*` labels, so the trigger is scope — issues spanning 3+ workspaces across `packages/`, `services/` and `apps/`. Sub-issues created during decomposition are added to the current wave's queue (not deferred to Wave 2).
 
 After each issue, output the wave progress table:
 
@@ -113,11 +137,11 @@ After each issue, output the wave progress table:
 
 | # | Issue | Branch | PR | Review | Status | Attempt |
 |---|-------|--------|----|--------|--------|---------|
-| 1 | #12 — Add retry logic | 12-add-retry | #45 | Approve | Done | W1 |
-| 2 | #15 — Leaderboard | — | — | — | Decomposed → #20,#21 | W1 |
-| 3 | #20 — LB data model | 20-lb-model | #46 | Request Changes | Retry (W2) | W1 |
-| 4 | #18 — Auth tests | 18-auth-tests | #47 | Approve | Done | W1 |
-| 5 | #21 — LB display | — | — | — | In progress | W1 |
+| 1 | #12 — Retry BullMQ consumer | feat/12-retry-bullmq-consumer | #45 | Approve | Done — PR open | W1 |
+| 2 | #15 — Medication reconciliation | — | — | — | Decomposed → #20,#21 | W1 |
+| 3 | #20 — Reconciliation data model | feat/20-reconciliation-data-model | #46 | Request Changes | Retry (W2) | W1 |
+| 4 | #18 — Auth MFA tests | feat/18-auth-mfa-tests | #47 | Approve | Done — PR open | W1 |
+| 5 | #21 — Reconciliation portal view | — | — | — | In progress | W1 |
 ```
 
 ### Phase 2: Queue Replenishment (Between Waves)
@@ -130,7 +154,7 @@ From `MASTER_LOG`, gather issues where the latest attempt was not `Done`:
 
 | Status | Meaning | Retry? |
 |--------|---------|--------|
-| Done | PR created, review clean | No — skip in future waves |
+| Done | Review-clean and left open — this repo's Critical Rule 5 withholds merge authority, so "Done" never means merged by the session | No — skip in future waves |
 | Retry | Tests failing or review found critical issues | Yes — re-attempt |
 | Flagged | 2 fix attempts failed in a wave | Yes — with different strategy |
 | Skipped | Non-automatable (blocked, no criteria, etc.) | No — genuinely blocked |
@@ -155,11 +179,11 @@ Add new unassigned issues to the queue if they match the original filter criteri
 
 ```bash
 gh pr list --state merged --json number,headRefName,mergedAt --limit 30 \
-  | jq --arg start "$SESSION_START" --arg prefix "$BRANCH_PREFIX" \
-    '[.[] | select(.mergedAt > $start) | select(.headRefName | startswith($prefix))]'
+  | jq --arg start "$SESSION_START" --arg prefix "$BRANCH_PREFIX_RE" \
+    '[.[] | select(.mergedAt > $start) | select(.headRefName | test($prefix))]'
 ```
 
-Note merged PRs. If a merged PR's issue is in the retry queue, remove it — the user handled it.
+Note merged PRs. Because this repo withholds session merge authority, every hit here is a merge the **user** performed. If a merged PR's issue is in the retry queue, remove it — the user handled it.
 
 #### 2d. Clean Up Failed Branches
 
@@ -206,7 +230,7 @@ For issues that failed in Wave 1:
 For issues that failed in both Wave 1 and Wave 2:
 1. **Analyze both previous failures** — what approaches were tried, why they failed
 2. **Try a fundamentally different approach:**
-   - If the implementation approach failed, try a different architecture
+   - If the implementation approach failed, try a different architecture — the Turborepo seam (`packages/*` → `services/*` → `apps/*`) is usually where a stuck change wants to be split
    - If tests were the issue, reconsider the test strategy
    - If review found design issues, rethink the design
 3. **Simplify scope** — implement the minimum viable version that satisfies core acceptance criteria. Defer edge cases to a follow-up issue.
@@ -265,22 +289,21 @@ After each wave, check for convergence BEFORE entering the next wave:
 **Reason:** {e.g., "3 new completions, 2 retries remaining — continuing" or "0 new completions, same 2 issues failing — converged"}
 ```
 
-### Phase 5: Optional Batch Merge
+### Phase 5: Merge Accounting
 
-If `merge:true` was specified AND at least one PR is ready:
+Critical Rule 5 withholds merge authority for this repo, so **nothing merges inline during waves**: the Unattended Merge Gate does not apply, and every review-clean PR is left open for the user. This phase is accounting only, and it accounts for the **whole marathon, across every wave** — with per-wave session restarts, the last wave's memory is not the session's history:
 
-1. List all PRs created during this session that have clean reviews
-2. Run `/batch-merge` with those PR numbers
-3. Record merge results in the morning summary
-
-If `merge:true` was NOT specified, skip this phase and note in the summary:
+1. Collect every PR the marathon left open, **across all waves** — aggregate the ledger's per-wave tables (an on-demand-allowed ledger read; see Session Boundaries) so the Morning Summary covers waves the current segment never saw
+2. Any PR that passed review but failed a later gate (e.g. CI red after the last push) is listed under Needs Attention with the failed gate named
+3. Record any merges the **user** performed mid-marathon (from the Phase 2c scan) so the summary distinguishes them from the session's own output — the session merged nothing
+4. Because rule 5 withholds merge authority for this repo, no self-merges happened; note in the summary:
 ```
 **Ready to merge:** Run `/batch-merge {PR_NUMS}` to merge completed PRs.
 ```
 
 ### Phase 6: Morning Summary
 
-Output a comprehensive summary designed for the user to read when they return. This is the primary deliverable of an overnight session.
+Output a comprehensive summary designed for the user to read when they return. This is the primary deliverable of an overnight session. It covers the **entire marathon across all waves** — build it from the ledger's per-wave tables and full history (an on-demand-allowed read; see Session Boundaries), not from what the current session segment happens to remember.
 
 ```markdown
 ## Marathon Session Complete
@@ -295,34 +318,34 @@ Output a comprehensive summary designed for the user to read when they return. T
 | Metric | Count |
 |--------|-------|
 | Issues attempted | {N} |
-| PRs created (ready to merge) | {M} |
-| PRs flagged (needs attention) | {K} |
+| PRs open and review-clean (ready to merge) | {M} |
+| PRs open (needs attention) | {K} |
 | Issues decomposed | {D} → {S} sub-issues |
 | Issues blocked (auto) | {B} |
 | Issues skipped | {J} |
-| Issues merged by user during session | {U} |
+| PRs merged by user during session | {U} |
 | Total waves executed | {W} |
 
 ### All PRs Created
 
 | Issue | PR | Wave | Review | Status |
 |-------|-----|------|--------|--------|
-| #12 — Add retry logic | [#45](url) | W1 | Approve | Ready to merge |
-| #20 — LB data model | [#46](url) | W1→W2 | Approve | Ready to merge (fixed in W2) |
-| #18 — Auth tests | [#47](url) | W1 | Request Changes | Needs attention |
-| #21 — LB display | [#48](url) | W1 | Approve | Ready to merge |
+| #12 — Retry BullMQ consumer | [#45](url) | W1 | Approve | Open — ready for review |
+| #20 — Reconciliation data model | [#46](url) | W1→W2 | Approve | Open — ready for review (fixed in W2) |
+| #18 — Auth MFA tests | [#47](url) | W1 | Request Changes | Needs attention |
+| #21 — Reconciliation portal view | [#48](url) | W1 | Approve | Open — ready for review |
 
 ### Needs Attention ({K} PRs)
 
 These PRs were created but have unresolved issues after maximum retry attempts:
 
-- **PR #47** (#18 — Auth tests): Review found auth token not validated. Attempted fix in W1 (2 attempts) and W2 — token validation conflicts with existing middleware pattern. See review comments for details.
+- **PR #47** (#18 — Auth MFA tests): Review found the TOTP replay window unenforced. Attempted fix in W1 (2 attempts) and W2 — the guard conflicts with the existing rate-limit middleware. See review comments for details.
 
 ### Blocked Issues ({B})
 
 These issues could not be implemented after {W} waves. Each has a detailed comment on the GitHub issue:
 
-- **#30** — Complex auth refactor: Requires changes to 3 interconnected systems. Each wave's approach created regressions in a different area. Recommend manual implementation with incremental PRs.
+- **#30** — Cross-service clinical-flag refactor: Requires changes to 3 interconnected services. Each wave's approach created regressions in a different area. Recommend manual implementation with incremental PRs.
 
 ### Skipped Issues ({J})
 
@@ -331,7 +354,7 @@ These issues could not be implemented after {W} waves. Each has a detailed comme
 
 ### Decomposition Log
 
-- **#15** (enhancement) → #20, #21, #22 — all completed in W1
+- **#15** (spans clinical-data, ai-oversight, clinician-portal) → #20, #21, #22 — all completed in W1
 
 ### Wave-by-Wave Summary
 
@@ -343,7 +366,7 @@ These issues could not be implemented after {W} waves. Each has a detailed comme
 
 ### Next Steps
 
-1. **Merge ready PRs:** `/batch-merge {PR_NUMS}`
+1. **Merge the review-clean PRs:** `/batch-merge {PR_NUMS}` — this repo withholds unattended merge authority, so the session merged nothing
 2. **Review flagged PRs:** {list with specific issues to check}
 3. **Address blocked issues:** {list with recommendations}
 4. **New issues created:** {list of sub-issues or follow-up issues}
@@ -351,11 +374,11 @@ These issues could not be implemented after {W} waves. Each has a detailed comme
 
 ## Resume Strategy
 
-This skill uses **GitHub state** for resume — no local state files. Same as `/autonomous-dev-flow`.
+This skill resumes from **GitHub state** — GitHub remains the source of truth for issue/PR status, same as `/autonomous-dev-flow`. The session ledger carries the plan/decision record and the wave handoff note carries only session-boundary seeds (queue position, blockers, awaiting-user, last verified merge); both are disposable for resume purposes — everything they seed is re-derivable from GitHub.
 
 If a marathon session is interrupted (crash, timeout, user stops it), re-running with the same arguments will:
 
-1. Query GitHub for existing session branches (matching `BRANCH_PREFIX`) and PRs referencing each issue
+1. Query GitHub for existing session branches (matching `BRANCH_PREFIX_RE`) and PRs referencing each issue
 2. Detect which wave the session was in by counting attempts per issue
 3. Skip issues that already have merged or clean open PRs
 4. Resume from the first unfinished issue in the current wave
@@ -370,21 +393,24 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 
 ## Critical Rules
 
-1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions. Zero Attribution Policy.
+1. **NO attribution** — No Co-Authored-By, no "Generated with Claude", no AI mentions. Zero Attribution Policy (see CLAUDE.md).
 2. **TDD is mandatory** — RED → GREEN → REFACTOR for every issue, every wave. No skipping tests.
 3. **Branch from main every time** — Never stack branches. Fresh branch for every attempt, including retries.
-4. **One confirmation point** — The initial marathon queue approval. Everything after — including all waves and retries — is fully autonomous.
-5. **Never merge (unless merge:true)** — PRs accumulate for user review. Only `/batch-merge` at the end if explicitly requested.
+4. **One confirmation point** — The initial marathon queue approval. Everything after — including all waves and retries — is fully autonomous; the sole sanctioned stop besides convergence is the per-wave cost circuit breaker (see Session Boundaries and the Session Ledger).
+5. **Self-merge authority for this repo** — NEVER merge, however clean the PR is. This repo does not grant unattended merge authority, so the Unattended Merge Gate does not apply here and `merge:on` is NOT honoured — an invocation flag cannot grant authority the repo withholds. Every PR accumulates for `/batch-merge` or user review, so `merge:off` is redundant here rather than required.
 6. **Clean up failed attempts** — Close old PRs and delete old branches before retrying. Don't leave orphaned PRs.
 7. **Escalate strategy across waves** — Wave 1: standard approach. Wave 2: fresh context + address failures. Wave 3: alternative approach + scope reduction. Don't repeat the same failing approach.
 8. **Converge, don't loop forever** — If a wave produces zero new completions, stop. Further waves won't help.
 9. **Progress table after every issue** — The user may check in at any time. The table must show wave context.
 10. **Respect the hard cap** — Max 30 issues across all waves (including sub-issues from decomposition). Refuse larger queues.
-11. **Resume from GitHub state** — No local state files. Detect wave progress from closed/open PR counts per issue.
-12. **Compose existing skills** — `/full-review` is called as-is. `/batch-merge` if `merge:true`. Don't reinvent their logic.
-13. **Decompose in Wave 1 only** — High-complexity decomposition happens once. Retries work on the sub-issues, not the parent.
+11. **Resume from GitHub state** — GitHub is the source of truth for issue/PR status; detect wave progress from closed/open PR counts per issue. The ledger and handoff note are seeds, never a second source of truth.
+12. **Compose existing skills** — `/full-review` is called as-is. Critical Rule 5 withholds self-merge here, so the Unattended Merge Gate (`unattended-merge`) never engages and `/batch-merge` handles every leftover PR. Don't reinvent their logic.
+13. **Decompose in Wave 1 only** — Oversized-issue decomposition happens once. Retries work on the sub-issues, not the parent.
 14. **Comment on blocked issues** — Every issue that fails all waves gets a detailed GitHub comment with what was tried and why it failed.
 15. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running `/full-review` in every wave.
 16. **Sync before every branch** — Always `git checkout main && git pull` before starting each issue in each wave.
 17. **Morning summary is mandatory** — Even if interrupted, output the best summary possible with data collected so far.
-<!-- skill-templates: tackle-issues b194666 2026-05-28 -->
+18. **Wave boundaries are session boundaries** — Shed context at each wave boundary, mode-aware: end + restart fresh from handoff note + queue + the ledger's STATE header where the user or a configured re-launcher will relaunch; force a boundary compaction and continue where nothing would — which is this repo's case, since no re-launcher is configured. Respect the ~150K main-thread context ceiling and the per-wave cost circuit breaker (see Session Boundaries and the Session Ledger).
+19. **STATE header over full re-reads** — After compaction, read only the ledger's STATE header; the full ledger history is on-demand reference, never a mandatory re-read.
+
+<!-- skill-templates: tackle-issues 8196307 2026-08-01 -->

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -330,10 +330,10 @@ Output a comprehensive summary designed for the user to read when they return. T
 
 | Issue | PR | Wave | Review | Status |
 |-------|-----|------|--------|--------|
-| #12 — Retry BullMQ consumer | [#45](url) | W1 | Approve | Open — ready for review |
-| #20 — Reconciliation data model | [#46](url) | W1→W2 | Approve | Open — ready for review (fixed in W2) |
+| #12 — Retry BullMQ consumer | [#45](url) | W1 | Approve | Open — ready for you to merge |
+| #20 — Reconciliation data model | [#46](url) | W1→W2 | Approve | Open — ready for you to merge (fixed in W2) |
 | #18 — Auth MFA tests | [#47](url) | W1 | Request Changes | Needs attention |
-| #21 — Reconciliation portal view | [#48](url) | W1 | Approve | Open — ready for review |
+| #21 — Reconciliation portal view | [#48](url) | W1 | Approve | Open — ready for you to merge |
 
 ### Needs Attention ({K} PRs)
 

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -112,8 +112,39 @@ Mindset: "Is this type-safe end-to-end? Does it handle clinical data correctly, 
 
 ## autonomous-dev-flow Customizations
 
+### Self-merge posture
+- **Withheld.** This repo does NOT grant unattended merge authority. Critical Rule 5
+  must be written in its WITHHELD form: the session never merges, the Unattended Merge
+  Gate does not apply, and every finished PR is flagged in the session report and left
+  open for the user. Because there are no session merges, the skill also OMITS the
+  `### Merged by this session` report section — an empty merge table reads as though a
+  merge happened.
+- **Why this is recorded here and not only in the skill file:** `.claude/commands/` is
+  regenerated wholesale on every `skill update`, while this profile is not. Without this
+  block, the next update silently takes the template's default posture (gated
+  self-merge) and re-enables unattended merges on a repo that never granted them. This
+  profile entry is the durable record; the command file is the derived artifact.
+
 ### Branch Prefix
 - Uses `feat/` (not `auto/`) — matches existing naming conventions
+- `BRANCH_PREFIX_RE` for merge/resume scans covers every prefix a session branch can
+  carry: `^(feat|fix|refactor|chore|docs|test)/`
+
+### Smoke Test
+- None. There is no per-PR UI smoke-test harness and no `/smoke-test` skill in this
+  repo, so the template's Phase 4.5 is dropped rather than pointed at something that
+  cannot serve. `pnpm smoke-test` (`tooling/smoke-test.ts`) is a hand-maintained
+  post-merge script pinned to specific merged PRs and requires a live Postgres plus
+  running services — do not wire it in as a per-PR gate.
+
+### Session Boundary Paths
+- Handoff note: `$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-handoff.md`
+- Durable queue: `$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-queue.json`
+- Both live outside the repo — `scratchpad/` is not in this repo's `.gitignore`, so an
+  in-tree queue file would surface in `git status`
+- Wave re-launcher: none configured (no cron entry, no LaunchAgent, no `/loop` wrapper)
+- Cost source: the statusline (`cost.total_cost_usd`). No per-session budget is set, so
+  the circuit breaker fires only against a budget named at invocation
 
 ### Decomposition Trigger
 - Treat issues touching 3+ packages/services as decomposition candidates
@@ -179,6 +210,22 @@ Shares all customization points with `autonomous-dev-flow` above.
 - Max concurrent: 3 (monorepo, parallel package builds safe)
 - Priority labels: `bug` > `from-review` > `enhancement`
 - Test gate: `pnpm typecheck && pnpm lint`
+- Session ledger: `$CLAUDE_BRIEF_DIR/../handoffs/carebridge-<YYYY-MM-DD>-session-ledger.md`
+  — kept outside the repo (nothing at the repo root is gitignored for it)
+
+### Self-merge posture
+- **Withheld.** This repo does NOT grant unattended merge authority. Critical Rule 5
+  must be written in its WITHHELD form: nothing merges inline during waves, the
+  Unattended Merge Gate never engages, `merge:on` is NOT honoured (an invocation flag
+  cannot grant authority the repo withholds), and `merge:off` is redundant rather than
+  required. Every PR accumulates for `/batch-merge` or user review. Because there are no
+  session merges, the Morning Summary also OMITS the `### Merged by this session`
+  section — an empty merge table reads as though a merge happened.
+- **Why this is recorded here and not only in the skill file:** `.claude/commands/` is
+  regenerated wholesale on every `skill update`, while this profile is not. Without this
+  block, the next update silently takes the template's default posture (gated
+  self-merge) and re-enables unattended merges on a repo that never granted them. This
+  profile entry is the durable record; the command file is the derived artifact.
 
 ## fix-ci Customizations
 - CI config: `.github/workflows/`


### PR DESCRIPTION
## Summary

`/autonomous-dev-flow` and `/tackle-issues` were both stamped `b194666 2026-05-28` and had drifted several template generations behind. They predate the Unattended Merge Gate, the session-boundary model, the session ledger and its STATE header, and the cost circuit breaker — so a marathon run against them had no context ceiling, no wave-boundary context shedding, and no merge accounting at all.

Both are reinstalled from registry template `8196307` and customized against this repo rather than left on template defaults.

## What was customized

| Point | Value | Source |
|-------|-------|--------|
| Branch prefix (created) | `feat/` | `.claude/skill-profile.md` |
| `BRANCH_PREFIX_RE` (scans) | `^(feat\|fix\|refactor\|chore\|docs\|test)/` | observed PR history + documented convention |
| Test runner | `pnpm test` (Vitest via Turborepo) | `package.json`, `vitest.workspace.ts` |
| Test file conventions | `src/__tests__/*.test.ts`, `*.int.test.ts`, `*.test.tsx` | actual tree |
| Static gates | `pnpm typecheck && pnpm lint`, `pnpm build` | `.github/workflows/ci.yml` |
| Decomposition trigger | scope — 3+ workspaces across `packages/`/`services/`/`apps/` | profile (no `complexity:*` labels exist) |
| Queue ordering | `bug` → `from-review` → `enhancement`, `p1`/`p2`/`p3` tiebreak | labels that actually exist |
| Commit scopes | `db`, `ai`, `notes`, `clinical`, `auth`, `gateway`, `portal`, `infra` | `CLAUDE.md` |
| Handoff / queue / ledger | beside the brief vault, **outside** the repo | `scratchpad/` and the repo root aren't gitignored for them |

The tackle-issues scans previously keyed on a single `feat/` prefix, so merged session branches under `fix/`, `refactor/`, `chore/`, `docs/` or `test/` were invisible to the merge and resume scans. `BRANCH_PREFIX_RE` closes that.

## What was dropped rather than invented

- **Phase 4.5, the per-PR UI smoke test.** There is no `/smoke-test` skill here, and `pnpm smoke-test` (`tooling/smoke-test.ts`) is a hand-maintained post-merge script pinned to specific merged PRs that needs a live Postgres plus running services. It cannot serve as a per-PR gate, so the phase and its `Smoke` report columns are gone rather than pointed at something that would fail on every run.
- **The circuit-breaker threshold.** The mechanism and its real cost source stay (the statusline's `cost.total_cost_usd`), but no per-session budget is configured for this repo, so no number was invented — the breaker fires only against a budget named at invocation, and the skill says so.

Both omissions are recorded in `.claude/skill-profile.md` so a later refresh doesn't silently re-add them.

## Self-merge posture: preserved and now pinned

This is a **preservation**, not a change. Both installs already withheld unattended merge authority. Critical Rule 5 is now written in its explicit WITHHELD form in both files: the session never merges, the Unattended Merge Gate does not apply, `merge:on` is not honoured, `merge:off` is redundant, and every PR is left open for `/batch-merge` or user review. The `### Merged by this session` report sections are omitted accordingly — an empty merge table reads as though a merge happened.

The posture is also pinned in `.claude/skill-profile.md` under both skills. `.claude/commands/` is regenerated wholesale on every `skill update` while the profile is not, so without that record the next refresh would take the template's default posture (gated self-merge) and silently re-enable unattended merges on a repo that never granted them.

## Test Plan

- [x] `skill-lint.sh autonomous-dev-flow` → exit 0 (7 guards ok, stamp ok)
- [x] `skill-lint.sh tackle-issues` → exit 0 (13 guards ok, stamp ok)
- [x] `grep -c '{{CUSTOMIZE'` → 0 in both files
- [x] Critical Rule 5 byte-matches the guard-anchored WITHHELD wording in both files
- [x] No `### Merged by this session` section in either file
- [x] Version stamps `8196307 2026-08-01` alone on the last non-blank line
- [x] Docs-only change — no code touched, so CI's typecheck/build/test jobs are unaffected

Not merging — this repo withholds unattended merge authority, so the merge is yours to make.